### PR TITLE
controller: fix stale-socket teardown race that killed the ESPHome listener (Lounge deaf 11h)

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -1671,15 +1671,28 @@ async def handle_control(ws: WebSocketServerProtocol):
 
     finally:
         if device:
-            log.info(f"[control] Device disconnected: {device.device_id}")
-            db.log_device(
-                device.device_id, "info", "controller", "Disconnected"
-            )
-            if _devices.get(device.device_id) is device:
+            if _devices.get(device.device_id) is not device:
+                # A replacement connection has already registered for this
+                # device_id — this socket is stale. Tearing down shared
+                # per-device services here would rip them out from under the
+                # live connection: on 2026-07-14 a stale close 4s after a
+                # reconnect stopped Lounge's ESPHome listener, so HA's
+                # redials hit connection-refused and every turn failed
+                # no_ha for 11 hours until the next device bounce.
+                log.info(
+                    f"[control] Stale connection closed for "
+                    f"{device.device_id} — replacement is active, keeping "
+                    f"services up"
+                )
+            else:
+                log.info(f"[control] Device disconnected: {device.device_id}")
+                db.log_device(
+                    device.device_id, "info", "controller", "Disconnected"
+                )
                 _devices.pop(device.device_id, None)
-            await api.notify_device_disconnected(device.device_id)
-            await esphome.device_disconnected(device.device_id)
-            await em_ble_proxy.device_disconnected(device.device_id)
+                await api.notify_device_disconnected(device.device_id)
+                await esphome.device_disconnected(device.device_id)
+                await em_ble_proxy.device_disconnected(device.device_id)
 
 
 # ─── Data plane handler ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What happened

Lounge was unresponsive from 13:34 to ~22:30 on 2026-07-14. The activity stats show wake word firing normally (scores 0.43-0.51) but every turn - wakeword *and* button - ending `outcome=no_ha`.

## Root cause

At 11:30:45 Lounge opened a replacement control WS; the old socket's close handler ran 4 seconds later. Its `finally` block identity-guards the `_devices` pop, but then **unconditionally** calls `esphome.device_disconnected()` / `em_ble_proxy.device_disconnected()` - stopping the live connection's ESPHome listener and closing HA's satellite connection. Nothing restarts the listener until the next full device bounce, so HA's redials got connection-refused for 11 hours.

## Fix

Skip all shared-service teardown (and the "Disconnected" device-log entry) when a replacement connection has already registered for the device_id. The data-plane handler already guards the same way via `device.data_ws is ws`.

## Verification

- `py_compile` clean
- Not yet deployed to the live controller (needs rebuild + restart - Wil's call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)