### PR TITLE
support: put the controller's own log in the bundle, and thin the noise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -470,6 +470,30 @@ redacting a line that quotes a transcript is a bet on a regex. Order matters —
 quotes are substituted before URLs, or the URL pattern eats the closing quote
 and leaves the line malformed.
 
+**Two log sources, and the distinction is load-bearing** (bundle `format` 2).
+`controller_log_tail` is the controller's OWN log, held in a bounded
+in-memory ring (`em_support.LogRing`, installed by `em_controller` at
+`basicConfig` time); `device_log_tail` is the relayed per-device
+`device_logs` table. Until 2026-08-02 only the second existed and it was
+named as if it were the first — so every line that would have explained #62
+(media state pushed to HA, the ESPHome command flow, barge-in decisions) was
+in neither, because it goes to stdout. **A bundle that cannot answer the
+issue it was built for is the failure mode to watch for here**, not a
+missing field.
+
+Both are sized against measurement, not intuition:
+- The ring **drops `aiohttp.access`** (65% of a measured 38 lines/min — the
+  dashboard polling itself) and holds 2000 lines, covering a couple of
+  hours. At 600 lines including access logs it covered sixteen minutes: a
+  ring that reliably contains everything except the event someone opened a
+  bundle to report.
+- Device lines are **thinned, not truncated**: `[mem]` heap dumps were 89% of
+  that table and 87% of a real bundle's tail. `thin_noise` keeps the newest
+  three per device and drops the rest — kept rather than dropped outright
+  because goroutine count is recorded nowhere else, so a leak hunt would
+  lose its only source. Measured effect: 339 lines of which 35 were evidence
+  became 195 lines of which 179 are.
+
 Serials ARE included: nothing correlates without them, and they identify the
 user's own hardware to them. User-facing contract: `docs/support-bundle.md`.
 

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -76,6 +76,22 @@ _PROCESS_START = time.time()
 _cpu_history = em_support.CpuHistory()
 CPU_SAMPLE_INTERVAL_S = em_support.CpuHistory.INTERVAL_S
 
+# The controller's own recent log, kept in memory for support bundles. Every
+# line that would have explained #62 goes to stdout, and stdout was not in
+# the bundle at all.
+_log_ring = em_support.LogRing()
+
+
+def install_log_ring(fmt: str) -> None:
+    """
+    Attach the in-memory log ring to the root logger.
+
+    Called from em_controller once logging is configured, with the same
+    format string, so a bundle reads exactly like the console does.
+    """
+    _log_ring.setFormatter(logging.Formatter(fmt))
+    logging.getLogger().addHandler(_log_ring)
+
 
 def sample_cpu() -> None:
     """
@@ -2292,6 +2308,11 @@ async def _get_provision_magisk_db(request: web.Request) -> web.Response:
 # without a firmware restart.
 DEVICE_TLS_DIR = "/data/local/etc/echomuse"
 
+# Per-device log lines in a support bundle, after thinning. Deep enough that
+# a startup line survives a day of chatter, small enough that six devices do
+# not bury the controller's own log.
+DEVICE_LOG_LINES = 120
+
 
 @auth.require_admin
 async def _post_provision_tls_credentials(request: web.Request) -> web.Response:
@@ -3380,8 +3401,15 @@ async def _get_support_bundle(request: web.Request) -> web.Response:
         metrics += [dict(m, device_id=did)
                     for m in await loop.run_in_executor(None, db.get_device_metrics, did, since)]
         counters += await loop.run_in_executor(None, db.get_wake_counters, did, since)
-        for lg in await loop.run_in_executor(None, db.get_device_logs, did, 100, None):
-            logs.append(f"{lg['ts']} [{lg['level']}] {lg['source']}: {lg['message']}")
+        # Fetch deep and thin, rather than fetching 100 and shipping noise:
+        # 89% of this table is [mem] heap dumps, so a flat 100 was ~11 lines
+        # of evidence. Newest first, which is what thin_noise expects.
+        raw = await loop.run_in_executor(None, db.get_device_logs, did, 500, None)
+        pairs = [(lg["ts"], f"{lg['ts']} [{lg['level']}] {lg['source']}: {lg['message']}")
+                 for lg in raw]
+        # Sorted oldest-first at the end: a log someone reads should run
+        # forwards, and per-device blocks in reverse order do not.
+        logs += em_support.thin_noise(pairs, key=lambda p: p[1])[:DEVICE_LOG_LINES]
 
     bundle = em_support.build(
         controller_version=CONTROLLER_VERSION,
@@ -3393,7 +3421,8 @@ async def _get_support_bundle(request: web.Request) -> web.Response:
         counters=counters,
         device_configs=device_configs,
         live_state=live_state,
-        log_tail=logs,
+        controller_log=_log_ring.tail(),
+        device_log=[ln for _, ln in sorted(logs)],
         # From the user table, not guessed at: an account name in log prose
         # has nothing to pattern-match on. Mapped to the ROLE it is replaced
         # with — "an admin opened a shell" is the diagnostic content, and

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -77,11 +77,17 @@ import em_ble_proxy
 import em_oww_models
 import em_player
 
+_LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s — %(message)s"
+
 logging.basicConfig(
     level=logging.DEBUG if os.environ.get("DEBUG") else logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s — %(message)s",
+    format=_LOG_FORMAT,
 )
 log = logging.getLogger("echomuse")
+
+# Keep the last few hundred lines in memory so a support bundle can carry the
+# controller's own log, not just the relayed per-device one.
+api.install_log_ring(_LOG_FORMAT)
 
 logging.getLogger("websockets.server").setLevel(logging.CRITICAL)
 

--- a/controller/em_support.py
+++ b/controller/em_support.py
@@ -48,6 +48,7 @@ without them nothing correlates — but nothing else is.
 from __future__ import annotations
 
 import json
+import logging
 import re
 import time
 from collections import deque
@@ -141,6 +142,83 @@ _URL = re.compile(r"""https?://[^\s'"]+""")
 # fixture had no such line.
 _IPV4 = re.compile(r"""\b\d{1,3}(?:\.\d{1,3}){3}\b""")
 _MAC = re.compile(r"""\b(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}\b""")
+
+
+# Device log lines that are pure volume. `[mem]` heap dumps were 89% of the
+# device_logs table and 87% of a real bundle's log tail — 294 lines of 339 —
+# which is the diagnostic budget spent on a number already in `metrics` as
+# `mem_used_avg`. They are THINNED, not dropped: the newest few still answer
+# "what is the heap doing right now", and goroutine count is not recorded
+# anywhere else, so a leak hunt would lose its only source.
+_LOG_NOISE = ("[mem]",)
+
+
+def is_noise(line: str) -> bool:
+    """True for a line that is volume rather than evidence."""
+    return any(marker in line for marker in _LOG_NOISE)
+
+
+def thin_noise(items: list, keep: int = 3, key=lambda x: x) -> list:
+    """
+    Keep the first `keep` noise items and drop the rest, order preserved.
+
+    `items` must be NEWEST FIRST, which is how `db.get_device_logs` returns
+    them — "first" is then "most recent", and the caller sorts for display.
+    `key` extracts the text, so callers can carry a timestamp alongside it
+    rather than parsing one back out of the formatted line.
+    """
+    out, seen = [], 0
+    for item in items:
+        if is_noise(key(item)):
+            seen += 1
+            if seen > keep:
+                continue
+        out.append(item)
+    return out
+
+
+class LogRing(logging.Handler):
+    """
+    The controller's own recent log, in memory, for support bundles.
+
+    The bundle shipped without it: `controller_log_tail` was in fact the
+    per-device `device_logs` table, while every line that would have
+    explained issue #62 — the media state pushed to HA, the ESPHome command
+    flow, barge-in decisions — goes to stdout and was nowhere in the file. A
+    bundle that cannot answer the issue it was built for is worth fixing
+    before it is released.
+
+    Bounded by line count, not bytes, and formatted on emit: holding the
+    LogRecord instead would keep every argument object alive for the length
+    of the ring, which is a memory leak wearing a cache's clothing.
+
+    Sized against the measured rate, not a guess: this controller emits ~38
+    lines a minute, of which **65% is `aiohttp.access`** — the dashboard
+    polling itself, which says nothing about a device. Dropping that and
+    holding 2000 lines covers a couple of hours, so someone who hits a
+    problem and then goes to collect a bundle still has the event in it. At
+    600 lines including access logs it was sixteen minutes, which is a ring
+    that reliably contains everything except the thing you wanted.
+    """
+
+    IGNORED = ("aiohttp.access",)
+
+    def __init__(self, capacity: int = 2000) -> None:
+        super().__init__()
+        self.lines: deque[str] = deque(maxlen=capacity)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.name.startswith(self.IGNORED):
+            return
+        try:
+            self.lines.append(self.format(record))
+        except Exception:
+            # A logging handler that raises takes down the call site it was
+            # only supposed to observe.
+            pass
+
+    def tail(self) -> list[str]:
+        return list(self.lines)
 
 
 class CpuHistory:
@@ -307,7 +385,8 @@ def build(
     counters: list,
     device_configs: dict[str, dict],
     live_state: dict[str, dict],
-    log_tail: list[str],
+    controller_log: list[str],
+    device_log: list[str],
     accounts: dict[str, str] | None = None,
     controller_stats: dict | None = None,
 ) -> dict:
@@ -317,7 +396,9 @@ def build(
     """
     bundle: dict = {
         "generated_at": int(time.time()),
-        "format": 1,
+        # 2: controller_log_tail became the CONTROLLER's log; the relayed
+        # per-device lines moved to device_log_tail.
+        "format": 2,
         "redaction": (
             "Allowlisted fields only. Contains no speech, no transcripts, no "
             "audio, no device labels, no account names, and no network "
@@ -340,7 +421,8 @@ def build(
         "turns": [_pick(t, _TURN_FIELDS) for t in turns],
         "metrics": [_pick(m, _METRIC_FIELDS) for m in metrics],
         "wake_counters": [_pick(c, _COUNTER_FIELDS) for c in counters],
-        "controller_log_tail": sanitise_log(log_tail, accounts),
+        "controller_log_tail": sanitise_log(controller_log, accounts),
+        "device_log_tail": sanitise_log(device_log, accounts),
     }
 
     for n, d in enumerate(devices, start=1):

--- a/controller/tests/test_support.py
+++ b/controller/tests/test_support.py
@@ -82,7 +82,12 @@ def _bundle():
                 "wifiBssid": SECRETS["bssid"], "wifiSsid": SECRETS["ssid"],
             }),
         }},
-        log_tail=[
+        controller_log=[
+            "10:00:01 [INFO] echomuse — Barge-in: cancelling playback",
+            "10:00:02 [DEBUG] echomuse.esphome — MediaPlayerCommandRequest command=PAUSE",
+            f"10:00:03 [INFO] echomuse — Shell session opened by {SECRETS['username']}",
+        ],
+        device_log=[
             f"[TURN] trigger=wakeword outcome=ok text='{SECRETS['speech']}'",
             "play_media: 'http://10.10.1.81:8097/flow/abc/media.flac'",
             "Playback chain: decoder spawned 3ms, first audio 194ms",
@@ -158,7 +163,7 @@ def test_the_useful_diagnostics_survive():
     assert b["controller"]["version"] == "v2.12.1"
     assert b["controller"]["schema_version"] == 16
 
-    log = "\n".join(b["controller_log_tail"])
+    log = "\n".join(b["device_log_tail"])
     assert "Playback chain" in log and "194ms" in log, \
         "timings are the point of shipping logs at all"
     assert "RTT excursion: 1450ms" in log
@@ -166,7 +171,7 @@ def test_the_useful_diagnostics_survive():
 
 def test_transcript_bearing_log_lines_are_dropped_whole():
     b = _bundle()
-    log = "\n".join(b["controller_log_tail"])
+    log = "\n".join(b["device_log_tail"])
     assert "[TURN]" not in log, \
         "turn traces quote transcripts verbatim and must not be sanitised in place"
 
@@ -373,3 +378,90 @@ class TestCpuWindows:
             h.add(float(i), i * 0.1)
         expected = S.CpuHistory.WINDOWS[-1][0] / S.CpuHistory.INTERVAL_S
         assert len(h._samples) <= expected + 3, "ring should hold ~1h of samples"
+
+
+def test_the_controllers_own_log_is_in_the_bundle():
+    """
+    It was not, and that is why the bundle could not answer #62: the media
+    state pushed to HA and the ESPHome command flow both go to stdout, while
+    `controller_log_tail` in fact held the relayed per-device table.
+    """
+    b = _bundle()
+    ctrl = "\n".join(b["controller_log_tail"])
+    assert "Barge-in: cancelling playback" in ctrl
+    assert "MediaPlayerCommandRequest command=PAUSE" in ctrl, \
+        "the HA command flow is the evidence #62 turned on"
+    assert "device_log_tail" in b, "the per-device log keeps its own key"
+    assert b["format"] >= 2, "the shape changed; the format marker must say so"
+
+
+def test_the_controller_log_is_sanitised_like_any_other():
+    """A new log source is a new leak path unless it goes through the same rules."""
+    b = _bundle()
+    text = json.dumps(b["controller_log_tail"])
+    assert SECRETS["username"] not in text and "<admin>" in text
+
+
+class TestNoiseThinning:
+    def test_heap_dumps_are_thinned_not_dropped(self):
+        """
+        [mem] was 87% of a real bundle's log tail, for a number already in
+        metrics — but goroutine count is recorded nowhere else, so a few of
+        the newest must survive for a leak hunt.
+        """
+        lines = [f"[mem] goroutines=19 heap_alloc={i}KB" for i in range(50)]
+        out = S.thin_noise(lines, keep=3)
+        assert len(out) == 3
+        assert out[0].endswith("heap_alloc=0KB"), "newest first must be kept"
+
+    def test_evidence_is_never_thinned(self):
+        lines = ["Wake word detected (score=1.000)"] + \
+                [f"[mem] heap_alloc={i}KB" for i in range(20)] + \
+                ["Device connected: ABC"]
+        out = S.thin_noise(lines, keep=2)
+        assert "Wake word detected (score=1.000)" in out
+        assert "Device connected: ABC" in out
+        assert sum(1 for l in out if "[mem]" in l) == 2
+
+    def test_a_key_lets_the_caller_carry_a_timestamp(self):
+        """So the caller sorts by real time instead of parsing it back out."""
+        pairs = [(3, "[mem] a"), (2, "[mem] b"), (1, "Wake word detected")]
+        out = S.thin_noise(pairs, keep=1, key=lambda p: p[1])
+        assert out == [(3, "[mem] a"), (1, "Wake word detected")]
+
+
+class TestLogRing:
+    def test_it_holds_the_most_recent_lines_and_no_more(self):
+        import logging
+        ring = S.LogRing(capacity=5)
+        ring.setFormatter(logging.Formatter("%(message)s"))
+        for i in range(20):
+            ring.emit(logging.LogRecord("x", logging.INFO, "f", 1, f"line {i}", None, None))
+        assert ring.tail() == [f"line {i}" for i in range(15, 20)]
+
+    def test_a_broken_record_cannot_take_down_its_call_site(self):
+        """
+        A logging handler that raises breaks the code it was only meant to
+        observe — and it would do it inside the bundle's own logging.
+        """
+        import logging
+        ring = S.LogRing(capacity=5)
+        ring.setFormatter(logging.Formatter("%(message)s %(nonexistent)s"))
+        ring.emit(logging.LogRecord("x", logging.INFO, "f", 1, "boom", None, None))
+        assert ring.tail() == [], "the bad record is dropped, not raised"
+
+
+def test_the_ring_ignores_the_dashboards_own_http_chatter():
+    """
+    aiohttp.access was 65% of the measured log rate and says nothing about a
+    device — it is the dashboard polling itself. Keeping it meant the ring
+    covered sixteen minutes, so it reliably held everything except the event
+    someone opened a bundle to report.
+    """
+    import logging
+    ring = S.LogRing(capacity=10)
+    ring.setFormatter(logging.Formatter("%(message)s"))
+    for name, msg in (("aiohttp.access", "GET /api/devices 200"),
+                      ("echomuse", "Barge-in: cancelling playback")):
+        ring.emit(logging.LogRecord(name, logging.INFO, "f", 1, msg, None, None))
+    assert ring.tail() == ["Barge-in: cancelling playback"]

--- a/docs/support-bundle.md
+++ b/docs/support-bundle.md
@@ -49,7 +49,8 @@ on a regular expression.
 | Hourly metrics per device — CPU, memory, storage, temperature, RSSI, RTT | Trends. Signal strength is included; the network's name is not. |
 | The controller's own CPU (1m/5m/1h), memory, storage and uptime | A device starving for audio can be the host running out of CPU, memory or disk. The three windows separate "busy right now" from "busy earlier", which need different answers. Sizes and counts only, never paths. |
 | Wake counters — near-misses, on-device drops, inference timings | Wake-word behaviour without any audio. |
-| Recent controller log lines, sanitised | Message types and timings, with quoted text and URLs removed. |
+| Recent controller log lines, sanitised | What the controller itself was doing — the part that explains most "it did the wrong thing" reports. Quoted text and URLs removed. |
+| Recent per-device log lines, sanitised | What each device reported. Repetitive memory dumps are thinned so they cannot crowd out the rest. |
 
 Roughly the last 24 hours, capped per device.
 


### PR DESCRIPTION
Asked whether a bundle could actually diagnose the two open reports, the answer was **no**, and the reason was structural.

## `controller_log_tail` was not the controller's log

It was the relayed per-device `device_logs` table. Every line that would have explained #62 — the media state pushed to HA, the ESPHome command flow, barge-in decisions — goes to stdout, and stdout was in the bundle **nowhere**.

The controller's log now rides in a bounded in-memory ring, formatted on emit (holding the `LogRecord` would keep every argument object alive for the length of the ring).

**Sized against measurement, not intuition.** This controller emits ~38 lines/min, of which **65% is `aiohttp.access`** — the dashboard polling itself, which says nothing about a device. Dropping that and holding 2000 lines covers a couple of hours. At the 600 lines including access logs it started at, coverage was **sixteen minutes**: a ring that reliably contains everything except the event someone opened a bundle to report.

## The device log was 87% heap dumps

`[mem]` lines were **89% of the device_logs table** and **294 of the 339 lines** in a real bundle — the diagnostic budget spent re-reporting a number already in `metrics` as `mem_used_avg`.

Thinned, not dropped: the newest three per device survive, because goroutine count is recorded nowhere else and a leak hunt would lose its only source.

Measured on live data: **339 lines with 35 of evidence became 195 with 179.**

## Honest limits

This makes the barge-in class of report diagnosable. It does **not** fully answer the ambient-light half: the device's `[als]` reason line is never relayed to the controller (zero such rows in 28,688 device_logs going back to 6 July), so that needs a firmware change to ride the next device tag.

## Verification

271 tests pass. Re-audited against the live database and the real controller log: no account name as a whole word, no bare IPs, no MACs, bundle 93KB.

Note a correction to an earlier audit of mine: a substring search flagged `wil` as leaked, which was `"will be rejected"`. Word-boundary matching shows it absent — short usernames need whole-word checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)