### PR TITLE
Backlog: VAD timing fix, OTA failure surfacing, [mem] forwarding, 48k TTS, mobile dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,8 @@ The always-on wake stream (`mic_start` without `lock_mic`) is **ungated and AGC-
 ### Controller audio pipeline
 
 1. **Wake word** — openwakeword (ONNX) runs in a thread executor per device on `mic_queue`
-2. **Voice turn** — on wake or dot-button: drain stale frames → acquire `voice_lock` → stream mic to HA via the ESPHome satellite → receive TTS URL → fetch + ffmpeg-decode → EQ (`em_eq.py`) → resample to 48kHz mono → stream back as 0x02 frames
-3. **Speaker** — the wire carries **mono** 48kHz (`resample_to_48k()`, numpy linear interpolation); the device duplicates L=R at the ALSA write (stereo ALSA config is an I2S/codec constraint, not a wire one). Device buffers ~5.5s (`audioChanDepth`) and holds playback until ~1s is queued or EOS arrives (`primePeriods`) — WiFi-stall protection for marginal links
+2. **Voice turn** — on wake or dot-button: drain stale frames → acquire `voice_lock` → stream mic to HA via the ESPHome satellite → receive TTS URL → fetch + ffmpeg-decode straight to 48kHz mono → EQ (`em_eq.py`) → stream back as 0x02 frames
+3. **Speaker** — the wire carries **mono** 48kHz; `_fetch_tts_audio` decodes at the wire rate (the satellite declares `supported_formats` 48k/mono/FLAC so HA transcodes at source when it can; ffmpeg resamples otherwise — no numpy resample step anymore). The device duplicates L=R at the ALSA write (stereo ALSA config is an I2S/codec constraint, not a wire one). Device buffers ~5.5s (`audioChanDepth`) and holds playback until ~1s is queued or EOS arrives (`primePeriods`) — WiFi-stall protection for marginal links
 
 ### Key Go packages
 

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -91,6 +91,15 @@ _event_clients: set[web.WebSocketResponse] = set()
 # Track in-progress OTA updates per device_id to enforce one-at-a-time.
 _updates_in_progress: set[str] = set()
 
+# Last OTA failure per device, surfaced as `update_error` in /api/devices so
+# the dashboard (fleet deploy modal + per-device update log) can show *why* a
+# tile stopped progressing instead of sitting at "updating…" forever. Set by
+# _update_failed on every _run_update/_run_rollback failure path; cleared when
+# a new update starts and on confirmed success. In-memory by design — a
+# controller restart clears stale errors along with the update tasks
+# themselves.
+_update_errors: dict[str, str] = {}
+
 # Pending local binary uploads — keyed by UUID token, expire after 10 minutes.
 _pending_uploads: dict[str, bytes] = {}
 
@@ -908,6 +917,23 @@ def _extract_binary_version(binary: bytes) -> str | None:
     return match.group(0).decode("ascii") if match else None
 
 
+async def _update_failed(device_id: str, reason: str) -> None:
+    """
+    Record and broadcast an OTA failure: device log line, in-memory
+    update_error (read back via /api/devices), and a device_update_failed
+    event for the dashboard WS. Every abort path in _run_update/_run_rollback
+    must come through here — a log-only failure leaves the dashboard tile at
+    "updating…" indefinitely.
+    """
+    _update_errors[device_id] = reason
+    await _push_log_event(device_id, "error", "controller", reason)
+    await _push_event({
+        "type":      "device_update_failed",
+        "device_id": device_id,
+        "error":     reason,
+    })
+
+
 async def _run_update(device_id: str, release: dict,
                       binary_override: bytes | None = None) -> None:
     """
@@ -921,6 +947,7 @@ async def _run_update(device_id: str, release: dict,
     6. Detect auto-rollback (start_server.sh retry exhausted).
     """
     _updates_in_progress.add(device_id)
+    _update_errors.pop(device_id, None)  # fresh attempt clears the last failure
     loop = asyncio.get_event_loop()
     version = release["version"]
 
@@ -936,8 +963,8 @@ async def _run_update(device_id: str, release: dict,
         else:
             binary = await _fetch_binary(release["url"])
             if binary is None:
-                await _push_log_event(device_id, "error", "controller",
-                                      "Failed to fetch binary from GitHub")
+                await _update_failed(device_id,
+                                     "Failed to fetch binary from GitHub")
                 return
 
         # Record current version as previous before anything changes
@@ -947,8 +974,8 @@ async def _run_update(device_id: str, release: dict,
 
         live = _devices.get(device_id)
         if live is None:
-            await _push_log_event(device_id, "error", "controller",
-                                  "Device disconnected before update could start")
+            await _update_failed(device_id,
+                                 "Device disconnected before update could start")
             return
 
         # Detect active slot and migrate legacy layout if needed — single shell
@@ -968,8 +995,8 @@ async def _run_update(device_id: str, release: dict,
         log.info(f"[api] Slot detect result for {device_id}: {detect_result!r}")
 
         if "MIGRATE_FAILED" in detect_result:
-            await _push_log_event(device_id, "error", "controller",
-                                  "A/B migration failed — aborting update")
+            await _update_failed(device_id,
+                                 "A/B migration failed — aborting update")
             return
 
         active_slot = None
@@ -981,8 +1008,8 @@ async def _run_update(device_id: str, release: dict,
                     break
 
         if active_slot is None:
-            await _push_log_event(device_id, "error", "controller",
-                                  f"Could not determine active slot — output: {detect_result!r}")
+            await _update_failed(device_id,
+                                 f"Could not determine active slot — output: {detect_result!r}")
             return
 
         if "MIGRATED" in detect_result:
@@ -1000,8 +1027,8 @@ async def _run_update(device_id: str, release: dict,
         # Stream binary to inactive slot
         ok = await _stream_binary_to_slot(live, binary, inactive_slot)
         if not ok:
-            await _push_log_event(device_id, "error", "controller",
-                                  f"Binary transfer to {inactive_slot} failed")
+            await _update_failed(device_id,
+                                 f"Binary transfer to {inactive_slot} failed")
             return
 
         # Brief pause so device can cleanly close the transfer shell before
@@ -1022,6 +1049,7 @@ async def _run_update(device_id: str, release: dict,
         confirmed = await _monitor_reconnect(device_id, version, previous_version=current_ver, timeout=90)
 
         if confirmed:
+            _update_errors.pop(device_id, None)
             await _push_log_event(device_id, "info", "controller",
                                   f"✓ Update confirmed: {version}")
             await _push_event({
@@ -1038,6 +1066,9 @@ async def _run_update(device_id: str, release: dict,
                 await loop.run_in_executor(
                     None, db.set_firmware_previous, device_id, None
                 )
+                _update_errors[device_id] = (
+                    f"auto-rolled back to {running} — new binary failed to start"
+                )
                 await _push_log_event(device_id, "warn", "controller",
                     f"Device auto-rolled back to {running} "
                     f"— new binary failed {3} start attempts")
@@ -1047,18 +1078,21 @@ async def _run_update(device_id: str, release: dict,
                     "version":   running,
                 })
             else:
+                _update_errors[device_id] = (
+                    f"timed out — device running {running}"
+                )
                 await _push_log_event(device_id, "warn", "controller",
                     f"Update timed out — device running: {running}")
                 await _push_event({
                     "type":      "device_update_failed",
                     "device_id": device_id,
+                    "error":     _update_errors[device_id],
                     "running":   running,
                 })
 
     except Exception as e:
         log.exception(f"[api] OTA update error for {device_id}: {e}")
-        await _push_log_event(device_id, "error", "controller",
-                              f"OTA exception: {e}")
+        await _update_failed(device_id, f"OTA exception: {e}")
     finally:
         _updates_in_progress.discard(device_id)
 
@@ -1070,14 +1104,15 @@ async def _run_rollback(device_id: str, target_version: str) -> None:
     No binary transfer needed — the old binary is already in the inactive slot.
     """
     _updates_in_progress.add(device_id)
+    _update_errors.pop(device_id, None)  # fresh attempt clears the last failure
     try:
         await _push_log_event(device_id, "info", "controller",
                               f"Rolling back to {target_version}")
 
         live = _devices.get(device_id)
         if live is None:
-            await _push_log_event(device_id, "error", "controller",
-                                  "Device disconnected before rollback")
+            await _update_failed(device_id,
+                                 "Device disconnected before rollback")
             return
 
         active_slot = None
@@ -1095,8 +1130,8 @@ async def _run_rollback(device_id: str, target_version: str) -> None:
                     break
 
         if active_slot is None:
-            await _push_log_event(device_id, "error", "controller",
-                                  "Cannot determine active slot — is A/B set up?")
+            await _update_failed(device_id,
+                                 "Cannot determine active slot — is A/B set up?")
             return
 
         inactive_slot = "server_b" if active_slot == "server_a" else "server_a"
@@ -1119,6 +1154,7 @@ async def _run_rollback(device_id: str, target_version: str) -> None:
         )
 
         if confirmed:
+            _update_errors.pop(device_id, None)
             await loop.run_in_executor(
                 None, db.set_firmware_previous, device_id, None
             )
@@ -1130,11 +1166,12 @@ async def _run_rollback(device_id: str, target_version: str) -> None:
                 "version":   target_version,
             })
         else:
-            await _push_log_event(device_id, "warn", "controller",
-                                  "Rollback did not reconnect within 90s")
+            await _update_failed(device_id,
+                                 "Rollback did not reconnect within 90s")
 
     except Exception as e:
         log.exception(f"[api] Rollback error for {device_id}: {e}")
+        await _update_failed(device_id, f"Rollback exception: {e}")
     finally:
         _updates_in_progress.discard(device_id)
 
@@ -2383,4 +2420,8 @@ def _merge_device(row) -> dict:
         "wifi":             wifi_state(device_id),
         # Update state
         "update_in_progress": device_id in _updates_in_progress,
+        # Last OTA/rollback failure (None when the last attempt succeeded or
+        # none was made) — lets the dashboard show a terminal ✗ state instead
+        # of "updating…" forever when an update aborts.
+        "update_error":       _update_errors.get(device_id),
     }

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -138,7 +138,6 @@ CHUNK_BYTES          = 1280 * 2   # 2560 bytes = 80ms at 16kHz S16_LE mono
 SPEAKER_RATE   = 48000
 SPEAKER_PERIOD = 2048
 SPEAKER_BYTES  = SPEAKER_PERIOD * 2       # 4096 bytes/period (mono S16)
-PIPER_RATE     = 22050
 
 # The device holds playback until ~this much audio is buffered (or EOS
 # arrives) — primePeriods in pcm_speaker.go. The post-playback drain sleep
@@ -489,33 +488,10 @@ async def leds_spin_green(device: Device, stop_event: asyncio.Event):
 
 # ─── Audio conversion ─────────────────────────────────────────────────────────
 
-def resample_to_48k(pcm: bytes, from_rate: int) -> bytes:
-    """
-    Resample mono S16_LE PCM from from_rate to 48kHz mono S16_LE.
-
-    Uses linear interpolation via numpy. For a 10s Piper response (~220k samples)
-    the old pure-Python loop took ~1-2s of wall time in the asyncio event loop;
-    numpy completes it in <5ms, keeping the perceived latency budget intact.
-
-    Output stays mono — the wire format is mono 48k, and the device
-    duplicates to stereo at the ALSA write (the stereo ALSA config is a
-    hardware constraint of the I2S/codec path, not a wire requirement).
-    """
-    if len(pcm) < 2:
-        return b""
-    samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float32)
-    n_in  = len(samples)
-    n_out = int(n_in * SPEAKER_RATE / from_rate)
-
-    # Source indices for each output sample — fractional positions in input
-    src  = np.arange(n_out, dtype=np.float64) * from_rate / SPEAKER_RATE
-    lo   = src.astype(np.int32)
-    hi   = np.minimum(lo + 1, n_in - 1)
-    frac = (src - lo).astype(np.float32)
-
-    resampled = samples[lo] * (1.0 - frac) + samples[hi] * frac
-    resampled = np.clip(resampled, -32768, 32767).astype(np.int16)
-    return resampled.tobytes()
+# (The numpy linear-interpolation resample_to_48k that used to live here is
+# gone: _fetch_tts_audio now decodes at SPEAKER_RATE directly, with ffmpeg
+# doing any rate conversion — and HA transcodes to 48kHz at source when it
+# honours the media player's declared supported_formats.)
 
 
 # ─── Voice pipeline ───────────────────────────────────────────────────────────
@@ -689,23 +665,23 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
 
 async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None:
     """
-    Post-turn timing concern: EQ, resample, stream to device, acoustic-feedback wait.
+    Post-turn timing concern: EQ, stream to device, acoustic-feedback wait.
 
-    voice_response is raw Piper-rate mono S16_LE PCM. Returns once the
-    device audio buffer has drained (or cancel_event fires), so the caller
-    can safely restart the mic without acoustic feedback into the next turn.
+    voice_response is 48kHz mono S16_LE PCM (_fetch_tts_audio decodes at the
+    wire rate now — no controller-side resample). Returns once the device
+    audio buffer has drained (or cancel_event fires), so the caller can
+    safely restart the mic without acoustic feedback into the next turn.
     """
     log.info(
         f"[{device.device_id}] EQ: bands={device.eq_bands} "
         f"loudness={device.eq_loudness}"
     )
-    # EQ + resample are a solid numpy crunch (hundreds of ms for a long
-    # response) — run them off the event loop, which otherwise freezes every
-    # device's LED frames, shell proxying, and WS handling right as playback
-    # starts (observed as spinner stutter and console typing judder).
+    # EQ is a solid numpy crunch (hundreds of ms for a long response) — run
+    # it off the event loop, which otherwise freezes every device's LED
+    # frames, shell proxying, and WS handling right as playback starts
+    # (observed as spinner stutter and console typing judder).
     def _prepare_pcm() -> bytes:
-        eq_pcm = em_eq.apply(voice_response, PIPER_RATE, device.eq_bands, device.eq_loudness)
-        return resample_to_48k(eq_pcm, PIPER_RATE)
+        return em_eq.apply(voice_response, SPEAKER_RATE, device.eq_bands, device.eq_loudness)
 
     speaker_pcm = await asyncio.get_event_loop().run_in_executor(None, _prepare_pcm)
     log.info(

--- a/controller/em_eq.py
+++ b/controller/em_eq.py
@@ -18,16 +18,12 @@ Band centre frequencies and types:
   6: 5500 Hz  — peaking, Q=1.4
   7: 8000 Hz  — high shelf
 
-Note: the linear interpolation resampler (22050→48kHz) introduces ~2dB
-sinc² rolloff at 8kHz, so band 7 will have slightly less effect than the
-gain value implies. Bands 0–6 are unaffected.
-
 All filter design uses the Audio EQ Cookbook by Robert Bristow-Johnson.
 High-pass uses scipy.signal.butter (already a dependency via openwakeword).
 
 Usage:
     import em_eq
-    eq_pcm = em_eq.apply(voice_response, PIPER_RATE, bands=[0]*8, loudness=False)
+    eq_pcm = em_eq.apply(voice_response, SPEAKER_RATE, bands=[0]*8, loudness=False)
 """
 
 import math
@@ -125,8 +121,9 @@ def apply(
     Apply EQ to mono S16_LE PCM. Returns mono S16_LE PCM at the same rate.
 
     Args:
-        pcm:         Raw mono S16_LE PCM bytes (Piper TTS output).
-        sample_rate: Sample rate of pcm (typically PIPER_RATE = 22050).
+        pcm:         Raw mono S16_LE PCM bytes (decoded TTS audio).
+        sample_rate: Sample rate of pcm (SPEAKER_RATE = 48000 in the
+                     playback pipeline since the 48k decode change).
         bands:       List of NUM_BANDS (8) gain values in dB. None = flat.
         loudness:    Add a +5dB speech-range presence boost if True.
 

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -325,12 +325,28 @@ class EchoMuseSatellite(SatelliteServerProtocol):
 
         if isinstance(msg, api_pb2.ListEntitiesRequest):
             log.debug(f"[{self._log_name}] ListEntitiesRequest from {self.peer}")
+            # supported_formats (Voice-PE-style): tells HA to run TTS and
+            # announcement audio through its ffmpeg proxy and hand us a URL
+            # already transcoded to 48kHz mono FLAC — the device's native
+            # wire rate — instead of whatever the TTS provider produced.
+            # _fetch_tts_audio then decodes without resampling. Harmless on
+            # HA versions that ignore it: ffmpeg decodes any format/rate.
+            _fmt = dict(format="flac", sample_rate=48000,
+                        num_channels=1, sample_bytes=2)
             yield api_pb2.ListEntitiesMediaPlayerResponse(
                 object_id="media_player",
                 key=MEDIA_PLAYER_KEY,
                 name=self.label,
                 supports_pause=True,
                 feature_flags=MEDIA_PLAYER_FEATURES,
+                supported_formats=[
+                    api_pb2.MediaPlayerSupportedFormat(
+                        purpose=api_pb2.MEDIA_PLAYER_FORMAT_PURPOSE_DEFAULT,
+                        **_fmt),
+                    api_pb2.MediaPlayerSupportedFormat(
+                        purpose=api_pb2.MEDIA_PLAYER_FORMAT_PURPOSE_ANNOUNCEMENT,
+                        **_fmt),
+                ],
             )
             yield api_pb2.ListEntitiesDoneResponse()
             return
@@ -1082,12 +1098,15 @@ class EchoMuseSatellite(SatelliteServerProtocol):
 
 async def _fetch_tts_audio(url: str) -> bytes:
     """
-    Fetch TTS audio from HA and decode to 22050Hz mono S16_LE PCM.
+    Fetch TTS audio from HA and decode to 48kHz mono S16_LE PCM — the
+    device wire rate, so downstream (EQ → stream) never resamples.
 
     Uses ffmpeg subprocess — handles MP3, WAV, FLAC, OGG transparently
-    regardless of which TTS provider HA is configured with. Output is raw
-    PCM at Piper rate (22050Hz mono S16_LE), matching what the existing
-    _run_post_turn_playback() / resample_to_48k() pipeline expects.
+    regardless of which TTS provider HA is configured with. When HA honours
+    our declared supported_formats the URL already serves 48kHz mono FLAC
+    and the -ar here is a no-op; otherwise ffmpeg's proper resampler does
+    the conversion (better than the numpy linear interpolation this
+    replaced, which cost ~2dB above 8kHz).
 
     Requires ffmpeg in PATH (installed via Dockerfile apt-get).
     """
@@ -1117,7 +1136,7 @@ async def _fetch_tts_audio(url: str) -> bytes:
     proc = await asyncio.create_subprocess_exec(
         "ffmpeg", "-hide_banner", "-loglevel", "error",
         "-i", "pipe:0",
-        "-f", "s16le", "-ar", "22050", "-ac", "1",
+        "-f", "s16le", "-ar", "48000", "-ac", "1",
         "pipe:1",
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
@@ -1138,7 +1157,7 @@ async def _fetch_tts_audio(url: str) -> bytes:
     if proc.returncode != 0:
         raise RuntimeError(f"ffmpeg decode failed: {err.decode()[:200]}")
 
-    log.debug(f"_fetch_tts_audio: decoded to {len(pcm)}b PCM (22050Hz mono S16_LE)")
+    log.debug(f"_fetch_tts_audio: decoded to {len(pcm)}b PCM (48kHz mono S16_LE)")
     return pcm
 
 

--- a/controller/static/dashboard.html
+++ b/controller/static/dashboard.html
@@ -26,6 +26,31 @@
       --muted:     #8a8680;
     }
     html, body { height: 100%; background: #ccc8c0; }
+
+    /* Mobile layout — the dashboard is inline-styled, so phone-width
+       adjustments live here as class-targeted media overrides (the classes
+       are on the structural containers in dashboard.jsx). !important is
+       required to beat the inline styles; keep these to layout only. */
+    @media (max-width: 640px) {
+      .em-page    { padding: 16px 12px 48px !important; }
+      .em-header  { flex-wrap: wrap !important; gap: 10px !important; margin-bottom: 20px !important; }
+      .em-summary { flex-wrap: wrap !important; }
+      .em-summary > div { flex: 1 1 40% !important; }
+      .em-summary > .em-summary-release { flex: 1 1 100% !important; }
+      /* Modals go full-screen — the desktop frame is min(900px,95vw) ×
+         min(700px,90vh), which leaves useless slivers of backdrop on a
+         phone. 100dvh tracks the browser chrome collapsing on scroll. */
+      .em-modal      { width: 100vw !important; height: 100dvh !important; border-radius: 0 !important; }
+      .em-modal-head { padding: 12px 14px 0 !important; }
+      .em-modal-headrow { flex-wrap: wrap !important; gap: 10px !important; }
+      .em-modal-body { padding: 14px !important; }
+      /* Two-column content grids stack on phones. */
+      .em-grid2 { grid-template-columns: 1fr !important; }
+    }
+    /* Tab strips scroll horizontally instead of overflowing on any width. */
+    .em-tabs { overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
+    .em-tabs::-webkit-scrollbar { display: none; }
+    .em-tabs > button { flex-shrink: 0; }
   </style>
 </head>
 <body>

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -924,6 +924,12 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
         if (d?.connected && d?.firmware_ver === targetVersion) {
           setPushLog(l => [...l, `✓ Running ${targetVersion}`, '✓ Update complete']);
           clearInterval(poll); setPushing(false); setLocalFile(null);
+        } else if (d?.update_error && !d?.update_in_progress) {
+          // Controller recorded a terminal failure (transfer failed, slot
+          // detect failed, exception…) — report it now instead of letting
+          // the poll run out its 2-minute timeout.
+          setPushLog(l => [...l, `✗ ${d.update_error}`]);
+          clearInterval(poll); setPushing(false);
         } else if (wasDisconnected && d?.connected && d?.firmware_ver && d.firmware_ver !== targetVersion) {
           setPushLog(l => [...l, `⚠ Device reconnected on ${d.firmware_ver} — auto-rolled back`]);
           clearInterval(poll); setPushing(false);
@@ -3330,13 +3336,23 @@ function DeployAllModal({ release, devices, deployState, onStarted, onDismiss, o
     if (!d)                              return { text: 'unknown',      color: 'var(--muted)' };
     if (d.connected && d.firmware_ver === target)
                                          return { text: '✓ updated',    color: '#286040' };
+    // A recorded failure is terminal — without this the row (and the header
+    // progress pill) sat at "updating…" forever after an aborted update.
+    if (d.update_error)                  return { text: `✗ ${d.update_error}`, color: '#c03030' };
     if (!d.connected)                    return { text: 'rebooting…',   color: '#96660a' };
     return { text: 'updating…', color: '#405878' };
   }
 
   const started = view?.started || [];
-  const allDone = started.length > 0 &&
-    started.every(id => { const d = byId[id]; return d && d.connected && d.firmware_ver === target; });
+  // Failed counts as done — the deploy reached a terminal state for that
+  // device, it just wasn't success.
+  const terminal = id => {
+    const d = byId[id];
+    return d && ((d.connected && d.firmware_ver === target) || d.update_error);
+  };
+  const failedCount = started.filter(id => byId[id]?.update_error &&
+    !(byId[id].connected && byId[id].firmware_ver === target)).length;
+  const allDone = started.length > 0 && started.every(terminal);
 
   async function deploy() {
     setRunning(true); setError('');
@@ -3399,7 +3415,9 @@ function DeployAllModal({ release, devices, deployState, onStarted, onDismiss, o
             )}
             <div style={{ fontFamily: mono, fontSize: 10, color: 'var(--muted)', marginTop: 14 }}>
               {allDone
-                ? 'All devices updated.'
+                ? (failedCount > 0
+                    ? `Finished — ${failedCount} device${failedCount === 1 ? '' : 's'} failed (see device logs).`
+                    : 'All devices updated.')
                 : 'Updates run in the background — you can close this and reopen it from the header to check progress.'}
             </div>
             <div style={{ marginTop: 14, display: 'flex', gap: 10 }}>
@@ -3748,7 +3766,14 @@ function App() {
                 const d = byId[id];
                 return d && d.connected && d.firmware_ver === deployState.version;
               }).length;
-              const complete = started.length > 0 && done === started.length;
+              // Failures are terminal too — otherwise one aborted update
+              // pinned the pill at "Deploying…" until the page was reloaded.
+              const failed = started.filter(id => {
+                const d = byId[id];
+                return d && d.update_error &&
+                  !(d.connected && d.firmware_ver === deployState.version);
+              }).length;
+              const complete = started.length > 0 && done + failed === started.length;
               // While a deploy is in flight the progress pill replaces the
               // Deploy all button — both open the same modal, and offering a
               // second deploy mid-run reads as a broken control. The button
@@ -3761,7 +3786,9 @@ function App() {
                 {deployState && (
                   <Pill small onClick={() => setShowDeployAll(true)}>
                     {complete
-                      ? `✓ Fleet on ${deployState.version}`
+                      ? (failed > 0
+                          ? `⚠ ${deployState.version}: ${done} ok, ${failed} failed`
+                          : `✓ Fleet on ${deployState.version}`)
                       : `Deploying ${deployState.version} — ${done}/${started.length}`}
                   </Pill>
                 )}

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -684,7 +684,7 @@ function ConnectivityTab({ device, row }) {
         </div>
       )}
 
-      <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:16, alignItems:'start' }}>
+      <div className="em-grid2" style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:16, alignItems:'start' }}>
         <Panel label="Current connection">
           {row('Network', currentSsid || '—')}
           {row('IP', device.ip && device.ip !== '127.0.0.1' ? device.ip : '—')}
@@ -730,7 +730,7 @@ function ConnectivityTab({ device, row }) {
           work out — including when it connects but can't reach this controller (wrong VLAN, isolated
           guest network). The previous network is only discarded once the device reports back here.
         </div>
-        <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr auto', gap:12, alignItems:'end' }}>
+        <div className="em-grid2" style={{ display:'grid', gridTemplateColumns:'1fr 1fr auto', gap:12, alignItems:'end' }}>
           <div>
             <div style={{ fontFamily:mono, fontSize:9, color:'var(--text2)', letterSpacing:'0.08em', marginBottom:4 }}>SSID</div>
             <input type="text" value={ssid} disabled={busy} onChange={e => setSsid(e.target.value)}
@@ -1009,10 +1009,10 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
       {/* Fixed height (not maxHeight): every tab renders in an identical
           frame — content scrolls inside, the window never resizes as you
           move between tabs. */}
-      <div style={{ width: 'min(900px,95vw)', height: 'min(700px,90vh)', background: 'linear-gradient(170deg,#e8e4de,#d8d4cc)', border: '1px solid #b8b4ac', borderRadius: 16, boxShadow: '0 24px 80px rgba(0,0,0,0.3),0 2px 0 rgba(255,255,255,0.8) inset', display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: 'fadeIn 0.15s ease' }}>
+      <div className="em-modal" style={{ width: 'min(900px,95vw)', height: 'min(700px,90vh)', background: 'linear-gradient(170deg,#e8e4de,#d8d4cc)', border: '1px solid #b8b4ac', borderRadius: 16, boxShadow: '0 24px 80px rgba(0,0,0,0.3),0 2px 0 rgba(255,255,255,0.8) inset', display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: 'fadeIn 0.15s ease' }}>
         {/* Header */}
-        <div style={{ background: 'linear-gradient(180deg,#dedad2,#ccc8c0)', borderBottom: '1px solid #b0aca4', padding: '20px 24px 0', boxShadow: '0 1px 0 rgba(255,255,255,0.5) inset' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 20, marginBottom: 16 }}>
+        <div className="em-modal-head" style={{ background: 'linear-gradient(180deg,#dedad2,#ccc8c0)', borderBottom: '1px solid #b0aca4', padding: '20px 24px 0', boxShadow: '0 1px 0 rgba(255,255,255,0.5) inset' }}>
+          <div className="em-modal-headrow" style={{ display: 'flex', alignItems: 'center', gap: 20, marginBottom: 16 }}>
             <LedRing state={state} size={72}/>
             <div style={{ flex: 1, minWidth: 0 }}>
               {renaming ? (
@@ -1067,7 +1067,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
               <CircleButton onClick={onClose} title="Close">×</CircleButton>
             </div>
           </div>
-          <div style={{ display: 'flex', gap: 2 }}>
+          <div className="em-tabs" style={{ display: 'flex', gap: 2 }}>
             {TABS.map(t => (
               <button key={t} onClick={() => setTab(t)} style={{ background: tab === t ? 'linear-gradient(180deg,#e8e4de,#d8d4cc)' : 'transparent', border: tab === t ? '1px solid #b0aca4' : '1px solid transparent', borderBottom: tab === t ? '1px solid #d8d4cc' : '1px solid transparent', borderRadius: '6px 6px 0 0', fontFamily: "'DM Mono',monospace", fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em', padding: '7px 14px', cursor: 'pointer', color: tab === t ? 'var(--text)' : 'var(--muted)', marginBottom: -1, transition: 'color 0.15s' }}>{t}</button>
             ))}
@@ -1075,7 +1075,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
         </div>
 
         {/* Body */}
-        <div style={{ flex: 1, overflowY: 'auto', padding: 24 }}>
+        <div className="em-modal-body" style={{ flex: 1, overflowY: 'auto', padding: 24 }}>
 
           {/* APPROVE */}
           {tab === 'approve' && (
@@ -1107,7 +1107,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
             const wwLabel = (cfgEff.owwModel || '—').replace(/_v[\d.]+$/, '').replace(/_/g, ' ');
             return (
               <div style={{ minHeight:'100%', display:'flex', flexDirection:'column', gap:16 }}>
-                <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:16 }}>
+                <div className="em-grid2" style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:16 }}>
                   <Panel label="Device">
                     {row('IP', (() => {
                       const ip = device.ip && device.ip !== '127.0.0.1' ? device.ip : null;
@@ -1151,7 +1151,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                     : bp.listening ? 'Waiting for HA' : 'Port down (device offline)';
                   return (
                     <Panel label="Bluetooth proxy">
-                      <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'0 24px' }}>
+                      <div className="em-grid2" style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:'0 24px' }}>
                         <div>
                           {row('Scanner', b ? (b.scanning ? 'Scanning' : 'Stopped') : '—', b?.scanning ? '#286040' : undefined)}
                           {row('Adverts seen', b ? String(b.advertsSeen ?? 0) : '—')}
@@ -1292,7 +1292,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
               </Panel>
 
               {/* Deploy sources, side by side */}
-              <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:16 }}>
+              <div className="em-grid2" style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:16 }}>
                 <Panel label="GitHub Release">
                   <div style={{ fontFamily:"'DM Mono',monospace", fontSize:10, color:'var(--muted)', lineHeight:1.6, marginBottom:14 }}>
                     Deploy the latest tagged release build to this device. A/B slots — the previous binary stays available for rollback.
@@ -3096,7 +3096,7 @@ function DeviceConfigForm({ config, onChange, disabled }) {
       <Stage n="01" title="Playback"
         chips={<><ScopeChip tone="controller">Controller</ScopeChip><ScopeChip tone="device">Speaker</ScopeChip></>}
         desc="Response audio: Home Assistant TTS → parametric EQ → resample → device speaker. Presets set the faders; drag any fader for a custom curve.">
-        <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 28, alignItems: 'start' }}>
+        <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 28, alignItems: 'start' }}>
           <div>
             <EqCurve bands={bands}/>
             <EqSliders bands={bands} onChange={nb => set('eqBands', nb)} disabled={disabled}/>
@@ -3136,7 +3136,7 @@ function DeviceConfigForm({ config, onChange, disabled }) {
       <Stage n="02" title="Wake word"
         chips={<ScopeChip tone="controller">Controller</ScopeChip>}
         desc="openwakeword scores the continuous mic stream on the controller. Sensitivity sets the detection threshold — attempts that score close but miss are counted as near-misses (Status tab).">
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, alignItems: 'start' }}>
+        <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, alignItems: 'start' }}>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, ...inputStyle }}>
             {WW_MODELS.map(m => (
               <div key={m.value} onClick={() => set('owwModel', m.value)} style={{
@@ -3492,17 +3492,17 @@ function SettingsPanel({ globalConfig, onGlobalConfigChange, onClose, username }
       onClick={e => e.target === e.currentTarget && onClose()}>
       {/* Same fixed frame as the device Detail modal — consistent window
           size across the whole dashboard. */}
-      <div style={{ width:'min(900px,95vw)', height:'min(700px,90vh)', background:'linear-gradient(170deg,#e8e4de,#d8d4cc)', border:'1px solid #b8b4ac', borderRadius:16, boxShadow:'0 24px 80px rgba(0,0,0,0.3),0 2px 0 rgba(255,255,255,0.8) inset', display:'flex', flexDirection:'column', overflow:'hidden', animation:'fadeIn 0.15s ease' }}>
+      <div className="em-modal" style={{ width:'min(900px,95vw)', height:'min(700px,90vh)', background:'linear-gradient(170deg,#e8e4de,#d8d4cc)', border:'1px solid #b8b4ac', borderRadius:16, boxShadow:'0 24px 80px rgba(0,0,0,0.3),0 2px 0 rgba(255,255,255,0.8) inset', display:'flex', flexDirection:'column', overflow:'hidden', animation:'fadeIn 0.15s ease' }}>
 
         {/* Header */}
-        <div style={{ background:'linear-gradient(180deg,#dedad2,#ccc8c0)', borderBottom:'1px solid #b0aca4', padding:'20px 24px 0', boxShadow:'0 1px 0 rgba(255,255,255,0.5) inset' }}>
+        <div className="em-modal-head" style={{ background:'linear-gradient(180deg,#dedad2,#ccc8c0)', borderBottom:'1px solid #b0aca4', padding:'20px 24px 0', boxShadow:'0 1px 0 rgba(255,255,255,0.5) inset' }}>
           <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:16 }}>
             <div style={{ fontFamily:"'DM Sans',sans-serif", fontSize:22, color:'var(--text)', fontWeight:600, letterSpacing:'-0.02em' }}>Settings</div>
             <CircleButton onClick={onClose} title="Close">×</CircleButton>
           </div>
           {/* Same raised folder-tab treatment as the device Detail modal —
               one tab style across the dashboard. */}
-          <div style={{ display:'flex', gap:2 }}>
+          <div className="em-tabs" style={{ display:'flex', gap:2 }}>
             {TABS.map(t => (
               <button key={t} onClick={() => setTab(t)} style={{ background: tab === t ? 'linear-gradient(180deg,#e8e4de,#d8d4cc)' : 'transparent', border: tab === t ? '1px solid #b0aca4' : '1px solid transparent', borderBottom: tab === t ? '1px solid #d8d4cc' : '1px solid transparent', borderRadius: '6px 6px 0 0', fontFamily: "'DM Mono',monospace", fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em', padding: '7px 14px', cursor: 'pointer', color: tab === t ? 'var(--text)' : 'var(--muted)', marginBottom: -1, transition: 'color 0.15s' }}>{TAB_LABELS[t]}</button>
             ))}
@@ -3510,7 +3510,7 @@ function SettingsPanel({ globalConfig, onGlobalConfigChange, onClose, username }
         </div>
 
         {/* Body */}
-        <div style={{ overflowY:'auto', padding:'24px 28px 32px', flex:1 }}>
+        <div className="em-modal-body" style={{ overflowY:'auto', padding:'24px 28px 32px', flex:1 }}>
 
           {tab === 'fleet' && (
             <>
@@ -3702,10 +3702,10 @@ function App() {
   const selectedDevice = selected ? devices.find(d => d.device_id === selected) : null;
 
   return (
-    <div style={{ minHeight: '100vh', padding: '32px 36px 60px' }}>
+    <div className="em-page" style={{ minHeight: '100vh', padding: '32px 36px 60px' }}>
 
       {/* Header */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 36 }}>
+      <div className="em-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 36 }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 14 }}>
           <div style={{ fontFamily: "'DM Sans',sans-serif", fontSize: 28, color: 'var(--text)', fontWeight: 600, letterSpacing: '-0.02em' }}>EchoMuse</div>
           <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)', letterSpacing: '0.12em', textTransform: 'uppercase' }}>Device Management</div>
@@ -3723,7 +3723,7 @@ function App() {
       </div>
 
       {/* Summary */}
-      <div style={{ display: 'flex', gap: 10, marginBottom: 36 }}>
+      <div className="em-summary" style={{ display: 'flex', gap: 10, marginBottom: 36 }}>
         {[
           ['Online', `${online}/${approved.length}`, online === approved.length ? '#286040' : '#806010'],
           ['Active', active, active > 0 ? '#2060b0' : 'var(--muted)'],
@@ -3736,7 +3736,7 @@ function App() {
           </div>
         ))}
         {release && (
-          <div style={{ background: 'linear-gradient(160deg,#2a2e28,#1e2219)', border: '1px solid #1a1c18', borderRadius: 8, padding: '12px 18px', flex: 2, boxShadow: 'inset 0 2px 6px rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div className="em-summary-release" style={{ background: 'linear-gradient(160deg,#2a2e28,#1e2219)', border: '1px solid #1a1c18', borderRadius: 8, padding: '12px 18px', flex: 2, boxShadow: 'inset 0 2px 6px rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <div>
               <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 8, color: 'var(--lcd-dim)', textTransform: 'uppercase', letterSpacing: '0.15em', marginBottom: 6 }}>Latest Release</div>
               <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 18, color: 'var(--lcd-green)', lineHeight: 1 }}>{release.version}</div>

--- a/controller/static/index.html
+++ b/controller/static/index.html
@@ -45,6 +45,9 @@
       max-width: 480px;
       width: 90vw;
     }
+    @media (max-width: 640px) {
+      .frame { padding: 32px 22px; }
+    }
 
     .dot-wrap {
       width: 180px;

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -379,11 +379,18 @@ func main() {
 			if tick%10 == 0 {
 				var ms runtime.MemStats
 				runtime.ReadMemStats(&ms)
-				log.Printf("[mem] goroutines=%d heap_alloc=%dKB heap_sys=%dKB heap_idle=%dKB released=%dKB stack=%dKB rss=%dKB num_gc=%d pause_total=%dms",
+				memLine := fmt.Sprintf("[mem] goroutines=%d heap_alloc=%dKB heap_sys=%dKB heap_idle=%dKB released=%dKB stack=%dKB rss=%dKB num_gc=%d pause_total=%dms",
 					runtime.NumGoroutine(),
 					ms.HeapAlloc/1024, ms.HeapSys/1024, ms.HeapIdle/1024,
 					ms.HeapReleased/1024, ms.StackSys/1024, selfRSSKb(),
 					ms.NumGC, ms.PauseTotalNs/1e6)
+				log.Print(memLine)
+				// Forward to the controller's device_logs too — the local
+				// /tmp/server.log is RAM-backed and dies with every reboot,
+				// and the 2026-07 leak hunt needed these lines pulled over
+				// the shell proxy by hand. One message per ~5min; SendLog
+				// silently drops while disconnected, same as SendStats.
+				controlClient.SendLog("info", memLine)
 			}
 			tick++
 		}

--- a/device/internal/client/data.go
+++ b/device/internal/client/data.go
@@ -65,19 +65,19 @@ const (
 // ─── VAD constants ────────────────────────────────────────────────────────────
 
 const (
-	vadMicChannels   = 9
-	vadByteSample    = 3
-	vadFramePeriod   = 512
-	vadBytePeriod    = vadFramePeriod * vadMicChannels * vadByteSample // 13824
-	vadOwwChunkBytes = 1280 * 2                                        // 2560 bytes = 80ms
+	vadOwwChunkBytes = 1280 * 2 // 2560 bytes = 80ms
 
-	// prerollPeriods is how many processed 32ms periods of pre-gate audio are
-	// retained while the VAD gate is closed and flushed upstream the moment it
-	// opens (~512ms at 16). Only applies to lockMic (bounded turn) streams —
-	// the always-on wake stream is ungated and sends everything, so OWW
-	// always sees a continuous stream. For turns, preroll gives STT the true
-	// first phoneme instead of a hard splice at gate-open.
-	prerollPeriods = 16
+	// prerollBudgetMs is how much pre-gate audio is retained while the VAD
+	// gate is closed and flushed upstream the moment it opens. The ring is
+	// sized in wall-clock terms because the mic delivers whole ALSA-buffer
+	// batches (160ms), not 32ms periods — a fixed batch count would drift
+	// with the batch size (the old prerollPeriods=16 was meant as ~512ms of
+	// periods but actually held 2.5s of batches). Only applies to lockMic
+	// (bounded turn) streams — the always-on wake stream is ungated and
+	// sends everything, so OWW always sees a continuous stream. For turns,
+	// preroll gives STT the true first phoneme instead of a hard splice at
+	// gate-open.
+	prerollBudgetMs = 512
 
 	// noSpeechTimeout bounds how long streamMic will wait for speech to
 	// ever be detected after a turn starts. If active never becomes true
@@ -507,7 +507,7 @@ func (d *DataClient) streamMic(conn *websocket.Conn, stopCh <-chan struct{}, loc
 	// closed, oldest first. Flushed into buf at gate open, cleared while
 	// active. Slices are retained (not copied): Process() returns a fresh
 	// allocation each period, so nothing aliases them.
-	preroll := make([][]byte, 0, prerollPeriods)
+	preroll := make([][]byte, 0, prerollBudgetMs/160+1) // capacity hint at the real batch cadence
 	var seqNum uint16
 	var periodCount uint64 // periodic RMS diagnostic
 	var lastClipped uint64 // clip count at last diag line
@@ -598,14 +598,6 @@ func (d *DataClient) streamMic(conn *websocket.Conn, stopCh <-chan struct{}, loc
 
 			snap := cfg.Snapshot()
 			threshold := snap.VadThreshold
-			speechNeeded := snap.VadSpeechMs / 32
-			silenceMax := snap.VadSilenceMs / 32
-			if speechNeeded < 1 {
-				speechNeeded = 1
-			}
-			if silenceMax < 1 {
-				silenceMax = 1
-			}
 
 			beamAngle := float64(-1)
 			if snap.BeamAngle != nil {
@@ -666,6 +658,26 @@ func (d *DataClient) streamMic(conn *websocket.Conn, stopCh <-chan struct{}, loc
 			// lockstep with micGainDb.
 			rms := vadPeriodRMS(mono)
 			speech := rms >= threshold*gainLin
+
+			// Gate windows in units of actual iterations: the mic delivers
+			// whole ALSA-buffer batches (160ms/2560 samples — see the
+			// pipeline note in CLAUDE.md), so divide the configured ms by
+			// the real batch duration. The old /32 assumed 32ms periods and
+			// silently made both windows 5× longer than configured (80ms
+			// speech-to-open was really 320ms; 600ms silence-to-close was
+			// really 2.9s).
+			batchMs := len(mono) / 32 // S16 mono @16kHz: 32 bytes per ms
+			if batchMs < 1 {
+				batchMs = 1
+			}
+			speechNeeded := (snap.VadSpeechMs + batchMs - 1) / batchMs
+			if speechNeeded < 1 {
+				speechNeeded = 1
+			}
+			silenceMax := (snap.VadSilenceMs + batchMs - 1) / batchMs
+			if silenceMax < 1 {
+				silenceMax = 1
+			}
 
 			// Periodic RMS diagnostic — every ~10 min, or within ~16s of
 			// the mic gain clamping a sample (clipping is the one signal
@@ -787,11 +799,15 @@ func (d *DataClient) streamMic(conn *websocket.Conn, stopCh <-chan struct{}, loc
 					buf = buf[vadOwwChunkBytes:]
 				}
 			} else {
-				// Gate closed — keep the most recent periods for the next
-				// gate open.
-				if len(preroll) >= prerollPeriods {
+				// Gate closed — keep the most recent batches for the next
+				// gate open, capped by duration rather than count.
+				prerollMax := prerollBudgetMs / batchMs
+				if prerollMax < 1 {
+					prerollMax = 1
+				}
+				for len(preroll) >= prerollMax {
 					copy(preroll, preroll[1:])
-					preroll = preroll[:prerollPeriods-1]
+					preroll = preroll[:len(preroll)-1]
 				}
 				preroll = append(preroll, mono)
 			}


### PR DESCRIPTION
Five backlog items, one commit each:

1. **device: VAD gate/preroll sized by real batch duration** — the streamMic loop iterates per 160ms GoTinyAlsa batch, not per 32ms period, so the `/32` conversions made the gate windows 5× longer than configured (80ms speech-to-open was really 320ms; 600ms silence-to-close was really 2.9s) and the preroll ring held 2.5s instead of ~512ms. Button (lock_mic) turns only — the wake stream is ungated.
2. **controller: OTA failures reach the dashboard** — every abort path in `_run_update`/`_run_rollback` now records `update_error` (exposed in `/api/devices`) and pushes `device_update_failed`. Fleet deploy rows show a terminal red ✗ with the reason and count toward completion ("n ok, m failed" header pill); the per-device update log reports failures immediately instead of waiting out its 2-minute poll.
3. **device: `[mem]` telemetry forwarded to `device_logs`** — one log control-message per ~5min alongside the local line; no more pulling leak telemetry over the shell proxy by hand.
4. **controller: `supported_formats` + 48kHz decode** — the satellite declares 48kHz/mono/FLAC (default + announcement) so HA transcodes TTS at source when it can; `_fetch_tts_audio` decodes straight to the wire rate either way, ffmpeg's resampler replaces the numpy linear-interpolation step (~2dB HF loss gone), EQ runs at 48k, `PIPER_RATE`/`resample_to_48k` deleted.
5. **dashboard: mobile-friendly layout** — ≤640px media overrides: modals go full-screen, header/summary wrap, two-column grids stack, tab strips scroll horizontally. Desktop unchanged.

Validated: ARM `compile.sh` build clean; Go test suite green (one pre-existing env-sensitive failure in `TestContextCancelReleasesMicStream`, fails identically on clean main in this container); `py_compile` clean; proto construction of `MediaPlayerSupportedFormat` verified against the vendored pb2; JSX validated with esbuild using the Dockerfile flags.

Deployment note: items 2, 4, 5 need a controller rebuild; items 1, 3 ride the next firmware release (v2.9.4 with PR #10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
