### PR TITLE
controller: report hardware model to HA, not the device label

### DIFF
--- a/controller/em_ble_proxy.py
+++ b/controller/em_ble_proxy.py
@@ -84,10 +84,11 @@ class BluetoothProxySatellite(SatelliteServerProtocol):
                 friendly_name=f"{self.label} BT Proxy",
                 mac_address=self.mac_address,
                 manufacturer="EchoMuse",
-                model="Echo Dot Gen 2 (biscuit)",
+                model=_device_model(),
                 # Dot required — HA splits project_name on "." (see
-                # em_esphome.EchoMuseSatellite.handle_message).
-                project_name=f"EchoMuse.{self.label}-bt",
+                # em_esphome.EchoMuseSatellite.handle_message), and shows
+                # the part after it as the device Model.
+                project_name=f"EchoMuse.{_device_model()}",
                 project_version=_project_version(),
                 bluetooth_proxy_feature_flags=BT_PROXY_FLAGS,
             )
@@ -219,6 +220,11 @@ def _project_version() -> str:
     return ESPHOME_PROJECT_VERSION
 
 
+def _device_model() -> str:
+    from em_esphome import ESPHOME_DEVICE_MODEL
+    return ESPHOME_DEVICE_MODEL
+
+
 def _proxy_mac(device_id: str) -> str:
     """
     Stable, distinct MAC identity for the BT proxy: the voice satellite's
@@ -249,7 +255,7 @@ def _make_mdns_info(device_id: str, label: str, port: int) -> ServiceInfo:
             # em_esphome._make_device_mdns_info.
             "mac": _proxy_mac(device_id).replace(":", "").lower(),
             "network": "ethwifi",
-            "project_name": f"EchoMuse.{label}-bt",
+            "project_name": f"EchoMuse.{_device_model()}",
             "project_version": _project_version(),
         },
         server=f"{svc_name}.local.",

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -165,6 +165,11 @@ MDNS_NAME    = os.environ.get("MDNS_NAME", "echomuse")
 # Defaults to the real controller version (version.py) so HA's device page
 # shows the same thing as the dashboard header; env var kept as an override.
 from version import VERSION as _CONTROLLER_VERSION
+# HA's ESPHome integration displays the segment after the dot in
+# project_name as the device Model (overriding DeviceInfo's model field),
+# so carry the hardware model there — not the device label.
+ESPHOME_DEVICE_MODEL = "Echo Dot Gen 2 (biscuit)"
+
 ESPHOME_PROJECT_VERSION = os.environ.get(
     "ESPHOME_PROJECT_VERSION", _CONTROLLER_VERSION
 )
@@ -312,12 +317,12 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 friendly_name=f"{self.label} Voice Assistant",
                 mac_address=self.mac_address,
                 manufacturer="EchoMuse",
-                model="Echo Dot Gen 2 (biscuit)",
+                model=ESPHOME_DEVICE_MODEL,
                 # CRITICAL: dot notation required — HA's manager.py does
                 # project_name.split(".") unconditionally. No dot → IndexError
                 # → device silently never appears in Devices & Services.
                 # (session handoff finding #1)
-                project_name=f"EchoMuse.{self.label}",
+                project_name=f"EchoMuse.{ESPHOME_DEVICE_MODEL}",
                 project_version=ESPHOME_PROJECT_VERSION,
                 voice_assistant_feature_flags=VOICE_ASSISTANT_FLAGS,
             )
@@ -1685,7 +1690,7 @@ def _make_device_mdns_info(device_id: str, label: str, port: int) -> ServiceInfo
             # _serialno_to_mac derivation, so they agree).
             "mac": _serialno_to_mac(device_id).replace(":", "").lower(),
             "network": "ethwifi",
-            "project_name": f"EchoMuse.{label}",
+            "project_name": f"EchoMuse.{ESPHOME_DEVICE_MODEL}",
             "project_version": ESPHOME_PROJECT_VERSION,
         },
         server=f"{svc_name}.local.",


### PR DESCRIPTION
HA shows `project_name`'s post-dot segment as the device Model (overriding the DeviceInfo `model` field), so devices displayed Model "Lounge" instead of the hardware. `project_name` now carries `EchoMuse.Echo Dot Gen 2 (biscuit)` for both the voice satellite and the BT proxy (shared `ESPHOME_DEVICE_MODEL` constant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)