### PR TITLE
ring: legible playback meter, honest turn-state, tunable curve

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -321,6 +321,17 @@ class Device:
         # playback_send_ms, which only times writing into the socket and
         # completes almost instantly however slow the link is.
         self.playback_send_t0: float | None = None
+        # Set when the device reports playback_stats for the stream being
+        # played. This is the authoritative "the audio has finished" signal
+        # — the device emits it once its audio channel has drained after
+        # EOS, i.e. when the last period has gone to ALSA. Cleared at the
+        # start of every speaker stream; awaited by _run_post_turn_playback
+        # in place of the wall-clock estimate that used to clear the ring
+        # while the device was still playing (up to 6.1s early, 2026-07-24).
+        self.playback_done = asyncio.Event()
+        # Outcome of the most recently persisted turn, set by em_esphome and
+        # consumed once by the turn loop's ring cleanup (see _leds_turn_end).
+        self.last_turn_outcome: str | None = None
         self.playback_send_ms: int = -1
         self.playback_eq_ms:   int = -1
 
@@ -472,6 +483,47 @@ async def leds_off(device: Device):
         await device.send_led_anim({"pattern": "off"})
     else:
         await device.set_leds(_make_leds(0, 0, 0))
+
+
+# Turn outcomes that get a distinguishing ring cue at turn end. Everything
+# else ("ok", "cancelled") ends silently: the user either heard a reply or
+# pressed the button themselves, so a cue would be noise.
+#
+# Rhythm carries the meaning, not colour — a new colour would collide with
+# red (mute), orange (link down) or cyan (volume), and the point of the
+# cue is to be understandable without a legend. One slow throb reads as
+# "nothing heard"; fast blinks read as "something went wrong".
+_OUTCOME_ANIM = {
+    "no_speech":     "nospeech_anim",
+    "no_tts":        "error_anim",
+    "tts_error":     "error_anim",
+    "timeout":       "error_anim",
+    "stream_timeout": "error_anim",
+}
+
+
+async def _leds_turn_end(device: Device):
+    """
+    Clear the ring at turn end, playing a brief self-clearing cue first if
+    the turn ended in a way the user would otherwise have no signal for.
+
+    The cue anims carry a 1s TTL, so the device retires them on its own
+    ticker with no follow-up message — nothing to leak if the controller
+    dies in between, and a continuation/barge repaint simply supersedes it
+    via the animator's generation counter.
+    """
+    outcome = device.last_turn_outcome
+    device.last_turn_outcome = None
+    key = _OUTCOME_ANIM.get(outcome or "")
+    # Barge-in re-enters a fresh turn immediately and repaints listening —
+    # a cue there would flash for a few frames and read as a glitch.
+    if key and device.led_anim_capable and not device.barge_detected:
+        anim = device.led_scene.get(key)
+        if anim:
+            log.info(f"[{device.device_id}] Turn ended '{outcome}' — ring cue")
+            await device.send_led_anim(anim)
+            return
+    await leds_off(device)
 
 
 async def leds_listening(device: Device):
@@ -721,6 +773,8 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
         f"({len(speaker_pcm)//SPEAKER_BYTES} periods)"
     )
     cancel_task    = asyncio.create_task(device.cancel_event.wait())
+    device.playback_done.clear()
+    done_task      = asyncio.create_task(device.playback_done.wait())
     stream_task    = asyncio.create_task(device.stream_speaker(speaker_pcm))
     t_stream_start = asyncio.get_event_loop().time()
     # Opens the delivery window measured against the device's
@@ -737,41 +791,58 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
         stream_task.cancel()
     else:
         if not device.cancel_event.is_set():
-            # Mono S16LE, plus the device's prime hold: playback doesn't
-            # start until ~1s of audio is buffered (or EOS for short clips),
-            # so the buffer finishes draining up to that much later than
-            # audio_duration alone suggests. Overestimating slightly is fine
-            # — this sleep races cancel_event, and barge-in keeps the mic
-            # running regardless.
+            # Wait for the DEVICE to say it finished, rather than estimating.
+            #
+            # The old code slept `audio_duration - elapsed` and declared
+            # completion. Two things made that wrong, and both bite hardest
+            # on exactly the links that need the most patience: `elapsed` is
+            # socket-write time (which completes near-instantly however slow
+            # the wire is) and was *subtracted*, and the estimate had no
+            # visibility of how long the device's own buffer took to drain.
+            # Measured 2026-07-24: the ring cleared 6.1s before the audio
+            # actually stopped on a Retreat turn, 3.2s early on Lounge.
+            #
+            # playback_stats is emitted once the device's audio channel has
+            # drained after EOS, so it is the real end of audio. The timeout
+            # is only a backstop for the report never arriving (device drop,
+            # pre-v2.9 firmware): generous, because ending the turn early is
+            # the failure we are fixing. cancel_event is still raced — a
+            # barge-in or a mute usually lands in this window, and an
+            # uncancellable wait here is what caused the 5.7s dead window
+            # fixed on 2026-07-10.
             audio_duration = len(speaker_pcm) / (SPEAKER_RATE * 2) + SPEAKER_PRIME_SECONDS
             elapsed        = asyncio.get_event_loop().time() - t_stream_start
-            remaining      = max(0.0, audio_duration - elapsed)
             device.playback_send_ms = int(elapsed * 1000)
+            timeout        = audio_duration * 2 + 10.0
             log.info(
                 f"[{device.device_id}] Socket write took {elapsed:.1f}s "
-                f"(NOT delivery — see delivery_ms), sleeping {remaining:.1f}s "
-                f"for buffer drain (total={audio_duration:.1f}s)"
+                f"(NOT delivery — see delivery_ms), awaiting device "
+                f"playback_stats (est {audio_duration:.1f}s, timeout {timeout:.1f}s)"
             )
-            if remaining > 0:
-                # The drain sleep must race cancel_event too: the WS write
-                # finishes well ahead of real-time playback, so a barge-in
-                # usually lands HERE, not mid-stream. An uncancellable sleep
-                # left the turn hanging for the rest of the response length
-                # after the device had already flushed — no listening LEDs,
-                # and the user's follow-up words piling into voice_queue
-                # (observed 5.7s dead window, 2026-07-10).
-                sleep_task = asyncio.create_task(asyncio.sleep(remaining))
-                await asyncio.wait(
-                    [sleep_task, cancel_task],
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                sleep_task.cancel()
+            timeout_task = asyncio.create_task(asyncio.sleep(timeout))
+            await asyncio.wait(
+                [done_task, cancel_task, timeout_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            timeout_task.cancel()
             if device.cancel_event.is_set():
-                log.info(f"[{device.device_id}] Cancelled during buffer drain")
+                log.info(f"[{device.device_id}] Cancelled during playback drain")
+            elif done_task.done():
+                actual = asyncio.get_event_loop().time() - t_stream_start
+                log.info(
+                    f"[{device.device_id}] Playback complete "
+                    f"(device-confirmed after {actual:.1f}s, est {audio_duration:.1f}s)"
+                )
             else:
-                log.info(f"[{device.device_id}] Playback complete")
+                # Ring held the full backstop. Either the device never
+                # reported (worth knowing) or delivery was pathological.
+                log.warning(
+                    f"[{device.device_id}] Playback completion timed out after "
+                    f"{timeout:.1f}s with no playback_stats — clearing ring anyway"
+                )
 
     cancel_task.cancel()
+    done_task.cancel()
 
 
 async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_wakeword: bool = False):
@@ -840,7 +911,7 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
                         await spin_task
                     except asyncio.CancelledError:
                         pass
-                await leds_off(device)
+                await _leds_turn_end(device)
 
             async def on_thinking_esphome():
                 nonlocal spin_task, watcher
@@ -879,7 +950,16 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
                     # the ALSA write). Replaces the thinking spinner on
                     # the device; spin_task keeps waiting on stop_event
                     # and its finally still clears the ring at turn end.
-                    await device.send_led_anim(device.led_scene["meter_anim"])
+                    #
+                    # TTL is sized to THIS response — a fixed dead-man would
+                    # eventually clear the ring part-way through a long
+                    # answer, which is the very bug being fixed elsewhere in
+                    # this turn path.
+                    meter = dict(device.led_scene["meter_anim"])
+                    meter["ttlSec"] = em_scenes.meter_ttl(
+                        len(voice_response) / (SPEAKER_RATE * 2)
+                    )
+                    await device.send_led_anim(meter)
                 if device.barge_in_enabled:
                     # Barge-in (§3.2): keep the mic running through
                     # playback — the device's AEC subtracts the speaker
@@ -1823,6 +1903,10 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                     periods   = int(msg.get("periods", 0))
                     underruns = int(msg.get("underruns", 0))
                     pstats    = msg.get("stats") or {}
+                    # Release _run_post_turn_playback: this report IS the
+                    # end of audio, and the ring clears on it rather than
+                    # on a wall-clock guess.
+                    device.playback_done.set()
                     # Delivery window: first speaker frame sent -> this
                     # report. The metric the 07-20 investigation lacked —
                     # "Streaming took Xs" times the socket write and reads

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -139,6 +139,18 @@ DEFAULT_DEVICE_CONFIG = {
     "ledScene":         "standard",
     "ledListenColor":   "#00b400",
     "ledThinkColor":    "#00c800",
+    # Playback "meter" ring response curve — how hard the ring throbs with
+    # the speaker level. Device-side defaults live in animator.go
+    # (meterDefaults) and these mirror them; both are clamped independently.
+    # Exposed as config because it is a taste parameter that needs several
+    # passes in a real room, and a firmware OTA per pass is not a sane
+    # tuning loop. See docs/led-ring-states.md.
+    "meterAttack":      0.6,   # envelope rise per 40ms tick
+    "meterDecay":       0.30,  # fall per tick; ~133ms tracks syllable rate
+    "meterFloor":       0.06,  # perceptual brightness at silence
+    "meterGamma":       2.2,   # >1 expands the dark end so the swing reads
+    "meterRef":         0.22,  # speaker RMS mapped to full brightness
+    "meterCurve":       0.7,   # <1 lifts quiet consonants
     # agcEnabled: automatic gain control (lockMic/button turn streams only).
     # Disable to hear raw mic levels. (nsEnabled/RNNoise removed 2026-07-12
     # with the device-side RNNoise code — a stale nsEnabled key in stored

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -1560,6 +1560,10 @@ async def _persist_turn(device, turn_record: dict) -> None:
             turn_record["send_ms"] = device.playback_send_ms
             turn_record["eq_ms"]   = device.playback_eq_ms
         pending = None
+    # Surface the outcome to the turn loop's ring cleanup. Without this
+    # every ending looks identical to the user — "I didn't hear you",
+    # "HA errored" and "done, nothing to say" all just turn the ring off.
+    device.last_turn_outcome = turn_record.get("outcome")
     try:
         turn_id = await loop.run_in_executor(
             None, db.insert_turn, device.device_id, turn_record

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -1196,7 +1196,20 @@ async def _fetch_tts_audio(url: str) -> bytes:
     for attempt in range(2):
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+                # 60s, not 10s: HA's tts_proxy generates the audio while we
+                # hold this GET open, so this is a synthesis deadline, not a
+                # download one. Whether that shows up here or in tts_gen
+                # depends on the engine — a streaming-capable one hands over
+                # the URL early and does the work during the fetch, which is
+                # how a long response (a read-aloud story) blew the old 10s
+                # cap. Reported by @kopiro in #28.
+                #
+                # The proper fix is to stop buffering the whole response:
+                # em_player already streams a URL through ffmpeg into the
+                # same 0x02 plane with StreamingEQ, and pointing that at TTS
+                # would remove this deadline AND start playback seconds
+                # sooner. Until then this is a deliberate band-aid.
+                async with session.get(url, timeout=aiohttp.ClientTimeout(total=60)) as resp:
                     resp.raise_for_status()
                     audio_bytes = await resp.read()
             break

--- a/controller/em_scenes.py
+++ b/controller/em_scenes.py
@@ -84,6 +84,51 @@ def _leds(palette: list) -> list:
     return [{"id": i, "r": r, "g": g, "b": b} for i, (r, g, b) in enumerate(palette)]
 
 
+# Seconds added on top of a response's own duration when sizing the meter
+# ring's dead-man TTL. Also the placeholder TTL on the base spec.
+METER_TTL_PAD = 20
+
+# Dead-man TTL for the thinking spinner. It must outlast everything the
+# spinner spans — HA's think time AND the TTS fetch — because the ring is
+# showing "working on it" for the whole of both. That makes it coupled to
+# _fetch_tts_audio's timeout (60s, x2 attempts): a shorter TTL would clear
+# the ring part-way through exactly the long responses that need it most,
+# which is the same class of bug as the playback estimate this release
+# replaces. Keep these two in step if either moves.
+SPIN_TTL = 135
+
+# Meter response-curve config keys → the wire field the device reads, with
+# the range the dashboard offers. The device clamps independently
+# (resolveMeter in animator.go) — this is the UI range, not the guard.
+_METER_KEYS = {
+    "meterAttack": ("attack", 0.05, 1.0),
+    "meterDecay":  ("decay",  0.02, 1.0),
+    "meterFloor":  ("floor",  0.0,  0.6),
+    "meterGamma":  ("gamma",  1.0,  3.5),
+    "meterRef":    ("ref",    0.02, 1.0),
+    "meterCurve":  ("curve",  0.3,  2.0),
+}
+
+
+def _meter_curve(config: dict) -> dict:
+    """
+    Pull the meter response-curve overrides out of a device config.
+
+    Only keys actually present are emitted: an absent field means "use the
+    firmware default", which keeps the wire spec small and lets the device
+    move its defaults without every stored config pinning the old ones.
+    """
+    out = {}
+    for cfg_key, (wire_key, lo, hi) in _METER_KEYS.items():
+        if cfg_key not in config or config[cfg_key] is None:
+            continue
+        try:
+            out[wire_key] = min(hi, max(lo, float(config[cfg_key])))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
 def resolve(config: dict) -> dict:
     """
     Turn a device config dict into a render-ready scene. Unknown scene
@@ -123,25 +168,33 @@ def resolve(config: dict) -> dict:
     # so spinner smoothness stops depending on controller/WiFi jitter.
     # ttlSec is a dead-man switch: if the controller dies mid-turn the
     # ring self-clears instead of spinning forever.
+    # TTLs are bounded by what each phase can legitimately take, not by a
+    # single generous constant. The old flat 180s meant a controller that
+    # died mid-turn left the ring animating for three minutes, which reads
+    # as broken long before it self-clears. Ceilings used: the mic stream's
+    # 20s hard cap for listening, and observed worst-case HA think time of
+    # 14.7s (2026-07-25, n=57) for the spinner — each with ~2-3x headroom.
+    # meter is the exception: response length is unbounded, so its TTL is
+    # set per playback from the actual audio duration (see METER_TTL_PAD).
     if preset["rotate"]:
         spin_anim = {
             "pattern":  "rotate",
             "colors":   [list(c) for c in preset["listening"]],
             "periodMs": 80,
-            "ttlSec":   180,
+            "ttlSec":   SPIN_TTL,
         }
     else:
         spin_anim = {
             "pattern":  "spin",
             "colors":   [list(preset["spin_head"]), list(preset["spin_trail"])],
             "periodMs": 80,
-            "ttlSec":   180,
+            "ttlSec":   SPIN_TTL,
         }
     listening_anim = {
         "pattern":   "solid",
         "colors":    [list(c) for c in preset["listening"]],
         "listening": True,
-        "ttlSec":    180,
+        "ttlSec":    30,
     }
     # Playback: the ring throbs with the live speaker level (device-side
     # RMS at the ALSA write). Solid scenes throb the spinner head colour;
@@ -151,8 +204,18 @@ def resolve(config: dict) -> dict:
     meter_anim = {
         "pattern": "meter",
         "colors":  [list(c) for c in meter_palette],
-        "ttlSec":  180,
+        # Placeholder — the caller overrides this per playback with
+        # meter_ttl(audio_seconds). A long TTS must never self-clear its own
+        # ring mid-response, which a fixed TTL would eventually do.
+        "ttlSec":  METER_TTL_PAD,
+        **_meter_curve(config or {}),
     }
+
+    # A brief self-clearing cue played at turn end so outcomes are
+    # distinguishable. Rhythm carries the meaning, not colour: adding a new
+    # colour would collide with red (mute) / orange (link) / cyan (volume).
+    outcome_colors = ([list(preset["spin_head"])] if not preset["rotate"]
+                      else [list(c) for c in preset["listening"]])
 
     return {
         "name":           name,
@@ -161,4 +224,24 @@ def resolve(config: dict) -> dict:
         "listening_anim": listening_anim,
         "spin_anim":      spin_anim,
         "meter_anim":     meter_anim,
+        # One slow throb — "I was listening and heard nothing."
+        "nospeech_anim":  {
+            "pattern": "pulse", "colors": outcome_colors,
+            "periodMs": 900, "ttlSec": 1,
+        },
+        # Fast agitated blinks — "something went wrong."
+        "error_anim":     {
+            "pattern": "pulse", "colors": outcome_colors,
+            "periodMs": 220, "ttlSec": 1,
+        },
     }
+
+
+def meter_ttl(audio_seconds: float) -> int:
+    """
+    Dead-man TTL for a playback meter ring, sized to the response actually
+    being played. Bounded below so a very short clip still gets a sane
+    window, and padded so a slow link (delivery has been observed at ~2x
+    the audio duration) cannot trip it mid-response.
+    """
+    return int(max(30.0, audio_seconds * 2.0 + METER_TTL_PAD))

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -3122,6 +3122,7 @@ function DeviceConfigForm({ config, onChange, disabled }) {
   const activeEqPreset = (EQ_PRESETS.find(([, vals]) => JSON.stringify(vals) === JSON.stringify(bands)) || [null])[0];
 
   const [advMics, setAdvMics] = useState(false);
+  const [advRing, setAdvRing] = useState(false);
 
   const inputStyle = disabled ? { opacity: 0.45, pointerEvents: 'none' } : {};
   const mono = "'DM Mono',monospace";
@@ -3350,6 +3351,34 @@ function DeviceConfigForm({ config, onChange, disabled }) {
             </div>
           )}
         </div>
+        <StageAdvanced open={advRing} onToggle={() => setAdvRing(o => !o)} disabledStyle={inputStyle}>
+          <div style={{ fontFamily: mono, fontSize: 10, color: 'var(--text2)', lineHeight: 1.6, marginBottom: 12 }}>
+            While a response plays, the ring throbs with the live speaker level. These shape how
+            hard it throbs — the device renders it locally, so changes apply on the next response
+            with no restart. Defaults are tuned for speech; raise Decay and Gamma for a punchier
+            ring, lower them for a calmer one.
+          </div>
+          <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px 24px' }}>
+            <Slider label="Decay" sub="how fast it falls — higher tracks individual syllables"
+              value={config.meterDecay ?? 0.30} min={0.02} max={1} step={0.02}
+              onChange={v => set('meterDecay', v)}/>
+            <Slider label="Attack" sub="how fast it rises on a peak"
+              value={config.meterAttack ?? 0.6} min={0.05} max={1} step={0.05}
+              onChange={v => set('meterAttack', v)}/>
+            <Slider label="Gamma" sub="contrast — higher makes the swing more visible"
+              value={config.meterGamma ?? 2.2} min={1} max={3.5} step={0.1}
+              onChange={v => set('meterGamma', v)}/>
+            <Slider label="Floor" sub="brightness during silence; 0 = fully dark between words"
+              value={config.meterFloor ?? 0.06} min={0} max={0.6} step={0.02}
+              onChange={v => set('meterFloor', v)}/>
+            <Slider label="Reference" sub="speaker level mapped to full brightness — lower = more sensitive"
+              value={config.meterRef ?? 0.22} min={0.02} max={1} step={0.02}
+              onChange={v => set('meterRef', v)}/>
+            <Slider label="Curve" sub="below 1 lifts quiet consonants into view"
+              value={config.meterCurve ?? 0.7} min={0.3} max={2} step={0.05}
+              onChange={v => set('meterCurve', v)}/>
+          </div>
+        </StageAdvanced>
       </Stage>
 
       {/* 05 ADVANCED — button-turn internals: processing + speech gate */}

--- a/controller/tests/test_scenes.py
+++ b/controller/tests/test_scenes.py
@@ -66,3 +66,70 @@ def test_pride_rotates_whole_palette():
     for i in range(em_scenes.NUM_LEDS):
         a, b = f1[i], f0[(i - 1) % em_scenes.NUM_LEDS]
         assert (a["r"], a["g"], a["b"]) == (b["r"], b["g"], b["b"])
+
+
+# ─── meter response curve (dashboard-tunable) ────────────────────────────────
+
+def test_meter_curve_omits_absent_keys():
+    """
+    Absent config keys must NOT be sent: an empty override means "use the
+    firmware default", which lets the device move its defaults without every
+    stored config pinning the old ones.
+    """
+    anim = em_scenes.resolve({})["meter_anim"]
+    for k in ("attack", "decay", "floor", "gamma", "ref", "curve"):
+        assert k not in anim
+
+
+def test_meter_curve_passes_through_and_clamps():
+    anim = em_scenes.resolve({
+        "meterDecay": 0.5, "meterFloor": 0.0,
+        "meterGamma": 99, "meterRef": -1, "meterCurve": "bogus",
+    })["meter_anim"]
+    assert anim["decay"] == 0.5
+    assert anim["floor"] == 0.0          # 0 is a real value, not "absent"
+    assert anim["gamma"] == 3.5          # clamped to the top of the range
+    assert anim["ref"] == 0.02           # clamped to the bottom
+    assert "curve" not in anim           # unparseable is dropped, not crashed
+
+
+def test_turn_state_ttls_are_bounded():
+    """
+    A controller that dies mid-turn used to leave the ring animating for
+    three minutes. Each phase's TTL must now be bounded by what that phase
+    can legitimately take.
+    """
+    scene = em_scenes.resolve({})
+    assert scene["listening_anim"]["ttlSec"] <= 30
+    # The spinner spans HA think time AND the TTS fetch, so its TTL has to
+    # outlast _fetch_tts_audio's timeout (60s, two attempts) or it clears
+    # the ring during exactly the long responses that need it. Guard the
+    # coupling so moving one without the other fails here.
+    assert scene["spin_anim"]["ttlSec"] >= 120
+    assert scene["spin_anim"]["ttlSec"] <= 180
+
+
+def test_meter_ttl_scales_with_response_length():
+    """
+    The meter TTL must always exceed the response it is showing — a fixed
+    value would clear the ring part-way through a long answer, which is the
+    exact bug the playback_stats rendezvous fixes at the other end.
+    """
+    assert em_scenes.meter_ttl(0.5) >= 30           # short clips get a floor
+    for seconds in (5, 30, 120, 600):
+        assert em_scenes.meter_ttl(seconds) > seconds * 1.5
+
+
+def test_outcome_cues_are_self_clearing_and_distinct():
+    """
+    Cues must retire on the device's own ticker (no follow-up message to
+    lose) and must be told apart by rhythm, since colour is already spoken
+    for by mute/link/volume.
+    """
+    scene = em_scenes.resolve({})
+    ns, err = scene["nospeech_anim"], scene["error_anim"]
+    for a in (ns, err):
+        assert a["pattern"] == "pulse"
+        assert 0 < a["ttlSec"] <= 2
+    assert ns["periodMs"] != err["periodMs"]
+    assert err["periodMs"] < ns["periodMs"]   # error reads as more agitated

--- a/device/internal/server/animator.go
+++ b/device/internal/server/animator.go
@@ -37,6 +37,66 @@ type AnimSpec struct {
 	// TTLSec auto-clears the ring if no newer spec arrives — protects
 	// against a controller that died mid-turn. 0 → no TTL.
 	TTLSec int `json:"ttlSec"`
+
+	// ── meter-only response curve ────────────────────────────────────────
+	// Pointer-typed so 0 is expressible and "absent" is distinguishable
+	// from "zero" (same reason micGainDb is a pointer in ConfigMessage).
+	// Nil fields fall back to the meterDefaults below.
+	//
+	// Tunable from the dashboard because this is a *taste* parameter: the
+	// original fixed curve measured only ~23% perceived brightness
+	// variation on speech (see docs/led-ring-states.md), and finding a
+	// value that reads well in a real room takes several passes. Shipping
+	// them as config turns that loop into a page refresh instead of a
+	// firmware OTA per iteration.
+	Attack *float64 `json:"attack"` // envelope rise coefficient per 40ms tick
+	Decay  *float64 `json:"decay"`  // envelope fall coefficient per 40ms tick
+	Floor  *float64 `json:"floor"`  // perceptual brightness at silence
+	Gamma  *float64 `json:"gamma"`  // output gamma; >1 expands the dark end
+	Ref    *float64 `json:"ref"`    // RMS mapped to full scale
+	Curve  *float64 `json:"curve"`  // input exponent; <1 lifts quiet detail
+}
+
+// meterDefaults are the shipped response curve. Derived in
+// docs/led-ring-states.md §"Why it's barely visible":
+//   - decay 0.30 → τ≈133ms, which tracks syllables (150-250ms). The old
+//     0.12 gave τ≈333ms and smoothed everything below phrase rate away,
+//     which is why the ring looked nearly static during speech.
+//   - floor 0.06 + gamma 2.2: the paint is (floor+span*env)^gamma, so the
+//     value is a *perceptual* target rather than a raw duty cycle. Without
+//     the gamma the eye sees roughly the 1/2.2 power of the linear swing,
+//     which is what compressed the old range into invisibility.
+//   - ref 0.22 / curve 0.7 replace sqrt(rms/0.35): a gentler lift that
+//     keeps quiet consonants visible without squashing normal speech into
+//     the top of the range.
+var meterDefaults = struct {
+	attack, decay, floor, gamma, ref, curve float64
+}{
+	attack: 0.6,
+	decay:  0.30,
+	floor:  0.06,
+	gamma:  2.2,
+	ref:    0.22,
+	curve:  0.7,
+}
+
+// resolveMeter returns spec's meter parameters with defaults filled in and
+// each value clamped to a range that cannot produce a dead or seizure-grade
+// ring — a bad config push must not be able to break the display.
+func resolveMeter(spec AnimSpec) (attack, decay, floor, gamma, ref, curve float64) {
+	pick := func(p *float64, def, lo, hi float64) float64 {
+		if p == nil {
+			return def
+		}
+		return math.Min(hi, math.Max(lo, *p))
+	}
+	attack = pick(spec.Attack, meterDefaults.attack, 0.05, 1.0)
+	decay = pick(spec.Decay, meterDefaults.decay, 0.02, 1.0)
+	floor = pick(spec.Floor, meterDefaults.floor, 0.0, 0.6)
+	gamma = pick(spec.Gamma, meterDefaults.gamma, 1.0, 3.5)
+	ref = pick(spec.Ref, meterDefaults.ref, 0.02, 1.0)
+	curve = pick(spec.Curve, meterDefaults.curve, 0.3, 2.0)
+	return
 }
 
 // animator owns the ring animation goroutine. One animation at a time; a
@@ -180,16 +240,19 @@ func (s *Server) runPulse(gen int, spec AnimSpec) {
 }
 
 // runMeter throbs the palette with the live speaker level: fast attack,
-// slow decay envelope over the RMS the speaker reports at its ALSA write —
-// so the ring follows what is audible *now*, not the controller's send
-// pace (~5.5s of device buffer sits between the two). A 15% floor keeps
-// the ring visibly owned by the turn through inter-word silence.
+// decay envelope over the RMS the speaker reports at its ALSA write — so
+// the ring follows what is audible *now*, not the controller's send pace
+// (~5.5s of device buffer sits between the two). The floor keeps the ring
+// visibly owned by the turn through inter-word silence. Response curve is
+// config-tunable — see AnimSpec's meter fields and meterDefaults.
 func (s *Server) runMeter(gen int, spec AnimSpec) {
 	var deadline time.Time
 	if spec.TTLSec > 0 {
 		deadline = time.Now().Add(time.Duration(spec.TTLSec) * time.Second)
 	}
 	base := paletteFrame(spec.Colors)
+	attack, decay, floor, gamma, ref, curve := resolveMeter(spec)
+	span := 1.0 - floor
 	env := 0.0
 	ticker := time.NewTicker(40 * time.Millisecond)
 	defer ticker.Stop()
@@ -204,15 +267,19 @@ func (s *Server) runMeter(gen int, spec AnimSpec) {
 			}
 			return
 		}
-		// Speech RMS at the speaker typically peaks ~0.2-0.4 full-scale;
-		// sqrt lifts the quiet tail so consonants still register.
-		level := math.Sqrt(math.Min(1, s.getAudioLevel()/0.35))
+		// Input curve: normalise the speaker RMS against ref, then apply
+		// curve (<1 lifts quiet detail so consonants register).
+		level := math.Pow(math.Min(1, s.getAudioLevel()/ref), curve)
 		if level > env {
-			env += 0.6 * (level - env) // fast attack
+			env += attack * (level - env) // fast attack
 		} else {
-			env += 0.12 * (level - env) // slow decay
+			env += decay * (level - env) // decay tracks syllable rate
 		}
-		b := 0.15 + 0.85*env
+		// floor+span*env is a PERCEPTUAL brightness target; raising it to
+		// gamma converts to the duty cycle that the eye reads as that
+		// target. Painting the target directly (the pre-2026-07-25
+		// behaviour) is what made the throb near-invisible.
+		b := math.Pow(floor+span*env, gamma)
 		s.SetLEDs(scaleFrame(base, b), boolPtr(false))
 		<-ticker.C
 	}

--- a/device/internal/server/animator_test.go
+++ b/device/internal/server/animator_test.go
@@ -1,6 +1,9 @@
 package server
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestSpinFrame(t *testing.T) {
 	spec := AnimSpec{
@@ -72,5 +75,65 @@ func TestPaletteFrame(t *testing.T) {
 	frame = paletteFrame([][3]uint8{{1, 0, 0}, {2, 0, 0}})
 	if frame[0].R != 1 || frame[1].R != 2 || frame[2].R != 0 {
 		t.Fatalf("partial palette wrong: %+v", frame[:3])
+	}
+}
+
+func TestResolveMeterDefaultsAndClamps(t *testing.T) {
+	// Absent fields fall back to the shipped curve.
+	a, d, f, g, r, c := resolveMeter(AnimSpec{Pattern: "meter"})
+	if a != meterDefaults.attack || d != meterDefaults.decay ||
+		f != meterDefaults.floor || g != meterDefaults.gamma ||
+		r != meterDefaults.ref || c != meterDefaults.curve {
+		t.Fatalf("defaults not applied: %v %v %v %v %v %v", a, d, f, g, r, c)
+	}
+
+	// floor=0 must survive: it is a legitimate value (fully dark at
+	// silence), which is the whole reason these fields are pointers.
+	zero := 0.0
+	_, _, f0, _, _, _ := resolveMeter(AnimSpec{Floor: &zero})
+	if f0 != 0.0 {
+		t.Fatalf("floor 0 not honoured, got %v", f0)
+	}
+
+	// Out-of-range values clamp rather than producing a dead ring: a
+	// config push must not be able to break the display.
+	huge, neg := 99.0, -5.0
+	at, dc, fl, gm, rf, cv := resolveMeter(AnimSpec{
+		Attack: &huge, Decay: &neg, Floor: &huge,
+		Gamma: &neg, Ref: &neg, Curve: &huge,
+	})
+	if at != 1.0 || dc != 0.02 || fl != 0.6 || gm != 1.0 || rf != 0.02 || cv != 2.0 {
+		t.Fatalf("clamping wrong: %v %v %v %v %v %v", at, dc, fl, gm, rf, cv)
+	}
+}
+
+// TestMeterCurveIsVisiblyVaried is the regression guard for the reported
+// "too subtle to distinguish from a solid ring" bug. It asserts the shipped
+// curve produces a wide PERCEPTUAL swing across ordinary speech levels —
+// the old curve (sqrt(rms/0.35), floor .15, no gamma) managed only ~23%.
+func TestMeterCurveIsVisiblyVaried(t *testing.T) {
+	_, _, floor, gamma, ref, curve := resolveMeter(AnimSpec{Pattern: "meter"})
+	span := 1.0 - floor
+
+	// Perceived lightness of a painted duty cycle b is ~b^(1/gamma), so
+	// with the gamma encoding the perceptual value is just floor+span*env.
+	perceived := func(rms float64) float64 {
+		env := math.Pow(math.Min(1, rms/ref), curve)
+		b := math.Pow(floor+span*env, gamma)
+		return math.Pow(b, 1.0/gamma)
+	}
+
+	quiet, loud := perceived(0.02), perceived(0.20)
+	if got := loud - quiet; got < 0.55 {
+		t.Fatalf("perceptual swing across speech only %.2f, want >=0.55 "+
+			"(quiet=%.2f loud=%.2f) — meter will read as a solid ring", got, quiet, loud)
+	}
+	// Silence must still be visibly lit: the ring belongs to the turn.
+	if s := perceived(0.0); s < 0.03 {
+		t.Fatalf("silence too dark (%.3f) — ring reads as off mid-response", s)
+	}
+	// And full scale must not clip below full brightness.
+	if p := perceived(1.0); p < 0.99 {
+		t.Fatalf("peak not full brightness: %.3f", p)
 	}
 }

--- a/docs/led-ring-states.md
+++ b/docs/led-ring-states.md
@@ -1,0 +1,456 @@
+# LED Ring State Model
+
+The 12-LED ring (plus the discrete mute-button LED) is EchoMuse's entire user
+interface. There is no screen and no other indicator, so the ring carries the
+whole burden of telling someone what the device is doing.
+
+**Core requirement:** the ring must be *unjarring*, *consistent*, and
+*understandable*. A ring that lights and then leads nowhere is worse than a
+ring that never lit.
+
+This document is the authoritative behavioural spec: every ring owner, every
+event, and the outcome for each. Entries are tagged:
+
+- **[today]** — current shipped behaviour (v2.9.7)
+- **[proposed]** — design not yet built, pending sign-off
+
+---
+
+## 1. Design principles
+
+1. **Never show a state the system cannot honour.** Optimistic feedback is
+   allowed only where it can be *bounded and resolved* — confirmed by the
+   controller, or visibly withdrawn.
+2. **Feedback local, decisions remote.** The device owns what it can know
+   first-hand (a button was pressed, its own speaker buffer emptied, it is
+   muted). The controller owns what requires knowledge the device lacks (was
+   a wake word spoken, did HA answer, which device should respond).
+3. **One meaning per signal.** Orange already means "controller unreachable".
+   New failure modes resolve into existing vocabulary rather than inventing
+   signals a user would have to learn.
+4. **Every provisional state resolves.** No state may be held indefinitely on
+   an assumption. Provisional paints carry a deadline; animations carry a TTL
+   dead-man.
+5. **Device-sovereign states are never overridden by the network.** Mute is
+   the canonical case: it must be correct with the controller absent, wedged,
+   or lying.
+
+---
+
+## 2. Ring owners — priority ladder
+
+Highest layer that is active wins the physical paint. Lower layers still
+*record* their state (`baseLEDs`) so the ring can be handed back correctly on
+expiry.
+
+| # | Owner | Visual | Lifetime | Sovereignty | Code |
+|---|---|---|---|---|---|
+| 1 | **Volume arc** | Cyan, N of 12 proportional | 2s window (`volumeLEDSecs`) | Device-local; physical presses only | `volume.go:145` |
+| 2 | **Mute ring** | Solid red `(180,0,0)` + button LED (gpio444, active-high) | Until unmuted; survives reboot + OTA | **Device-sovereign**, persisted to `/data/local/etc/echomuse/state.json` | `mute.go:132` |
+| 3 | **Link state** | Orange sine pulse (disconnected) / white slow pulse (pending approval) | Until link resolves | Device-local | `cmd/server.go:161,174` |
+| 4 | **Turn / media animation** | `solid` · `spin` · `rotate` · `pulse` · `meter` · `off`, scene-coloured | Until replaced or `ttlSec` (180s) expires | Controller-specified, device-rendered | `animator.go:53` |
+| 5 | **Direction overlay** | Base ring colour brightened toward white at the beam angle | While listening ring is up | Device-local, requires `listeningLEDs` | `server.go:269` |
+| 6 | **Idle** | All off | — | — | — |
+
+### Suppression rules [today]
+
+Both layer 1 and layer 2 suppress the hardware paint for layers 3–5, while
+still recording into `baseLEDs`:
+
+```go
+if s.volume.DisplayActive() || s.mute.IsMuted() {
+    return          // server.go:381 (SetLEDs), server.go:275 (SetDirectionLEDs)
+}
+```
+
+Between layers 1 and 2, the volume arc wins for its window — both paint the
+hardware directly, and the arc paints last. Its expiry timer is mute-aware and
+restores the red ring rather than handing back to the controller:
+
+```go
+if vc.isMuted != nil && vc.isMuted() {
+    lc.SetLEDs(redRing...)      // volume.go:177
+} else if expire != nil {
+    expire()                    // → paintBaseLEDs()
+}
+```
+
+Layer 4 animations run on the device's own ticker and route every frame through
+`SetLEDs`, so they inherit the suppressions and keep `baseLEDs` current. This
+makes the volume-arc hand-back seamless mid-animation: the animator has been
+updating `baseLEDs` throughout the suppressed window, so `paintBaseLEDs()`
+paints the *latest* frame, and the next tick (≤80ms) resumes normally.
+
+Replacement is atomic via a generation counter — a stale animation goroutine
+can never paint over its successor (`animator.go:45-48`).
+
+---
+
+## 3. Link availability — three states, not two
+
+Local feedback must be link-aware, which requires a sharper notion of
+availability than the code currently has.
+
+| State | Meaning | Local feedback permitted? |
+|---|---|---|
+| **LINKED** | Control WS registered *and* recent inbound evidence | Yes |
+| **SUSPECT** | Socket believed up, but no recent evidence — or an interaction went unconfirmed | No — resolve to DOWN |
+| **DOWN** | Socket closed, or awaiting approval | No — show link state (layer 3) |
+
+### The problem with what exists [today]
+
+```go
+func (c *ControlClient) IsConnected() bool {
+    return c.conn != nil        // control.go:131
+}
+```
+
+`c.conn` goes nil only when the read loop errors, which is governed by
+`wsPongWait = 45 * time.Second` (`data.go:61`). So for a silently-dead link —
+controller stopped, WiFi blackhole, controller event loop wedged — the device
+reports **connected for up to 45 seconds** after the controller is gone, and
+the orange pulse does not start.
+
+Gating optimistic paint on `IsConnected()` therefore produces a 45s window in
+which the ring confidently lights and nothing happens. That window is *exactly*
+when a user is most likely to be pressing the button — they press because
+nothing responded. It satisfies the requirement literally and violates it
+completely.
+
+A second gap: socket liveness cannot see a controller that is connected but
+**unable to serve** — HA down, pipeline erroring, event loop stalled.
+
+### Passive detection has a floor [proposed]
+
+Inbound evidence during idle arrives from the controller's ping loop every
+**30s** (`em_controller.py:1674`). So a passive freshness threshold cannot be
+tighter than ~35s without false positives. **Passive liveness alone cannot
+give fast detection.** This is the structural reason the design below is
+built on per-interaction confirmation rather than a connection flag.
+
+### Per-interaction confirmation [proposed]
+
+Don't ask "is the controller there?" Ask "did the controller acknowledge
+*this* interaction?"
+
+- On a local interaction, paint immediately and arm a **confirmation deadline**.
+- Any controller message that owns the ring (`led_anim` / `leds`) before the
+  deadline confirms it and replaces the provisional paint. **This mechanism
+  already exists** — the generation counter does exactly this. No protocol
+  change.
+- Deadline expires with nothing → the interaction was not honoured. Transition
+  to DOWN and show the orange pulse (layer 3).
+
+Measured basis: the controller emits its response **sub-millisecond** after a
+button event arrives, so the deadline needs to cover only two network hops.
+Observed uplink latency, detection → first mic frame, over 79 wake turns:
+
+| device | median | p90 | max | RSSI |
+|---|---|---|---|---|
+| Office | 264ms | 272ms | 278ms | −25 |
+| Lounge | 260ms | 294ms | 952ms | −52 |
+| Retreat | 258ms | 1046ms | 1225ms | −66 |
+
+The tail tracks RSSI, so any deadline must clear Retreat's worst case, not
+Office's typical. See §6 Q3 — because the deadline costs nothing in the happy
+path, the answer is to set it generously rather than tightly, which makes RTT
+instrumentation confirmatory rather than blocking.
+
+Side benefit: an unconfirmed interaction is a far faster link-failure detector
+than the 45s pong timeout. The button becomes an active probe, and local
+feedback and connection-awareness reinforce each other instead of conflicting.
+
+---
+
+## 4. Event → outcome tables
+
+State names used below: `IDLE`, `LISTENING`, `THINKING`, `PLAYING`, `MUTED`,
+`VOL-DISPLAY` (2s arc window), `DISCONNECTED`, `PENDING`.
+
+### 4.1 Action (dot) button — clickType 138
+
+| # | State | Link | Device action | Ring outcome | Controller | Status |
+|---|---|---|---|---|---|---|
+| A1 | IDLE | LINKED | Send button event | *Nothing until controller replies* — ring lights one RTT later | Starts turn, sends `led_anim` listening | [today] |
+| A2 | IDLE | LINKED | Send button event **+ paint listening ring locally**, arm confirmation deadline | Listening ring **immediately** | Confirms with `led_anim` listening, replacing provisional paint | [proposed] |
+| A3 | IDLE | LINKED, no confirmation before deadline | Withdraw provisional paint, mark link DOWN | **Hard cut** to orange pulse — no fade (§6 Q4) | — | [proposed] |
+| A4 | IDLE | DOWN / SUSPECT | Do not send, do not paint a turn state | Orange pulse continues (unchanged) | — | [proposed] |
+| A5 | LISTENING / THINKING / PLAYING | LINKED | Send button event | Ring clears when controller's cleanup arrives | Cancels turn (`cancel_event` + `speaker_flush`); **local only — HA's pipeline runs to completion, result discarded** (`em_esphome.py:1158`) | [today] |
+| A6 | LISTENING / THINKING / PLAYING | LINKED | Send button event **+ clear ring locally** (press during a turn state is unambiguously *cancel*) | Ring clears **immediately** | Cancels as above | [proposed] |
+| A7 | **MUTED** | any | **Blocked device-side — event never sent** (`cmd/server.go:149`) | Red ring unchanged — **silent by design** (see §6 Q1) | — | [today, keep] |
+| A9 | VOL-DISPLAY | LINKED | Send button event; arc keeps the ring for its window | Arc completes, then hands back to the turn animation | Starts turn normally | [today] |
+
+### 4.2 Mute button — clickType 113 (device-local, never leaves the device)
+
+| # | State | Device action | Ring outcome | Controller | Status |
+|---|---|---|---|---|---|
+| M1 | IDLE | ADC mute all 4 codec pairs, persist to state.json, button LED on | Solid red; **suppresses all controller paints** | Notified via `mute_state` | [today] |
+| M2 | LISTENING / THINKING / PLAYING | As M1 | Solid red immediately; the cancelled turn's LED cleanup arrives *after* and is correctly ignored | Cancels turn + `speaker_flush` | [today] |
+| M3 | MUTED (unmute) | ADC unmute, clear ring, button LED off, persist | Ring black; next controller frame repaints | Notified via `mute_state` | [today] |
+| M4 | VOL-DISPLAY | As M1 — red painted directly | Red wins (painted last); arc expiry is mute-aware and restores red | Notified | [today] |
+| M5 | DISCONNECTED | As M1 — **works with no controller at all** | Solid red replaces orange pulse | None | [today] |
+| M6 | Boot after reboot/OTA while muted | `RestoreMuted()` — ADC + flag pre-connect; ring + button LED once LED init completes | Red, before any controller contact | None | [today] |
+
+Mute is the reference implementation of principle 5, and its behaviour is
+**not changing**.
+
+### 4.3 Volume buttons — clickType 115 / 114 (device-local)
+
+| # | State | Device action | Ring outcome | Status |
+|---|---|---|---|---|
+| V1 | IDLE | `Set(level, showRing=true)` | Cyan arc 2s → black | [today] |
+| V2 | LISTENING / THINKING / PLAYING | As V1 | Cyan arc 2s → hands back to the live animation mid-frame | [today] |
+| V3 | MUTED | As V1 | Cyan arc 2s → **red ring restored** (expiry is mute-aware) | [today] |
+| V4 | DISCONNECTED | As V1 | Cyan arc 2s → orange pulse resumes | [today] |
+| V5 | Remote set (controller / HA) or boot-time `SeedVolume` | `Set(level, showRing=false)` | **No arc** — nobody is at the device | [today] |
+
+### 4.4 Controller-originated ring messages
+
+| # | Message | State | Ring outcome | Status |
+|---|---|---|---|---|
+| C1 | `led_anim` listening (`solid`, `listening:true`) | any unsuppressed | Scene listening colour; enables direction overlay | [today] |
+| C2 | `led_anim` `spin`/`rotate` (thinking) | any unsuppressed | Spinner on device ticker, 80ms | [today] |
+| C3 | `led_anim` `meter` (playing) | any unsuppressed | Throbs with live speaker RMS at the ALSA write | [today] |
+| C4 | `led_anim` `off` | any unsuppressed | Ring black | [today] |
+| C5 | Any `led_anim` / `leds` | MUTED or VOL-DISPLAY | **Recorded into `baseLEDs`, not painted** | [today] |
+| C6 | Legacy `leds` frame | any unsuppressed | Atomically replaces any running animation (generation counter) | [today] |
+| C7 | No replacement within `ttlSec` (180s) | animation running | Dead-man clears the ring — protects against a controller that died mid-turn | [today] |
+
+### 4.5 Audio / link lifecycle
+
+| # | Event | State | Ring outcome | Status |
+|---|---|---|---|---|
+| L1 | Control WS registered | PENDING / DISCONNECTED | Pulse stops; mute ring restored if muted, else hand back | [today] |
+| L2 | Control WS closed (read-loop error) | any | `StopAnim()` then orange pulse | [today] |
+| L3 | Awaiting admin approval | boot | White slow pulse | [today] |
+| L4 | Link silently dead | any | **Nothing for up to 45s** — ring keeps showing the last state | [today] |
+| L5 | Link silently dead | any | Detected on the next interaction (§3) or by inbound-freshness timeout | [proposed] |
+| L6 | **Speaker stream ends** (EOS received *and* audio channel empty) | PLAYING | **Controller estimates this from wall-clock and clears the ring early on slow links** — measured up to 6.1s premature | [today] |
+| L7 | Speaker stream ends | PLAYING | Device clears / hands back the ring itself, from the signal it already logs (`pcm_speaker.go:309`) | [proposed] |
+
+---
+
+## 5. Why L6 is wrong today
+
+`_run_post_turn_playback` never learns when playback actually ended
+(`em_controller.py:746`):
+
+```python
+audio_duration = len(speaker_pcm) / (SPEAKER_RATE * 2) + SPEAKER_PRIME_SECONDS
+remaining      = max(0.0, audio_duration - elapsed)
+```
+
+`elapsed` is *socket-write* time and is **subtracted**, so the estimate shrinks
+on precisely the streams that need it longest. Measured against `delivery_ms`
+(the device's `playback_stats` arrival — a true end-of-audio signal) across the
+last 40 instrumented turns, 4 cleared the ring more than 0.5s early:
+
+| turn | tts | send_ms | delivery_ms | recv_span | ring cleared |
+|---|---|---|---|---|---|
+| 07-24 23:53 Retreat | 2.6s | 1154 | 9764 | 8193 | **6.1s early** |
+| 07-24 22:31 Lounge | 5.0s | 4296 | 9353 | 2039 | **3.2s early** |
+| 07-24 05:26 Lounge | 9.6s | 5364 | 13833 | 8275 | **3.1s early** |
+| 07-22 22:14 Lounge | 4.6s | 1 | 7417 | 4112 | **1.7s early** |
+
+Every one correlates with inflated `recv_span_ms` / `max_gap_ms`. On healthy
+turns the estimate is ~1s *conservative*, which is why this only surfaces
+occasionally.
+
+The device is the only party that knows when its own buffer empties. It already
+detects and logs exactly that. Under principle 2 this belongs to the device,
+and needs **no confirmation** — nothing is being predicted.
+
+---
+
+## 5b. Termination at the deadline [proposed]
+
+When the confirmation deadline expires, the interaction is over. Four things
+must happen, and the third is the one with teeth.
+
+**1. Ring — hard cut to orange** (§6 Q4). The device is now in link state DOWN.
+
+**2. Revert the mic locally.** By deadline time the device may already have
+received `mic_start_turn` (it precedes `led_anim` in the controller's send
+order), so a bounded turn stream may be running. The device must stop it and
+return to the continuous wake stream — `StopMic()` then `StartMic(false)`.
+
+**3. Tell the controller to abandon the turn.** Best-effort `turn_abort` control
+message. **This is mandatory, not optional, and the reason is privacy rather
+than tidiness:** without it the controller runs a full voice turn — streaming
+mic audio to HA — while the device shows orange. A device that is listening with
+no ring is exactly the state that must never exist. The controller releases
+`voice_lock`, cancels the turn, and stops the mic stream.
+
+The abort reaches the controller in the common case, because the common cause of
+a late reply is a controller that is *slow but alive*. If the link genuinely
+dropped, reconnection already resets the ring (`leds_off` on config push,
+`em_controller.py:1638`) and the controller's own turn fails with the socket.
+
+**4. Refuse late arrivals for the abandoned interaction.** Belt-and-braces for
+the race where the abort and a late `led_anim` cross in flight. The device
+stamps each local interaction with a monotonically increasing **interaction
+epoch**, sends it with the button event, and the controller echoes it on the
+turn's ring messages. An `led_anim` carrying an epoch older than the device's
+current one is discarded.
+
+This is the same generation-counter pattern the animator already uses
+(`animator.go:45`), extended across the wire — a stale response can never paint
+over its successor. Blanket-ignoring `led_anim` for a period would be wrong: it
+would also suppress a legitimate *new* turn from a second press or a wake word.
+
+### Interaction with the pre-existing button race
+
+There is a latent race in `handle_button_event` that termination semantics would
+turn from harmless into user-visible. The start/cancel decision reads
+`device.voice_lock.locked()`, but the spawned task does not acquire the lock
+until several awaits later:
+
+```python
+if device.voice_lock.locked():   # em_controller.py:1433
+    ...cancel...
+else:
+    _btn_task = asyncio.create_task(_button_voice_turn())   # acquires the lock later
+```
+
+Two presses inside that window both see the lock free and both queue a turn. The
+second turn's `led_anim` is then delayed by however long the first turn takes —
+easily beyond any sane deadline. Under termination semantics the device would go
+orange, abort, and the controller would still run the queued turn.
+
+**So this fix belongs in the same change:** make the start path claim the turn
+synchronously in the handler (a `turn_pending` flag set before spawning, or
+acquire the lock in the handler), so the cancel/start decision is atomic. It was
+not observable in the 2026-07-25 field test — presses ~700ms apart never
+collided — but a fast double-tap would.
+
+---
+
+## 6. Decisions
+
+### Q1 — refused press while muted: **stay silent** (decided)
+
+The red ring plus the red mute-button LED are sufficient signal that the device
+is deaf. This is how Alexa behaves, and there is no reason to reinvent
+behaviour that extensive focus-group work has already settled. No re-assert
+flash, no refusal signal. Row A7 stands as-is.
+
+### Q2 — how the device knows it is mid-turn: **semantic field on `led_anim`** (recommended)
+
+This matters only for row A6 (clearing the ring immediately on a cancel press).
+Without it, the device would have to paint listening on *every* dot press,
+which flashes the wrong state for one RTT whenever the press was a cancel.
+
+**Option A — infer from the current animation.** The animator stores only
+`{mu, gen}` (`animator.go:45`) — no pattern — so this needs the current pattern
+recorded alongside the generation. Roughly three lines.
+
+*Correctness today is exact:* neither `em_player` nor the announcement path
+paints the ring (announcements call `_run_post_turn_playback` directly, which
+has no LED calls), so "ring shows a turn state" ⟺ "a voice turn is active".
+
+*The risk is a future foot-gun, not a present bug.* The equivalence is an
+implicit contract. The day music playback gains a meter ring — a very natural
+feature request — the dot button silently changes meaning during music, and
+nothing fails loudly. The ring would simply start clearing on presses that
+actually start turns.
+
+**Option B — derive from device audio/mic state.** Not viable. Wake-triggered
+turns deliberately keep the continuous ungated stream and never send
+`mic_start_turn` (P0-1), so `micActive && lockMic` is **false during the
+listening phase of the most common turn type**. And `streamActive` is also true
+for music and announcements — the inverse of A's problem. Neither signal, alone
+or combined, covers the state space.
+
+**Option C — explicit semantic from the controller.** The authority for "will
+my press be read as cancel?" is literally `device.voice_lock.locked()`; any
+device-side inference is a replica. The controller already sends an `led_anim`
+on **every** turn-state change, so adding a semantic field to that message
+(`state: listening | thinking | playing | idle`) costs **zero extra traffic**
+and two transitions per turn.
+
+**Recommendation: Option C.** It keeps A's zero-cost property while removing
+A's implicit contract — the device reads a declared state instead of inferring
+intent from pixel colour, and a future music-meter feature cannot silently
+change button semantics. It also makes the provisional paint self-describing:
+the device sets its own semantic state when it paints optimistically, and the
+controller's next `led_anim` either confirms or overrides it.
+
+Staleness (one RTT) is identical for A and C and is irreducible, so it does not
+differentiate them. Both drift directions self-correct within one RTT.
+
+### Q3 — confirmation deadline: **fixed, 3–3.5s** (recommended)
+
+Because the deadline **terminates the turn** (Q4), a false withdrawal now costs
+the user a real turn, not just a flicker. The deadline is therefore *not* free,
+and its floor is the worst legitimate time-to-first-inbound-message.
+
+That worst case is one full round trip: the controller emits its first response
+sub-millisecond after the button event arrives (measured — "Dot button → voice
+turn" and "Voice turn starting" land in the same millisecond), so the only
+variable is the wire. Retreat's uplink leg measures 1046ms p90 / 1225ms max, so
+a round trip worst case is ~2.5s.
+
+**3–3.5s** clears that with margin while remaining ~13× better than today's 45s
+blindness. Erring long is still correct: over-waiting costs a slower error
+indication, under-waiting kills turns the user wanted.
+
+**Fixed, not adaptive.** Per-device adaptive deadlines add state and a tuning
+surface to guard against a rare failure. Revisit only if field data shows
+Retreat-class devices false-aborting.
+
+**Confirmation is *any* inbound control message, not specifically `led_anim`.**
+This matters and it is not obvious: for a button turn the controller sends
+`mic_stop` → `mic_start_turn` → `led_anim`, so `mic_start_turn` is an *earlier*
+proof of life than the ring message. Arming the deadline against any inbound
+traffic is a strictly weaker condition, satisfied sooner, and therefore
+false-aborts less. `led_anim` remains the sole authority for ring *state*;
+liveness and ring-state authority are separate concerns.
+
+*RTT instrumentation* stays confirmatory rather than blocking — validate in the
+field that no legitimate first response exceeds the deadline.
+
+### Q4 — provisional-paint withdrawal: **hard cut to orange, and terminate the turn** (decided)
+
+A hard cut draws attention to an error state; a fade softens something that
+should be noticed.
+
+**The deadline terminates the interaction — it is not merely a repaint.** Once
+the device has gone orange and told the user "the controller is not answering",
+a late arrival that resurrects the turn only confuses them. The turn ends at the
+deadline, and anything that arrives afterwards for that interaction is refused.
+
+See §5b for what termination requires. Note the knock-on to Q3: because the
+deadline now ends a real turn rather than just changing a colour, it is no
+longer free, and its floor is set by the worst legitimate round trip.
+
+---
+
+## 7. Invariants — do not break
+
+- **Mute is device-sovereign.** Correct with no controller, wedged controller,
+  or lying controller. Persisted locally; survives OTA slot flips.
+- **The volume arc owns the ring for its full 2s window.** Turn animations
+  repaint every ~80ms and would otherwise stomp it within one frame.
+- **Arc expiry is mute-aware.** It must restore red when muted, never hand back
+  to controller state.
+- **`ttlSec` dead-man stays.** It is the only protection against a controller
+  that dies mid-animation.
+- **Animation replacement stays atomic** (generation counter). A stale
+  goroutine must never paint over its successor.
+- **`baseLEDs` keeps recording while suppressed.** This is what makes hand-back
+  seamless.
+- **The direction overlay requires `listeningLEDs`** and brightens the base
+  colour — it must never paint a hardcoded green, which reads as a glitch on
+  any non-standard scene.
+
+---
+
+## 8. Risk note
+
+The LED priority system is the most-repaired subsystem in this codebase — the
+two paint suppressions in §2 were each won the hard way, and their comments
+record why. Adding a provisional-paint layer means adding a **fourth**
+arbitration rule. The proposals here are deliberately staged so the
+lowest-risk, fully-evidenced change (L7) can ship independently of the
+provisional-paint layer (A2/A3/A6), which carries the new arbitration rule and
+the `led_anim` semantic field.


### PR DESCRIPTION
Ring UX work driven by field reports, plus @kopiro's TTS fetch timeout fix from #28.

### 1. The playback meter was invisible

Reported as "too subtle, barely distinguishable from a solid listening ring". Four causes compounded — decay too slow to track syllables (t~333ms), `sqrt(rms/0.35)` squashing speech into the top of the range, a 0.15 floor narrowing it further, and the result painted as a raw duty cycle when the eye reads roughly its 1/2.2 power. Net perceptual swing across speech was **~0.28**.

Now ~0.70, about 2.5x, and **all six curve parameters are tunable from Config -> Ring -> Advanced** — this is a taste setting, and a firmware OTA per tuning pass is not a sane loop. Device clamps independently of the UI ranges.

### 2. The ring cleared before the audio finished

`_run_post_turn_playback` estimated completion from wall-clock and *subtracted* socket-write time, which completes near-instantly however slow the wire is — so the estimate shrank on exactly the streams that needed longest. Measured **6.1s early** on Retreat, 3.2s on Lounge. Now waits for the device's `playback_stats`, which is the real end of audio.

### 3. Turn-state TTLs were a flat 180s

A controller dying mid-turn left the ring animating for three minutes. Listening 30s, spinner 135s (deliberately coupled to the TTS fetch timeout, with a test guarding the pair), meter computed per playback from actual response length.

### 4. Every turn ending looked identical

`no_speech`, `no_tts` and success all just turned the ring off. Now distinguished by rhythm — colour is already spoken for by mute/link/volume.

### Field validation

Fleet is running this as `20260725-0547-dev` (no tag). Meter legibility confirmed by eye. Both controller-side paths confirmed live in logs:

```
awaiting device playback_stats (est 3.4s, timeout 16.7s)
Playback complete (device-confirmed after 2.4s, est 3.4s)
Turn ended 'no_tts' - ring cue
```

### Not tested

- Outcome cues have not been provoked deliberately yet (seen firing in logs, not watched in the room)
- The meter curve is tuned by eye on one scene; other scenes may want different values
- Long-response TTL behaviour is reasoned, not exercised

### Docs

`docs/led-ring-states.md` is the full state model — ring owners, priority ladder, event-by-event outcome tables, and the reasoning for what is deliberately **not** built yet (device-local optimistic paint needs link awareness `IsConnected()` cannot give, since it only flips after `wsPongWait` = 45s).

75 controller tests, `go vet` clean, Go tests pass, JSX compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)