### PR TITLE
device+controller: action button holds and ambient light as HA entities

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -1900,6 +1900,20 @@ async def handle_button_event(device: Device, event: dict):
         return
 
     if click_type == 138:   # DotClick
+        # A HOLD is a separate gesture, forwarded to HA rather than starting a
+        # turn. heldMs is measured on the device: timing the down/up messages
+        # here would be at the mercy of RTT excursions measured past 1600ms on
+        # this fleet, which would misread taps as holds.
+        #
+        # Absent heldMs (firmware predating this) reads as a tap, so the action
+        # button keeps working exactly as before on devices that have not
+        # updated — degrade to old behaviour, never to a wrong answer.
+        held_ms = event.get("heldMs") or 0
+        if held_ms >= esphome.BUTTON_HOLD_MS:
+            log.info(f"[{device.device_id}] Dot button held {held_ms}ms → HA event")
+            esphome.send_button_event(device.device_id, "long")
+            return
+
         if device.voice_lock.locked():
             log.info(f"[{device.device_id}] Dot button — cancelling voice turn")
             device.cancel_event.set()
@@ -2123,6 +2137,10 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                 await em_player.resume_interrupted(_d.device_id)
         async def _send_volume_set(level: int, _d=_device_ref) -> None:
             await _d.send_control({"type": "volume_set", "level": level})
+        # Capabilities before the servers come up: they decide which HA
+        # entities are advertised, and advertising is a one-shot at
+        # ListEntities time.
+        esphome.set_device_capabilities(device_id, capabilities)
         await esphome.device_connected(
             device_id,
             SERVER_HOST,
@@ -2255,6 +2273,10 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                         "coresOnline":      msg.get("coresOnline"),
                         "coresTotal":       msg.get("coresTotal"),
                         "thermalCoreLimit": msg.get("thermalCoreLimit"),
+                        # Ambient light (TSL2540). None on a device without
+                        # the sensor — 0 lux is a real reading (covered), so
+                        # the two must not collapse into each other.
+                        "ambientLux":       msg.get("ambientLux"),
                         # v13 on-device shadow window summary, absent when the
                         # device is not scoring (see the allowlist note above:
                         # DeviceStats, here, and the consumer below).
@@ -2281,6 +2303,12 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                             )
                     if msg.get("ble"):
                         em_ble_proxy.update_stats(device_id, msg["ble"])
+                    # Ambient light straight through to HA's sensor entity.
+                    # Rides the existing ~30s stats tick — light does not
+                    # change fast enough to justify a channel of its own, and
+                    # nothing per-frame is the standing rule here.
+                    if "ambientLux" in msg:
+                        esphome.update_ambient_lux(device_id, msg.get("ambientLux"))
                     # Fold into the persistent hourly rollup (CPU/RAM/storage/
                     # RSSI trends) — one cheap upsert per ~30s report. The
                     # last_seen refresh rides the same executor hop: a stats

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -351,6 +351,18 @@ class EchoMuseSatellite(SatelliteServerProtocol):
 
     # ── Message handling ─────────────────────────────────────────────────
 
+    def _device_has(self, cap: str) -> bool:
+        srv = self._owning_server
+        return bool(srv is not None and cap in (srv.capabilities or []))
+
+    @property
+    def _button_hold_capable(self) -> bool:
+        return self._device_has("button_hold")
+
+    @property
+    def _ambient_lux_capable(self) -> bool:
+        return self._device_has("ambient_light")
+
     @property
     def _current_volume(self) -> float:
         """Current volume as HA float (0.0–1.0), read from owning server."""
@@ -1482,6 +1494,15 @@ class DeviceESPhomeServer:
         # sends a volume_set control-plane message to the physical device.
         # None when no device is connected.
         self._send_volume_set = None
+        # What the DEVICE says it implements, from its register message.
+        # Drives which HA entities are advertised — negotiate by capability,
+        # never by version (CLAUDE.md). Empty until the device connects, so a
+        # satellite that attaches first simply advertises fewer entities and
+        # picks them up on the next HA reconnect.
+        self.capabilities: list[str] = []
+
+    def set_capabilities(self, caps: list[str]) -> None:
+        self.capabilities = list(caps or [])
 
     def get_satellite(self) -> Optional[EchoMuseSatellite]:
         """Return the active HA connection's satellite instance, or None."""
@@ -2047,6 +2068,54 @@ async def device_disconnected(device_id: str) -> None:
     server._send_volume_set = None
     await server.stop()
     log.info(f"[esphome.{device_id[-8:]}] ESPHome port {server.port} down (device disconnected)")
+
+
+def set_device_capabilities(device_id: str, caps: list[str]) -> None:
+    """Called by em_controller when a device registers."""
+    server = _servers.get(device_id)
+    if server is not None:
+        server.set_capabilities(caps)
+
+
+def send_button_event(device_id: str, event_type: str) -> None:
+    """
+    Fire the action-button event entity in HA.
+
+    Fire-and-forget: a button press whose event cannot be delivered is not
+    worth failing a turn over, and HA reconnects on its own.
+    """
+    server = _servers.get(device_id)
+    if server is None:
+        return
+    satellite = server.get_satellite()
+    if satellite is None:
+        return
+    log.info(f"[esphome.{device_id[-8:]}] action button {event_type} → HA")
+    satellite._send_one(api_pb2.EventResponse(
+        key=EVENT_KEY,
+        event_type=event_type,
+    ))
+
+
+def update_ambient_lux(device_id: str, lux) -> None:
+    """
+    Push the ambient light reading to HA.
+
+    lux is None on a device with no sensor, which is sent as missing_state
+    rather than 0 — a covered sensor reads a genuine 0 lux, so the two must
+    stay distinguishable.
+    """
+    server = _servers.get(device_id)
+    if server is None:
+        return
+    satellite = server.get_satellite()
+    if satellite is None:
+        return
+    satellite._send_one(api_pb2.SensorStateResponse(
+        key=AMBIENT_LUX_KEY,
+        state=float(lux) if lux is not None else 0.0,
+        missing_state=lux is None,
+    ))
 
 
 def update_device_volume(device_id: str, volume: float) -> None:

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -207,6 +207,24 @@ ESPHOME_PROJECT_VERSION = os.environ.get(
 # Required: HA's ESPHome integration silently ignores devices with zero
 # entities (confirmed empirically, see session handoff finding #2).
 MEDIA_PLAYER_KEY = 1
+# Entity keys are per-device and must be stable across reconnects — HA keys
+# its entity registry on them, so renumbering renames everyone's entities.
+# Append only.
+EVENT_KEY        = 2   # action-button hold, as an HA event entity
+AMBIENT_LUX_KEY  = 3   # TSL2540 ambient light, as an HA sensor
+
+# Press types the event entity advertises. Only "long" is emitted today:
+# double/triple were deliberately parked, because detecting them means
+# delaying the single press by the multi-tap window to know it was single —
+# a latency cost on the primary action for a feature most people will not
+# bind. Adding one later is additive; HA tolerates new event types.
+BUTTON_EVENT_TYPES = ["long"]
+
+# How long the action button must be held to count as a hold rather than a
+# tap. Measured ON THE DEVICE (heldMs) rather than by timing the down/up
+# messages here: RTT excursions past 1600ms have been measured on this fleet,
+# which would turn a 750ms gesture into noise.
+BUTTON_HOLD_MS = 750
 
 MEDIA_PLAYER_FEATURES = int(
     MediaPlayerEntityFeature.PAUSE
@@ -391,6 +409,33 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                         **_fmt),
                 ],
             )
+            # Action button holds, as an event entity — it shows up in HA's
+            # automation editor with the press type as a dropdown, rather
+            # than needing a hand-written trigger on a raw esphome.* event.
+            #
+            # Advertised only when the firmware can measure a hold. An entity
+            # whose events can never fire is worse than no entity: someone
+            # writes an automation against it and it silently never runs.
+            if self._button_hold_capable:
+                yield api_pb2.ListEntitiesEventResponse(
+                    object_id="action_button",
+                    key=EVENT_KEY,
+                    name=f"{self.label} Action Button",
+                    device_class="button",
+                    event_types=BUTTON_EVENT_TYPES,
+                )
+            # Ambient light. Amazon's Android layer reports no sensors at all
+            # on this hardware; the TSL2540 is only visible on raw i2c.
+            if self._ambient_lux_capable:
+                yield api_pb2.ListEntitiesSensorResponse(
+                    object_id="ambient_light",
+                    key=AMBIENT_LUX_KEY,
+                    name=f"{self.label} Ambient Light",
+                    unit_of_measurement="lx",
+                    accuracy_decimals=0,
+                    device_class="illuminance",
+                    state_class=1,   # STATE_CLASS_MEASUREMENT
+                )
             yield api_pb2.ListEntitiesDoneResponse()
             return
 

--- a/controller/tests/test_capabilities.py
+++ b/controller/tests/test_capabilities.py
@@ -22,14 +22,24 @@ ROOT = Path(__file__).resolve().parent.parent.parent
 CONTROL_GO = ROOT / "device" / "internal" / "client" / "control.go"
 CONTROLLER = ROOT / "controller" / "em_controller.py"
 API = ROOT / "controller" / "em_api.py"
+ESPHOME = ROOT / "controller" / "em_esphome.py"
 
 
 def device_capabilities() -> list[str]:
-    """The capability list the firmware announces in its register message."""
+    """
+    Every capability the firmware can announce.
+
+    Read from the whole capabilities() function rather than a single literal:
+    the list is no longer fixed — "ambient_light" is appended only when the
+    hardware actually has a readable sensor, because the controller advertises
+    an HA entity off the back of it. A parser that only understood one literal
+    would silently stop covering the conditional ones, which is the direction
+    that hides a typo rather than surfacing it.
+    """
     src = CONTROL_GO.read_text()
-    m = re.search(r'"capabilities":\s*\[\]string\{([^}]*)\}', src)
-    assert m, "could not find the capabilities list in control.go"
-    return re.findall(r'"([^"]+)"', m.group(1))
+    m = re.search(r'func capabilities\(\) \[\]string \{(.*?)\n\}', src, re.S)
+    assert m, "could not find func capabilities() in control.go"
+    return re.findall(r'"([a-z_]+)"', m.group(1))
 
 
 def test_device_announces_expected_capabilities():
@@ -45,9 +55,15 @@ def test_every_capability_the_controller_checks_is_one_the_device_sends():
     the device-side test cannot.
     """
     caps = set(device_capabilities())
-    src = CONTROLLER.read_text()
-    # `"<cap>" in (self.capabilities or [])` is the established idiom.
-    checked = set(re.findall(r'"([a-z_]+)"\s+in\s+\(self\.capabilities', src))
+    # Two idioms, both scanned: `"<cap>" in (self.capabilities or [])` on
+    # Device in em_controller, and _device_has("<cap>") on the ESPHome
+    # satellite, which decides which HA entities get advertised. A typo in
+    # either is an entity that never appears or never fires, with no error
+    # anywhere — exactly what this test exists to catch.
+    checked = set(re.findall(r'"([a-z_]+)"\s+in\s+\(self\.capabilities',
+                             CONTROLLER.read_text()))
+    checked |= set(re.findall(r'_device_has\(\s*"([a-z_]+)"\s*\)',
+                              ESPHOME.read_text()))
     assert checked, "no capability checks found — has the idiom changed?"
     unknown = checked - caps
     assert not unknown, (

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/wilbowes/EchoMuse/internal/aec"
+	"github.com/wilbowes/EchoMuse/internal/bindings/als"
 	internalbuttons "github.com/wilbowes/EchoMuse/internal/bindings/buttons"
 	"github.com/wilbowes/EchoMuse/internal/bindings/mic"
 	"github.com/wilbowes/EchoMuse/internal/bindings/speaker"
@@ -489,6 +490,7 @@ func collectStats() client.DeviceStats {
 	speed, freq, bssid := linkInfo()
 	cpuC, maxC, coreLimit := thermals()
 	return client.DeviceStats{
+		AmbientLux:       als.Lux(),
 		CPUTempC:         cpuC,
 		MaxTempC:         maxC,
 		CoresOnline:      coresOnline(),

--- a/device/internal/bindings/als/als.go
+++ b/device/internal/bindings/als/als.go
@@ -1,0 +1,101 @@
+// Package als reads the Echo Dot's ambient light sensor.
+//
+// The Dot carries an ams TSL2540 on i2c, which Amazon's Android layer does
+// not expose AT ALL: `dumpsys sensorservice` reports an empty sensor list,
+// there is nothing under /sys/class/sensors or /sys/bus/iio, and no ALS input
+// device. It is visible only on the raw i2c bus — the same shape as the mute
+// LED sitting on a different GPIO than the vendor HAL believed.
+//
+// Verified on hardware: covering the sensor by hand takes it from 309 lux to
+// 0 and back to 308 within a second, with both raw channels tracking.
+//
+// There is a SECOND ALS on the bus (tsl2584tsv at 0x29) whose sysfs directory
+// carries nothing beyond name/modalias — enumerated but not driven, so it is
+// unusable without writing a driver. The 2540 is the one with a real
+// interface, hence matching that name specifically rather than "tsl".
+//
+// This is its own package because two callers need it at different moments:
+// the register message needs to know whether the sensor EXISTS, to declare
+// the capability; the stats tick needs to READ it.
+package als
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// driverName is the sysfs `name` of the sensor that has a usable interface.
+const driverName = "tsl2540"
+
+var (
+	once sync.Once
+	path string // absolute path to als_lux; empty when there is no sensor
+)
+
+// resolve finds the sensor BY NAME, not by i2c address.
+//
+// 0-0039 is where it sits on every device measured, but an address is an
+// enumeration accident: hardcoding it would work here and silently read
+// nothing on a device that enumerated differently. Same reasoning as
+// resolving thermal zones by type rather than by index.
+func resolve() string {
+	once.Do(func() {
+		names, err := filepath.Glob("/sys/bus/i2c/devices/*/name")
+		if err != nil {
+			return
+		}
+		for _, n := range names {
+			b, err := os.ReadFile(n)
+			if err != nil {
+				continue
+			}
+			if strings.TrimSpace(string(b)) != driverName {
+				continue
+			}
+			p := filepath.Join(filepath.Dir(n), "als_lux")
+			// A matching name is not enough — the 2584 on this same bus has
+			// a name and no readable attributes at all.
+			if _, err := os.Stat(p); err != nil {
+				continue
+			}
+			path = p
+			log.Printf("[als] ambient light sensor at %s", path)
+			return
+		}
+		log.Printf("[als] no ambient light sensor found")
+	})
+	return path
+}
+
+// Present reports whether this device has a readable ambient light sensor.
+//
+// Used to decide whether to declare the capability at registration, so the
+// controller never advertises an HA entity that could not produce a reading.
+func Present() bool { return resolve() != "" }
+
+// Lux returns the ambient light level, or nil when there is no sensor or the
+// read fails.
+//
+// nil, never 0: a covered sensor reads a genuine 0 lux, so reporting 0 for
+// "absent" would make a dark room and a device without the hardware
+// indistinguishable — the same NULL-not-zero rule the playback and shadow
+// counters follow.
+func Lux() *int {
+	p := resolve()
+	if p == "" {
+		return nil
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil {
+		return nil
+	}
+	return &n
+}

--- a/device/internal/bindings/buttons/evdev_controller.go
+++ b/device/internal/bindings/buttons/evdev_controller.go
@@ -3,6 +3,7 @@ package buttons
 import (
 	"context"
 	"errors"
+	"time"
 	"github.com/wilbowes/EchoMuse/pkg/buttons"
 	evdev "github.com/gvalkov/golang-evdev"
 	"os/exec"
@@ -65,6 +66,11 @@ func (e *EvDevController) SubscribeToButton(callback buttons.ButtonClickCallback
 
 		beforeClickType := buttons.ClickType(0)
 		beforeDown := false
+		// When each click type was pressed, so a release can report how long
+		// it was held. Keyed by click type because the dot device carries the
+		// mute button too, and interleaving the two must not attribute one
+		// button's hold to the other.
+		downAt := map[buttons.ClickType]time.Time{}
 
 		for {
 			if ctx.Err() != nil {
@@ -112,10 +118,19 @@ func (e *EvDevController) SubscribeToButton(callback buttons.ButtonClickCallback
 				continue
 			}
 
+			var heldMs int64
+			if down {
+				downAt[clickType] = time.Now()
+			} else if t, ok := downAt[clickType]; ok {
+				heldMs = time.Since(t).Milliseconds()
+				delete(downAt, clickType)
+			}
+
 			callback(buttons.ButtonClickEvent{
 				Button:    btn,
 				ClickType: clickType,
 				Down:      down,
+				HeldMs:    heldMs,
 			})
 		}
 	}

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/wilbowes/EchoMuse/internal/config"
 	"github.com/wilbowes/EchoMuse/internal/discovery"
+	"github.com/wilbowes/EchoMuse/internal/bindings/als"
 	"github.com/wilbowes/EchoMuse/pkg/buttons"
 	"github.com/wilbowes/EchoMuse/pkg/led"
 )
@@ -260,7 +261,7 @@ func (c *ControlClient) connect(ctx context.Context, server *discovery.ServerInf
 		// uses it to decide whether owwOnDevice is even offerable, so an older
 		// device shows "needs newer firmware" rather than a toggle that
 		// silently does nothing.
-		"capabilities": []string{"mic", "speaker", "leds", "led_anim", "buttons", "oww_shadow", "button_hold"},
+		"capabilities": capabilities(),
 	}
 	// Resolved fresh per registration: a cached-at-startup value goes stale
 	// after a WiFi change, and if the process started while the network was
@@ -691,6 +692,21 @@ func (c *ControlClient) runShellSession(ctx context.Context, baseURL string, pty
 		master.Close()
 	}
 	log.Println("[shell] Session closed")
+}
+
+// capabilities is what this firmware implements, negotiated by capability
+// rather than by version so the controller needs no knowledge of our release
+// history (see CLAUDE.md). "ambient_light" is conditional on the hardware
+// actually having a readable sensor — the controller advertises an HA entity
+// off the back of it, and an entity that can never produce a reading is worse
+// than no entity at all.
+func capabilities() []string {
+	caps := []string{"mic", "speaker", "leds", "led_anim", "buttons",
+		"oww_shadow", "button_hold"}
+	if als.Present() {
+		caps = append(caps, "ambient_light")
+	}
+	return caps
 }
 
 func (c *ControlClient) SendButton(event buttons.ButtonClickEvent) {

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -260,7 +260,7 @@ func (c *ControlClient) connect(ctx context.Context, server *discovery.ServerInf
 		// uses it to decide whether owwOnDevice is even offerable, so an older
 		// device shows "needs newer firmware" rather than a toggle that
 		// silently does nothing.
-		"capabilities": []string{"mic", "speaker", "leds", "led_anim", "buttons", "oww_shadow"},
+		"capabilities": []string{"mic", "speaker", "leds", "led_anim", "buttons", "oww_shadow", "button_hold"},
 	}
 	// Resolved fresh per registration: a cached-at-startup value goes stale
 	// after a WiFi change, and if the process started while the network was
@@ -699,6 +699,11 @@ func (c *ControlClient) SendButton(event buttons.ButtonClickEvent) {
 		"type":      "button",
 		"clickType": int(event.ClickType),
 		"down":      event.Down,
+		// Absent on a press and on firmware predating this, which the
+		// controller must read as "a tap" — an unknown hold time becoming a
+		// long press would silently stop the action button starting voice
+		// turns on older devices.
+		"heldMs": event.HeldMs,
 		"button": map[string]string{
 			"type": string(event.Button.Type),
 		},

--- a/device/internal/client/stats.go
+++ b/device/internal/client/stats.go
@@ -38,6 +38,10 @@ type DeviceStats struct {
 	// changed. ThermalCoreLimit is the sharpest throttling signal this SoC
 	// offers: below 4 means the thermal governor is capping capacity, which
 	// bites long before a temperature reading looks alarming.
+	// AmbientLux is the room light level from the TSL2540 on i2c, or nil on
+	// a device with no sensor. Pointer, not int: a covered sensor reads a
+	// genuine 0 lux, so 0 must not also mean "no hardware".
+	AmbientLux       *int     `json:"ambientLux"`
 	CPUTempC         *float64 `json:"cpuTempC"`
 	MaxTempC         *float64 `json:"maxTempC"`
 	CoresOnline      int      `json:"coresOnline,omitempty"`
@@ -73,6 +77,7 @@ func (c *ControlClient) SendStats(s DeviceStats) {
 		"rxCrcErrors":    s.RxCrcErrors,
 		"ble":              s.Ble,
 		"owwShadow":        s.OwwShadow,
+		"ambientLux":       s.AmbientLux,
 		"cpuTempC":         s.CPUTempC,
 		"maxTempC":         s.MaxTempC,
 		"coresOnline":      s.CoresOnline,

--- a/device/pkg/buttons/subscription.go
+++ b/device/pkg/buttons/subscription.go
@@ -10,6 +10,12 @@ type ButtonClickEvent struct {
 	Button    Button    `json:"button"`
 	ClickType ClickType `json:"clickType"`
 	Down      bool      `json:"down"`
+	// HeldMs is how long the button was held, set on RELEASE only (0 on the
+	// press). It exists so the controller can tell a tap from a hold without
+	// timing the two messages itself — the link has been measured with RTT
+	// excursions past 1600ms, which would make controller-side timing of a
+	// ~750ms gesture report noise as intent.
+	HeldMs int64 `json:"heldMs,omitempty"`
 }
 
 type EventSubscription struct {


### PR DESCRIPTION
Two device capabilities Home Assistant could not see. Closes the button half of #53.

## Action button hold → HA event entity

A hold now fires an **event entity**, so it shows up in HA's automation editor with the press type as a dropdown — no hand-written trigger on a raw `esphome.*` event. A hold no longer starts a voice turn; a tap still does.

**Only `long` is advertised.** Double and triple were deliberately parked (@wilbowes' call): detecting them means delaying the *single* press by the multi-tap window in order to know it was single, which is a latency cost on the primary action for a gesture most people won't bind. Adding one later is additive.

Hold time is measured **on the device**, not by timing the down/up messages controller-side — RTT excursions past **1600ms** have been measured on this fleet, which would turn a 750ms gesture into noise. Firmware that doesn't report `heldMs` reads as a tap, so the button behaves exactly as before on devices that haven't updated.

## Ambient light → HA sensor entity

The Dot carries an **ams TSL2540** that Amazon's Android layer does not expose at all: `dumpsys sensorservice` reports an empty sensor list, nothing under `/sys/class/sensors` or `/sys/bus/iio`, no ALS input device. It's visible only on the raw i2c bus — the same shape as the mute LED sitting on a different GPIO than the vendor HAL believed.

Verified on hardware — a hand over the sensor:

```
lux=309  ch0=1511 ch1=4008   ambient
lux=0    ch0=30   ch1=145    covered (held ~10s)
lux=308  ch0=1522 ch1=4047   uncovered — recovers within a second
```

Resolved **by name, not i2c address**: `0-0039` is where it sits on every device measured, but an address is an enumeration accident and hardcoding it would work here and silently read nothing elsewhere. There's a second ALS on the same bus (`tsl2584tsv`) that's enumerated but not driven, so the name match is specific rather than a prefix.

Rides the existing ~30s stats tick. A device with no sensor sends `missing_state`, not 0 — **a covered sensor reads a genuine 0 lux**, so the two must stay distinguishable.

## Both entities are capability-gated

Advertised only when the device says it can back them. An entity whose events can never fire, or whose state is permanently missing, is worse than no entity: someone writes an automation against it and it silently never runs.

**The capability guard test needed strengthening, not just unbreaking.** It parsed a single string literal in `control.go`, which no longer holds now `ambient_light` is appended conditionally; and it scanned only `em_controller` for checks, so the new `_device_has()` idiom on the satellite — which decides what HA even sees — was invisible to it. Both fixed, verified by introducing a typo and watching it fail.

231 controller tests, Go tests pass, ARM firmware builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)