### PR TITLE
esphome: stop asserting IDLE on volume reports and after announcements

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -518,12 +518,12 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 muted=False,
             )
             yield api_pb2.VoiceAssistantAnnounceFinished(success=True)
-            yield api_pb2.MediaPlayerStateResponse(
-                key=MEDIA_PLAYER_KEY,
-                state=MediaPlayerState.IDLE,
-                volume=self._current_volume,
-                muted=False,
-            )
+            # Real state, not IDLE: an announcement over music pauses the
+            # session, so PAUSED is the truth here and resume_interrupted
+            # follows with PLAYING once the feed is back up. Asserting IDLE
+            # made the entity wrong for as long as it took the music to
+            # restart.
+            yield self._media_state_msg()
             return
 
         log.debug(
@@ -2020,12 +2020,18 @@ def update_device_volume(device_id: str, volume: float) -> None:
     log.debug(f"[esphome.{device_id[-8:]}] volume updated → {volume:.3f}")
     satellite = server.get_satellite()
     if satellite is not None:
-        satellite._send_one(api_pb2.MediaPlayerStateResponse(
-            key=MEDIA_PLAYER_KEY,
-            state=MediaPlayerState.IDLE,
-            volume=volume,
-            muted=False,
-        ))
+        # The MEDIA state, not a hardcoded IDLE.
+        #
+        # This asserted IDLE on EVERY device volume report — so turning the
+        # volume knob during music told HA the player had stopped, while it
+        # audibly had not (reported 2026-08-01, Music Assistant showing
+        # stopped over playing audio). _media_state_msg reads the volume back
+        # from the server, which set_volume above has already updated, so the
+        # new level still rides this message.
+        #
+        # Same fault as the turn-end IDLE fixed in #53, in a second place.
+        # Hence the test that now forbids the shape rather than the instance.
+        satellite._send_one(satellite._media_state_msg())
 
 
 # ─── mDNS helpers ────────────────────────────────────────────────────────────

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -422,3 +422,44 @@ def test_turn_end_reports_real_media_state_not_a_hardcoded_idle():
         "a hardcoded IDLE at turn end overwrites the feed's PLAYING and "
         "leaves HA showing idle over audible music"
     )
+
+
+def test_no_unjustified_hardcoded_media_state():
+    """
+    Forbid the SHAPE, not just the instances.
+
+    A hardcoded MediaPlayerState sent to HA asserts what the player is doing
+    without asking em_player, so it is wrong whenever the guess is wrong — and
+    it wins, because the feed announces PLAYING exactly once, at the start.
+
+    This has now been the same bug twice: the turn-end IDLE (#53, "reports
+    idle even though the music continues to play"), and then IDLE on every
+    device volume report, which told Music Assistant the music had stopped
+    while it was audibly playing. Fixing instances one at a time is how the
+    second one survived the first fix, so this pins the rule.
+
+    Two remain legitimate and are named explicitly:
+      - PLAYING for play_media, documented as optimistic — the feed pushes
+        the authoritative state moments later.
+      - ANNOUNCING, a genuine transition with no em_player equivalent.
+
+    Anything else must go through _media_state_msg(), which reads em_player
+    truth.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parent.parent / "em_esphome.py").read_text()
+
+    allowed = {"MediaPlayerState.PLAYING", "MediaPlayerState.ANNOUNCING"}
+    found = [
+        line.strip()
+        for line in src.splitlines()
+        if "state=MediaPlayerState." in line
+    ]
+    offenders = [
+        ln for ln in found
+        if not any(a in ln for a in allowed)
+    ]
+    assert not offenders, (
+        f"hardcoded media state(s) {offenders} — use _media_state_msg() so the "
+        f"entity reflects what em_player is actually doing"
+    )


### PR DESCRIPTION
Reported live: Music Assistant showing the music **stopped while it was audibly playing**, with no voice turn involved.

`update_device_volume()` sent a hardcoded `MediaPlayerState.IDLE` on **every device volume report**. Touching the volume during music told HA the player had stopped. The feed announces PLAYING exactly once, when the decoder starts, so anything after that is the last word — and nothing corrected it.

**This is the same fault as the turn-end IDLE fixed hours earlier for the same issue, in a second place.** Fixing instances one at a time is exactly how this one survived that fix, so the test here forbids the *shape*: any hardcoded `MediaPlayerState` sent to HA, except the two that are legitimate and named explicitly — the optimistic PLAYING for `play_media` (the feed confirms it moments later) and ANNOUNCING (a real transition with no em_player equivalent). Everything else goes through `_media_state_msg()`, which reads em_player truth.

Also fixes the trailing IDLE after an announcement: an announcement over music *pauses* the session, so PAUSED is the truth, with `resume_interrupted` following with PLAYING.

Verified by reintroducing the hardcoded state and watching the guard fail. 231 tests pass.