### PR TITLE
ci: verify the release binary carries the tag, not a string-layout artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,18 @@ jobs:
         run: |
           file device/build/server
           ls -lh device/build/server
-          strings device/build/server | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          # Assert the binary carries THIS tag. The previous check grepped for
+          # any version-shaped line (^v1.2.3$), which was wrong twice over: it
+          # never confirmed the version was the one being released, and it
+          # depended on string LAYOUT — Go concatenates string constants into
+          # one blob, so the version reads as "@v2.9.11" with no line break
+          # around it. Adding two unrelated constants shifted the blob and
+          # broke the release of v2.9.11 with a perfectly good binary.
+          if ! strings device/build/server | grep -qF "$GITHUB_REF_NAME"; then
+            echo "::error::binary does not contain $GITHUB_REF_NAME — ldflags did not take"
+            exit 1
+          fi
+          echo "binary carries $GITHUB_REF_NAME"
 
       # Release notes come from the ANNOTATED TAG MESSAGE.
       #


### PR DESCRIPTION
The v2.9.11 release failed on a **perfectly good binary**.

`strings server | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'` was wrong twice over:

1. It never confirmed the version was the one being released — any version-shaped line satisfied it.
2. It depended on string **layout**, not content. Go concatenates string constants into one blob, so the version reads as `@v2.9.11` with no line break around it. Adding two unrelated constants to the shadow scorer shifted the blob and the anchored regex stopped matching.

Reproduced locally before changing anything: the binary contains `v2.9.11` three times, and the anchored grep returns zero matches.

Now greps for `$GITHUB_REF_NAME` as a fixed string — stronger (the *right* version, not any version) and independent of how Go lays out its string data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)