### PR TITLE
Persistent activity stats: per-turn wake scores, underruns, hourly HW metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,10 @@ The always-on wake stream (`mic_start` without `lock_mic`) is **ungated and AGC-
 | `em_ble_proxy.py` | BLE proxy ESPHome servers — a second, separate ESPHome device per Echo (own port from the shared counter, own mDNS, MAC = serial-derived with the locally-administered bit flipped). Forwards `ble_adverts` control messages from the device's passive scanner (`device/internal/bluetooth`, raw HCI over `/dev/stpbt`; enabling durably disables Android's BT stack) to HA as raw advertisements. Lifecycle = idempotent `reconcile()` driven by `bleProxyEnabled` |
 | `esphome/` | ESPHome native API protocol layer (framing, handshake, vendored protobufs) |
 
+## Persistent activity stats
+
+Every voice turn is persisted to SQLite at completion (`turns` table, `db.insert_turn` from `em_esphome`): trigger, wake model/score/threshold, room noise floor at detection, outcome, STT text, stage latencies, and playback underruns. The underrun count arrives asynchronously — the device reports `playback_stats` (periods + underruns) once per completed speaker stream, and the controller attaches it to `device.last_turn_id` (consumed on use so an announcement's report can't overwrite a turn's stats; NULL underruns = never reported, e.g. pre-v2.9 firmware). Two hourly rollup tables ride alongside: `wake_counters` (near-miss counts/max score, flushed through the existing 2s-rate-limited near-miss path; plus non-turn underruns) and `device_metrics` (CPU/RAM/storage/RSSI sums+extremes upserted per ~30s device stats report — averages computed at read). `Device.turn_history` is hydrated from `turns` on connect, so the dashboard Activity tab survives restarts. Read APIs: `/api/devices/{id}/turns` (raw, `limit`/`since`) and `/api/devices/{id}/activity?days=N` (per-day aggregates, per-wake-model rollups, counters, metrics — plot-ready). Keep instrumentation at this cost class: one insert per turn, one upsert per 30s/2s — nothing per audio frame.
+
 ## OTA update system
 
 The device runs an A/B slot binary system:

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -187,6 +187,7 @@ async def create_app() -> web.Application:
     app.router.add_post("/api/devices/{id}/config",       _post_device_config)
     app.router.add_get("/api/devices/{id}/logs",          _get_device_logs)
     app.router.add_get("/api/devices/{id}/turns",         _get_device_turns)
+    app.router.add_get("/api/devices/{id}/activity",      _get_device_activity)
     app.router.add_post("/api/devices/{id}/wifi",         _post_device_wifi)
     app.router.add_post("/api/devices/{id}/wifi/scan",    _post_device_wifi_scan)
     app.router.add_post("/api/devices/{id}/update",       _post_device_update)
@@ -359,11 +360,112 @@ async def _get_device(request: web.Request) -> web.Response:
 
 @auth.require_auth
 async def _get_device_turns(request: web.Request) -> web.Response:
-    """GET /api/devices/{id}/turns — recent voice-turn traces (in-memory,
-    newest last). Powers the Status tab's observability panel."""
+    """GET /api/devices/{id}/turns — recent voice-turn traces, newest last.
+    Served from the persistent turns table (survives controller and device
+    restarts). Powers the Activity tab's observability panel.
+
+    Query params: limit (default 50, max 1000), since (epoch seconds)."""
     device_id = request.match_info["id"]
-    d = _devices.get(device_id)
-    return _ok(list(d.turn_history) if d is not None else [])
+    try:
+        limit = min(int(request.query.get("limit", 50)), 1000)
+        since = request.query.get("since")
+        since = float(since) if since is not None else None
+    except ValueError:
+        return _error("bad_request", "limit/since must be numeric", 400)
+    loop  = asyncio.get_event_loop()
+    turns = await loop.run_in_executor(
+        None, lambda: db.get_turns(device_id, limit, since)
+    )
+    return _ok(turns)
+
+
+@auth.require_auth
+async def _get_device_activity(request: web.Request) -> web.Response:
+    """GET /api/devices/{id}/activity?days=7 — aggregated activity stats
+    for trend review: per-day turn buckets (counts, outcomes, latency
+    percentiles, wake scores, underruns), per-wake-model rollups, hourly
+    near-miss counters, and hourly hardware metrics (CPU/RAM/storage/RSSI)."""
+    device_id = request.match_info["id"]
+    try:
+        days = min(int(request.query.get("days", 7)), 180)
+    except ValueError:
+        return _error("bad_request", "days must be an integer", 400)
+    since = time.time() - days * 86400
+
+    loop     = asyncio.get_event_loop()
+    turns    = await loop.run_in_executor(
+        None, lambda: db.get_turns(device_id, 50_000, since)
+    )
+    counters = await loop.run_in_executor(
+        None, lambda: db.get_wake_counters(device_id, since)
+    )
+    metrics  = await loop.run_in_executor(
+        None, lambda: db.get_device_metrics(device_id, since)
+    )
+
+    def pct(sorted_vals, p):
+        if not sorted_vals:
+            return None
+        return sorted_vals[min(len(sorted_vals) - 1, int(len(sorted_vals) * p))]
+
+    # Per-day buckets (local time), oldest first.
+    day_buckets: dict[str, list[dict]] = {}
+    for t in turns:
+        day = time.strftime("%Y-%m-%d", time.localtime(t["ts"]))
+        day_buckets.setdefault(day, []).append(t)
+
+    days_out = []
+    for day in sorted(day_buckets):
+        ts_list   = day_buckets[day]
+        ok        = [t for t in ts_list if t["outcome"] == "ok"]
+        totals    = sorted(t["total_ms"] for t in ok if (t["total_ms"] or 0) > 0)
+        scores    = [t["wake_score"] for t in ts_list if t["wake_score"] is not None]
+        underruns = sum(t["underruns"] or 0 for t in ts_list)
+        outcomes: dict[str, int] = {}
+        for t in ts_list:
+            outcomes[t["outcome"] or "?"] = outcomes.get(t["outcome"] or "?", 0) + 1
+        days_out.append({
+            "date":           day,
+            "turns":          len(ts_list),
+            "ok":             len(ok),
+            "outcomes":       outcomes,
+            "total_ms_p50":   pct(totals, 0.50),
+            "total_ms_p95":   pct(totals, 0.95),
+            "wake_score_avg": round(sum(scores) / len(scores), 3) if scores else None,
+            "wake_score_min": round(min(scores), 3) if scores else None,
+            "underruns":      underruns,
+        })
+
+    # Per-wake-model rollup — supports A/B-ing custom OWW models.
+    models: dict[str, dict] = {}
+    for t in turns:
+        if not t["wake_model"]:
+            continue
+        m = models.setdefault(
+            t["wake_model"], {"turns": 0, "score_sum": 0.0, "score_min": None}
+        )
+        m["turns"] += 1
+        if t["wake_score"] is not None:
+            m["score_sum"] += t["wake_score"]
+            m["score_min"] = (
+                t["wake_score"] if m["score_min"] is None
+                else min(m["score_min"], t["wake_score"])
+            )
+    models_out = {
+        name: {
+            "turns":     m["turns"],
+            "score_avg": round(m["score_sum"] / m["turns"], 3) if m["turns"] else None,
+            "score_min": m["score_min"],
+        }
+        for name, m in models.items()
+    }
+
+    return _ok({
+        "days":          days_out,
+        "wake_models":   models_out,
+        "wake_counters": [dict(r) for r in counters],
+        "metrics":       metrics,
+    })
 
 
 @auth.require_admin

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -22,6 +22,7 @@ Device WebSocket protocol:
      "version": "v2.0.1", "capabilities": [...]}
     {"type": "button", "clickType": 138, "down": false}
     {"type": "log", "level": "info", "message": "..."}
+    {"type": "playback_stats", "periods": 123, "underruns": 0}
     {"type": "pong"}
 
   /control — Server → Device:
@@ -272,8 +273,28 @@ class Device:
 
         # Recent voice-turn traces (dicts derived from TurnTrace at emit
         # time in em_esphome) — powers the Status tab's observability panel.
-        # In-memory only; bounded.
+        # Hydrated from the persistent turns table on connect (handle_control),
+        # appended live; bounded.
         self.turn_history: collections.deque = collections.deque(maxlen=50)
+
+        # Wake detection detail for the turn about to start — set by
+        # wake_word_listener / _barge_watcher at detection, popped by
+        # em_esphome.trigger_voice_turn into the turn's trace. None for
+        # button/continuation turns.
+        self.last_wake: dict | None = None
+
+        # Playback stats rendezvous. The device reports playback_stats when
+        # its buffer drains, the controller persists the turn when its
+        # (deliberately overestimated) drain sleep ends — either can happen
+        # first. last_turn_id covers stats-after-persist: set at persist for
+        # turns that played audio, consumed by handle_control (cleared on
+        # use so an announcement's report can't overwrite a turn's stats).
+        # pending_playback_stats covers stats-before-persist: (ts, periods,
+        # underruns) stashed by handle_control, folded into the record by
+        # em_esphome._persist_turn if fresh (staleness window keeps a
+        # long-ago announcement's stats out of an unrelated later turn).
+        self.last_turn_id: int | None = None
+        self.pending_playback_stats: tuple[float, int, int] | None = None
 
     async def send_control(self, msg: dict):
         try:
@@ -591,6 +612,15 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
                         f"Barge-in during {phase} (score={score:.3f})"
                     )
                     device.barge_detected = True
+                    # Wake detail for the interrupting turn's persistent
+                    # record — popped when the turn loop re-enters
+                    # trigger_voice_turn with trigger "barge-in".
+                    device.last_wake = {
+                        "model":       device._barge_model_key,
+                        "score":       round(score, 4),
+                        "threshold":   threshold,
+                        "noise_floor": round(device.noise_floor, 5),
+                    }
                     device.cancel_event.set()
                     if in_playback:
                         await device.send_control({"type": "speaker_flush"})
@@ -990,6 +1020,8 @@ async def wake_word_listener(device: Device):
 
     buf = bytearray()
     last_near_miss_log_ts = 0.0  # Q4: rate-limit near-miss INFO logging to 1/2s
+    nm_pending = 0    # near-misses buffered since the last hourly-rollup flush
+    nm_max     = 0.0  # highest buffered near-miss score
     try:
         while True:
             if device.oww_model != current_model_name or device.oww_speex_ns != current_speex_ns:
@@ -1102,6 +1134,8 @@ async def wake_word_listener(device: Device):
                 # logs at all.
                 if score > 0.05:
                     device.oww_near_misses += 1
+                    nm_pending += 1
+                    nm_max = max(nm_max, score)
                     log.debug(
                         f"[{device.device_id}] OWW score: {score:.3f} "
                         f"(threshold={device.oww_threshold:.3f}, "
@@ -1120,6 +1154,19 @@ async def wake_word_listener(device: Device):
                             "device_id": device.device_id,
                             "state":     {"owwNearMisses": device.oww_near_misses},
                         })
+                        # Flush the buffered near-miss counts into the hourly
+                        # persistent rollup. Riding this rate-limited branch
+                        # caps the DB cost at one upsert per 2s per device,
+                        # however noisy the room.
+                        _nm, _mx = nm_pending, nm_max
+                        nm_pending, nm_max = 0, 0.0
+                        await loop.run_in_executor(
+                            None,
+                            lambda: db.bump_wake_counters(
+                                device.device_id,
+                                near_misses=_nm, near_miss_max=_mx,
+                            ),
+                        )
 
                 if score >= device.oww_threshold:
                     log.info(
@@ -1145,6 +1192,14 @@ async def wake_word_listener(device: Device):
                         model.reset()
                         buf.clear()
                         device.cancel_event.clear()
+                        # Wake detail for the turn's persistent record —
+                        # popped by esphome.trigger_voice_turn.
+                        device.last_wake = {
+                            "model":       model_key,
+                            "score":       round(score, 4),
+                            "threshold":   device.oww_threshold,
+                            "noise_floor": round(device.noise_floor, 5),
+                        }
                         device.oww_paused.set()
                         log.debug(
                             f"[{device.device_id}] OWW: oww_paused set, "
@@ -1320,6 +1375,15 @@ async def handle_control(ws: WebSocketServerProtocol):
         )
 
         device = Device(device_id, ip, capabilities, ws)
+        # Hydrate the observability panel's turn history from the persistent
+        # turns table so it survives controller and device restarts.
+        try:
+            past_turns = await loop.run_in_executor(
+                None, db.get_turns, device_id, device.turn_history.maxlen
+            )
+            device.turn_history.extend(past_turns)
+        except Exception as e:
+            log.warning(f"[{device_id}] Turn history hydration failed: {e}")
         _devices[device_id] = device
 
         log.info(
@@ -1465,6 +1529,11 @@ async def handle_control(ws: WebSocketServerProtocol):
                     }
                     if msg.get("ble"):
                         em_ble_proxy.update_stats(device_id, msg["ble"])
+                    # Fold into the persistent hourly rollup (CPU/RAM/storage/
+                    # RSSI trends) — one cheap upsert per ~30s report.
+                    await loop.run_in_executor(
+                        None, db.record_device_stats, device_id, device.stats
+                    )
                     await api._push_event({
                         "type":      "device_update",
                         "device_id": device_id,
@@ -1506,6 +1575,52 @@ async def handle_control(ws: WebSocketServerProtocol):
                             "device_id": device_id,
                             "state":     {"wifi": st},
                         })
+
+                elif msg_type == "playback_stats":
+                    # One report per completed speaker stream (firmware
+                    # >= v2.9): periods played + mid-stream underruns.
+                    # Attach to the turn persisted just before playback;
+                    # consume last_turn_id so a later announcement's report
+                    # can't overwrite a turn's stats. Reports with no
+                    # pending turn (HA announcements, TTS after a controller
+                    # restart) roll into the hourly counters instead.
+                    periods   = int(msg.get("periods", 0))
+                    underruns = int(msg.get("underruns", 0))
+                    turn_id   = device.last_turn_id
+                    device.last_turn_id = None
+                    if turn_id is not None:
+                        await loop.run_in_executor(
+                            None, db.set_turn_playback,
+                            turn_id, periods, underruns,
+                        )
+                        for rec in reversed(device.turn_history):
+                            if rec.get("turn_id") == turn_id:
+                                rec["playback_periods"] = periods
+                                rec["underruns"]        = underruns
+                                break
+                    else:
+                        # The turn row may not exist yet (device buffers
+                        # usually drain before the controller's drain sleep
+                        # ends) — stash for _persist_turn to fold in. A
+                        # displaced earlier stash was an announcement's:
+                        # keep its underruns in the hourly counters.
+                        prev = device.pending_playback_stats
+                        device.pending_playback_stats = (
+                            asyncio.get_event_loop().time(), periods, underruns
+                        )
+                        if prev and prev[2]:
+                            await loop.run_in_executor(
+                                None,
+                                lambda: db.bump_wake_counters(
+                                    device_id, underruns=prev[2]
+                                ),
+                            )
+                    if underruns:
+                        log.warning(
+                            f"[{device_id}] Playback underruns: {underruns} "
+                            f"in {periods} periods"
+                            f"{f' (turn {turn_id})' if turn_id else ''}"
+                        )
 
                 elif msg_type == "ble_adverts":
                     # BLE proxy data path — batched adverts from the

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -3,7 +3,8 @@ db.py — EchoMuse Controller persistence layer
 ==============================================
 
 SQLite-backed storage for device registry, per-device config, logs,
-users, sessions, and system configuration.
+users, sessions, system configuration, and activity stats (voice turns,
+hourly wake/near-miss counters, hourly hardware metrics).
 
 All public functions are synchronous — they are intended to be called
 from asyncio handlers via loop.run_in_executor() when called on the
@@ -141,6 +142,13 @@ DEFAULT_DEVICE_CONFIG = {
 # Maximum log rows retained per device. Older rows are pruned on insert.
 LOG_RETENTION = 10_000
 
+# Maximum voice-turn rows retained per device (pruned on insert). At even
+# 100 turns/day this is many months of history.
+TURN_RETENTION = 20_000
+
+# Hourly wake_counters rows older than this are pruned on upsert.
+WAKE_COUNTER_RETENTION_DAYS = 180
+
 # ─── Migrations ───────────────────────────────────────────────────────────────
 #
 # Rules:
@@ -244,6 +252,81 @@ MIGRATIONS: list[str] = [
     ALTER TABLE devices ADD COLUMN ble_proxy_port INTEGER;
 
     UPDATE system_config SET value = '4' WHERE key = 'schema_version';
+    """,
+
+    # ── v5 — persistent activity stats ────────────────────────────────────────
+    #
+    # turns: one row per voice turn (wake/button/barge-in/continuation),
+    # written at turn completion from the TurnTrace in em_esphome. Survives
+    # controller and device restarts — the in-memory Device.turn_history is
+    # hydrated from here on connect. trigger_type not "trigger": TRIGGER is
+    # an SQLite keyword. underruns/playback_periods arrive asynchronously
+    # (device playback_stats message, firmware >= v2.9) and are NULL until
+    # then — NULL means "not reported", 0 means "clean playback".
+    #
+    # wake_counters: hourly per-device rollups for signals too frequent to
+    # store per-event — near-misses (wake score > 0.05 but below threshold)
+    # and underruns from non-turn playback (announcements). One UPSERT at
+    # most every ~2s per device (piggybacks the existing rate-limited
+    # near-miss log path), so the instrumentation cost is negligible.
+    #
+    # device_metrics: hourly rollup of the device's ~30s hardware stats
+    # report (CPU, RAM, storage, WiFi RSSI) for historic trend review.
+    # Sums + extremes are upserted in place per report (averages computed
+    # at read time), so an hour is one row however many samples land in it.
+    # cpu_max keeps short spikes visible through the hourly average;
+    # rssi_min keeps marginal-WiFi dips visible the same way.
+    """
+    CREATE TABLE IF NOT EXISTS turns (
+        id               INTEGER PRIMARY KEY AUTOINCREMENT,
+        device_id        TEXT    NOT NULL,
+        ts               REAL    NOT NULL,
+        trigger_type     TEXT,
+        wake_model       TEXT,
+        wake_score       REAL,
+        wake_threshold   REAL,
+        noise_floor      REAL,
+        outcome          TEXT,
+        stt_text         TEXT,
+        total_ms         INTEGER,
+        vad_end_ms       INTEGER,
+        stt_ms           INTEGER,
+        tts_url_ms       INTEGER,
+        tts_fetch_ms     INTEGER,
+        playback_ms      INTEGER,
+        audio_ms         INTEGER,
+        tts_bytes        INTEGER,
+        underruns        INTEGER,
+        playback_periods INTEGER
+    );
+    CREATE INDEX IF NOT EXISTS idx_turns_device_ts ON turns(device_id, ts DESC);
+
+    CREATE TABLE IF NOT EXISTS wake_counters (
+        device_id     TEXT    NOT NULL,
+        hour_ts       INTEGER NOT NULL,
+        near_misses   INTEGER NOT NULL DEFAULT 0,
+        near_miss_max REAL    NOT NULL DEFAULT 0,
+        underruns     INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (device_id, hour_ts)
+    );
+
+    CREATE TABLE IF NOT EXISTS device_metrics (
+        device_id        TEXT    NOT NULL,
+        hour_ts          INTEGER NOT NULL,
+        samples          INTEGER NOT NULL DEFAULT 0,
+        cpu_sum          REAL    NOT NULL DEFAULT 0,
+        cpu_max          REAL    NOT NULL DEFAULT 0,
+        mem_used_sum     REAL    NOT NULL DEFAULT 0,
+        mem_total_mb     REAL,
+        storage_used_mb  REAL,
+        storage_total_mb REAL,
+        rssi_sum         REAL    NOT NULL DEFAULT 0,
+        rssi_samples     INTEGER NOT NULL DEFAULT 0,
+        rssi_min         REAL,
+        PRIMARY KEY (device_id, hour_ts)
+    );
+
+    UPDATE system_config SET value = '5' WHERE key = 'schema_version';
     """,
 ]
 
@@ -823,6 +906,221 @@ def get_device_logs(
         """,
         (device_id, limit),
     )
+
+
+# ─── Activity stats ───────────────────────────────────────────────────────────
+#
+# Persistent per-turn records + hourly rollups (near-misses, hardware
+# metrics). Written from the voice pipeline via run_in_executor; read by the
+# /api/devices/{id}/turns and /api/devices/{id}/activity endpoints.
+
+# Turn dict keys ↔ column names. "trigger" is the dict key used everywhere
+# in the pipeline and API (matches the pre-persistence turn_record shape);
+# the column is trigger_type because TRIGGER is an SQLite keyword.
+_TURN_COLUMNS = {
+    "trigger":          "trigger_type",
+    "wake_model":       "wake_model",
+    "wake_score":       "wake_score",
+    "wake_threshold":   "wake_threshold",
+    "noise_floor":      "noise_floor",
+    "outcome":          "outcome",
+    "stt_text":         "stt_text",
+    "total_ms":         "total_ms",
+    "vad_end_ms":       "vad_end_ms",
+    "stt_ms":           "stt_ms",
+    "tts_url_ms":       "tts_url_ms",
+    "tts_fetch_ms":     "tts_fetch_ms",
+    "playback_ms":      "playback_ms",
+    "audio_ms":         "audio_ms",
+    "tts_bytes":        "tts_bytes",
+    "underruns":        "underruns",
+    "playback_periods": "playback_periods",
+}
+
+
+def insert_turn(device_id: str, rec: dict) -> int:
+    """
+    Persist one completed voice turn. rec is the turn_record dict built in
+    em_esphome (missing keys stored as NULL). Returns the new rowid so a
+    late playback_stats report can attach to this turn. Prunes to
+    TURN_RETENTION rows per device.
+    """
+    cols   = ["device_id", "ts"] + list(_TURN_COLUMNS.values())
+    values = [device_id, rec.get("ts", time.time())] + [
+        rec.get(k) for k in _TURN_COLUMNS
+    ]
+    with _tx() as conn:
+        cur = conn.execute(
+            f"INSERT INTO turns ({', '.join(cols)}) "
+            f"VALUES ({', '.join('?' * len(cols))})",
+            values,
+        )
+        conn.execute(
+            """
+            DELETE FROM turns
+            WHERE device_id = ?
+              AND id NOT IN (
+                  SELECT id FROM turns
+                  WHERE device_id = ?
+                  ORDER BY ts DESC
+                  LIMIT ?
+              )
+            """,
+            (device_id, device_id, TURN_RETENTION),
+        )
+        return cur.lastrowid
+
+
+def set_turn_playback(turn_id: int, periods: int, underruns: int) -> None:
+    """Attach the device's playback_stats report to a persisted turn."""
+    with _tx() as conn:
+        conn.execute(
+            "UPDATE turns SET playback_periods = ?, underruns = ? WHERE id = ?",
+            (periods, underruns, turn_id),
+        )
+
+
+def get_turns(
+    device_id: str,
+    limit: int = 50,
+    since: Optional[float] = None,
+) -> list[dict]:
+    """
+    Recent turns for a device as turn_record-shaped dicts (plus turn_id),
+    oldest first (newest last — the order turn_history and the API use).
+    since: optional epoch-seconds lower bound.
+    """
+    if since is not None:
+        rows = _q(
+            "SELECT * FROM turns WHERE device_id = ? AND ts >= ? "
+            "ORDER BY ts DESC LIMIT ?",
+            (device_id, since, limit),
+        )
+    else:
+        rows = _q(
+            "SELECT * FROM turns WHERE device_id = ? ORDER BY ts DESC LIMIT ?",
+            (device_id, limit),
+        )
+    out = []
+    for row in reversed(rows):
+        rec = {"turn_id": row["id"], "ts": row["ts"]}
+        for key, col in _TURN_COLUMNS.items():
+            rec[key] = row[col]
+        out.append(rec)
+    return out
+
+
+def bump_wake_counters(
+    device_id: str,
+    near_misses: int = 0,
+    near_miss_max: float = 0.0,
+    underruns: int = 0,
+) -> None:
+    """Accumulate into the current hour's wake_counters row (upsert)."""
+    hour_ts = int(time.time()) // 3600 * 3600
+    with _tx() as conn:
+        conn.execute(
+            """
+            INSERT INTO wake_counters (device_id, hour_ts, near_misses, near_miss_max, underruns)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT (device_id, hour_ts) DO UPDATE SET
+                near_misses   = near_misses + excluded.near_misses,
+                near_miss_max = MAX(near_miss_max, excluded.near_miss_max),
+                underruns     = underruns + excluded.underruns
+            """,
+            (device_id, hour_ts, near_misses, near_miss_max, underruns),
+        )
+        conn.execute(
+            "DELETE FROM wake_counters WHERE hour_ts < ?",
+            (hour_ts - WAKE_COUNTER_RETENTION_DAYS * 86400,),
+        )
+
+
+def get_wake_counters(device_id: str, since: float) -> list[sqlite3.Row]:
+    """Hourly wake counters for a device from `since` (epoch s), oldest first."""
+    return _q(
+        "SELECT * FROM wake_counters WHERE device_id = ? AND hour_ts >= ? "
+        "ORDER BY hour_ts",
+        (device_id, since),
+    )
+
+
+def record_device_stats(device_id: str, stats: dict) -> None:
+    """
+    Fold one ~30s hardware stats report into the current hour's
+    device_metrics rollup. Missing/None fields are skipped. Averages are
+    computed at read time from the sums; gauges (storage, mem total) keep
+    the latest value. Prunes rows older than WAKE_COUNTER_RETENTION_DAYS.
+    """
+    hour_ts = int(time.time()) // 3600 * 3600
+    cpu     = stats.get("cpuPct")
+    mem     = stats.get("memUsedMb")
+    rssi    = stats.get("wifiRssi")
+    with _tx() as conn:
+        conn.execute(
+            """
+            INSERT INTO device_metrics (
+                device_id, hour_ts, samples, cpu_sum, cpu_max, mem_used_sum,
+                mem_total_mb, storage_used_mb, storage_total_mb,
+                rssi_sum, rssi_samples, rssi_min
+            ) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (device_id, hour_ts) DO UPDATE SET
+                samples          = samples + 1,
+                cpu_sum          = cpu_sum + excluded.cpu_sum,
+                cpu_max          = MAX(cpu_max, excluded.cpu_max),
+                mem_used_sum     = mem_used_sum + excluded.mem_used_sum,
+                mem_total_mb     = COALESCE(excluded.mem_total_mb, mem_total_mb),
+                storage_used_mb  = COALESCE(excluded.storage_used_mb, storage_used_mb),
+                storage_total_mb = COALESCE(excluded.storage_total_mb, storage_total_mb),
+                rssi_sum         = rssi_sum + excluded.rssi_sum,
+                rssi_samples     = rssi_samples + excluded.rssi_samples,
+                rssi_min         = CASE
+                    WHEN excluded.rssi_min IS NULL THEN rssi_min
+                    ELSE MIN(COALESCE(rssi_min, excluded.rssi_min), excluded.rssi_min)
+                END
+            """,
+            (
+                device_id, hour_ts,
+                float(cpu or 0.0), float(cpu or 0.0), float(mem or 0.0),
+                stats.get("memTotalMb"),
+                stats.get("storageUsedMb"), stats.get("storageTotalMb"),
+                float(rssi) if rssi is not None else 0.0,
+                1 if rssi is not None else 0,
+                float(rssi) if rssi is not None else None,
+            ),
+        )
+        conn.execute(
+            "DELETE FROM device_metrics WHERE hour_ts < ?",
+            (hour_ts - WAKE_COUNTER_RETENTION_DAYS * 86400,),
+        )
+
+
+def get_device_metrics(device_id: str, since: float) -> list[dict]:
+    """
+    Hourly hardware metrics for a device from `since` (epoch s), oldest
+    first, with averages resolved from the stored sums.
+    """
+    rows = _q(
+        "SELECT * FROM device_metrics WHERE device_id = ? AND hour_ts >= ? "
+        "ORDER BY hour_ts",
+        (device_id, since),
+    )
+    out = []
+    for r in rows:
+        n = r["samples"] or 1
+        out.append({
+            "hour_ts":          r["hour_ts"],
+            "samples":          r["samples"],
+            "cpu_avg":          round(r["cpu_sum"] / n, 1),
+            "cpu_max":          r["cpu_max"],
+            "mem_used_avg":     round(r["mem_used_sum"] / n, 1),
+            "mem_total_mb":     r["mem_total_mb"],
+            "storage_used_mb":  r["storage_used_mb"],
+            "storage_total_mb": r["storage_total_mb"],
+            "rssi_avg":         round(r["rssi_sum"] / r["rssi_samples"], 1) if r["rssi_samples"] else None,
+            "rssi_min":         r["rssi_min"],
+        })
+    return out
 
 
 # ─── Users ────────────────────────────────────────────────────────────────────

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -107,6 +107,10 @@ class TurnTrace:
     t_playback_ms:    int   = -1      # ms from t0 to playback started
     t_complete_ms:    int   = -1      # ms from t0 to turn complete
     outcome:          str   = ""      # "ok", "no_speech", "cancelled", "tts_error", "timeout"
+    # Wake detection detail (model, score, threshold, noise_floor) popped
+    # from device.last_wake at turn start — None for button/continuation
+    # turns. Persisted with the turn for threshold tuning and model A/Bs.
+    wake_info:        Optional[dict] = None
 
     def elapsed_ms(self) -> int:
         return int((time.monotonic() - self.t0) * 1000)
@@ -754,19 +758,26 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 trace.emit()
                 # Record for the dashboard's Status-tab observability panel
                 # and nudge any open dashboards to refresh.
+                wi = trace.wake_info or {}
                 turn_record = {
-                    "ts":           time.time(),
-                    "trigger":      trace.trigger,
-                    "outcome":      trace.outcome,
-                    "total_ms":     trace.t_complete_ms,
-                    "vad_end_ms":   trace.t_vad_end_ms,
-                    "stt_ms":       trace.t_stt_ms,
-                    "tts_url_ms":   trace.t_tts_url_ms,
-                    "tts_fetch_ms": trace.t_tts_fetched_ms,
-                    "playback_ms":  trace.t_playback_ms,
-                    "audio_ms":     trace.audio_frames * 80,
-                    "stt_text":     trace.stt_text,
+                    "ts":             time.time(),
+                    "trigger":        trace.trigger,
+                    "wake_model":     wi.get("model"),
+                    "wake_score":     wi.get("score"),
+                    "wake_threshold": wi.get("threshold"),
+                    "noise_floor":    wi.get("noise_floor"),
+                    "outcome":        trace.outcome,
+                    "total_ms":       trace.t_complete_ms,
+                    "vad_end_ms":     trace.t_vad_end_ms,
+                    "stt_ms":         trace.t_stt_ms,
+                    "tts_url_ms":     trace.t_tts_url_ms,
+                    "tts_fetch_ms":   trace.t_tts_fetched_ms,
+                    "playback_ms":    trace.t_playback_ms,
+                    "audio_ms":       trace.audio_frames * 80,
+                    "tts_bytes":      trace.tts_bytes,
+                    "stt_text":       trace.stt_text,
                 }
+                await _persist_turn(device, turn_record)
                 device.turn_history.append(turn_record)
                 try:
                     await api._push_event({
@@ -1357,6 +1368,71 @@ def get_server(device_id: str) -> Optional[DeviceESPhomeServer]:
 
 # ─── Voice turn trigger ───────────────────────────────────────────────────────
 
+async def _record_dropped_turn(device, trigger_label: str, wake_info) -> None:
+    """
+    Persist a stub record for a turn that never started (no ESPHome server /
+    no HA connection). Without this, wakes during an HA outage would vanish
+    from the activity history — exactly the "device woke but nothing
+    happened" events worth seeing in a trend review.
+    """
+    wi = wake_info or {}
+    turn_record = {
+        "ts":             time.time(),
+        "trigger":        trigger_label,
+        "wake_model":     wi.get("model"),
+        "wake_score":     wi.get("score"),
+        "wake_threshold": wi.get("threshold"),
+        "noise_floor":    wi.get("noise_floor"),
+        "outcome":        "no_ha",
+        "total_ms":       0,
+    }
+    await _persist_turn(device, turn_record)
+    device.turn_history.append(turn_record)
+
+
+async def _persist_turn(device, turn_record: dict) -> None:
+    """
+    Write a completed turn to SQLite (survives controller restarts) and
+    remember the rowid on the device so the firmware's asynchronous
+    playback_stats report — which lands after the turn has already been
+    recorded — can attach its underrun count to this turn. Best-effort:
+    a DB hiccup must never take down the voice pipeline.
+    """
+    loop        = asyncio.get_running_loop()
+    played      = (turn_record.get("playback_ms") or -1) >= 0
+    pending     = device.pending_playback_stats
+    device.pending_playback_stats = None
+    if played and pending is not None and loop.time() - pending[0] < 30.0:
+        # Device reported this playback's stats before the turn row existed
+        # (its buffer drained ahead of our overestimated drain sleep).
+        turn_record["playback_periods"] = pending[1]
+        turn_record["underruns"]        = pending[2]
+        pending = None
+    try:
+        turn_id = await loop.run_in_executor(
+            None, db.insert_turn, device.device_id, turn_record
+        )
+        turn_record["turn_id"] = turn_id
+        if played and "underruns" not in turn_record:
+            # Playback happened but its stats haven't arrived — leave the
+            # rendezvous open for handle_control's playback_stats branch.
+            device.last_turn_id = turn_id
+    except Exception as e:
+        log.warning(f"[{device.device_id}] Failed to persist turn: {e}")
+    if pending is not None and pending[2]:
+        # Stale/unmatched stash (announcement playback) — keep its underruns
+        # in the hourly counters rather than dropping them.
+        try:
+            await loop.run_in_executor(
+                None,
+                lambda: db.bump_wake_counters(
+                    device.device_id, underruns=pending[2]
+                ),
+            )
+        except Exception:
+            pass
+
+
 async def trigger_voice_turn(
     device,           # em_controller.Device
     on_thinking,      # async callable() — LED/state transition
@@ -1385,12 +1461,19 @@ async def trigger_voice_turn(
 
     If no active HA connection exists, logs and returns False.
     """
+    # Pop the wake detection detail set by wake_word_listener/_barge_watcher
+    # — pop, not read, so continuation turns (which loop back here with no
+    # new detection) don't inherit the original wake's score.
+    wake_info        = device.last_wake
+    device.last_wake = None
+
     server = get_server(device.device_id)
     if server is None:
         log.warning(
             f"[{device.device_id}] esphome: no server registered for this device "
             f"— was start_esphome_servers() called?"
         )
+        await _record_dropped_turn(device, trigger_label, wake_info)
         return False
 
     satellite = server.get_satellite()
@@ -1399,9 +1482,12 @@ async def trigger_voice_turn(
             f"[{device.device_id}] esphome: no active HA connection — "
             f"cannot start voice turn (HA not connected to this device's port)"
         )
+        await _record_dropped_turn(device, trigger_label, wake_info)
         return False
 
-    trace = TurnTrace(trigger=trigger_label, t0=time.monotonic())
+    trace = TurnTrace(
+        trigger=trigger_label, t0=time.monotonic(), wake_info=wake_info
+    )
 
     await satellite.run_esphome_voice_turn(
         device=device,

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -540,6 +540,8 @@ function TurnObservability({ turns, nearMisses, stateLabel, stateColor }) {
         <Lcd label="Median reply" value={medianReply != null ? fmtS(medianReply) : '—'} color="var(--lcd-dim)" size={16}/>
         <Lcd label="Near-misses" value={nearMisses != null ? nearMisses : '—'}
              color={nearMisses > 0 ? 'var(--lcd-amber)' : 'var(--lcd-dim)'} size={16}/>
+        <Lcd label="Underruns" value={turns.reduce((s, t) => s + (t.underruns || 0), 0)}
+             color={turns.some(t => t.underruns > 0) ? 'var(--lcd-amber)' : 'var(--lcd-dim)'} size={16}/>
       </div>
 
       {recent.length === 0 ? (
@@ -593,6 +595,8 @@ function TurnObservability({ turns, nearMisses, stateLabel, stateColor }) {
               <div style={{ marginTop: 10, background: 'rgba(0,0,0,0.05)', border: '1px solid rgba(0,0,0,0.1)', borderRadius: 6, padding: '8px 12px', fontFamily: mono, fontSize: 10, color: 'var(--text2)', lineHeight: 1.7 }}>
                 <span style={{ color: 'var(--muted)' }}>{t.trigger}</span>
                 {' · '}listening {fmtS(seg.listen)} · transcribe {fmtS(seg.transcribe)} · respond {fmtS(seg.respond)} · total {fmtS(Math.max(t.total_ms, 0))}
+                {t.wake_model ? <><br/>wake {t.wake_model.replace(/\.[a-z]+$/, '').split('/').pop()} score {t.wake_score?.toFixed(3)} (thr {t.wake_threshold?.toFixed(2)}) · noise floor {t.noise_floor?.toFixed(4)}</> : null}
+                {t.underruns != null ? <>{t.wake_model ? ' · ' : <br/>}underruns <span style={{ color: t.underruns > 0 ? '#a04010' : 'inherit' }}>{t.underruns}</span></> : null}
                 {t.stt_text ? <><br/>“{t.stt_text.length > 90 ? t.stt_text.slice(0, 90) + '…' : t.stt_text}”</> : null}
               </div>
             );

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -196,6 +196,12 @@ func main() {
 		pcmSpeaker.Flush()
 	})
 
+	// Per-stream playback stats — underrun/period counts reported upstream
+	// once per completed TTS stream, persisted against the voice turn.
+	pcmSpeaker.OnStreamStats(func(periods, underruns uint64) {
+		controlClient.SendPlaybackStats(periods, underruns)
+	})
+
 	// WiFi change — the executor owns the whole switch/rollback sequence
 	// (internal/wifi); the reconnect gate polls IsConnected. The outcome
 	// is sent as wifi_result with at-least-once delivery: retried on a

--- a/device/internal/bindings/speaker/pcm_speaker.go
+++ b/device/internal/bindings/speaker/pcm_speaker.go
@@ -89,6 +89,23 @@ type PcmSpeaker struct {
 	// starts inside New, so it can't be set later without a race). Must be
 	// fast and non-blocking: it runs on the ALSA pump goroutine.
 	echoTap func([]byte)
+
+	// statsCb, when set, receives (periods, underruns) once per completed
+	// stream — at EOS consume in silenceLoop, flush included. Unlike echoTap
+	// it fires at most once per response, so a setter (OnStreamStats) is
+	// fine: silenceLoop reads it under statsMu only on that cold path.
+	statsMu sync.Mutex
+	statsCb func(periods, underruns uint64)
+}
+
+// OnStreamStats registers a per-stream stats callback: (periods played,
+// underruns injected) reported once when a stream reaches its EOS. Invoked
+// on its own goroutine so a slow consumer (network send) can never stall
+// the ALSA pump. Safe to call any time after New.
+func (p *PcmSpeaker) OnStreamStats(cb func(periods, underruns uint64)) {
+	p.statsMu.Lock()
+	p.statsCb = cb
+	p.statsMu.Unlock()
 }
 
 func NewPcmSpeaker(echoTap func([]byte)) (*PcmSpeaker, error) {
@@ -154,6 +171,10 @@ func (p *PcmSpeaker) silenceLoop() {
 	defer close(p.deadCh)
 	audioStreaming := false
 	var underruns uint64 // loop-local: only this goroutine drains audioCh
+	// Per-stream accounting for the stats callback: accumulates across
+	// mid-stream drains (a drain flips audioStreaming but the stream isn't
+	// over until its EOS), reported and reset at EOS consume.
+	var streamPeriods, streamUnderruns uint64
 	for {
 		// Prime gate: while idle, hold on silence until the buffer has
 		// primePeriods queued or the stream's EOS is already in (short
@@ -176,6 +197,7 @@ func (p *PcmSpeaker) silenceLoop() {
 			return
 		case period := <-audioSrc:
 			audioStreaming = true
+			streamPeriods++
 			if p.echoTap != nil {
 				p.echoTap(period)
 			}
@@ -189,7 +211,14 @@ func (p *PcmSpeaker) silenceLoop() {
 					// Natural end of stream (0x03 received), or a barge-in
 					// flush (Flush sets eosPending so its drain isn't
 					// miscounted as an underrun).
-					log.Printf("[speaker] stream complete — returning to silence")
+					log.Printf("[speaker] stream complete — returning to silence (periods=%d underruns=%d)", streamPeriods, streamUnderruns)
+					p.statsMu.Lock()
+					cb := p.statsCb
+					p.statsMu.Unlock()
+					if cb != nil && streamPeriods > 0 {
+						go cb(streamPeriods, streamUnderruns)
+					}
+					streamPeriods, streamUnderruns = 0, 0
 				} else {
 					// Mid-stream drain: the WS sender fell behind real-time
 					// playback and a silence gap is being injected — the
@@ -197,6 +226,7 @@ func (p *PcmSpeaker) silenceLoop() {
 					// drain event (not per silence period); rate-limited so
 					// a chronically starved link can't flood the log.
 					underruns++
+					streamUnderruns++
 					if underruns == 1 || underruns%16 == 0 {
 						log.Printf("[speaker] UNDERRUN: audio channel drained mid-stream — injecting silence (underruns=%d)", underruns)
 					}

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -669,6 +669,19 @@ func (c *ControlClient) SendWifiResult(ok bool, ssid, errMsg string) {
 	})
 }
 
+// SendPlaybackStats reports one completed speaker stream: how many periods
+// played and how many mid-stream underruns (silence injections) occurred.
+// Sent once per TTS response/announcement; the controller attaches it to
+// the voice turn it just persisted. Safe for concurrent use — silently
+// drops if not connected (the stat is diagnostic, not state).
+func (c *ControlClient) SendPlaybackStats(periods, underruns uint64) {
+	_ = c.writeJSON(map[string]interface{}{
+		"type":      "playback_stats",
+		"periods":   periods,
+		"underruns": underruns,
+	})
+}
+
 // SendBleAdverts forwards a batch of BLE advertisements to the controller
 // (bluetooth_proxy path). adverts is marshalled as-is — []bluetooth.Advert,
 // whose Data field JSON-encodes as base64. Safe for concurrent use —


### PR DESCRIPTION
## What

Captures activity stats that survive controller **and** device restarts, sized for trend plotting and config tuning without hot-path cost.

### Per-turn records (`turns` table, schema v5)
Every voice turn persists at completion: trigger (wakeword/button/barge-in/continuation), **wake model + score + threshold**, room **noise floor at detection**, outcome (incl. new `no_ha` stub for wakes during an HA outage), STT text, all stage latencies, TTS bytes, and **playback underruns**.

### Underrun reporting (device firmware)
`pcm_speaker` counts periods + mid-stream underruns per stream and reports a single `playback_stats` control message at EOS (flush included; callback runs off the ALSA pump goroutine). Controller attaches it via a two-sided rendezvous — the device's buffer usually drains *before* the controller's overestimated drain sleep ends, so either the report or the turn row can land first; a 30s staleness window keeps announcement stats out of unrelated turns (they roll into hourly counters instead). Old firmware simply never sends it (`underruns = NULL` ≠ `0`).

### Hourly rollups (one row/device/hour)
- `wake_counters` — near-miss count + max score (flushed through the existing 2s-rate-limited near-miss path), announcement underruns
- `device_metrics` — CPU avg/**max**, RAM avg, storage, RSSI avg/**min** from the existing ~30s device stats report (previously discarded after the live dashboard update)

### Read side
- `Device.turn_history` hydrates from DB on connect → the existing Activity tab now survives restarts with no UI change
- `/api/devices/{id}/turns` now DB-backed (`limit`, `since`)
- **New** `/api/devices/{id}/activity?days=N` — plot-ready per-day aggregates (outcomes, p50/p95 latency, wake score avg/min, underruns), per-wake-model rollups (for hey_clara vs hey_clarra A/B), hourly counters + metrics
- Dashboard: underruns stat tile + wake model/score/noise-floor/underruns in the turn hover detail

### Cost
One insert per turn, one upsert per 30s (metrics) / ≥2s (near-miss bursts). Nothing per audio frame; device adds one JSON message per playback.

## Verification
- Device: full ARM build in `echomuse-compiler` ✓; `go test ./pkg/...` (linux/amd64) ✓
- Controller: all modules import in the dev image ✓; DB smoke test of every new function incl. NULL-RSSI edge ✓; **v5 migration run against a read-only snapshot of the production DB** (2 devices, schema 4→5, insert/readback) ✓
- Rendezvous logic unit-tested in all four orderings (stats-first, row-first, stale stash, no playback) ✓
- JSX parses (esbuild) ✓

Note: the firmware change needs a device release + OTA before underruns populate; everything else works immediately on controller deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
