### PR TITLE
controller: ride out a data-plane blip instead of truncating the audio

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -204,6 +204,27 @@ def _ha_volume_to_device(volume: float) -> int:
 
 # ─── Device registry ──────────────────────────────────────────────────────────
 
+# How long a speaker stream will wait, IN TOTAL, for a dropped data connection
+# to come back before giving up on the rest of it.
+#
+# A brief Wi-Fi blip mid-stream used to truncate the audio outright: send_data
+# saw data_ws was None, logged, and dropped every remaining frame, so a
+# reconnect a second later arrived to find the audio already thrown away
+# (reported by @kopiro in #28, on long read-aloud responses).
+#
+# The budget is per STREAM, not per frame, and that distinction is the whole
+# design. send_data is called once per audio period; a per-frame wait means a
+# device that is genuinely gone stalls every remaining frame in turn, so a
+# stream that should abort in seconds instead drains for hours holding the
+# voice lock. Spending one shared budget across the stream rides out a blip
+# and still fails fast on a real disconnect.
+#
+# 3s because it is covering a reconnect, not an outage: measured RTT
+# excursions on this fleet peak around 1.7s, and the device's own buffer holds
+# ~5.5s, so a blip inside this window is inaudible.
+DATA_RECONNECT_GRACE_S = 3.0
+
+
 class Device:
     def __init__(
         self,
@@ -218,6 +239,10 @@ class Device:
         self.control_ws   = control_ws
 
         self.data_ws: WebSocketServerProtocol | None = None
+        # Remaining reconnect grace for the speaker stream in flight. Armed by
+        # begin_data_stream(); spent down by send_data so the whole stream
+        # shares one budget rather than each frame having its own.
+        self._data_grace_left: float = 0.0
         self.voice_lock   = asyncio.Lock()
         self.cancel_event = asyncio.Event()
         self.mic_queue:   asyncio.Queue[bytes] = asyncio.Queue(maxsize=64)
@@ -454,7 +479,35 @@ class Device:
         except Exception as e:
             log.warning(f"[{self.device_id}] Control send failed: {e}")
 
+    def begin_data_stream(self) -> None:
+        """
+        Arm the reconnect grace for one speaker stream.
+
+        Called at the start of each stream so the budget is fresh, and so a
+        stream that already spent it cannot borrow from the next one.
+        """
+        self._data_grace_left = DATA_RECONNECT_GRACE_S
+
+    async def _await_data_reconnect(self, budget: float) -> float:
+        """Wait up to `budget` seconds for the data plane. Returns time spent."""
+        step = 0.1
+        waited = 0.0
+        while waited < budget:
+            await asyncio.sleep(step)
+            waited += step
+            if self.data_ws is not None:
+                log.info(f"[{self.device_id}] Data connection back after "
+                         f"{waited:.1f}s — resuming stream")
+                break
+        return waited
+
     async def send_data(self, data: bytes):
+        if self.data_ws is None and self._data_grace_left > 0:
+            # Ride out a blip rather than discarding the rest of the audio.
+            # The budget is spent down, so a device that never returns costs
+            # the stream DATA_RECONNECT_GRACE_S once, not once per frame.
+            self._data_grace_left -= await self._await_data_reconnect(
+                self._data_grace_left)
         if self.data_ws is None:
             log.warning(f"[{self.device_id}] No data connection")
             return
@@ -532,6 +585,7 @@ class Device:
 
     async def stream_speaker(self, pcm: bytes):
         """Stream resampled mono 48kHz PCM as 0x02 frames, then 0x03 EOS."""
+        self.begin_data_stream()
         self.speaking = True
         try:
             offset = 0
@@ -569,6 +623,7 @@ class Device:
         are retained until more PCM arrives and padded only once, at the true
         end of the response.
         """
+        self.begin_data_stream()
         self.speaking = True
         pending = bytearray()
         total_pcm = 0

--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -399,6 +399,11 @@ class MediaSession:
         src_max_ms = 0.0
         src_stalls = 0
 
+        # Arm the data-plane reconnect grace for this feed: a Wi-Fi blip
+        # mid-song should cost a pause, not the rest of the track.
+        if hasattr(device, "begin_data_stream"):
+            device.begin_data_stream()
+
         try:
             proc = await self._spawn_decoder(self.url, start_pos)
             self._proc = proc

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -577,3 +577,39 @@ def test_a_failed_update_asks_for_the_supervisor_log():
     connect = connect[:connect.index("\nasync def ", 1)]
     assert "_collect_supervisor_log" in connect, \
         "nothing collects the supervisor log when the device comes back"
+
+
+def test_data_reconnect_grace_is_per_stream_not_per_frame():
+    """
+    A dropped data connection mid-stream should cost a pause, not the rest of
+    the audio (#28, @kopiro — long read-aloud responses truncated by a brief
+    Wi-Fi blip).
+
+    The budget must be spent DOWN across the stream, never a fresh wait on
+    each call. send_data runs once per audio period, so a per-frame wait means
+    a device that is genuinely gone stalls every remaining frame in turn — a
+    stream that should abort in seconds instead drains for hours holding the
+    voice lock. That failure is worse than the truncation it replaces, which
+    is why the shape is pinned rather than the constant.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parent.parent / "em_controller.py").read_text()
+
+    fn = src[src.index("    async def send_data(self, data: bytes):"):]
+    fn = fn[:fn.index("\n    async def ", 1)]
+
+    assert "_data_grace_left -=" in fn, (
+        "the reconnect grace must be spent down across the stream; a wait that "
+        "does not decrement is a per-frame stall"
+    )
+    assert "_data_grace_left > 0" in fn, \
+        "send_data must stop waiting once the stream's budget is exhausted"
+
+    # Every path that streams audio has to arm it, or the budget is stale from
+    # whatever ran last.
+    for stream_fn in ("async def stream_speaker(self",
+                      "async def stream_speaker_chunks(self"):
+        body = src[src.index(stream_fn):]
+        body = body[:body.index("\n    async def ", 1)]
+        assert "begin_data_stream()" in body, \
+            f"{stream_fn} does not arm the reconnect grace"


### PR DESCRIPTION
Reworks the second half of #28 (@kopiro), credited as co-author.

**The problem is real.** A brief Wi-Fi or WebSocket drop mid-stream truncated playback outright — `send_data` saw `data_ws` was None, logged, and discarded every remaining frame, so a reconnect a second later found the audio already thrown away. Plausible on this fleet: RTT excursions have been measured peaking around **1.7s**.

**Same intent, different shape.** The original waited inside `send_data` for the connection to return. But `send_data` is called once per audio period, so the wait was per frame — a device that is genuinely gone would stall every remaining frame in turn, and a stream that should abort in seconds would instead drain for hours holding the voice lock. That failure is worse than the truncation it replaces.

So the grace is a budget for the **stream**: armed by `begin_data_stream()`, spent down by `send_data`. A blip costs a pause; a real disconnect costs it once and then fails fast. Armed by both speaker paths and the music feed, so a blip mid-song costs a pause rather than the rest of the track.

**3s rather than 15.** Worth flagging: the PR description said "up to 5 seconds" but the code was `range(150)` at 0.1s — 15s. Either way this covers a reconnect, not an outage; the device buffers ~5.5s, so a blip absorbed inside this window is inaudible.

**The other half of #28 already landed** — the 10s TTS fetch cap is now 60s, credited to @kopiro in the comment above it. Worth noting it has since been largely superseded by his own streaming work in #47: voice-turn TTS no longer buffers at all, so a slow generator is bounded by `sock_read` rather than a total deadline. The 60s cap still covers standalone announcements.

The test pins the **stream-scoped** property rather than the constant — the constant is taste, the scoping is the correctness argument. Verified by reintroducing a per-frame wait and watching it fail. 236 tests pass.

Closes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)