### PR TITLE
controller: tell the dashboard when a newer controller is published

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -56,6 +56,8 @@ import em_pki
 import em_recordings
 import em_scenes
 from version import VERSION as CONTROLLER_VERSION
+from version import compare as _compare_versions
+from version import parse as _parse_version
 
 log = logging.getLogger("echomuse.api")
 
@@ -75,6 +77,25 @@ GITHUB_API_URL = "https://api.github.com/repos/{repo}/releases?per_page=10"
 _release_cache: dict = {}
 _release_cache_ts: float = 0.0
 RELEASE_CACHE_TTL = 60  # seconds
+
+# Controller releases are `controller-v*` TAGS with no GitHub Release behind
+# them — controller-release.yml publishes a GHCR image and nothing else (see
+# "Versioning / releases" in CLAUDE.md). So the notes come from the tag's own
+# annotation: matching-refs lists the tags, and an annotated tag's object
+# carries the message.
+#
+# Deliberately NOT solved by publishing GitHub Releases for controller tags.
+# The releases list is the DEVICE firmware's update feed and
+# _fetch_latest_release scans it for the newest v* tag carrying a `server`
+# asset; adding controller rows puts non-firmware entries in front of that
+# scan for no gain, when the annotation we already write says the same thing.
+GITHUB_TAGS_URL = (
+    "https://api.github.com/repos/{repo}/git/matching-refs/tags/controller-v"
+)
+GITHUB_TAG_OBJECT_URL = "https://api.github.com/repos/{repo}/git/tags/{sha}"
+
+_controller_cache: dict = {}
+_controller_cache_ts: float = 0.0
 
 # Reference to the live devices dict from em_controller — set by init().
 _devices: dict = {}
@@ -227,6 +248,7 @@ async def create_app() -> web.Application:
 
     # Releases
     app.router.add_get("/api/releases/latest",   _get_latest_release)
+    app.router.add_get("/api/releases/controller", _get_controller_release)
     app.router.add_post("/api/releases/check",   _post_check_release)
     app.router.add_post("/api/releases/deploy",  _post_deploy_all)
 
@@ -2387,6 +2409,13 @@ async def _get_system_status(request: web.Request) -> web.Response:
         "pending":        sum(1 for r in all_rows if not r["approved"]),
         "approval_mode":  db.get_config("device_approval", "strict"),
         "latest_release": release["version"] if release else None,
+        # Controller update, surfaced alongside the firmware one so the header
+        # can badge it without a second round trip. Read-only by design: the
+        # controller runs as a container the user owns, and updating it is a
+        # `docker compose pull` they perform — there is deliberately no action
+        # here, only the information needed to decide to take it.
+        "controller_update": _controller_cache.get("version")
+            if _controller_cache.get("available") else None,
         "updates_available": sum(
             1 for r in all_rows
             if r["firmware_ver"] and release
@@ -2806,6 +2835,122 @@ async def _fetch_latest_release(force: bool = False) -> Optional[dict]:
         return None
 
 
+async def _fetch_controller_release(force: bool = False) -> Optional[dict]:
+    """
+    Find the newest controller-v* tag and its annotation.
+
+    Two requests, not one per tag: matching-refs returns every controller-v*
+    ref, the newest is picked by parsed version (NOT by list order — the API
+    sorts refs lexically, which puts v2.9.0 after v2.10.0), and only that one
+    tag's object is dereferenced for its message.
+
+    A lightweight tag has no annotation and no message; that is a degraded
+    release, not a broken one, so it still reports the version with empty
+    notes.
+    """
+    global _controller_cache, _controller_cache_ts
+
+    if (not force and _controller_cache
+            and (time.monotonic() - _controller_cache_ts) < RELEASE_CACHE_TTL):
+        return _controller_cache
+
+    repo = db.get_config("github_repo", "wilbowes/EchoMuse")
+    headers = {"Accept": "application/vnd.github+json"}
+    timeout = aiohttp.ClientTimeout(total=10)
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                GITHUB_TAGS_URL.format(repo=repo), headers=headers, timeout=timeout
+            ) as resp:
+                if resp.status != 200:
+                    log.warning(f"[api] Controller tag list returned {resp.status}")
+                    return _controller_cache or None
+                refs = await resp.json()
+
+            newest = None
+            for ref in refs or []:
+                tag = (ref.get("ref") or "").removeprefix("refs/tags/")
+                parsed = _parse_version(tag)
+                if parsed is None:
+                    continue
+                if newest is None or parsed > newest[0]:
+                    newest = (parsed, tag, ref.get("object") or {})
+
+            if newest is None:
+                log.info("[api] No controller-v* tags published yet")
+                return None
+
+            _, tag, obj = newest
+            notes = ""
+            published_at = ""
+            if obj.get("type") == "tag" and obj.get("sha"):
+                async with session.get(
+                    GITHUB_TAG_OBJECT_URL.format(repo=repo, sha=obj["sha"]),
+                    headers=headers, timeout=timeout,
+                ) as resp:
+                    if resp.status == 200:
+                        tag_obj = await resp.json()
+                        notes = (tag_obj.get("message") or "").strip()
+                        published_at = (tag_obj.get("tagger") or {}).get("date", "")
+
+        version = tag.removeprefix("controller-")
+        previous = db.get_config("latest_controller_version")
+
+        db.set_config("latest_controller_version", version)
+        db.set_config("latest_controller_notes", notes)
+        db.set_config("latest_controller_published_at", published_at)
+
+        _controller_cache = {
+            "version":      version,
+            "current":      CONTROLLER_VERSION,
+            "notes":        notes,
+            "published_at": published_at,
+            "release_url":  f"https://github.com/{repo}/releases/tag/{tag}",
+            **_compare_versions(CONTROLLER_VERSION, version),
+        }
+        _controller_cache_ts = time.monotonic()
+
+        log.info(f"[api] Latest controller release: {version} "
+                 f"(running {CONTROLLER_VERSION}, {_controller_cache['status']})")
+        if version != previous:
+            # Same live-push as device releases: a dashboard left open should
+            # not sit on stale information until someone reloads.
+            await _push_event({
+                "type":         "controller_update",
+                "version":      version,
+                "notes":        notes,
+                "published_at": published_at,
+                **_compare_versions(CONTROLLER_VERSION, version),
+            })
+        return _controller_cache
+
+    except Exception as e:
+        log.error(f"[api] Controller release fetch failed: {e}")
+        return _controller_cache or None
+
+
+async def _get_controller_release(request: web.Request) -> web.Response:
+    """GET /api/releases/controller"""
+    data = await _fetch_controller_release()
+    if data is None:
+        # Fall back to the DB cache so a GitHub outage does not blank the
+        # panel — offline is not the same as "no update exists".
+        version = db.get_config("latest_controller_version", "") or ""
+        if not version:
+            return _ok({"version": None, "current": CONTROLLER_VERSION,
+                        "status": "unknown", "available": False})
+        data = {
+            "version":      version,
+            "current":      CONTROLLER_VERSION,
+            "notes":        db.get_config("latest_controller_notes", "") or "",
+            "published_at": db.get_config("latest_controller_published_at", "") or "",
+            "release_url":  "",
+            **_compare_versions(CONTROLLER_VERSION, version),
+        }
+    return _ok(data)
+
+
 async def _fetch_binary(download_url: str) -> Optional[bytes]:
     """Download the binary from a GitHub release asset URL."""
     log.info(f"[api] Fetching binary: {download_url}")
@@ -2842,6 +2987,13 @@ async def release_poll_loop() -> None:
             await _fetch_latest_release()
         except Exception as e:
             log.error(f"[api] Release poll loop error: {e}")
+
+        # Same cadence, separate failure domain: a GitHub hiccup on one must
+        # not cost the other its poll.
+        try:
+            await _fetch_controller_release(force=True)
+        except Exception as e:
+            log.error(f"[api] Controller release poll error: {e}")
 
         interval = int(db.get_config("update_check_interval", "3600") or 3600)
         await asyncio.sleep(interval)

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -4143,6 +4143,8 @@ function App() {
   const [devices, setDevices] = useState([]);
   const [selected, setSelected] = useState(null);
   const [release, setRelease] = useState(null);
+  const [ctrlRelease, setCtrlRelease] = useState(null);
+  const [ctrlNotesOpen, setCtrlNotesOpen] = useState(false);
   const [checkingRelease, setCheckingRelease] = useState(false);
   const [status, setStatus] = useState(null);
   const [loadError, setLoadError] = useState(null);
@@ -4180,10 +4182,12 @@ function App() {
       API.get('/api/system/status'),
       API.get('/api/releases/latest').catch(() => null),
       API.get('/api/global/config').catch(() => null),
-    ]).then(([devs, stat, rel, gcfg]) => {
+      API.get('/api/releases/controller').catch(() => null),
+    ]).then(([devs, stat, rel, gcfg, ctrl]) => {
       setDevices(devs);
       setStatus(stat);
       setRelease(rel);
+      setCtrlRelease(ctrl);
       if (gcfg) setGlobalConfig(gcfg);
     }).catch(e => {
       if (e.code === 'not_authenticated') { handleLogout(); }
@@ -4231,6 +4235,11 @@ function App() {
         case 'device_approved':
           // Full refresh for structural changes
           API.get('/api/devices').then(setDevices).catch(() => {});
+          break;
+        case 'controller_update':
+          // The controller polls GitHub hourly; a dashboard left open should
+          // learn about a new controller without a reload.
+          setCtrlRelease(msg);
           break;
         case 'device_pending':
           API.get('/api/devices').then(setDevices).catch(() => {});
@@ -4293,6 +4302,73 @@ function App() {
           <Pill small onClick={handleLogout}>Sign out</Pill>
         </div>
       </div>
+
+
+      {/* Controller update notice.
+          Rendered ONLY when a newer controller-v* tag exists, so it is an
+          alert rather than permanent chrome — a panel that is always present
+          stops being read.
+
+          There is deliberately no update button. The controller is a
+          container the user owns and updates with their own docker tooling;
+          an in-app "update" would have to restart the process serving the
+          page, mid-request, with no way to report the outcome. So this shows
+          the version, what changed, and the exact command — everything needed
+          to decide — and leaves the doing to them. */}
+      {ctrlRelease?.available && ctrlRelease?.version && (
+        <div className="em-ctrl-update" style={{
+          background: 'linear-gradient(160deg,#2e2a1e,#221e14)',
+          border: '1px solid #3a3220', borderRadius: 8,
+          padding: '14px 18px', marginBottom: 24,
+        }}>
+          <div style={{ display:'flex', alignItems:'center', gap:12, flexWrap:'wrap' }}>
+            <span style={{ fontFamily:"'DM Mono',monospace", fontSize:8, color:'#a08840',
+                           textTransform:'uppercase', letterSpacing:'0.15em' }}>
+              Controller update
+            </span>
+            <span style={{ fontFamily:"'DM Mono',monospace", fontSize:14, color:'#d8b860' }}>
+              {ctrlRelease.version}
+            </span>
+            <span style={{ fontFamily:"'DM Mono',monospace", fontSize:10, color:'var(--muted)' }}>
+              running {ctrlRelease.current || status?.controller_version || '—'}
+            </span>
+            {ctrlRelease.notes && (
+              <span onClick={() => setCtrlNotesOpen(o => !o)} style={{
+                fontFamily:"'DM Mono',monospace", fontSize:9, color:'var(--muted)',
+                cursor:'pointer', userSelect:'none', marginLeft:'auto',
+                textTransform:'uppercase', letterSpacing:'0.15em',
+              }}>
+                {ctrlNotesOpen ? '▾' : '▸'} What&apos;s in it
+              </span>
+            )}
+          </div>
+          {ctrlNotesOpen && (
+            <div style={{ marginTop:12, borderTop:'1px solid rgba(255,255,255,0.06)', paddingTop:12 }}>
+              <pre style={{
+                fontFamily:"'DM Mono',monospace", fontSize:10, lineHeight:1.65,
+                color:'var(--text2)', whiteSpace:'pre-wrap', wordBreak:'break-word',
+                margin:0, maxHeight:320, overflowY:'auto',
+              }}>{ctrlRelease.notes}</pre>
+              <div style={{ fontFamily:"'DM Mono',monospace", fontSize:9, color:'var(--muted)',
+                            marginTop:14, lineHeight:1.6 }}>
+                Update it yourself, from wherever your compose file lives:
+              </div>
+              <pre style={{
+                fontFamily:"'DM Mono',monospace", fontSize:10, color:'var(--lcd-green)',
+                background:'rgba(0,0,0,0.35)', border:'1px solid rgba(0,0,0,0.5)',
+                borderRadius:6, padding:'10px 12px', margin:'8px 0 0', overflowX:'auto',
+              }}>docker compose pull &amp;&amp; docker compose up -d</pre>
+              {ctrlRelease.release_url && (
+                <a href={ctrlRelease.release_url} target="_blank" rel="noreferrer"
+                   style={{ fontFamily:"'DM Mono',monospace", fontSize:9, color:'var(--muted)',
+                            display:'inline-block', marginTop:10 }}>
+                  View tag on GitHub →
+                </a>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Summary */}
       <div className="em-summary" style={{ display: 'flex', gap: 10, marginBottom: 36 }}>

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -282,3 +282,52 @@ def test_meter_gate_fires_for_responses_shorter_than_the_prime_window():
         "the generator must fire on exhaustion for sub-prime-length responses"
     assert "SPEAKER_PRIME_SECONDS" in fn, \
         "the threshold must track the device's actual prime window"
+
+
+def test_controller_update_is_advisory_only():
+    """
+    The dashboard may TELL you a newer controller exists; it must never offer
+    to apply it.
+
+    The controller is a container the user owns and updates with their own
+    docker tooling. An in-app update would have to restart the process serving
+    the page, mid-request, with no way to report the outcome — and it is an
+    explicit product decision (Wil, 2026-07-31) that this stays out of the
+    interface. The notice is information for a decision the user takes
+    elsewhere.
+    """
+    from pathlib import Path
+    root = Path(__file__).resolve().parent.parent
+
+    jsx = (root / "static" / "dashboard.jsx").read_text()
+    start = jsx.index("{/* Controller update notice.")
+    banner = jsx[start:jsx.index("{/* Summary */}", start)]
+    for forbidden in ("API.post", "API.put", "API.delete", "onClick={doUpdate"):
+        assert forbidden not in banner, (
+            f"the controller update notice must not perform actions, found "
+            f"{forbidden!r} — updating is the user's docker command to run"
+        )
+
+    api = (root / "em_api.py").read_text()
+    assert 'add_get("/api/releases/controller"' in api, \
+        "the controller release endpoint must be read-only (GET)"
+    for verb in ("add_post", "add_put", "add_delete"):
+        assert f'{verb}("/api/releases/controller' not in api, \
+            f"{verb} on /api/releases/controller would make the update actionable"
+
+
+def test_controller_notes_come_from_the_tag_annotation():
+    """
+    controller-v* tags ship a GHCR image and no GitHub Release (CLAUDE.md,
+    "Versioning / releases"), so the notes must be read from the annotated
+    tag object. Reading them from the releases list would return the newest
+    DEVICE firmware release instead — right shape, wrong product.
+    """
+    from pathlib import Path
+    api = (Path(__file__).resolve().parent.parent / "em_api.py").read_text()
+    fn = api[api.index("async def _fetch_controller_release"):]
+    fn = fn[:fn.index("\nasync def ", 1)]
+    assert "GITHUB_TAGS_URL" in fn and "GITHUB_TAG_OBJECT_URL" in fn, \
+        "controller notes must come from the tag annotation, not /releases"
+    assert "GITHUB_API_URL" not in fn, \
+        "that is the device firmware release feed, not the controller's"

--- a/controller/tests/test_version.py
+++ b/controller/tests/test_version.py
@@ -20,3 +20,68 @@ def test_no_env_no_git_is_dev(monkeypatch):
     monkeypatch.setattr(version.subprocess, "run",
                         lambda *a, **k: (_ for _ in ()).throw(OSError("no git")))
     assert version._resolve() == "dev"
+
+
+# ─── Controller update comparison ────────────────────────────────────────────
+#
+# The controller can only tell you an update exists; applying it is a
+# `docker compose pull` the user performs. That makes a WRONG answer here
+# unusually expensive — there is no button to press that would reveal the
+# mistake, so a bad comparison just quietly misinforms.
+
+import pytest
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("v2.10.0",                    (2, 10, 0)),
+    ("controller-v2.10.0",         (2, 10, 0)),
+    ("2.10.0",                     (2, 10, 0)),
+    ("v2.10.0-3-gabc1234",         (2, 10, 0)),
+    ("v2.10.0-3-gabc1234-dirty",   (2, 10, 0)),
+    ("dev",                        None),
+    ("",                           None),
+    ("v",                          None),
+])
+def test_parse_handles_every_form_the_resolver_can_produce(text, expected):
+    assert version.parse(text) == expected
+
+
+def test_newer_tag_is_an_update():
+    assert version.compare("v2.10.0", "v2.11.0") == {
+        "status": "update", "available": True}
+
+
+def test_tags_sort_numerically_not_lexically():
+    """
+    v2.9.0 vs v2.10.0 is the case a string compare gets backwards, and the
+    GitHub refs API returns tags in lexical order — so this is not a
+    hypothetical, it is the ordering the caller is handed.
+    """
+    assert version.parse("v2.10.0") > version.parse("v2.9.0")
+    assert version.compare("v2.9.0", "v2.10.0")["available"] is True
+    assert version.compare("v2.10.0", "v2.9.0")["available"] is False
+
+
+def test_running_the_newest_tag_is_not_an_update():
+    assert version.compare("v2.11.0", "v2.11.0") == {
+        "status": "current", "available": False}
+
+
+def test_a_build_ahead_of_the_tag_is_not_an_update():
+    """
+    A bare-metal checkout between tags describes as v2.11.0-3-gabc1234, whose
+    base parses EQUAL to v2.11.0. It is ahead, not behind — nagging a
+    developer to 'update' to the tag they are already past is the bug.
+    """
+    assert version.compare("v2.11.0-3-gabc1234", "v2.11.0")["available"] is False
+    assert version.compare("v2.11.0-3-gabc1234-dirty", "v2.11.0")["available"] is False
+
+
+def test_an_unknown_running_version_never_claims_to_be_up_to_date():
+    """
+    "dev" (no env var, no git) cannot be compared. Reporting "current" would
+    be the answer that stops someone looking; unknown is the honest one.
+    """
+    result = version.compare("dev", "v2.11.0")
+    assert result["status"] == "unknown"
+    assert result["available"] is False

--- a/controller/version.py
+++ b/controller/version.py
@@ -49,3 +49,45 @@ def _resolve() -> str:
 
 
 VERSION = _resolve()
+
+
+def parse(text: str) -> tuple | None:
+    """
+    ("v2.10.0", "controller-v2.10.0", "v2.10.0-3-gabc1234-dirty") -> (2, 10, 0).
+
+    None for anything that is not a version at all ("dev", a bare source
+    copy). Callers must treat that as "cannot compare" rather than as zero —
+    a controller that does not know its own version has no business claiming
+    to be out of date.
+    """
+    text = (text or "").strip().removeprefix(_PREFIX).lstrip("v")
+    if not text:
+        return None
+    parts = text.split("-")[0].split(".")
+    if not parts or not all(p.isdigit() for p in parts):
+        return None
+    return tuple(int(p) for p in parts[:3])
+
+
+def compare(current: str, latest: str) -> dict:
+    """
+    Is `latest` newer than the running `current`?
+
+    Three outcomes, and the distinction matters more than a boolean would:
+      - "update"  — a strictly newer version exists.
+      - "current" — running the newest, or a build AHEAD of it. A local build
+                    between tags describes as v2.10.0-3-gabc1234, whose base
+                    parses equal to v2.10.0, so a `>` test alone is right here
+                    only because it is strict; anything looser would claim an
+                    update forever on a dev checkout.
+      - "unknown" — the running version is not comparable ("dev"). Say so
+                    rather than guessing: a false "up to date" is worse than
+                    an honest shrug, because it is the answer that stops
+                    someone looking.
+    """
+    c, l = parse(current), parse(latest)
+    if c is None or l is None:
+        return {"status": "unknown", "available": False}
+    if l > c:
+        return {"status": "update", "available": True}
+    return {"status": "current", "available": False}


### PR DESCRIPTION
Device firmware has had an update notice with release notes for a while. The controller itself had none, so the only way to learn a new one existed was to go and look at the repo.

**Where the notes come from.** Controller releases publish a GHCR image and no GitHub Release, by design — the releases list is the device OTA feed and `_fetch_latest_release` scans it for the newest `v*` tag carrying a `server` asset. Rather than change that, this reads the annotation off the `controller-v*` tag itself: `matching-refs` lists them, and only the newest is dereferenced for its message. Two requests, and the annotation we already write for every release is exactly the content wanted.

**The newest tag is chosen by parsed version, not list order.** The refs API sorts lexically, so `controller-v2.9.0` comes back *after* `controller-v2.10.0`. Verified against the live API — taking the last element reports a downgrade. There's a test for it.

**Advisory only.** No update button, and a test enforces that: the notice contains no mutating call and the endpoint is GET-only. The controller is a container the user owns; an in-app update would have to restart the process serving the page, mid-request, with no way to report the outcome. The notice gives the version, the annotation and the `docker compose pull` command, then gets out of the way. It renders only when an update actually exists, so it stays an alert rather than permanent chrome.

**Edge cases that would otherwise misinform:** a build between tags (`v2.10.0-3-gabc1234`) parses equal to its tag and is *ahead*, so a dev checkout is never nagged; an unresolvable version reports `unknown` rather than claiming to be up to date, because a false "current" is the answer that stops someone looking.

Comparison logic lives in `version.py` — pure, no aiohttp — so it is genuinely unit-tested rather than shape-checked. 175 controller tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)