### PR TITLE
controller: stream Home Assistant TTS during generation

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -573,6 +573,13 @@ class Device:
         pending = bytearray()
         total_pcm = 0
         eq_seconds = 0.0
+        # Accumulated time spent WRITING to the socket, excluding time waiting
+        # for the source to produce audio. send_ms is documented as socket-write
+        # time that "completes near-instantly however slow the link is" — timing
+        # the whole streaming loop instead would fold HA's synthesis time into
+        # it and make it read like delivery, which is the misreading that cost
+        # an investigation on 2026-07-20.
+        send_seconds = 0.0
         first_send_time = None
         try:
             async for pcm in pcm_chunks:
@@ -595,7 +602,9 @@ class Device:
                             f"[{self.device_id}] First streamed PCM period "
                             "sent to device"
                         )
+                    _t_send = asyncio.get_event_loop().time()
                     await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
+                    send_seconds += asyncio.get_event_loop().time() - _t_send
 
             if pending and not self.cancel_event.is_set():
                 chunk = bytes(pending)
@@ -607,7 +616,9 @@ class Device:
                         f"[{self.device_id}] First streamed PCM period "
                         "sent to device"
                     )
+                _t_send = asyncio.get_event_loop().time()
                 await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
+                send_seconds += asyncio.get_event_loop().time() - _t_send
         finally:
             self.speaking = False
             # One EOS terminates the complete response. Sending EOS per HTTP
@@ -617,7 +628,7 @@ class Device:
             except BaseException:
                 pass
 
-        return total_pcm, int(eq_seconds * 1000), first_send_time
+        return total_pcm, int(eq_seconds * 1000), first_send_time, int(send_seconds * 1000)
 
 
 # The live device registry — keyed by device_id (ro.serialno).
@@ -1049,7 +1060,12 @@ async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
         device.eq_bands,
         device.eq_loudness,
     )
+    # Cleared BEFORE streaming starts: the device sets it when its audio
+    # channel drains after EOS, and a stale set from the previous response
+    # would end this turn the moment we started waiting.
+    device.playback_done.clear()
     cancel_task = asyncio.create_task(device.cancel_event.wait())
+    done_task   = asyncio.create_task(device.playback_done.wait())
     stream_task = asyncio.create_task(
         device.stream_speaker_chunks(pcm_chunks, stream_eq)
     )
@@ -1064,46 +1080,73 @@ async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
             log.info(f"[{device.device_id}] Cancelled during streamed playback")
             return 0
 
-        total_pcm, eq_ms, first_send_time = stream_task.result()
+        total_pcm, eq_ms, first_send_time, send_ms = stream_task.result()
         device.playback_eq_ms = eq_ms
-        elapsed = asyncio.get_event_loop().time() - t_stream_start
-        device.playback_send_ms = int(elapsed * 1000)
+        device.playback_send_ms = send_ms
+        stream_elapsed = asyncio.get_event_loop().time() - t_stream_start
         audio_duration = total_pcm / (SPEAKER_RATE * 2) + SPEAKER_PRIME_SECONDS
-        playback_elapsed = (
-            asyncio.get_event_loop().time() - first_send_time
-            if first_send_time is not None
-            else 0.0
-        )
-        remaining = (
-            max(0.0, audio_duration - playback_elapsed)
-            if total_pcm
-            else 0.0
-        )
+
+        if not total_pcm:
+            log.info(f"[{device.device_id}] Streamed response contained no audio")
+            return 0
+
+        # Wait for the DEVICE to say it finished, exactly as the buffered path
+        # does — do NOT sleep a computed `audio_duration - elapsed`.
+        #
+        # That estimate was removed on 2026-07-24 because it has no visibility
+        # of the device's own buffer and cleared the ring 6.1s early on Retreat
+        # and 3.2s on Lounge. Streaming makes it worse, not better: the time
+        # spent streaming already covers most of the audio duration, so the
+        # remainder computes to ~0 and the wait vanishes entirely while up to
+        # ~5.5s is still queued in audioChanDepth. playback_stats is emitted
+        # once that channel drains after EOS, so it is the real end of audio.
+        # The timeout is only a backstop for the report never arriving (device
+        # drop, pre-v2.9 firmware). cancel_event is still raced so a barge-in
+        # or mute lands promptly.
+        timeout = audio_duration * 2 + 10.0
         log.info(
             f"[{device.device_id}] Streamed {total_pcm} bytes "
-            f"({total_pcm//SPEAKER_BYTES} periods) while HA generated audio in "
-            f"{elapsed:.1f}s; sleeping {remaining:.1f}s for buffer drain "
-            f"(total={audio_duration:.1f}s)"
+            f"({total_pcm//SPEAKER_BYTES} periods) in {stream_elapsed:.1f}s "
+            f"while HA generated audio (socket writes {send_ms}ms — NOT "
+            f"delivery, see delivery_ms); awaiting device playback_stats "
+            f"(est {audio_duration:.1f}s, timeout {timeout:.1f}s)"
         )
-
-        if remaining > 0:
-            sleep_task = asyncio.create_task(asyncio.sleep(remaining))
+        timeout_task = asyncio.create_task(asyncio.sleep(timeout))
+        try:
             await asyncio.wait(
-                [sleep_task, cancel_task],
+                [done_task, cancel_task, timeout_task],
                 return_when=asyncio.FIRST_COMPLETED,
             )
-            sleep_task.cancel()
+        finally:
+            timeout_task.cancel()
+            await asyncio.gather(timeout_task, return_exceptions=True)
 
         if device.cancel_event.is_set():
             log.info(f"[{device.device_id}] Cancelled during streamed buffer drain")
+        elif done_task.done():
+            log.info(f"[{device.device_id}] Streamed playback complete (device reported)")
         else:
-            log.info(f"[{device.device_id}] Streamed playback complete")
+            log.warning(
+                f"[{device.device_id}] No playback_stats after {timeout:.1f}s — "
+                f"continuing (device drop or pre-v2.9 firmware)"
+            )
         return total_pcm
     finally:
-        cancel_task.cancel()
+        for t in (cancel_task, done_task):
+            t.cancel()
         if not stream_task.done():
             stream_task.cancel()
-        await asyncio.gather(cancel_task, stream_task, return_exceptions=True)
+        await asyncio.gather(cancel_task, done_task, stream_task, return_exceptions=True)
+        # Close the async generator explicitly rather than leaving it to the
+        # event loop's asyncgen hooks: its finally is what kills ffmpeg, and on
+        # a barge-in (a routine path here) deferring that to GC leaves a decoder
+        # running for an indeterminate window.
+        aclose = getattr(pcm_chunks, "aclose", None)
+        if aclose is not None:
+            try:
+                await aclose()
+            except Exception as e:
+                log.debug(f"[{device.device_id}] TTS stream close: {e}")
 
 
 async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_wakeword: bool = False):

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -1042,6 +1042,36 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
     cancel_task.cancel()
     done_task.cancel()
 
+async def _meter_at_playback_start(pcm_chunks, on_start):
+    """
+    Pass PCM through untouched, firing `on_start` when the device will have
+    begun playing it.
+
+    The device holds audio until roughly SPEAKER_PRIME_SECONDS is queued, or
+    until EOS for a response shorter than that (primePeriods, pcm_speaker.go).
+    Counting bytes handed to the streamer tracks that closely enough — the
+    socket write completes near-instantly however slow the link is, which is
+    the same property that makes send_ms useless as a delivery measure.
+
+    Exhaustion fires it too, so a two-word answer still gets a meter. If the
+    stream is cancelled or yields nothing, it never fires and the spinner
+    simply stays up until the turn's ring cleanup — the failure direction
+    that looks like "still working" rather than "dead".
+    """
+    prime_bytes = int(SPEAKER_PRIME_SECONDS * SPEAKER_RATE * 2)
+    sent = 0
+    fired = False
+    async for chunk in pcm_chunks:
+        yield chunk
+        if not fired:
+            sent += len(chunk)
+            if sent >= prime_bytes:
+                fired = True
+                await on_start()
+    if not fired:
+        await on_start()
+
+
 async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
     """
     Play decoded HA TTS while the HTTP response is still arriving.
@@ -1256,13 +1286,24 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
                     # the device; spin_task keeps waiting on stop_event
                     # and its finally still clears the ring at turn end.
                     #
+                    # RAISED WHEN AUDIO STARTS, NOT WHEN PLAYBACK IS SET UP.
+                    # The meter renders the live speaker RMS, so before the
+                    # device's ALSA write begins it draws an unlit ring. On
+                    # the buffered path that was invisible (the fetch had
+                    # already completed, so frames flushed at socket speed),
+                    # but streaming moves the fetch+decode INSIDE playback:
+                    # sending it here left the ring dark from the end of the
+                    # spinner until HA returned audio — seconds on a slow
+                    # response, and indistinguishable from a failed turn
+                    # (user report 2026-07-31). The spinner keeps running
+                    # until _meter_on fires, so the handover is continuous.
+                    #
                     # A streamed response has no known duration up front.
                     # Refresh the same bounded dead-man TTL while PCM arrives:
                     # long speech cannot outlive its meter, but a controller
                     # crash still lets the device clear the ring on its own.
                     meter = dict(device.led_scene["meter_anim"])
                     meter["ttlSec"] = em_scenes.meter_ttl(0.0)
-                    await device.send_led_anim(meter)
 
                     async def _refresh_meter_dead_man() -> None:
                         refresh_seconds = max(1.0, meter["ttlSec"] / 2)
@@ -1270,9 +1311,16 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
                             await asyncio.sleep(refresh_seconds)
                             await device.send_led_anim(meter)
 
-                    meter_refresh_task = asyncio.create_task(
-                        _refresh_meter_dead_man()
-                    )
+                    async def _meter_on() -> None:
+                        nonlocal meter_refresh_task
+                        if meter_refresh_task is not None:
+                            return
+                        await device.send_led_anim(meter)
+                        meter_refresh_task = asyncio.create_task(
+                            _refresh_meter_dead_man()
+                        )
+
+                    pcm_chunks = _meter_at_playback_start(pcm_chunks, _meter_on)
 
                 if device.barge_in_enabled:
                     # Barge-in (§3.2): keep the mic running through

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -560,6 +560,65 @@ class Device:
             except BaseException:
                 pass  # WS gone / re-cancelled — device flush self-heals on reconnect
 
+    async def stream_speaker_chunks(self, pcm_chunks, stream_eq):
+        """
+        Stream an asynchronous PCM source as one device speaker session.
+
+        StreamingEQ stays alive for the complete response so its biquad state
+        crosses HTTP chunk boundaries without clicks. Partial device periods
+        are retained until more PCM arrives and padded only once, at the true
+        end of the response.
+        """
+        self.speaking = True
+        pending = bytearray()
+        total_pcm = 0
+        eq_seconds = 0.0
+        first_send_time = None
+        try:
+            async for pcm in pcm_chunks:
+                if self.cancel_event.is_set():
+                    break
+                total_pcm += len(pcm)
+                eq_started = asyncio.get_event_loop().time()
+                pending.extend(stream_eq.process(pcm))
+                eq_seconds += asyncio.get_event_loop().time() - eq_started
+
+                while len(pending) >= SPEAKER_BYTES:
+                    if self.cancel_event.is_set():
+                        break
+                    chunk = bytes(pending[:SPEAKER_BYTES])
+                    del pending[:SPEAKER_BYTES]
+                    if first_send_time is None:
+                        first_send_time = asyncio.get_event_loop().time()
+                        self.playback_send_t0 = first_send_time
+                        log.info(
+                            f"[{self.device_id}] First streamed PCM period "
+                            "sent to device"
+                        )
+                    await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
+
+            if pending and not self.cancel_event.is_set():
+                chunk = bytes(pending)
+                chunk += bytes(SPEAKER_BYTES - len(chunk))
+                if first_send_time is None:
+                    first_send_time = asyncio.get_event_loop().time()
+                    self.playback_send_t0 = first_send_time
+                    log.info(
+                        f"[{self.device_id}] First streamed PCM period "
+                        "sent to device"
+                    )
+                await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
+        finally:
+            self.speaking = False
+            # One EOS terminates the complete response. Sending EOS per HTTP
+            # chunk would make the device repeatedly prime and flush.
+            try:
+                await asyncio.shield(self.send_data(bytes([SPEAKER_EOS_TYPE])))
+            except BaseException:
+                pass
+
+        return total_pcm, int(eq_seconds * 1000), first_send_time
+
 
 # The live device registry — keyed by device_id (ro.serialno).
 # em_api receives a reference to this dict at startup.
@@ -972,6 +1031,80 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
     cancel_task.cancel()
     done_task.cancel()
 
+async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
+    """
+    Play decoded HA TTS while the HTTP response is still arriving.
+
+    The voice-turn path keeps one ffmpeg decoder, one stateful EQ chain, and
+    one device 0x02...0x03 stream alive across all synthesized utterances.
+    Closing any layer at an arbitrary network boundary would corrupt decoding,
+    reset the EQ filters, or turn each chunk into a separate announcement.
+    """
+    log.info(
+        f"[{device.device_id}] Streaming EQ: bands={device.eq_bands} "
+        f"loudness={device.eq_loudness}"
+    )
+    stream_eq = em_eq.StreamingEQ(
+        SPEAKER_RATE,
+        device.eq_bands,
+        device.eq_loudness,
+    )
+    cancel_task = asyncio.create_task(device.cancel_event.wait())
+    stream_task = asyncio.create_task(
+        device.stream_speaker_chunks(pcm_chunks, stream_eq)
+    )
+    t_stream_start = asyncio.get_event_loop().time()
+
+    try:
+        done, _ = await asyncio.wait(
+            [stream_task, cancel_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if cancel_task in done:
+            log.info(f"[{device.device_id}] Cancelled during streamed playback")
+            return 0
+
+        total_pcm, eq_ms, first_send_time = stream_task.result()
+        device.playback_eq_ms = eq_ms
+        elapsed = asyncio.get_event_loop().time() - t_stream_start
+        device.playback_send_ms = int(elapsed * 1000)
+        audio_duration = total_pcm / (SPEAKER_RATE * 2) + SPEAKER_PRIME_SECONDS
+        playback_elapsed = (
+            asyncio.get_event_loop().time() - first_send_time
+            if first_send_time is not None
+            else 0.0
+        )
+        remaining = (
+            max(0.0, audio_duration - playback_elapsed)
+            if total_pcm
+            else 0.0
+        )
+        log.info(
+            f"[{device.device_id}] Streamed {total_pcm} bytes "
+            f"({total_pcm//SPEAKER_BYTES} periods) while HA generated audio in "
+            f"{elapsed:.1f}s; sleeping {remaining:.1f}s for buffer drain "
+            f"(total={audio_duration:.1f}s)"
+        )
+
+        if remaining > 0:
+            sleep_task = asyncio.create_task(asyncio.sleep(remaining))
+            await asyncio.wait(
+                [sleep_task, cancel_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            sleep_task.cancel()
+
+        if device.cancel_event.is_set():
+            log.info(f"[{device.device_id}] Cancelled during streamed buffer drain")
+        else:
+            log.info(f"[{device.device_id}] Streamed playback complete")
+        return total_pcm
+    finally:
+        cancel_task.cancel()
+        if not stream_task.done():
+            stream_task.cancel()
+        await asyncio.gather(cancel_task, stream_task, return_exceptions=True)
+
 
 async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_wakeword: bool = False):
     """
@@ -1066,12 +1199,13 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
                         _barge_watcher(device, playback_started)
                     )
 
-            async def post_turn_play_esphome(voice_response: bytes):
+            async def post_turn_play_esphome(pcm_chunks):
                 nonlocal spin_task, watcher
                 if spin_task is None or spin_task.done():
                     spin_task = asyncio.create_task(
                         leds_spin_green(device, stop_spin)
                     )
+                meter_refresh_task = None
                 if device.led_anim_capable:
                     # Playback ring: throb with the response's live audio
                     # level (device-side "meter" pattern, RMS measured at
@@ -1079,15 +1213,24 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
                     # the device; spin_task keeps waiting on stop_event
                     # and its finally still clears the ring at turn end.
                     #
-                    # TTL is sized to THIS response — a fixed dead-man would
-                    # eventually clear the ring part-way through a long
-                    # answer, which is the very bug being fixed elsewhere in
-                    # this turn path.
+                    # A streamed response has no known duration up front.
+                    # Refresh the same bounded dead-man TTL while PCM arrives:
+                    # long speech cannot outlive its meter, but a controller
+                    # crash still lets the device clear the ring on its own.
                     meter = dict(device.led_scene["meter_anim"])
-                    meter["ttlSec"] = em_scenes.meter_ttl(
-                        len(voice_response) / (SPEAKER_RATE * 2)
-                    )
+                    meter["ttlSec"] = em_scenes.meter_ttl(0.0)
                     await device.send_led_anim(meter)
+
+                    async def _refresh_meter_dead_man() -> None:
+                        refresh_seconds = max(1.0, meter["ttlSec"] / 2)
+                        while True:
+                            await asyncio.sleep(refresh_seconds)
+                            await device.send_led_anim(meter)
+
+                    meter_refresh_task = asyncio.create_task(
+                        _refresh_meter_dead_man()
+                    )
+
                 if device.barge_in_enabled:
                     # Barge-in (§3.2): keep the mic running through
                     # playback — the device's AEC subtracts the speaker
@@ -1108,20 +1251,29 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
                         watcher = asyncio.create_task(
                             _barge_watcher(device, playback_started)
                         )
-                    await _run_post_turn_playback(device, voice_response)
-                    return
-                # Acoustic-feedback guard (barge-in off): stop the mic
-                # BEFORE playback, not just in the post-turn finally.
-                # With the mic running through TTS pre-AEC, the device
-                # processed its own speaker echo (63-65 junk frames per
-                # turn measured 2026-07-06) and sent it upstream on the
-                # same Wi-Fi radio receiving the TTS frames (speaker
-                # underruns → audible stutter). The finally's mic_stop
-                # stays as a safety net (StopMic no-ops when already
-                # stopped); restart is owned by the continuation branch /
-                # wake listener / button handler as before.
-                await device.mic_stop()
-                await _run_post_turn_playback(device, voice_response)
+                else:
+                    # Acoustic-feedback guard (barge-in off): stop the mic
+                    # BEFORE playback, not just in the post-turn finally.
+                    # With the mic running through TTS pre-AEC, the device
+                    # processed its own speaker echo (63-65 junk frames per
+                    # turn measured 2026-07-06) and sent it upstream on the
+                    # same Wi-Fi radio receiving the TTS frames (speaker
+                    # underruns → audible stutter). The finally's mic_stop
+                    # stays as a safety net (StopMic no-ops when already
+                    # stopped); restart is owned by the continuation branch /
+                    # wake listener / button handler as before.
+                    await device.mic_stop()
+
+                try:
+                    return await _run_streaming_post_turn_playback(
+                        device, pcm_chunks
+                    )
+                finally:
+                    if meter_refresh_task is not None:
+                        meter_refresh_task.cancel()
+                        await asyncio.gather(
+                            meter_refresh_task, return_exceptions=True
+                        )
 
             # P0-1: no mic_start_turn() here on the initial (wake/button)
             # entry — for a wake turn the stream is already running on
@@ -1135,7 +1287,7 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
             # than returning to OWW idle. The reference implementation
             # (linux-voice-assistant) uses a 0.5s settle delay after TTS
             # before opening the mic — that's already covered by
-            # _run_post_turn_playback's buffer drain sleep, so no
+            # the streaming playback path's buffer drain sleep, so no
             # additional delay is needed here.
             #
             # C2 fix (2026-07-05 review): the `finally` below runs

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -40,8 +40,8 @@ Voice turn flow:
   5. Sends VoiceAssistantAudio(end=True) on VAD sentinel
   6. Receives VoiceAssistantEventResponse stream from HA (RUN_START,
      STT_END, TTS_START, etc — see ESPHOME_SPEC.md §4)
-  7. VoiceAssistantAnnounceRequest carries TTS audio URL → fetch + play
-     via existing device speaker pipeline (_run_post_turn_playback)
+  7. HA's TTS URL is decoded and played incrementally through the device
+     speaker pipeline while Assist is still producing utterances
   8. Sends VoiceAssistantAnnounceFinished when playback completes
 
 Cancel (esphome mode):
@@ -58,7 +58,7 @@ import os
 import socket
 import time
 import uuid
-from typing import TYPE_CHECKING, Optional
+from typing import AsyncIterator, TYPE_CHECKING, Optional
 
 import numpy as np
 
@@ -693,7 +693,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self,
         device,            # em_controller.Device — avoids circular import
         on_thinking,       # async callable()
-        post_turn_play,    # async callable(voice_response: bytes)
+        post_turn_play,    # async callable(pcm_chunks) -> decoded byte count
         trace: "TurnTrace | None" = None,
         preroll_discard: int = VOICE_PREROLL_DISCARD,
     ) -> None:
@@ -702,12 +702,12 @@ class EchoMuseSatellite(SatelliteServerProtocol):
 
         Called by trigger_voice_turn() in the controller, with device.voice_lock
         already held. Streams mic audio to HA, waits for TTS response, and
-        hands PCM to post_turn_play() for device-side playback.
+        hands a decoded PCM stream to post_turn_play() for device playback.
 
         on_thinking() is called when STT_VAD_END arrives — the LED/state
         transition point into the thinking phase.
-        post_turn_play(pcm_bytes) wraps _run_post_turn_playback() —
-        EQ, resample, stream_speaker, acoustic-feedback drain.
+        post_turn_play(pcm_chunks) wraps the controller's streaming playback
+        path: stateful EQ, stream_speaker, and acoustic-feedback drain.
 
         preroll_discard: number of ~80ms voice_queue frames to drop before
         streaming to HA. Wake-word turns pass VOICE_PREROLL_DISCARD (removes
@@ -803,22 +803,27 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 return
 
             if self._tts_audio_url:
-                # ── Fetch TTS audio and play it ───────────────────────────
-                log.info(f"[{self._log_name}] Fetching TTS audio from {self._tts_audio_url}")
+                # HA deliberately keeps a streaming TTS response open while
+                # new utterances are synthesized. Buffering it with resp.read()
+                # postpones all playback until the final sentence and erases
+                # the latency benefit of Assist's streaming contract.
+                log.info(f"[{self._log_name}] Streaming TTS audio from {self._tts_audio_url}")
                 try:
-                    pcm_bytes = await _fetch_tts_audio(self._tts_audio_url)
+                    if trace:
+                        trace.t_playback_ms = trace.elapsed_ms()
+                    pcm_bytes = await post_turn_play(
+                        _stream_tts_audio(self._tts_audio_url)
+                    )
                 except Exception as e:
-                    log.error(f"[{self._log_name}] TTS audio fetch failed: {e}")
+                    log.error(f"[{self._log_name}] TTS audio stream failed: {e}")
                     if trace: trace.outcome = "tts_error"
                     return
 
                 if trace:
                     trace.t_tts_fetched_ms = trace.elapsed_ms()
-                    trace.tts_bytes = len(pcm_bytes) if pcm_bytes else 0
+                    trace.tts_bytes = pcm_bytes or 0
 
                 if pcm_bytes and not self._turn_cancelled:
-                    if trace: trace.t_playback_ms = trace.elapsed_ms()
-                    await post_turn_play(pcm_bytes)
                     if trace: trace.outcome = "ok"
             else:
                 log.info(f"[{self._log_name}] No TTS audio URL received — turn ended without response")
@@ -1200,6 +1205,96 @@ class EchoMuseSatellite(SatelliteServerProtocol):
 
 # ─── TTS audio fetch ─────────────────────────────────────────────────────────
 
+async def _stream_tts_audio(url: str) -> AsyncIterator[bytes]:
+    """
+    Incrementally fetch and decode HA TTS audio to 48kHz mono S16_LE PCM.
+
+    The HTTP response is piped into one long-lived ffmpeg process while decoded
+    PCM is yielded immediately. Neither the encoded response nor decoded speech
+    is accumulated in memory. A retry is safe only before PCM has been emitted;
+    retrying later would repeat audio the user has already heard.
+    """
+    emitted = False
+    last_exc: Exception | None = None
+    for attempt in range(2):
+        try:
+            async for pcm in _stream_tts_audio_once(url):
+                emitted = True
+                yield pcm
+            return
+        except Exception as err:
+            last_exc = err
+            if attempt == 0 and not emitted:
+                log.warning(
+                    f"_stream_tts_audio: stream failed before playback ({err}) "
+                    "— retrying once"
+                )
+                await asyncio.sleep(0.5)
+                continue
+            raise
+
+    raise last_exc
+
+
+async def _stream_tts_audio_once(url: str) -> AsyncIterator[bytes]:
+    """Run one HTTP-to-ffmpeg streaming attempt for _stream_tts_audio."""
+    import aiohttp
+
+    proc: asyncio.subprocess.Process | None = None
+    feeder: asyncio.Task | None = None
+    try:
+        timeout = aiohttp.ClientTimeout(
+            total=None,
+            connect=10,
+            sock_connect=10,
+            sock_read=60,
+        )
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url) as resp:
+                resp.raise_for_status()
+                proc = await asyncio.create_subprocess_exec(
+                    "ffmpeg", "-hide_banner", "-loglevel", "error",
+                    "-i", "pipe:0",
+                    "-f", "s16le", "-ar", "48000", "-ac", "1",
+                    "pipe:1",
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+
+                async def _feed_encoded_audio() -> None:
+                    assert proc is not None and proc.stdin is not None
+                    try:
+                        async for chunk in resp.content.iter_chunked(16 * 1024):
+                            proc.stdin.write(chunk)
+                            await proc.stdin.drain()
+                    finally:
+                        if not proc.stdin.is_closing():
+                            proc.stdin.close()
+                            await proc.stdin.wait_closed()
+
+                feeder = asyncio.create_task(_feed_encoded_audio())
+                assert proc.stdout is not None
+                while pcm := await proc.stdout.read(16 * 1024):
+                    yield pcm
+
+                await feeder
+                assert proc.stderr is not None
+                err = await proc.stderr.read()
+                return_code = await asyncio.wait_for(proc.wait(), timeout=15.0)
+                if return_code != 0:
+                    raise RuntimeError(
+                        f"ffmpeg streaming decode failed: {err.decode()[:200]}"
+                    )
+    finally:
+        if feeder is not None and not feeder.done():
+            feeder.cancel()
+            await asyncio.gather(feeder, return_exceptions=True)
+        if proc is not None and proc.returncode is None:
+            proc.kill()
+            await proc.wait()
+
+
 async def _fetch_tts_audio(url: str) -> bytes:
     """
     Fetch TTS audio from HA and decode to 48kHz mono S16_LE PCM — the
@@ -1231,11 +1326,8 @@ async def _fetch_tts_audio(url: str) -> bytes:
                 # how a long response (a read-aloud story) blew the old 10s
                 # cap. Reported by @kopiro in #28.
                 #
-                # The proper fix is to stop buffering the whole response:
-                # em_player already streams a URL through ffmpeg into the
-                # same 0x02 plane with StreamingEQ, and pointing that at TTS
-                # would remove this deadline AND start playback seconds
-                # sooner. Until then this is a deliberate band-aid.
+                # Voice-turn TTS no longer uses this buffered helper, but
+                # standalone announcements still do.
                 async with session.get(url, timeout=aiohttp.ClientTimeout(total=60)) as resp:
                     resp.raise_for_status()
                     audio_bytes = await resp.read()
@@ -1689,7 +1781,7 @@ async def _persist_turn(device, turn_record: dict) -> None:
 async def trigger_voice_turn(
     device,           # em_controller.Device
     on_thinking,      # async callable() — LED/state transition
-    post_turn_play,   # async callable(pcm_bytes: bytes) — playback + drain
+    post_turn_play,   # async callable(pcm_chunks) -> decoded byte count
     trigger_label: str = "unknown",  # "wakeword(0.522)" or "button" for trace
     preroll_discard: int = VOICE_PREROLL_DISCARD,
 ) -> bool:

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -808,11 +808,27 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 # postpones all playback until the final sentence and erases
                 # the latency benefit of Assist's streaming contract.
                 log.info(f"[{self._log_name}] Streaming TTS audio from {self._tts_audio_url}")
+                # t_tts_fetched_ms stamps the FIRST decoded audio, not the end
+                # of playback. fetch_ms is derived from it, and stamping it after
+                # post_turn_play returns would fold the entire playback and
+                # buffer drain into a column that has meant fetch+decode since
+                # it was added — the metric that diagnosed #28 in the first
+                # place. For a streaming design "time to first audio" is both
+                # truthful and the more useful number.
+                async def _stamp_first_audio(chunks):
+                    stamped = False
+                    async for chunk in chunks:
+                        if not stamped:
+                            stamped = True
+                            if trace:
+                                trace.t_tts_fetched_ms = trace.elapsed_ms()
+                        yield chunk
+
                 try:
                     if trace:
                         trace.t_playback_ms = trace.elapsed_ms()
                     pcm_bytes = await post_turn_play(
-                        _stream_tts_audio(self._tts_audio_url)
+                        _stamp_first_audio(_stream_tts_audio(self._tts_audio_url))
                     )
                 except Exception as e:
                     log.error(f"[{self._log_name}] TTS audio stream failed: {e}")
@@ -820,7 +836,6 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     return
 
                 if trace:
-                    trace.t_tts_fetched_ms = trace.elapsed_ms()
                     trace.tts_bytes = pcm_bytes or 0
 
                 if pcm_bytes and not self._turn_cancelled:
@@ -1242,6 +1257,7 @@ async def _stream_tts_audio_once(url: str) -> AsyncIterator[bytes]:
 
     proc: asyncio.subprocess.Process | None = None
     feeder: asyncio.Task | None = None
+    stderr_task: asyncio.Task | None = None
     try:
         timeout = aiohttp.ClientTimeout(
             total=None,
@@ -1274,22 +1290,35 @@ async def _stream_tts_audio_once(url: str) -> AsyncIterator[bytes]:
                             await proc.stdin.wait_closed()
 
                 feeder = asyncio.create_task(_feed_encoded_audio())
+
+                # stderr is drained CONCURRENTLY, not after stdout EOF. A pipe
+                # holds ~64KB; if ffmpeg fills it, it blocks writing stderr,
+                # stops producing stdout, and the reader below waits forever.
+                # -loglevel error keeps that rare, but the case that produces
+                # lots of stderr is a malformed or truncated response — exactly
+                # the degraded case this path has to survive.
+                assert proc.stderr is not None
+                stderr_task = asyncio.create_task(proc.stderr.read())
+
                 assert proc.stdout is not None
                 while pcm := await proc.stdout.read(16 * 1024):
                     yield pcm
 
                 await feeder
-                assert proc.stderr is not None
-                err = await proc.stderr.read()
+                err = await stderr_task
                 return_code = await asyncio.wait_for(proc.wait(), timeout=15.0)
                 if return_code != 0:
                     raise RuntimeError(
                         f"ffmpeg streaming decode failed: {err.decode()[:200]}"
                     )
     finally:
-        if feeder is not None and not feeder.done():
-            feeder.cancel()
-            await asyncio.gather(feeder, return_exceptions=True)
+        for t in (feeder, stderr_task):
+            if t is not None and not t.done():
+                t.cancel()
+        await asyncio.gather(
+            *[t for t in (feeder, stderr_task) if t is not None],
+            return_exceptions=True,
+        )
         if proc is not None and proc.returncode is None:
             proc.kill()
             await proc.wait()

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -190,3 +190,46 @@ def test_release_change_is_pushed_to_open_dashboards():
     upd = jsx[jsx.index("if (tab !== 'updates') return;"):]
     assert "setInterval" in upd[:600], \
         "the Updates tab must refresh while open, not fetch once on entry"
+
+
+def test_streamed_playback_waits_for_the_device_not_a_computed_sleep():
+    """
+    Turn playback must end when the DEVICE says its buffer drained, never on an
+    `audio_duration - elapsed` estimate.
+
+    That estimate was removed on 2026-07-24: it has no visibility of the
+    device's own buffer and cleared the ring 6.1s early on Retreat, 3.2s on
+    Lounge. The streaming path reintroduced it (PR #47) where it is worse still
+    — streaming already consumes most of the audio duration, so the remainder
+    computes to ~0 and the wait disappears while up to ~5.5s is queued in
+    audioChanDepth.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parent.parent / "em_controller.py").read_text()
+    fn = src[src.index("async def _run_streaming_post_turn_playback"):]
+    fn = fn[:fn.index("\nasync def ", 1)]
+
+    assert "playback_done" in fn, \
+        "streamed playback must await the device's playback_stats"
+    assert "asyncio.sleep(remaining)" not in fn, \
+        "the computed drain estimate was removed on 2026-07-24 — do not restore it"
+
+
+def test_send_ms_stays_socket_write_time():
+    """
+    send_ms is documented as socket-write time that completes near-instantly
+    however slow the link is — "never read it as delivery; that mistake cost a
+    whole investigation on 2026-07-20". Timing the whole streaming loop instead
+    folds HA's synthesis time in and makes it read exactly like delivery.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parent.parent / "em_controller.py").read_text()
+    fn = src[src.index("async def stream_speaker_chunks"):]
+    fn = fn[:fn.index("\n    async def ", 1) if "\n    async def " in fn[1:] else len(fn)]
+    assert "send_seconds" in fn, \
+        "socket-write time must be accumulated around the send calls"
+
+    caller = src[src.index("async def _run_streaming_post_turn_playback"):]
+    caller = caller[:caller.index("\nasync def ", 1)]
+    assert "device.playback_send_ms = send_ms" in caller, \
+        "send_ms must come from accumulated write time, not the loop duration"

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -233,3 +233,52 @@ def test_send_ms_stays_socket_write_time():
     caller = caller[:caller.index("\nasync def ", 1)]
     assert "device.playback_send_ms = send_ms" in caller, \
         "send_ms must come from accumulated write time, not the loop duration"
+
+
+def test_meter_ring_is_raised_when_audio_starts_not_at_playback_setup():
+    """
+    The meter pattern renders the live speaker RMS, so it draws an UNLIT ring
+    until the device's ALSA write actually begins.
+
+    On the buffered path that was invisible: the TTS fetch had already
+    completed, so frames flushed at socket speed and audio began almost at
+    once. Streaming moves fetch+decode inside playback, so raising the meter at
+    setup time leaves the ring dark from the end of the spinner until HA
+    returns audio — seconds on a slow response, and indistinguishable from a
+    failed turn (user report 2026-07-31).
+
+    The spinner must therefore stay up until the meter has something to show.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parent.parent / "em_controller.py").read_text()
+    fn = src[src.index("async def post_turn_play_esphome"):]
+    fn = fn[:fn.index("\n            # P0-1")]
+
+    assert "_meter_at_playback_start(pcm_chunks" in fn, \
+        "the meter must be gated on the first audio reaching the device"
+
+    # A meter send is legitimate inside the nested helpers (_meter_on, and the
+    # dead-man refresher). What must not exist is one in the function's OWN
+    # body — that runs at setup, before any audio. Nested bodies are indented
+    # deeper, so indentation is the discriminator.
+    assert "\n" + " " * 20 + "await device.send_led_anim(meter)" not in fn, \
+        ("the meter is being raised at playback setup — on the streaming path "
+         "that is before HA has returned any audio, leaving the ring dark")
+
+
+def test_meter_gate_fires_for_responses_shorter_than_the_prime_window():
+    """
+    A response shorter than SPEAKER_PRIME_SECONDS never reaches the byte
+    threshold — the device starts playing it at EOS instead. Exhaustion must
+    fire the callback too, or short answers play with no ring at all.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parent.parent / "em_controller.py").read_text()
+    fn = src[src.index("async def _meter_at_playback_start"):]
+    fn = fn[:fn.index("\nasync def ", 1)]
+
+    body = fn.split("async for")[1]
+    assert "if not fired:" in body.rsplit("\n", 4)[-4:][0] or "if not fired" in body, \
+        "the generator must fire on exhaustion for sub-prime-length responses"
+    assert "SPEAKER_PRIME_SECONDS" in fn, \
+        "the threshold must track the device's actual prime window"


### PR DESCRIPTION
## Summary

- Pipe Home Assistant's TTS response into one long-lived ffmpeg decoder and yield 48 kHz mono PCM as it becomes available.
- Keep one stateful `StreamingEQ` instance and one device speaker session alive for the complete response.
- Preserve cancellation, a single end-of-stream marker, playback metrics, and the existing buffer-drain behavior.
- Keep standalone ESPHome announcements on their existing buffered path.

## Root cause

Voice turns fetched the complete `/api/tts_proxy/` response with `resp.read()` before starting ffmpeg, EQ, or speaker playback. Streaming-capable TTS providers therefore provided no latency benefit: EchoMuse waited for every utterance to be synthesized and buffered before sending the first PCM period.

This is the structural follow-up suggested in #28. It removes the full-response fetch deadline from the voice-turn path instead of extending that deadline again.

## Impact

Playback can begin as soon as ffmpeg decodes the first audio. Encoded and decoded responses are no longer accumulated in memory, and a retry is attempted only before PCM has been emitted so already-heard audio cannot repeat.

The reconnect retry from #28 is intentionally not included. Text-originated pipelines without an active microphone turn are also outside this PR; this change is limited to native ESPHome voice turns.

## Validation

- `python3 -m py_compile controller/em_controller.py controller/em_esphome.py`
- Live ESPHome satellite validation: the TTS request returned successfully, the first PCM period was sent through the streaming path, and playback completed without a stream error.
