### PR TITLE
TLS + per-device token auth for the device↔controller link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
             echomuse-compiler \
             -c "cd /sdk && mkdir -p build && go build \
               -tags server \
-              -ldflags \"-X github.com/wilbowes/EchoMuse/internal/client.Version=${{ github.ref_name }}\" \
+              -ldflags \"-X github.com/wilbowes/EchoMuse/internal/client.Version=${{ github.ref_name }} \
+                         -X github.com/wilbowes/EchoMuse/internal/client.BuildUnix=$(date +%s)\" \
               -o build/server \
               ./cmd/"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,16 @@ Each device opens **three** WebSocket connections to the controller:
 
 Controller is discovered by the device via mDNS (`_emcontroller._tcp.local`).
 
+### Device-link TLS + token auth
+
+All three WS planes exist twice: plain on `SERVER_PORT` (8767) and TLS on `SERVER_TLS_PORT` (8770, `wss://`). `em_pki.py` generates a private CA + server cert on first start (persisted in `tls/` next to the SQLite DB; delete the dir to rotate — every device then needs a fresh credential push). The leaf's identity is the fixed DNS SAN `echomuse-controller` (`TLS_SERVER_NAME`, coupled with `tlsServerName` in `device/internal/client/tlscreds.go`) — never an IP, so the controller can move address freely. Certs are backdated 10y/valid 25y **and** the device clamps its verification clock to the firmware build time (`BuildUnix` ldflag): Echos boot with bogus clocks pre-NTP, and a device that can't connect can't fix its clock. Don't "normalise" either half of that.
+
+Device behaviour (`tlscreds.go`): credentials live at `/data/local/etc/echomuse/{ca.pem,token}` (canonical path constant: `em_api.DEVICE_TLS_DIR`) and are **re-read on every dial**, so a push takes effect on the next reconnect, no restart. CA present + `tls_port` mDNS TXT property → dial wss; CA present but no TXT → plain with a warning (deliberate rollout fallback). The token rides as `X-EM-Token` on all three dials.
+
+Controller enforcement (`_link_auth_ok`): presented-but-wrong token always rejects; stored-token-but-none-presented is allowed (the credential push itself rides the plain shell plane — rejecting there would deadlock the rollout) until `REQUIRE_DEVICE_TLS=1` flips the posture to TLS+token mandatory. Flip it only when every device shows `wss (TLS)` in the dashboard (Status tab "Link" row; `linkTls` in `/api/devices`).
+
+Credential delivery: the provisioning wizard installs credentials over adb pre-first-contact (`POST /api/provision/tls_credentials` mints the token + pending device row from the serial); already-fleet devices get the dashboard **Secure link** action (`POST /api/devices/{id}/secure_link` — shell-plane file push, then a connection bounce to redial over wss).
+
 ### Device audio pipeline
 
 Each mic buffer passes through, in order:

--- a/controller/.env.example
+++ b/controller/.env.example
@@ -5,6 +5,16 @@
 SERVER_HOST=0.0.0.0
 # WebSocket server port — devices connect here (/control, /data, /shell)
 SERVER_PORT=8767
+# Device-link TLS (wss) port — same three WS planes wrapped in TLS with a
+# controller-generated private CA (persisted next to the database, tls/
+# subdirectory). Devices holding pushed credentials connect here instead;
+# 0 disables the TLS listener. Advertised to devices via mDNS (tls_port).
+SERVER_TLS_PORT=8770
+# Enforcing posture: 1 rejects any device connection that is not TLS with a
+# valid per-device token. Leave 0 until every device shows "wss (TLS)" in
+# the dashboard — plain connections are the pre-TLS default and the
+# credential push itself needs a working (plain) shell plane.
+REQUIRE_DEVICE_TLS=0
 # HTTP API + dashboard port
 API_PORT=8768
 # IP address of this host on the LAN — advertised via mDNS

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -49,6 +49,7 @@ import websockets
 import em_db as db
 import em_auth as auth
 import em_ble_proxy
+import em_pki
 import em_scenes
 from version import VERSION as CONTROLLER_VERSION
 
@@ -73,6 +74,16 @@ RELEASE_CACHE_TTL = 60  # seconds
 
 # Reference to the live devices dict from em_controller — set by init().
 _devices: dict = {}
+
+# Device-link TLS material directory — set by em_controller.main() once
+# em_pki.ensure_pki() succeeds. None = TLS listener not running (no
+# cryptography package / setup failure); credential endpoints then 503.
+_tls_dir: str | None = None
+
+
+def set_tls_dir(tls_dir: str) -> None:
+    global _tls_dir
+    _tls_dir = tls_dir
 
 # Set of connected /api/events WebSocket clients.
 _event_clients: set[web.WebSocketResponse] = set()
@@ -215,6 +226,8 @@ async def create_app() -> web.Application:
     app.router.add_get("/api/provision/debloat_packages", _get_provision_debloat_packages)
     app.router.add_get("/api/provision/magisk_db",    _get_provision_magisk_db)
     app.router.add_get("/api/provision/latest_binary", _get_provision_latest_binary)
+    app.router.add_post("/api/provision/tls_credentials", _post_provision_tls_credentials)
+    app.router.add_post("/api/devices/{id}/secure_link",  _post_secure_link)
 
     # Live events WebSocket
     app.router.add_get("/api/events", _ws_events)
@@ -1256,9 +1269,10 @@ async def _stream_binary_to_slot(live, binary: bytes, slot: str) -> bool:
     return await _stream_file_to_device(live, binary, f"/data/local/bin/{slot}")
 
 
-async def _stream_file_to_device(live, data: bytes, dest: str) -> bool:
+async def _stream_file_to_device(live, data: bytes, dest: str,
+                                 mode: str = "755") -> bool:
     """
-    Transfer a file to `dest` on the device via shell heredoc (mode 755).
+    Transfer a file to `dest` on the device via shell heredoc (default mode 755).
 
     Detects available base64 decoder (busybox base64, python3, python) before
     transferring, since 'base64' is not always in PATH on Android/FireOS.
@@ -1325,7 +1339,7 @@ async def _stream_file_to_device(live, data: bytes, dest: str) -> bool:
         # Single shell command: decode heredoc → dest, set permissions, confirm
         await ws.send(
             f"{decode_cmd} << '{DELIM}' > {dest} && "
-            f"chmod 755 {dest} && "
+            f"chmod {mode} {dest} && "
             f"echo TRANSFER_OK\n"
         )
 
@@ -1715,6 +1729,111 @@ async def _get_provision_magisk_db(request: web.Request) -> web.Response:
         content_type='application/octet-stream',
         headers={'Content-Disposition': 'attachment; filename="magisk.db"'},
     )
+
+
+# ─── Device-link TLS credentials ──────────────────────────────────────────────
+
+# Canonical on-device credential paths — coupled with
+# device/internal/client/tlscreds.go. The Go client re-reads them on every
+# dial attempt, so pushed credentials take effect on the next reconnect
+# without a firmware restart.
+DEVICE_TLS_DIR = "/data/local/etc/echomuse"
+
+
+@auth.require_admin
+async def _post_provision_tls_credentials(request: web.Request) -> web.Response:
+    """
+    POST /api/provision/tls_credentials  {device_id}
+
+    Provisioning-wizard path: returns the CA cert plus the device's link
+    token (minting one — and a pending device row — if needed) so the
+    wizard can install them over adb before the device's first contact.
+    """
+    if _tls_dir is None:
+        return _error("tls_unavailable",
+                      "Device-link TLS is not active on this controller", 503)
+    body      = await _json_body(request)
+    device_id = _require_str(body, "device_id")
+
+    loop  = asyncio.get_event_loop()
+    token = await loop.run_in_executor(None, db.ensure_device_token, device_id)
+    return _ok({
+        "ca_pem": em_pki.ca_pem(_tls_dir),
+        "token":  token,
+        "dir":    DEVICE_TLS_DIR,
+    })
+
+
+@auth.require_admin
+async def _post_secure_link(request: web.Request) -> web.Response:
+    """
+    POST /api/devices/{id}/secure_link
+
+    Fleet path for already-provisioned devices: pushes ca.pem + token to
+    the device over the (still-plain) shell plane, then bounces the
+    control connection so the device redials — over wss, now that the CA
+    file exists. Requires the device to be connected.
+    """
+    if _tls_dir is None:
+        return _error("tls_unavailable",
+                      "Device-link TLS is not active on this controller", 503)
+    device_id = request.match_info["id"]
+    live = _devices.get(device_id)
+    if live is None:
+        return _error("device_offline", f"Device not connected: {device_id}", 409)
+
+    task = asyncio.create_task(_run_secure_link(device_id))
+    task.add_done_callback(_log_task_exception_api)
+    return _ok({"started": True})
+
+
+def _log_task_exception_api(task: asyncio.Task) -> None:
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        log.error(f"[api] Unhandled exception in background task: {exc}", exc_info=exc)
+
+
+async def _run_secure_link(device_id: str) -> None:
+    """Background task: install TLS credentials on a live device."""
+    loop = asyncio.get_event_loop()
+    live = _devices.get(device_id)
+    if live is None:
+        return
+    try:
+        await _push_log_event(device_id, "info", "controller",
+                              "Secure link: pushing TLS credentials")
+        token = await loop.run_in_executor(None, db.ensure_device_token, device_id)
+        ca    = em_pki.ca_pem(_tls_dir)
+
+        await _shell_run(live, f"mkdir -p {DEVICE_TLS_DIR}")
+        await asyncio.sleep(1.0)  # let the shell session close cleanly
+
+        ok = await _stream_file_to_device(
+            live, ca.encode("ascii"), f"{DEVICE_TLS_DIR}/ca.pem", mode="644")
+        if ok:
+            await asyncio.sleep(1.0)
+            ok = await _stream_file_to_device(
+                live, token.encode("ascii"), f"{DEVICE_TLS_DIR}/token", mode="600")
+        if not ok:
+            await _push_log_event(device_id, "error", "controller",
+                                  "Secure link: credential transfer failed")
+            return
+
+        await _push_log_event(
+            device_id, "info", "controller",
+            "Secure link: credentials installed — bouncing connection to switch to wss")
+        # The Go client reloads credentials on every dial, so a reconnect
+        # is enough to move to the TLS listener.
+        try:
+            await live.control_ws.close()
+        except Exception:
+            pass
+    except Exception as e:
+        log.exception(f"[api] Secure link failed for {device_id}: {e}")
+        await _push_log_event(device_id, "error", "controller",
+                              f"Secure link failed: {e}")
 
 
 # ─── System ───────────────────────────────────────────────────────────────────
@@ -2252,6 +2371,10 @@ def _merge_device(row) -> dict:
         # Controller-side BT proxy state — non-None only while the device's
         # bleProxyEnabled config has a proxy server instantiated.
         "bleProxy":         em_ble_proxy.get_status(device_id),
+        # Device-link security: token issued (persistent) + whether the
+        # current control connection came in over the TLS listener (live).
+        "linkTokenIssued":  bool(row["token"]) if "token" in row.keys() else False,
+        "linkTls":          getattr(live, "secure", False) if live else False,
         # Q4 fix (2026-07-05 review): near-miss counter — same lifecycle as
         # the rest of this "Live" section (resets on reconnect, since it
         # lives on the per-connection Device object, not the DB row).

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -49,6 +49,7 @@ Device WebSocket protocol:
 
 import asyncio
 import collections
+import contextlib
 import json
 import logging
 import os
@@ -66,6 +67,7 @@ from websockets.asyncio.server import ServerConnection as WebSocketServerProtoco
 import em_db as db
 import em_auth as auth
 import em_api as api
+import em_pki
 import em_eq
 import em_scenes
 import em_esphome as esphome
@@ -102,6 +104,16 @@ def _log_task_exception(task: asyncio.Task) -> None:
 
 SERVER_HOST  = os.environ.get("SERVER_HOST", "0.0.0.0")
 SERVER_PORT  = int(os.environ.get("SERVER_PORT", "8767"))
+# Device-link TLS listener (wss) — same three WS planes as SERVER_PORT,
+# wrapped in TLS with the em_pki-generated cert. 0 disables. Devices pick
+# it up from the tls_port mDNS TXT property and dial wss iff they hold the
+# pushed CA file (see device/internal/client/tlscreds.go).
+SERVER_TLS_PORT = int(os.environ.get("SERVER_TLS_PORT", "8770"))
+# Enforcing posture: reject device connections that are not TLS + a valid
+# per-device token. Leave 0 until the whole fleet shows tls=true —
+# a plain, tokenless connection is the legacy default and must keep
+# working during the rollout.
+REQUIRE_DEVICE_TLS = os.environ.get("REQUIRE_DEVICE_TLS", "0") == "1"
 API_PORT     = int(os.environ.get("API_PORT", "8768"))
 SERVER_IP    = os.environ.get("SERVER_IP", "10.10.1.236")
 MDNS_NAME    = os.environ.get("MDNS_NAME", "echomuse")
@@ -1382,7 +1394,48 @@ async def handle_button_event(device: Device, event: dict):
 
 # ─── Control plane handler ────────────────────────────────────────────────────
 
-async def handle_control(ws: WebSocketServerProtocol):
+async def _link_auth_ok(
+    ws: WebSocketServerProtocol, device_id: str, secure: bool, plane: str
+) -> bool:
+    """
+    Device-link auth gate, applied to all three WS planes once the
+    device_id is known.
+
+    Rules (rollout-safe by construction):
+      - a presented token that MISMATCHES the stored one always rejects;
+      - a stored token with NO token presented is allowed unless
+        REQUIRE_DEVICE_TLS — the DB row is minted before the files land
+        on the device, and rejecting in that window would cut off the
+        shell plane that the credential push itself rides on;
+      - REQUIRE_DEVICE_TLS=1 requires TLS + a matching token, full stop.
+    """
+    import hmac as _hmac
+
+    presented = None
+    try:
+        presented = ws.request.headers.get("X-EM-Token")
+    except AttributeError:
+        pass
+
+    loop = asyncio.get_event_loop()
+    expected = await loop.run_in_executor(None, db.get_device_token, device_id)
+
+    if presented and expected and not _hmac.compare_digest(presented, expected):
+        log.warning(f"[{plane}] {device_id}: token mismatch — rejecting")
+        return False
+    if presented and not expected:
+        log.warning(f"[{plane}] {device_id}: token presented but none on record — rejecting")
+        return False
+    if REQUIRE_DEVICE_TLS and not (secure and presented and expected):
+        log.warning(
+            f"[{plane}] {device_id}: REQUIRE_DEVICE_TLS is set and connection "
+            f"is {'plain' if not secure else 'missing a valid token'} — rejecting"
+        )
+        return False
+    return True
+
+
+async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
     """
     Handle a /control WebSocket connection from a device.
     """
@@ -1401,6 +1454,10 @@ async def handle_control(ws: WebSocketServerProtocol):
             return
 
         device_id    = msg["device_id"]
+
+        if not await _link_auth_ok(ws, device_id, secure, "control"):
+            await ws.close()
+            return
         ip           = msg.get("ip", str(remote[0]))
         version      = msg.get("version")
         capabilities = msg.get("capabilities", [])
@@ -1457,6 +1514,9 @@ async def handle_control(ws: WebSocketServerProtocol):
         )
 
         device = Device(device_id, ip, capabilities, ws)
+        # Link-security telemetry for the dashboard: True when this control
+        # connection arrived over the TLS listener.
+        device.secure = secure
         # Hydrate the observability panel's turn history from the persistent
         # turns table so it survives controller and device restarts.
         try:
@@ -1771,7 +1831,7 @@ async def handle_control(ws: WebSocketServerProtocol):
 
 # ─── Data plane handler ───────────────────────────────────────────────────────
 
-async def handle_data(ws: WebSocketServerProtocol):
+async def handle_data(ws: WebSocketServerProtocol, secure: bool = False):
     device = None
     remote = ws.remote_address
 
@@ -1787,6 +1847,10 @@ async def handle_data(ws: WebSocketServerProtocol):
             return
 
         device_id = msg["device_id"]
+
+        if not await _link_auth_ok(ws, device_id, secure, "data"):
+            await ws.close()
+            return
 
         for _ in range(20):
             device = _devices.get(device_id)
@@ -1864,7 +1928,7 @@ async def handle_data(ws: WebSocketServerProtocol):
 
 # ─── Shell plane handler ──────────────────────────────────────────────────────
 
-async def handle_shell(ws: WebSocketServerProtocol, path: str):
+async def handle_shell(ws: WebSocketServerProtocol, path: str, secure: bool = False):
     import aiohttp as _aiohttp
 
     # Path may carry a query: /shell/{device_id}?pty=1 signals that the
@@ -1876,6 +1940,10 @@ async def handle_shell(ws: WebSocketServerProtocol, path: str):
     pty_mode = "pty=1" in query
     if not device_id:
         log.warning("[shell] Missing device_id in path")
+        await ws.close()
+        return
+
+    if not await _link_auth_ok(ws, device_id, secure, "shell"):
         await ws.close()
         return
 
@@ -1946,29 +2014,42 @@ async def handle_shell(ws: WebSocketServerProtocol, path: str):
         if not done_future.done():
             done_future.set_result(None)
 
-async def router(ws: WebSocketServerProtocol):
+async def _route(ws: WebSocketServerProtocol, secure: bool):
     path = ws.request.path if hasattr(ws, "request") else getattr(ws, "path", "/")
 
     if path == "/control":
-        await handle_control(ws)
+        await handle_control(ws, secure)
     elif path == "/data":
-        await handle_data(ws)
+        await handle_data(ws, secure)
     elif path.startswith("/shell/"):
-        await handle_shell(ws, path)
+        await handle_shell(ws, path, secure)
     else:
         log.warning(f"Unknown WebSocket path: {path} from {ws.remote_address}")
         await ws.close()
 
 
+async def router(ws: WebSocketServerProtocol):
+    await _route(ws, secure=False)
+
+
+async def router_tls(ws: WebSocketServerProtocol):
+    await _route(ws, secure=True)
+
+
 # ─── mDNS ─────────────────────────────────────────────────────────────────────
 
-def _make_mdns_info() -> ServiceInfo:
+def _make_mdns_info(tls_active: bool) -> ServiceInfo:
+    props = {"version": "1", "server": MDNS_NAME}
+    if tls_active:
+        # Devices holding the pushed CA dial wss://<addr>:<tls_port> instead
+        # of the plain port. Absent property = pre-TLS controller → plain ws.
+        props["tls_port"] = str(SERVER_TLS_PORT)
     return ServiceInfo(
         "_emcontroller._tcp.local.",
         f"{MDNS_NAME}._emcontroller._tcp.local.",
         addresses=[socket.inet_aton(SERVER_IP)],
         port=SERVER_PORT,
-        properties={"version": "1", "server": MDNS_NAME},
+        properties=props,
         server=f"{MDNS_NAME}.local.",
     )
 
@@ -1999,26 +2080,56 @@ async def main():
     release_task       = asyncio.create_task(api.release_poll_loop())
     session_prune_task = asyncio.create_task(api.session_prune_loop())
 
+    # Device-link TLS: generate/load the CA + server cert. Failure to set
+    # up TLS (missing cryptography package, unwritable dir) must never take
+    # the plain listener down with it — the fleet lives on that during
+    # rollout.
+    tls_ctx = None
+    if SERVER_TLS_PORT:
+        try:
+            tls_dir = em_pki.ensure_pki(DB_PATH)
+            if tls_dir:
+                tls_ctx = em_pki.server_ssl_context(tls_dir)
+                api.set_tls_dir(tls_dir)
+        except Exception as e:
+            log.error(f"Device-link TLS setup failed — wss listener disabled: {e}")
+
     azc  = AsyncZeroconf()
-    info = _make_mdns_info()
+    info = _make_mdns_info(tls_active=tls_ctx is not None)
     await azc.async_register_service(info, allow_name_change=True)
     log.info(
         f"mDNS advertising {MDNS_NAME}._emcontroller._tcp.local "
         f"→ {SERVER_IP}:{SERVER_PORT}"
+        + (f" (tls_port={SERVER_TLS_PORT})" if tls_ctx else "")
     )
     mdns_task = asyncio.create_task(_mdns_refresh_loop(azc, info))
 
     log.info(f"WebSocket server starting on {SERVER_HOST}:{SERVER_PORT}")
 
     try:
-        async with websockets.serve(
-            router,
-            SERVER_HOST,
-            SERVER_PORT,
-            ping_interval=20,
-            ping_timeout=10,
-            max_size=10 * 1024 * 1024,
-        ):
+        async with contextlib.AsyncExitStack() as stack:
+            await stack.enter_async_context(websockets.serve(
+                router,
+                SERVER_HOST,
+                SERVER_PORT,
+                ping_interval=20,
+                ping_timeout=10,
+                max_size=10 * 1024 * 1024,
+            ))
+            if tls_ctx is not None:
+                await stack.enter_async_context(websockets.serve(
+                    router_tls,
+                    SERVER_HOST,
+                    SERVER_TLS_PORT,
+                    ssl=tls_ctx,
+                    ping_interval=20,
+                    ping_timeout=10,
+                    max_size=10 * 1024 * 1024,
+                ))
+                log.info(f"Device-link TLS (wss) listening on {SERVER_HOST}:{SERVER_TLS_PORT}")
+            if REQUIRE_DEVICE_TLS:
+                log.info("REQUIRE_DEVICE_TLS=1 — plain/tokenless device connections will be rejected")
+
             await esphome.start_esphome_servers(_devices, SERVER_HOST)
             # After the voice satellites — BT proxies reuse their zeroconf.
             await em_ble_proxy.start_ble_proxy_servers(SERVER_HOST)

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -328,6 +328,21 @@ MIGRATIONS: list[str] = [
 
     UPDATE system_config SET value = '5' WHERE key = 'schema_version';
     """,
+
+    # ── v6 — device-link auth token (TLS rollout) ─────────────────────────────
+    #
+    # token: shared secret the device presents in the X-EM-Token header on
+    # all three WebSocket planes (/control, /data, /shell). Minted by
+    # ensure_device_token() when credentials are first pushed (provisioning
+    # wizard or the dashboard "Secure link" action) and stored on the device
+    # at /data/local/etc/echomuse/token. NULL = no credentials issued yet —
+    # such devices connect unauthenticated (legacy posture) until
+    # REQUIRE_DEVICE_TLS=1 flips the controller to enforcing.
+    """
+    ALTER TABLE devices ADD COLUMN token TEXT;
+
+    UPDATE system_config SET value = '6' WHERE key = 'schema_version';
+    """,
 ]
 
 # ─── Connection management ────────────────────────────────────────────────────
@@ -536,6 +551,54 @@ def upsert_device_seen(
             WHERE device_id = ?
             """,
             (ip, version, _now(), device_id),
+        )
+
+
+def get_device_token(device_id: str) -> Optional[str]:
+    """Return the device's link-auth token, or None if never issued."""
+    row = _q1("SELECT token FROM devices WHERE device_id = ?", (device_id,))
+    return row["token"] if row and row["token"] else None
+
+
+def ensure_device_token(device_id: str) -> str:
+    """
+    Return the device's link-auth token, minting one if absent.
+
+    Creates a pending device row first if the device has never connected —
+    the provisioning wizard pushes credentials before first contact, so the
+    row may not exist yet. Approval state is untouched either way.
+    """
+    import secrets
+
+    existing = get_device_token(device_id)
+    if existing:
+        return existing
+
+    token = secrets.token_urlsafe(32)
+    now = _now()
+    with _tx() as conn:
+        conn.execute(
+            """
+            INSERT INTO devices
+                (device_id, label, approved, ip, firmware_ver, first_seen, last_seen, config)
+            VALUES (?, NULL, 0, NULL, NULL, ?, ?, ?)
+            ON CONFLICT(device_id) DO NOTHING
+            """,
+            (device_id, now, now, json.dumps(DEFAULT_DEVICE_CONFIG)),
+        )
+        conn.execute(
+            "UPDATE devices SET token = ? WHERE device_id = ?",
+            (token, device_id),
+        )
+    log.info(f"[db] Link token minted for {device_id}")
+    return token
+
+
+def clear_device_token(device_id: str) -> None:
+    """Revoke a device's link token (next credential push mints a new one)."""
+    with _tx() as conn:
+        conn.execute(
+            "UPDATE devices SET token = NULL WHERE device_id = ?", (device_id,)
         )
 
 

--- a/controller/em_pki.py
+++ b/controller/em_pki.py
@@ -1,0 +1,161 @@
+"""
+EchoMuse Controller — device-link PKI.
+
+Generates and persists a private CA plus a server certificate for the
+device WebSocket TLS listener. Files live in TLS_DIR (default: a tls/
+directory next to the SQLite database, so the existing /app/data volume
+mount persists them across container rebuilds):
+
+    ca.pem / ca.key         — the EchoMuse controller CA (what devices pin)
+    server.pem / server.key — leaf cert presented on the TLS listener
+
+Design constraints (see CLAUDE.md "TLS device link"):
+
+- Devices verify the chain against the pinned CA only — no system roots,
+  no IP SANs. The leaf carries a fixed DNS SAN (TLS_SERVER_NAME); devices
+  set the same name as tls.Config.ServerName regardless of the IP that
+  mDNS handed them, so the controller can move address freely.
+- Echo Dots can boot with a wildly wrong clock (no RTC battery; NTP takes
+  a while after WiFi comes up). Certs are therefore backdated 10 years
+  and valid for 25, and the device additionally clamps its verification
+  time to the firmware build time. Do not "fix" the validity window to
+  something conventional — a device that can't connect can't sync time.
+- Everything is generated lazily on first use and reused forever after.
+  Deleting TLS_DIR rotates the CA; devices then need a fresh credential
+  push (dashboard "Secure link" action) before they can reconnect over
+  TLS.
+"""
+
+from __future__ import annotations
+
+import datetime
+import ipaddress  # noqa: F401  (kept: handy in a REPL when debugging SANs)
+import logging
+import os
+import ssl
+
+log = logging.getLogger("echomuse.pki")
+
+# DNS name devices expect in the server cert — coupled with
+# device/internal/client/tlscreds.go (tlsServerName). Not resolvable on
+# purpose; it's an identity label, not an address.
+TLS_SERVER_NAME = "echomuse-controller"
+
+_NOT_BEFORE_BACKDATE = datetime.timedelta(days=3650)   # 10 years
+_VALIDITY            = datetime.timedelta(days=365 * 25)
+
+
+def _tls_dir(db_path: str) -> str:
+    d = os.environ.get("TLS_DIR")
+    if not d:
+        d = os.path.join(os.path.dirname(db_path) or ".", "tls")
+    return d
+
+
+def _generate(tls_dir: str) -> None:
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    os.makedirs(tls_dir, exist_ok=True)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    not_before = now - _NOT_BEFORE_BACKDATE
+    not_after  = now + _VALIDITY
+
+    def _write(path: str, data: bytes) -> None:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+
+    # ── CA ────────────────────────────────────────────────────────────────
+    ca_key  = ec.generate_private_key(ec.SECP256R1())
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "EchoMuse Controller CA")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=True, crl_sign=True,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    # ── Server leaf ───────────────────────────────────────────────────────
+    srv_key  = ec.generate_private_key(ec.SECP256R1())
+    srv_cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, TLS_SERVER_NAME)]))
+        .issuer_name(ca_name)
+        .public_key(srv_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(TLS_SERVER_NAME)]),
+            critical=False,
+        )
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.SERVER_AUTH]),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    pem = serialization.Encoding.PEM
+    _write(os.path.join(tls_dir, "ca.key"), ca_key.private_bytes(
+        pem, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()))
+    _write(os.path.join(tls_dir, "ca.pem"), ca_cert.public_bytes(pem))
+    _write(os.path.join(tls_dir, "server.key"), srv_key.private_bytes(
+        pem, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()))
+    _write(os.path.join(tls_dir, "server.pem"), srv_cert.public_bytes(pem))
+    log.info(f"Generated device-link CA + server cert in {tls_dir} "
+             f"(SAN={TLS_SERVER_NAME}, valid to {not_after.date()})")
+
+
+def ensure_pki(db_path: str) -> str | None:
+    """
+    Make sure CA + server cert exist; returns the TLS dir, or None if the
+    cryptography package is unavailable (TLS listener is then skipped —
+    the plain listener keeps the fleet alive).
+    """
+    tls_dir = _tls_dir(db_path)
+    needed  = ("ca.pem", "ca.key", "server.pem", "server.key")
+    if all(os.path.exists(os.path.join(tls_dir, f)) for f in needed):
+        return tls_dir
+    try:
+        import cryptography  # noqa: F401
+    except ImportError:
+        log.warning("python 'cryptography' package not installed — "
+                    "device-link TLS listener disabled")
+        return None
+    _generate(tls_dir)
+    return tls_dir
+
+
+def server_ssl_context(tls_dir: str) -> ssl.SSLContext:
+    """SSLContext for the device-facing wss listener (server-auth only)."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    ctx.load_cert_chain(
+        os.path.join(tls_dir, "server.pem"),
+        os.path.join(tls_dir, "server.key"),
+    )
+    return ctx
+
+
+def ca_pem(tls_dir: str) -> str:
+    with open(os.path.join(tls_dir, "ca.pem"), "r", encoding="ascii") as f:
+        return f.read()

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -10,6 +10,10 @@ websockets==16.0
 aiohttp==3.13.5
 # Password hashing
 bcrypt==5.0.0
+# Device-link TLS: CA + server cert generation (em_pki.py). The controller
+# runs fine without it (plain ws only, wss listener disabled) but the
+# published image always ships it.
+cryptography==44.0.1
 # mDNS advertisement (_emcontroller._tcp.local)
 zeroconf==0.148.0
 # Wake word inference — openwakeword deps installed manually to avoid

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -794,6 +794,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
   const [renameSaving, setRenameSaving] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [securing, setSecuring] = useState(false);
   const fileInputRef = useRef(null);
   const [turns, setTurns] = useState([]);
   const state = deviceState(device);
@@ -863,6 +864,18 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
       }
     } catch(e) { alert(e.error || 'Failed to push config'); }
     setSaving(false);
+  }
+
+  async function doSecureLink() {
+    // Pushes CA + link token over the shell plane, then the controller
+    // bounces the connection; the device redials over wss. The "Link" row
+    // flips to wss (TLS) on the next device-list refresh after reconnect.
+    setSecuring(true);
+    try {
+      await API.post(`/api/devices/${device.device_id}/secure_link`, {});
+    } catch(e) { alert(e.error || 'Secure link failed'); }
+    // Leave the button disabled briefly — transfer + reconnect takes ~10s.
+    setTimeout(() => setSecuring(false), 15000);
   }
 
   async function doUpdate() {
@@ -1099,7 +1112,16 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                     {row('ESPHome port', device.esphome_port != null ? String(device.esphome_port) : '—')}
                     {row('Last seen', relTime(device.last_seen))}
                     {row('Connected', device.connected ? 'Yes' : 'No', device.connected ? '#286040' : '#c0601a')}
+                    {row('Link', device.connected ? (device.linkTls ? 'wss (TLS)' : 'plain ws') : '—',
+                         device.connected ? (device.linkTls ? '#286040' : '#806010') : undefined)}
                     {row('Config', (device.use_global_config ?? true) ? 'Fleet' : 'Device override')}
+                    {isAdmin && device.connected && !device.linkTls && (
+                      <div style={{ marginTop: 8 }}>
+                        <Pill small accent disabled={securing} onClick={doSecureLink}>
+                          {securing ? 'Securing…' : 'Secure link'}
+                        </Pill>
+                      </div>
+                    )}
                   </Panel>
                   <Panel label="Resources">
                     <StatBar label="CPU"     pct={s?.cpuPct}    text={cpuText}/>
@@ -2465,6 +2487,40 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     await c.push('/sdcard/start_server.sh', new TextEncoder().encode(script));
     await c.shell("su -c 'cp /sdcard/start_server.sh /data/local/bin/start_server.sh && chmod 755 /data/local/bin/start_server.sh'");
     addLog('EchoMuse installed.', 'ok');
+
+    // Device-link TLS credentials — pushed pre-first-contact so the very
+    // first connection this device ever makes to the controller is wss +
+    // token-authenticated. The controller mints the token against the
+    // serial (a pending device row is created if needed; approval flow is
+    // unchanged). A 503 means this controller has no TLS listener
+    // (cryptography package missing) — provision proceeds plain, and the
+    // dashboard "Secure link" action can retrofit credentials later.
+    addLog('Fetching device-link TLS credentials…');
+    const serial = (await c.shell('getprop ro.serialno')).trim();
+    if (!serial) {
+      addLog('Could not read device serial — skipping TLS credential install.', 'warn');
+    } else {
+      const tlsResp = await fetch('/api/provision/tls_credentials', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device_id: serial }),
+      });
+      if (tlsResp.status === 503) {
+        addLog('Controller has no TLS listener — device will connect over plain ws.', 'warn');
+      } else if (!tlsResp.ok) {
+        throw new Error(`Controller returned ${tlsResp.status} fetching TLS credentials.`);
+      } else {
+        const creds = await tlsResp.json();
+        await c.push('/sdcard/em-ca.pem', new TextEncoder().encode(creds.ca_pem));
+        await c.push('/sdcard/em-token', new TextEncoder().encode(creds.token));
+        await c.shell(`su -c 'mkdir -p ${creds.dir} && cp /sdcard/em-ca.pem ${creds.dir}/ca.pem && cp /sdcard/em-token ${creds.dir}/token && chmod 644 ${creds.dir}/ca.pem && chmod 600 ${creds.dir}/token && rm -f /sdcard/em-ca.pem /sdcard/em-token'`);
+        const tlsListing = (await c.shell(`su -c 'ls ${creds.dir}' 2>&1`)).trim();
+        if (!tlsListing.includes('ca.pem') || !tlsListing.includes('token')) {
+          throw new Error(`TLS credential install verification failed — ${creds.dir} contains: "${tlsListing}".`);
+        }
+        addLog('TLS credentials installed — device will connect over wss.', 'ok');
+      }
+    }
     addLog('Rebooting device to finish provisioning…');
     try { await c.shell('su -c reboot'); } catch {}
     await c.close();

--- a/device/compile.sh
+++ b/device/compile.sh
@@ -20,9 +20,14 @@ SUPPRESS="-Wno-deprecated-declarations -Wno-null-dereference"
 # Previously we relied on the base image entrypoint to use $VERSION, which
 # is opaque. This embeds the version string into the binary at compile time
 # so the device reports the correct version to the controller on connect.
+# BuildUnix floors the TLS verification clock — an Echo can boot with a
+# bogus date before NTP syncs, and cert NotBefore checks would otherwise
+# strand it (see internal/client/tlscreds.go).
+BUILD_UNIX=$(date +%s)
 BUILD_CMD="cd /sdk && mkdir -p build && go build \
     -tags server \
-    -ldflags \"-X github.com/wilbowes/EchoMuse/internal/client.Version=${VERSION}\" \
+    -ldflags \"-X github.com/wilbowes/EchoMuse/internal/client.Version=${VERSION} \
+               -X github.com/wilbowes/EchoMuse/internal/client.BuildUnix=${BUILD_UNIX}\" \
     -o build/server ./cmd/"
 
 if docker run --rm \

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"log"
 	"net"
-	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -86,10 +86,14 @@ type ControlClient struct {
 	conn         *websocket.Conn
 	connMu       sync.Mutex
 
-	// serverAddr is the controller address (host:port), set on successful connect.
-	// Used by the shell dialler to connect back to the controller.
-	serverAddr   string
-	serverAddrMu sync.RWMutex
+	// serverBaseURL is the WebSocket base URL actually in use
+	// ("ws://host:port" or "wss://host:tlsport"), set on successful
+	// connect. Used by the shell dialler to connect back to the
+	// controller on the same plane. lastServer keeps the discovered
+	// controller info (incl. TLS port) for the mDNS-skipping fast path.
+	serverBaseURL string
+	lastServer    *discovery.ServerInfo
+	serverAddrMu  sync.RWMutex
 
 	// shellCancel cancels a running shell session when shell_close is received.
 	shellCancel context.CancelFunc
@@ -148,15 +152,28 @@ func (c *ControlClient) Run(ctx context.Context, data *DataClient) error {
 		// it's what makes a controller on a different subnet reachable at
 		// all (multicast rarely crosses subnets, so mDNS alone would fail
 		// the change's reconnect gate and revert a working network).
-		addr := c.lastKnownAddr()
-		if addr != "" && probeTCP(addr, 3*time.Second) {
-			log.Printf("[control] Last-known controller %s reachable — skipping mDNS", addr)
+		// The probe targets the plain port — it's a reachability check,
+		// not a plane choice; connect() re-decides ws vs wss every dial.
+		server := c.lastKnownServer()
+		if server != nil && server.TLSPort == 0 && loadLinkCreds().tlsConf != nil {
+			// CA installed but the cached endpoint predates the
+			// controller's TLS listener (e.g. controller upgraded, or a
+			// Secure-link push just landed, mid-run). One fresh browse so
+			// the tls_port TXT is picked up; keep the cached endpoint if
+			// mDNS fails — after a WiFi change the controller can sit on
+			// another subnet where multicast doesn't reach.
+			if found, err := discovery.FindServerOnce(ctx); err == nil && found != nil {
+				server = found
+			}
+		}
+		if server != nil && probeTCP(server.Addr, 3*time.Second) {
+			log.Printf("[control] Last-known controller %s reachable — skipping mDNS", server.Addr)
 		} else {
-			server, err := discovery.FindServer(ctx)
+			found, err := discovery.FindServer(ctx)
 			if err != nil {
 				return err
 			}
-			addr = server.Addr
+			server = found
 		}
 
 		dataCtx, cancelData := context.WithCancel(ctx)
@@ -166,8 +183,7 @@ func (c *ControlClient) Run(ctx context.Context, data *DataClient) error {
 			}
 		}()
 
-		log.Printf("[control] Connecting to %s", addr)
-		err := c.connect(ctx, addr, data)
+		err := c.connect(ctx, server, data)
 
 		cancelData()
 
@@ -198,17 +214,37 @@ func (c *ControlClient) Run(ctx context.Context, data *DataClient) error {
 	}
 }
 
-func (c *ControlClient) connect(ctx context.Context, addr string, data *DataClient) error {
-	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
-	conn, _, err := dialer.DialContext(ctx, "ws://"+addr+"/control", http.Header{})
+func (c *ControlClient) connect(ctx context.Context, server *discovery.ServerInfo, data *DataClient) error {
+	// Credentials are re-read on every dial: a "Secure link" push from the
+	// controller lands mid-run, and the very next reconnect should pick it
+	// up without a restart.
+	creds := loadLinkCreds()
+	baseURL := "ws://" + server.Addr
+	if creds.tlsConf != nil {
+		if server.TLSPort > 0 {
+			baseURL = "wss://" + net.JoinHostPort(server.Host, strconv.Itoa(server.TLSPort))
+		} else {
+			// CA on disk but controller has no TLS listener (or a pre-TLS
+			// controller). Deliberate fallback during rollout — flipping
+			// REQUIRE_DEVICE_TLS controller-side is what eventually closes
+			// this downgrade path.
+			log.Printf("[control] CA installed but controller advertises no tls_port — dialling plain ws")
+		}
+	}
+
+	log.Printf("[control] Connecting to %s", baseURL)
+	dialer := creds.dialer()
+	conn, _, err := dialer.DialContext(ctx, baseURL+"/control", creds.header())
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
 
-	// Store controller address for outbound shell connections
+	// Store base URL for outbound shell connections + the discovered
+	// server for the reconnect fast path.
 	c.serverAddrMu.Lock()
-	c.serverAddr = addr
+	c.serverBaseURL = baseURL
+	c.lastServer = server
 	c.serverAddrMu.Unlock()
 
 	reg := map[string]interface{}{
@@ -267,7 +303,7 @@ func (c *ControlClient) connect(ctx context.Context, addr string, data *DataClie
 	if c.connectedCallback != nil {
 		c.connectedCallback()
 	}
-	data.NotifyReady(addr)
+	data.NotifyReady(baseURL)
 
 	// Keepalive — same mechanism as the data client (see wsPingInterval in
 	// data.go). The app-level "pong" keeps the controller's last_seen fresh;
@@ -412,10 +448,10 @@ func (c *ControlClient) connect(ctx context.Context, addr string, data *DataClie
 			c.shellMu.Unlock()
 
 			c.serverAddrMu.RLock()
-			controllerAddr := c.serverAddr
+			baseURL := c.serverBaseURL
 			c.serverAddrMu.RUnlock()
 
-			go c.runShellSession(shellCtx, controllerAddr, shellMsg.Pty)
+			go c.runShellSession(shellCtx, baseURL, shellMsg.Pty)
 
 		case "shell_close":
 			log.Printf("[control] shell_close received — closing shell session")
@@ -488,7 +524,7 @@ const (
 // so the dashboard can match its framing. pty=false is the legacy raw
 // pipe used by programmatic sessions. If PTY allocation fails, the
 // session falls back to the pipe so a shell is always available.
-func (c *ControlClient) runShellSession(ctx context.Context, controllerAddr string, pty bool) {
+func (c *ControlClient) runShellSession(ctx context.Context, baseURL string, pty bool) {
 	var master, slave *os.File
 	if pty {
 		var err error
@@ -499,14 +535,15 @@ func (c *ControlClient) runShellSession(ctx context.Context, controllerAddr stri
 		}
 	}
 
-	shellURL := "ws://" + controllerAddr + "/shell/" + c.deviceID
+	shellURL := baseURL + "/shell/" + c.deviceID
 	if pty {
 		shellURL += "?pty=1"
 	}
 	log.Printf("[shell] Connecting to controller: %s", shellURL)
 
-	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
-	conn, _, err := dialer.DialContext(ctx, shellURL, http.Header{})
+	creds := loadLinkCreds()
+	dialer := creds.dialer()
+	conn, _, err := dialer.DialContext(ctx, shellURL, creds.header())
 	if err != nil {
 		log.Printf("[shell] Failed to connect to controller: %v", err)
 		if master != nil {
@@ -731,10 +768,10 @@ func (c *ControlClient) writeJSON(v interface{}) error {
 	return c.conn.WriteJSON(v)
 }
 
-func (c *ControlClient) lastKnownAddr() string {
+func (c *ControlClient) lastKnownServer() *discovery.ServerInfo {
 	c.serverAddrMu.RLock()
 	defer c.serverAddrMu.RUnlock()
-	return c.serverAddr
+	return c.lastServer
 }
 
 // probeTCP reports whether addr (host:port) accepts a TCP connection

--- a/device/internal/client/data.go
+++ b/device/internal/client/data.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"log"
 	"math"
-	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -293,9 +292,13 @@ func (d *DataClient) Run(ctx context.Context) error {
 	}
 }
 
-func (d *DataClient) connect(ctx context.Context, addr string) error {
-	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
-	conn, _, err := dialer.DialContext(ctx, "ws://"+addr+"/data", http.Header{})
+// connect dials baseURL+"/data" — baseURL ("ws://…" or "wss://…") comes
+// from the control client via NotifyReady, so both planes always ride the
+// same listener. Credentials are re-read per dial (see tlscreds.go).
+func (d *DataClient) connect(ctx context.Context, baseURL string) error {
+	creds := loadLinkCreds()
+	dialer := creds.dialer()
+	conn, _, err := dialer.DialContext(ctx, baseURL+"/data", creds.header())
 	if err != nil {
 		return err
 	}

--- a/device/internal/client/tlscreds.go
+++ b/device/internal/client/tlscreds.go
@@ -1,0 +1,107 @@
+package client
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Device-link TLS credentials — pushed by the controller (provisioning
+// wizard over adb, or the dashboard "Secure link" action over the shell
+// plane). Paths are coupled with controller/em_api.py DEVICE_TLS_DIR.
+//
+//	ca.pem — the controller CA the device pins (chain verification uses
+//	         ONLY this pool; system roots are irrelevant)
+//	token  — shared secret sent as X-EM-Token on all three WS dials
+//
+// Credentials are re-read on every dial attempt, so a push takes effect
+// on the next reconnect without a process restart.
+const (
+	credCAPath    = "/data/local/etc/echomuse/ca.pem"
+	credTokenPath = "/data/local/etc/echomuse/token"
+
+	// Must match the DNS SAN in the controller's server cert
+	// (controller/em_pki.py TLS_SERVER_NAME). It is an identity label,
+	// not a resolvable name — mDNS supplies the actual address.
+	tlsServerName = "echomuse-controller"
+)
+
+// BuildUnix is the firmware build timestamp (seconds since epoch), set at
+// build time via ldflags — see device/compile.sh. It floors the TLS
+// verification clock: an Echo fresh off a reboot can sit at a bogus date
+// until Android's NTP syncs, and a strict NotBefore check would then
+// brick the connection that time sync itself may depend on.
+var BuildUnix = ""
+
+type linkCreds struct {
+	tlsConf *tls.Config // nil — no CA on disk, plain ws
+	token   string      // "" — no token on disk
+}
+
+// loadLinkCreds reads the credential files. Absent files are the normal
+// pre-rollout state, not an error.
+func loadLinkCreds() linkCreds {
+	var creds linkCreds
+
+	if pem, err := os.ReadFile(credCAPath); err == nil {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			log.Printf("[tls] %s exists but contains no valid PEM certificate — ignoring", credCAPath)
+		} else {
+			creds.tlsConf = &tls.Config{
+				RootCAs:    pool,
+				ServerName: tlsServerName,
+				MinVersion: tls.VersionTLS12,
+				Time:       tlsNow,
+			}
+		}
+	}
+
+	if tok, err := os.ReadFile(credTokenPath); err == nil {
+		creds.token = strings.TrimSpace(string(tok))
+	}
+
+	return creds
+}
+
+// header returns the WS handshake headers for a dial: the link token if
+// one is installed, empty otherwise.
+func (c linkCreds) header() http.Header {
+	h := http.Header{}
+	if c.token != "" {
+		h.Set("X-EM-Token", c.token)
+	}
+	return h
+}
+
+// dialer returns a websocket dialer carrying the pinned-CA TLS config
+// (nil TLSClientConfig is fine for plain ws dials).
+func (c linkCreds) dialer() websocket.Dialer {
+	return websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:  c.tlsConf,
+	}
+}
+
+// tlsNow is the verification clock for cert validity: never earlier than
+// the firmware build time. The controller additionally backdates its certs
+// 10 years (see em_pki.py), so between the two, a wrong device clock in
+// either direction cannot strand the device off the network.
+func tlsNow() time.Time {
+	now := time.Now()
+	if BuildUnix != "" {
+		if sec, err := strconv.ParseInt(BuildUnix, 10, 64); err == nil {
+			if bt := time.Unix(sec, 0); now.Before(bt) {
+				return bt
+			}
+		}
+	}
+	return now
+}

--- a/device/internal/discovery/mdns.go
+++ b/device/internal/discovery/mdns.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/grandcat/zeroconf"
@@ -16,6 +18,10 @@ type ServerInfo struct {
 	Host string
 	Port int
 	Addr string // host:port
+	// TLSPort is the controller's device-link wss listener, from the
+	// tls_port TXT property. 0 = controller does not offer TLS (pre-TLS
+	// controller or listener disabled).
+	TLSPort int
 }
 
 func FindServer(ctx context.Context) (*ServerInfo, error) {
@@ -46,6 +52,13 @@ func FindServer(ctx context.Context) (*ServerInfo, error) {
 			backoff = maxBackoff
 		}
 	}
+}
+
+// FindServerOnce is a single browse round with no retry loop — for
+// callers that want fresher TXT data (e.g. a tls_port that appeared after
+// the endpoint was cached) but have a working fallback if mDNS fails.
+func FindServerOnce(ctx context.Context) (*ServerInfo, error) {
+	return browse(ctx)
 }
 
 func browse(ctx context.Context) (*ServerInfo, error) {
@@ -100,15 +113,29 @@ func browse(ctx context.Context) (*ServerInfo, error) {
 			}
 
 			return &ServerInfo{
-				Host: host,
-				Port: entry.Port,
-				Addr: addr,
+				Host:    host,
+				Port:    entry.Port,
+				Addr:    addr,
+				TLSPort: parseTLSPort(entry.Text),
 			}, nil
 
 		case <-browseCtx.Done():
 			return nil, fmt.Errorf("browse timeout")
 		}
 	}
+}
+
+// parseTLSPort extracts the tls_port key from mDNS TXT records
+// ("key=value" strings). Returns 0 when absent or malformed.
+func parseTLSPort(txt []string) int {
+	for _, t := range txt {
+		if v, ok := strings.CutPrefix(t, "tls_port="); ok {
+			if p, err := strconv.Atoi(v); err == nil && p > 0 && p < 65536 {
+				return p
+			}
+		}
+	}
+	return 0
 }
 
 func verifyServer(addr string) bool {


### PR DESCRIPTION
Implements option 1 from the TLS planning discussion: private CA + server-auth TLS + per-device token.

## What's here

**Controller**
- `em_pki.py` — generates a private CA + server cert once, into `tls/` next to the SQLite DB (persisted by the existing `/app/data` volume). Leaf identity is the fixed DNS SAN `echomuse-controller`; mDNS supplies the IP, the cert never does. Certs backdated 10y / valid 25y (Echo clocks are wrong pre-NTP).
- Second `websockets` listener on `SERVER_TLS_PORT` (default 8770, `wss`) serving the same `/control` `/data` `/shell` planes; advertised to devices via a `tls_port` mDNS TXT property. Missing `cryptography` package or PKI failure disables the TLS listener but never the plain one.
- Schema v6: `devices.token`. All three planes check `X-EM-Token`: a wrong token always rejects; an absent one is allowed (legacy) until `REQUIRE_DEVICE_TLS=1` flips the controller to enforcing (TLS + valid token mandatory). Dashboard shows per-device link state (`linkTls`).
- Credential delivery: `POST /api/provision/tls_credentials` (wizard installs CA + token over adb before first contact, minting a pending device row from the serial) and `POST /api/devices/{id}/secure_link` (fleet retrofit: file push over the shell plane, then a connection bounce so the device redials over wss). New "Secure link" button on the device Status tab.

**Device**
- `internal/client/tlscreds.go` — reads `/data/local/etc/echomuse/{ca.pem,token}` on **every dial**, so a push takes effect on the next reconnect with no restart. Pinned-CA verification with `ServerName=echomuse-controller`; verification clock floored at the firmware build time (`BuildUnix` ldflag in `compile.sh` + release workflow) so a bogus boot clock can't strand the device.
- All three dials ride one computed base URL: CA on disk + `tls_port` advertised → `wss`, otherwise plain `ws` with a logged warning (deliberate rollout fallback; the enforcement flag closes it later).
- Reconnect fast path re-browses mDNS once when a CA is installed but the cached endpoint predates the TLS listener.

## Rollout order (safe by construction)
1. Rebuild + restart controller (TLS listener + TXT appear; fleet stays on plain ws).
2. OTA the new firmware fleet-wide (still plain ws — no credentials yet).
3. Per device: dashboard **Secure link** → device reconnects on `wss (TLS)`.
4. When every device shows TLS: set `REQUIRE_DEVICE_TLS=1`.

New provisions get credentials in the wizard's install step, so their first-ever connection is already wss + token.

## Verified
- PKI smoke test: real pinned-CA TLS 1.3 handshake against `em_pki`'s context, fixed server name, SAN checked; file perms 600; idempotent regen.
- Schema v6 migration + token mint/stability/revoke on a fresh DB.
- `py_compile` on all touched modules; `esbuild` parse of `dashboard.jsx`.
- `go vet` + full cross-build in the `echomuse-compiler` image.
- Not exercised: live handshake from real hardware — needs a controller rebuild + one device; suggest Office first (Lounge stays the debloat control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)