### PR TITLE
controller: ship em_pki.py in the Docker image

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -55,6 +55,7 @@ COPY em_auth.py .
 COPY em_eq.py .
 COPY em_scenes.py .
 COPY em_ns.py .
+COPY em_pki.py .
 COPY em_esphome.py .
 COPY em_ble_proxy.py .
 COPY version.py .


### PR DESCRIPTION
Missed COPY line — image crash-looped on import at first TLS deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)