### PR TITLE
Duck and mix music under voice instead of pausing (#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,56 @@ The always-on wake stream (`mic_start` without `lock_mic`) is **ungated and AGC-
 
 1. **Wake word** — openwakeword (ONNX) runs in a thread executor per device on `mic_queue`. When 2+ devices are connected, `em_arbiter.py` applies **first-detector-wins** suppression: the first device to cross threshold answers *immediately* (no added latency, the claim is synchronous) and any other device detecting within `wakeArbitrationMs` (default 700, 0 = off) stands down and logs "Wake ceded". The claim is released at turn end. Do NOT reinstate the original best-SNR-after-a-wait design: it taxed every wake ~364ms (it gated on devices *connected*, not in earshot) and field data showed SNR at detection was indistinguishable across devices (0.9/1.15/0.93) while the SNR winner produced a worse transcript than the first detector.
 2. **Voice turn** — on wake or dot-button: drain stale frames → acquire `voice_lock` → stream mic to HA via the ESPHome satellite → receive TTS URL → fetch + ffmpeg-decode straight to 48kHz mono → EQ (`em_eq.py`) → stream back as 0x02 frames
+### Ducking: music and voice are separate planes on the device
+
+**A voice turn DUCKS music; it does not pause it** — on firmware announcing
+the `audio_mix` capability. Music rides its own frame types (`0x04`/`0x05`)
+into a second buffer on the device, and the two are mixed at the ALSA write.
+
+It has to be device-side, and that is the whole design constraint. `LEAD_S` =
+4.0s means the next four seconds of music are already in the device's buffer
+when a wake word fires, so **audio that has left the controller cannot be
+ducked by the controller**. Every controller-side alternative buys ducking by
+shortening that lead — giving back the stall protection it exists for, during
+the seconds the user is listening most closely.
+
+What this removes, not just improves: pausing needed a seek to resume, and a
+Music Assistant flow stream **cannot seek**, so a 28s turn cost 28s of the
+song and a long one landed in the next track. Behaviour differed by source
+with no way for the user to tell which they had.
+
+- **Voice is never attenuated**; only the bed under it. The sum saturates
+  rather than wrapping (a wrap turns a loud peak into full-scale opposite
+  polarity, far worse than the clipping).
+- **The gain ramp is a constant slew, not proportional.** `(target-gain)/n`
+  per period is an exponential approach, which made "4 periods" a time
+  constant rather than a duration — measured at 31 periods (1.3s) to settle
+  against the 170ms intended. Gain is interpolated per SAMPLE across the
+  period: a step at a period boundary is a click, landing on exactly the
+  moment the user started speaking.
+- **`duckDb` is config** (default −18dB, Playback section), because it is a
+  taste parameter that wants tuning by ear in a real room — same reasoning as
+  the LED meter response curve.
+- **`music_flush` vs `speaker_flush`.** A genuine stop/pause flushes the
+  MUSIC plane; `speaker_flush` would cut the response and leave the music
+  playing. A voice turn sends neither — flushing discards the buffered audio
+  that makes ducking instant, and on a non-seekable stream it cannot be
+  recovered.
+- **`MediaSession.ducked` changes what turn end must do.** On the pausing
+  path `interrupt()` had already paused, so a deferred user "pause" needed no
+  wire action. When we duck, nothing was ever paused — the pause has to
+  actually happen at release, or it is silently dropped and the music plays
+  on.
+- **Music does NOT count as "streaming"** for the device's wake threshold
+  (`IsStreaming` is voice-only). It is a quiet continuous bed, not a response
+  being talked over; reporting it would drop the device's wake bar for the
+  length of a song.
+- Taps see the MIXED output, which is more correct than before: the AEC
+  far-end reference is what needs cancelling from the mic, and with music
+  under a response the echo is the sum.
+- `reported_state` stays for firmware that cannot mix. On the ducking path it
+  is simply never triggered, because nothing is ever paused behind HA's back.
+
 3. **Media playback** (`em_player.py`) — the HA `media_player` entity accepts `play_media`/browse (PLAY_MEDIA+BROWSE_MEDIA feature flags): ffmpeg subprocess streams s16le/48k/mono, fed to the same 0x02 plane, paced to `LEAD_S`=**4.0s** ahead of realtime. That is sized against the device's own depth (`audioChanDepth` 128 periods × 42.7ms ≈ 5.46s) leaving ~1.4s headroom so the feed can never outrun `audioCh`. It was 1.5s until 2026-07-25, which left ~4s of hardware buffer unused and let measured 1.8-2.6s link stalls drain it into audible gaps. **The lead is NOT what makes pause/stop/voice-preempt instant** — `speaker_flush` drains the device buffer and the discard-until-EOS contract swallows what is still in TCP; the old comment misattributed that. Resume passes `-ss` before `-i`, an INPUT seek: ffmpeg does NOT ignore a seek it cannot perform, it decodes and discards until it reaches the timestamp, so a 173s bookmark on a non-seekable live stream (Music Assistant flow) is 173s of silence — a first-chunk deadline (`SEEK_STALL_S`) catches that and rejoins the live edge. Pause = speaker_flush + position bookmark, resume = ffmpeg `-ss` (live streams rejoin the live edge); teardown always EOSes the stream (flush-discard contract, same as barge-in). **Voice turns and announcements OWN the speaker**: `interrupt()` takes ownership and `resume_interrupted()` releases it. Ownership is taken unconditionally, even with nothing playing — the old behaviour only paused what was ALREADY playing, which did nothing to stop something *starting* mid-turn, and "play some jazz" runs the intent **before** HA generates the spoken reply, so `play_media` lands while the TTS is still coming and puts music on the same 0x02 plane as the response. While owned, `play`/`resume`/`pause`/`stop` record the user's intent instead of touching the wire; the release applies it, **last write wins** ("play jazz… actually, pause"). A user command **overrides** the auto-resume — theirs is an instruction, `resume_after` is bookkeeping — which is what makes pausing during a barge-in possible at all (issue #53: `MediaSession.pause()` returns early unless PLAYING, so the command was discarded and then contradicted by the resume). Deferred commands still push the **intended** state to HA (`push_intent`) so the entity is not stale for the length of a turn. The feed must NOT set `device.speaking` (that makes the wake loop drop frames — deaf for a whole song); wake-over-music scores against `bargeInThreshold` when barge-in is enabled, same physics as barge during TTS. Music EQ runs through `em_eq.StreamingEQ` (chunk-carried filter state — per-chunk `apply()` would click at boundaries).
 
     **Never send HA a hardcoded `MediaPlayerState`.** The feed announces `playing` exactly ONCE, when the decoder starts producing audio, so anything sent afterwards becomes HA's last word. Two places asserted a constant `IDLE` — turn end, and every device volume report — and each left the entity showing idle over audible music (issue #53, twice: fixing the first instance is how the second survived). Use `_media_state_msg()`, which reads em_player truth. `tests/test_deploy.py` forbids the shape, allowing only the documented optimistic `PLAYING` for `play_media` and `ANNOUNCING`.
@@ -585,7 +635,7 @@ Two device behaviours the wizard works around rather than fixes:
 
 `config.ConfigMessage` JSON fields (camelCase) are sent from controller to device on connect and on per-device config change. Non-zero fields are applied; zero/nil fields are ignored (partial update). Changes take effect immediately — no restart required.
 
-Configurable parameters: `vadThreshold`, `vadSpeechMs`, `vadSilenceMs`, `owwThreshold`, `owwModel`, `owwSpeexNs`, `adcDigitalGain`, `adcMicpga`, `micGainDb`, `startupVolume`, `beamAngle`, `beamformingEnabled`, `aecEnabled`, `aecDelayMs`, `aecTailMs`, `agcEnabled`, `nsAsr`, `bargeInEnabled`, `bargeInThreshold`, `bleProxyEnabled`, `eqBands`, `eqLoudness`, `ledScene`, `ledListenColor`, `ledThinkColor`, `meterAttack`, `meterDecay`, `meterFloor`, `meterGamma`, `meterRef`, `meterCurve`, `wakeArbitrationMs`, `owwOnDevice` and `saveUtterances` (the last two are controller-consumed for scoping purposes, though `owwOnDevice` IS acted on by the device; `saveUtterances` and `wakeArbitrationMs` are ignored by it).
+Configurable parameters: `vadThreshold`, `vadSpeechMs`, `vadSilenceMs`, `owwThreshold`, `owwModel`, `owwSpeexNs`, `adcDigitalGain`, `adcMicpga`, `micGainDb`, `startupVolume`, `beamAngle`, `beamformingEnabled`, `aecEnabled`, `aecDelayMs`, `aecTailMs`, `agcEnabled`, `nsAsr`, `bargeInEnabled`, `bargeInThreshold`, `bleProxyEnabled`, `eqBands`, `eqLoudness`, `ledScene`, `ledListenColor`, `ledThinkColor`, `meterAttack`, `meterDecay`, `meterFloor`, `meterGamma`, `meterRef`, `meterCurve`, `wakeArbitrationMs`, `duckDb`, `owwOnDevice` and `saveUtterances` (the last two are controller-consumed for scoping purposes, though `owwOnDevice` IS acted on by the device; `saveUtterances` and `wakeArbitrationMs` are ignored by it).
 
 ### Fleet vs device scoping (schema v8)
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -679,3 +679,43 @@ are **append-only and in ascending date order** — new work goes at the end.
   fix. It was `"will be rejected"` — a substring search on a three-letter
   name. Word-boundary matching showed it absent. The wrong tool made me report
   a leak that was not there, one step after failing to report one that was.
+
+- **2026-08-02 — ducking had to happen on the device, and the reason is a number.**
+  Barge-in paused the music, answered, then resumed. Wil's framing was "no
+  bandaids — how would Alexa do it?", and the answer is that every assistant
+  people compare us to **ducks**. Pausing was not merely less familiar: it
+  needed a seek to resume, and a Music Assistant flow stream **cannot seek**,
+  so a 28-second turn cost 28 seconds of the song and a long one landed in the
+  next track. Behaviour differed by source with no way for the user to tell
+  which they had, and the `media_player` entity had to report `PLAYING` while
+  internally paused or HA would decline the user's own pause.
+
+  The obstacle was never the arithmetic — both streams are 48kHz mono s16, so
+  mixing is an add and a limiter. It is **`LEAD_S = 4.0`**: the next four
+  seconds of music are already in the device's buffer when a wake word fires,
+  and **audio that has left the controller cannot be ducked by the
+  controller**. Every controller-side option buys ducking by shortening that
+  lead — handing back the stall protection it exists for (raised from 1.5s
+  because measured 1.8–2.6s link stalls drained the shorter buffer), during
+  the seconds the user is listening hardest. So music got its own frame types
+  and its own buffer on the device, and the two planes mix at the ALSA write.
+
+  The mixer taught me something about ramps. My first gain ramp moved
+  `(target-gain)/n` per period, which is an *exponential* approach — "4
+  periods" was a time constant, not a duration, and a test measured it
+  settling in **31 periods (1.3s)** against the 170ms the comment claimed. A
+  constant slew, interpolated per sample so the change is a fade rather than a
+  click landing exactly when the user starts speaking.
+
+  Two traps on the controller side, both the same shape: an assumption that
+  quietly stopped being true. `speaker_flush` is the wrong flush for music —
+  it cuts the response and leaves the music playing. And the deferred "pause
+  the music" needed no wire action *because* `interrupt()` had already paused;
+  duck instead and nothing was ever paused, so the user's pause is silently
+  discarded and the music plays on. That is #53 again, arriving by a different
+  route, which is the second time this month a fix has had to be made twice
+  because the first one addressed the instance rather than the shape.
+
+  `reported_state` survives for firmware that cannot mix, and on the ducking
+  path is simply never triggered — the entity stops needing to lie because
+  nothing is paused behind HA's back.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -719,3 +719,62 @@ are **append-only and in ascending date order** — new work goes at the end.
   `reported_state` survives for firmware that cannot mix, and on the ducking
   path is simply never triggered — the entity stops needing to lie because
   nothing is paused behind HA's back.
+
+- **2026-08-03 — three bugs behind one symptom, and two of them were mine.**
+  The first real listening test of ducking. The duck itself was right on the
+  first try — music drops to a good level, the response mixes over it, no
+  seek, no position loss — and everything around it was wrong in a way that
+  only a room could reveal.
+
+  **Dropouts.** Music and TTS share one `/data` WebSocket, and the music feed
+  holds a 4s lead, so up to ~380KB of music can sit in the socket ahead of
+  the response. When the link hiccups the device must drain all of it before
+  reaching the TTS frames — head-of-line blocking. Measured: the response
+  waited 2087ms to start and took a 3549ms gap mid-stream, against 41ms/0ms
+  on turns with nothing else streaming. The feed now drops its lead while a
+  turn owns the speaker, so the music plays out of the buffer the device
+  already holds — the same buffer that forced ducking to be device-side,
+  paying for itself twice.
+
+  **The ring throbbing to the music.** I had routed both device taps to the
+  mixed output. That is right for the AEC reference — the mic hears the sum,
+  so the sum is what must be cancelled — and wrong for the meter, which
+  visualises the RESPONSE. Wil saw a low throb before the response started,
+  which is the ring reporting on a bed nobody asked it to watch.
+
+  **A response that ended after 15 of 56 periods.** The worst of the three,
+  and a regression I introduced: splitting the speaker into two planes
+  dropped a branch from `EndStream`. The original returned early when the
+  stream had been discarding — `flush()` already set `eosPending` and the
+  drain consumed it — while mine set it again, leaving the flag armed with no
+  stream behind it. The next response then reported itself complete at its
+  first buffer dip, so the controller ended the turn, cleared the ring and
+  released the duck while the device still held most of the audio. It needed
+  a cancelled turn immediately before to show up, which is why it looked
+  intermittent and why more testing made it seem to improve.
+
+  All three were found from recorded numbers rather than from listening
+  again: `periods=15` against `audio=2800ms` says something specific in a way
+  that "it sounded odd" cannot. And the fix carries tests because extracting
+  the buffering state machine into an untagged file made it host-testable —
+  before this, every one of those behaviours could only be checked by ear.
+
+- **2026-08-03 — the light sensor was fine; the entity never existed.**
+  Retreat had stopped reporting ambient light to Home Assistant and the other
+  devices' graphs came and went. The device was reporting all along, and the
+  controller was logging the readings.
+
+  A device registers BEFORE its ESPHome server is created — the listener only
+  comes up once the device is present — so `set_device_capabilities` looked
+  for a server, found none, and **silently did nothing**. The server was then
+  built with an empty capability list, and the entity list is a one-shot at
+  `ListEntities`: no `ambient_light` capability, no sensor entity, and HA
+  caches that for the life of the connection. Measured on Retreat: registered
+  05:25:33, server created 05:25:34.
+
+  Being a race, it resolved differently on every controller restart — which is
+  what made readings vanish and return rather than never work, and is why it
+  survived this long. It silently costs the action-button entity too. The
+  comment on the field claimed a satellite attaching first would "pick them up
+  on the next HA reconnect", which was true and was the problem: HA does not
+  reconnect on its own.

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -3743,6 +3743,7 @@ def _merge_device(row) -> dict:
         # scoring: a toggle that silently does nothing on old firmware is worse
         # than no toggle, because it looks like the feature is broken.
         "owwShadowCapable": getattr(live, "oww_shadow_capable", False) if live else False,
+        "audioMixCapable": getattr(live, "audio_mix_capable", False) if live else False,
         # WiFi change state (survives the reconnect a change causes)
         "wifi":             wifi_state(device_id),
         # Update state

--- a/controller/em_config_sections.py
+++ b/controller/em_config_sections.py
@@ -23,7 +23,7 @@ config key ends up belonging to no section.
 SECTIONS: dict[str, dict] = {
     "playback": {
         "label": "Playback",
-        "keys": ["eqBands", "eqLoudness"],
+        "keys": ["eqBands", "eqLoudness", "duckDb"],
     },
     "wakeword": {
         "label": "Wake word",

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -539,6 +539,23 @@ class Device:
         return "led_anim" in (self.capabilities or [])
 
     @property
+    def audio_mix_capable(self) -> bool:
+        """
+        Whether this firmware holds music on its own plane and mixes it with
+        voice at the ALSA write.
+
+        When it does, a voice turn DUCKS the music instead of pausing it —
+        which is the only place ducking can happen. The music feed runs
+        LEAD_S=4s ahead of realtime, so the next four seconds are already on
+        the device when a wake word fires, and audio that has left here
+        cannot be ducked from here. Without the capability the controller
+        keeps the pause/resume path: a device that cannot mix would never
+        play the 0x04 stream at all, which is silence rather than degraded
+        behaviour.
+        """
+        return "audio_mix" in (self.capabilities or [])
+
+    @property
     def oww_shadow_capable(self) -> bool:
         """
         Whether this firmware can score the wake word on-device at all.

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -103,6 +103,13 @@ DEFAULT_DEVICE_CONFIG = {
     # no self-trigger risk down to ~0.08.
     "bargeInEnabled":   False,
     "bargeInThreshold": 0.10,
+    # How far music is attenuated while a voice turn plays OVER it, on
+    # firmware that can mix the two planes (the "audio_mix" capability).
+    # Ducking replaces pausing there: the music feed runs 4s ahead of
+    # realtime, so pausing costs a seek that a Music Assistant flow stream
+    # cannot perform. A taste parameter — it wants tuning by ear in a real
+    # room, like the LED meter curve, not a firmware push per attempt.
+    "duckDb": -18.0,
     "owwModel":         "hey_jarvis_v0.1",
     # Multi-device wake SUPPRESSION window (ms), not a wait. The first
     # device to detect answers immediately; any other device detecting

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -1504,9 +1504,14 @@ class DeviceESPhomeServer:
         self._send_volume_set = None
         # What the DEVICE says it implements, from its register message.
         # Drives which HA entities are advertised — negotiate by capability,
-        # never by version (CLAUDE.md). Empty until the device connects, so a
-        # satellite that attaches first simply advertises fewer entities and
-        # picks them up on the next HA reconnect.
+        # never by version (CLAUDE.md).
+        #
+        # Seeded from _pending_caps at creation, because the device registers
+        # BEFORE this object exists and the entity list is a one-shot. The
+        # old comment here claimed a satellite attaching first would "pick
+        # them up on the next HA reconnect" — which is true, and was the
+        # problem: HA does not reconnect on its own, so the entity stayed
+        # missing for the life of the connection.
         self.capabilities: list[str] = []
 
     def set_capabilities(self, caps: list[str]) -> None:
@@ -1607,6 +1612,12 @@ class _RejectProtocol(SatelliteServerProtocol):
 
 # device_id → DeviceESPhomeServer
 _servers: dict[str, DeviceESPhomeServer] = {}
+
+# Capabilities reported by a device whose server does not exist yet. The
+# device's registration always precedes server creation (the listener only
+# comes up once the device is present), so without this the very first
+# ListEntities — the one HA caches — is built from an empty list.
+_pending_caps: dict[str, list[str]] = {}
 _azc: Optional[AsyncZeroconf] = None
 
 
@@ -1690,6 +1701,11 @@ async def _register_device_server(device_id: str, label: str | None) -> DeviceES
         oww_model_id=oww_model_id,
         port=port,
     )
+    # Capabilities that arrived before this server existed decide which HA
+    # entities are advertised, and advertising happens once.
+    caps = _pending_caps.get(device_id)
+    if caps:
+        server.set_capabilities(caps)
     _servers[device_id] = server
 
     # mDNS registration — _esphomelib._tcp, one per device port,
@@ -2079,7 +2095,20 @@ async def device_disconnected(device_id: str) -> None:
 
 
 def set_device_capabilities(device_id: str, caps: list[str]) -> None:
-    """Called by em_controller when a device registers."""
+    """
+    Called by em_controller when a device registers, BEFORE the server for it
+    exists — so the value is held here as well as pushed.
+
+    Dropping it when no server was registered yet is how Retreat lost its
+    ambient light sensor in Home Assistant (2026-08-03): the device connects,
+    the capability push finds no server and silently does nothing, the server
+    is created a beat later with an empty list, and the entity list — a
+    ONE-SHOT at ListEntities time — is then built without the sensor. HA
+    caches that until it reconnects, so the entity is simply absent for the
+    life of the connection. The same race decides it differently on each
+    controller restart, which is what made the graph come and go.
+    """
+    _pending_caps[device_id] = list(caps or [])
     server = _servers.get(device_id)
     if server is not None:
         server.set_capabilities(caps)

--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -56,6 +56,21 @@ BYTES_PER_SEC = SPEAKER_RATE * 2
 SPEAKER_FRAME_TYPE = 0x02
 SPEAKER_EOS_TYPE   = 0x03
 
+# Music rides its own plane on firmware that can mix (the "audio_mix"
+# capability), so a voice turn ducks it instead of pausing it. On older
+# firmware music stays on 0x02 and the pause/resume path is kept — a device
+# that cannot mix would never play 0x04 at all, which is silence rather than
+# degraded behaviour.
+MUSIC_FRAME_TYPE = 0x04
+MUSIC_EOS_TYPE   = 0x05
+
+
+def _frame_types(device) -> tuple[int, int]:
+    """(audio frame type, EOS type) for this device's music stream."""
+    if device is not None and getattr(device, "audio_mix_capable", False):
+        return MUSIC_FRAME_TYPE, MUSIC_EOS_TYPE
+    return SPEAKER_FRAME_TYPE, SPEAKER_EOS_TYPE
+
 # Feed-ahead target over realtime. The device buffers audioChanDepth=128
 # periods x 42.7ms = ~5.46s, so 1.5s left roughly four seconds of hardware
 # buffer unused — and control-plane RTT measurement shows stalls of 1.8s and
@@ -227,6 +242,21 @@ async def interrupt(device_id: str) -> None:
     s = _session(device_id)
     s.owned_by_turn = True
     s.pending = None
+
+    device = _get_device(device_id) if _get_device else None
+    if device is not None and getattr(device, "audio_mix_capable", False):
+        # DUCK, do not pause. The device holds music on its own plane and
+        # mixes it under the response, so the music keeps playing quietly and
+        # nothing is lost: no seek, no bookmark, no position drift on a
+        # non-seekable flow stream, and no need for the entity to claim it is
+        # playing while internally paused.
+        s.ducked = True
+        try:
+            await device.send_control({"type": "duck", "on": True})
+        except Exception as e:
+            log.warning(f"[{device_id}] duck failed: {e}")
+        return
+
     if s.state == PLAYING:
         s.resume_after = True
         await s.pause()
@@ -250,6 +280,17 @@ async def resume_interrupted(device_id: str) -> None:
     s.owned_by_turn = False
     pending, s.pending = s.pending, None
     resume_after, s.resume_after = s.resume_after, False
+    ducked, s.ducked = s.ducked, False
+
+    if ducked:
+        # Release the duck before settling any deferred command, so the music
+        # is already back at level by the time a stop or pause lands.
+        device = _get_device(device_id) if _get_device else None
+        if device is not None:
+            try:
+                await device.send_control({"type": "duck", "on": False})
+            except Exception as e:
+                log.warning(f"[{device_id}] unduck failed: {e}")
 
     if pending is not None:
         kind, url = pending
@@ -259,8 +300,12 @@ async def resume_interrupted(device_id: str) -> None:
             await s.resume()
         elif kind == "stop":
             await s.stop()
-        # "pause" needs no wire action: interrupt() already paused it, and
-        # dropping resume_after above is the whole of what the user asked for.
+        elif kind == "pause" and ducked:
+            # When we ducked, nothing was ever paused — so the user's pause
+            # has to actually happen here. On the pausing path interrupt()
+            # had already done it and dropping resume_after was the whole of
+            # what the user asked for.
+            await s.pause()
         return
 
     if resume_after and s.state == PAUSED:
@@ -288,6 +333,10 @@ class MediaSession:
         # WE paused something and should put it back afterwards — distinct
         # from ownership, and overridden by any pending user command.
         self.resume_after = False
+        # ducked: this turn lowered the music rather than pausing it (a device
+        # that mixes). It changes what turn end has to do — there is nothing
+        # to resume, but a deferred pause must actually be carried out.
+        self.ducked = False
         self._pos = 0.0            # seconds into the media at last pause
         self._task: asyncio.Task | None = None
         self._proc = None
@@ -379,10 +428,16 @@ class MediaSession:
 
     async def _halt(self, bookmark: bool) -> None:
         """
-        Tear down an active feed. Order matters and mirrors barge-in:
-        speaker_flush first (arms the device's discard-until-EOS + drains
-        its buffer), then cancel the feed — whose finally sends the EOS
-        that disarms the discard.
+        Tear down an active feed. Order matters and mirrors barge-in: flush
+        first (arms the device's discard-until-EOS + drains its buffer), then
+        cancel the feed — whose finally sends the EOS that disarms the
+        discard.
+
+        On a device that mixes, the flush must target the MUSIC plane:
+        speaker_flush would cut the voice stream and leave the music playing,
+        which is precisely backwards. This path is reached only when playback
+        genuinely ends — stop, pause, or a new track — never for a voice
+        turn, which ducks.
         """
         task = self._task
         self._task = None
@@ -392,10 +447,12 @@ class MediaSession:
             return
         device = _get_device(self.device_id) if _get_device else None
         if device is not None:
+            flush = ("music_flush" if getattr(device, "audio_mix_capable", False)
+                     else "speaker_flush")
             try:
-                await device.send_control({"type": "speaker_flush"})
+                await device.send_control({"type": flush})
             except Exception as e:
-                log.warning(f"[{self.device_id}] speaker_flush failed: {e}")
+                log.warning(f"[{self.device_id}] {flush} failed: {e}")
         task.cancel()
         try:
             await task
@@ -436,6 +493,10 @@ class MediaSession:
             self.state = IDLE
             await self._push_state()
             return
+
+        # Resolved once per feed rather than per chunk: the device cannot
+        # gain or lose the capability mid-stream, and this runs ~23×/s.
+        frame_type, eos_type = _frame_types(device)
 
         eq = em_eq.StreamingEQ(SPEAKER_RATE, device.eq_bands, device.eq_loudness)
         start_pos = self._pos
@@ -526,7 +587,7 @@ class MediaSession:
                     if chunk:
                         chunk = chunk + bytes(SPEAKER_BYTES - len(chunk))
                         await device.send_data(
-                            bytes([SPEAKER_FRAME_TYPE]) + eq.process(chunk))
+                            bytes([frame_type]) + eq.process(chunk))
                         sent += SPEAKER_BYTES
                     break
                 # Pacing: hold the lead at LEAD_S over realtime so a flush
@@ -535,7 +596,7 @@ class MediaSession:
                 if ahead > LEAD_S:
                     await asyncio.sleep(ahead - LEAD_S)
                 await device.send_data(
-                    bytes([SPEAKER_FRAME_TYPE]) + eq.process(chunk))
+                    bytes([frame_type]) + eq.process(chunk))
                 if t_first_send is None:
                     t_first_send = loop.time()
                     # The chain, as deltas from the play command. Without this
@@ -554,7 +615,7 @@ class MediaSession:
 
             # Natural end of media: close the stream and wait out the
             # device buffer before reporting idle.
-            await device.send_data(bytes([SPEAKER_EOS_TYPE]))
+            await device.send_data(bytes([eos_type]))
             eos_sent = True
             remaining = (sent / BYTES_PER_SEC
                          - (loop.time() - seg_start) + DRAIN_FUDGE_S)
@@ -594,7 +655,7 @@ class MediaSession:
                 # EOS — same contract as barge-in aborting stream_speaker.
                 try:
                     await asyncio.shield(
-                        device.send_data(bytes([SPEAKER_EOS_TYPE])))
+                        device.send_data(bytes([eos_type])))
                 except BaseException:
                     pass
             if proc is not None and proc.returncode is None:

--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -87,6 +87,27 @@ def _frame_types(device) -> tuple[int, int]:
 # explaining them. The stalls are still unexplained — see the RTT
 # instrumentation and docs/led-ring-states.md-era investigation notes.
 LEAD_S          = 4.0
+
+# The lead the music feed drops to while a voice turn owns the speaker.
+#
+# Music and TTS share ONE /data WebSocket, so a 4s music lead means up to
+# ~380KB of music can be queued ahead of the response in the socket. When the
+# link hiccups — and this fleet stalls for seconds at a time — the device must
+# drain all that music before it reaches the TTS frames. Measured on the first
+# ducked turn: the response waited 2087ms to start and then took a 3549ms gap
+# mid-stream, against 41ms/0ms on turns where nothing else was streaming.
+#
+# Dropping the lead makes the feed stop sending until it has drained back to
+# TURN_LEAD_S, which clears the queue ahead of the response. The music keeps
+# playing throughout, from the buffer the device already holds — that buffer
+# is exactly why ducking has to happen device-side, and this is the same
+# property paying for itself twice.
+#
+# Not zero: the music would then be sent frame-by-frame at the instant it is
+# needed, with no protection at all against a stall DURING the turn. This
+# trades the BACKGROUND's stall margin for the FOREGROUND's, which is the
+# right way round — the response is what the user is listening to.
+TURN_LEAD_S     = 1.0
 RESUME_REWIND_S = 1.0   # replay this much before the pause bookmark
 DRAIN_FUDGE_S   = 1.1   # device prime hold — same constant class as turns
 # How long to wait for the first decoded audio after a seek before deciding
@@ -251,6 +272,9 @@ async def interrupt(device_id: str) -> None:
         # non-seekable flow stream, and no need for the entity to claim it is
         # playing while internally paused.
         s.ducked = True
+        # Yield the shared data plane to the response. The music keeps
+        # playing from the device's own buffer while the feed holds off.
+        s.lead_s = TURN_LEAD_S
         try:
             await device.send_control({"type": "duck", "on": True})
         except Exception as e:
@@ -281,6 +305,7 @@ async def resume_interrupted(device_id: str) -> None:
     pending, s.pending = s.pending, None
     resume_after, s.resume_after = s.resume_after, False
     ducked, s.ducked = s.ducked, False
+    s.lead_s = LEAD_S
 
     if ducked:
         # Release the duck before settling any deferred command, so the music
@@ -337,6 +362,10 @@ class MediaSession:
         # that mixes). It changes what turn end has to do — there is nothing
         # to resume, but a deferred pause must actually be carried out.
         self.ducked = False
+        # Effective pacing lead. Reduced while a turn owns the speaker so the
+        # music feed stops monopolising the shared data plane (see
+        # TURN_LEAD_S); restored when the turn releases it.
+        self.lead_s = LEAD_S
         self._pos = 0.0            # seconds into the media at last pause
         self._task: asyncio.Task | None = None
         self._proc = None
@@ -590,11 +619,14 @@ class MediaSession:
                             bytes([frame_type]) + eq.process(chunk))
                         sent += SPEAKER_BYTES
                     break
-                # Pacing: hold the lead at LEAD_S over realtime so a flush
-                # (pause/stop/voice preempt) feels instant.
+                # Pacing. Read per chunk, not captured once: a voice turn
+                # lowers the lead mid-stream so the response gets the wire,
+                # and that has to take effect on the next frame rather than
+                # the next track.
+                lead = self.lead_s
                 ahead = sent / BYTES_PER_SEC - (loop.time() - seg_start)
-                if ahead > LEAD_S:
-                    await asyncio.sleep(ahead - LEAD_S)
+                if ahead > lead:
+                    await asyncio.sleep(ahead - lead)
                 await device.send_data(
                     bytes([frame_type]) + eq.process(chunk))
                 if t_first_send is None:

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -279,7 +279,7 @@ function CircleButton({ onClick, title, color, children }) {
   );
 }
 
-function Slider({ label, sub, value, min, max, step = 1, unit = '', formatValue, onChange }) {
+function Slider({ label, sub, value, min, max, step = 1, unit = '', formatValue, onChange, disabled = false }) {
   const display = formatValue ? formatValue(value) : `${value}${unit}`;
   // minWidth: 0 (root + label div) and width: 100% on the range input for
   // the same reason as Toggle below: a grid item's min-width defaults to
@@ -290,12 +290,16 @@ function Slider({ label, sub, value, min, max, step = 1, unit = '', formatValue,
     <div style={{ marginBottom: 20, minWidth: 0 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 7, minWidth: 0, gap: 8 }}>
         <div style={{ minWidth: 0 }}>
-          <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: 'var(--text2)' }}>{label}</span>
+          <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: disabled ? 'var(--muted)' : 'var(--text2)' }}>{label}</span>
           {sub && <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)', marginLeft: 8 }}>{sub}</span>}
         </div>
         <Lcd value={display} size={12} />
       </div>
-      <input type="range" min={min} max={max} step={step} value={value} style={{ width: '100%' }} onChange={e => onChange(Number(e.target.value))} />
+      {/* A control whose feature the device lacks is shown disabled WITH the
+          reason (in sub), never as one that silently does nothing. */}
+      <input type="range" min={min} max={max} step={step} value={value} disabled={disabled}
+        style={{ width: '100%', opacity: disabled ? 0.45 : 1 }}
+        onChange={e => onChange(Number(e.target.value))} />
     </div>
   );
 }
@@ -1701,6 +1705,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                 disabled={!isAdmin}
                 sections={sections}
                 shadowCapable={!device.connected || !!device.owwShadowCapable}
+                mixCapable={!device.connected || !!device.audioMixCapable}
                 onScopeChange={(id, local) => {
                   setSections(prev => local
                     ? [...prev, id]
@@ -4005,7 +4010,7 @@ const STAGE_MONO = "'DM Mono',monospace";
 // control sitting under a toggle that does not govern it would look fine and
 // be silently wrong.
 const CONFIG_SECTIONS = {
-  "playback": ["eqBands", "eqLoudness"],
+  "playback": ["eqBands", "eqLoudness", "duckDb"],
   "wakeword": ["owwModel", "owwThreshold", "owwSpeexNs", "bargeInEnabled", "bargeInThreshold", "wakeArbitrationMs", "owwOnDevice"],
   "microphones": ["adcMicpga", "adcDigitalGain", "micGainDb", "beamformingEnabled", "beamAngle", "aecEnabled", "aecDelayMs", "aecTailMs", "nsAsr", "saveUtterances"],
   "ring": ["ledScene", "ledListenColor", "ledThinkColor", "meterAttack", "meterDecay", "meterFloor", "meterGamma", "meterRef", "meterCurve"],
@@ -4123,7 +4128,7 @@ function StageAdvanced({ open, onToggle, disabledStyle, children }) {
 }
 
 function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
-                            shadowCapable = true }) {
+                            shadowCapable = true, mixCapable = true }) {
   // shadowCapable defaults TRUE because this form is also the fleet-config
   // view, where there is no single device whose capability could gate a
   // control. Referencing a `device` here is what blank-screened the Config
@@ -4273,6 +4278,14 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
           <div>
             <div style={inputStyle}>
               <Toggle label="Speech boost" sub="presence boost for voice" value={config.eqLoudness ?? false} onChange={v => set('eqLoudness', v)}/>
+            </div>
+            <div style={inputStyle}>
+              <Slider label="Duck depth" disabled={!mixCapable}
+                sub={mixCapable
+                  ? "how far music drops under a voice response — it keeps playing instead of pausing"
+                  : "needs firmware that mixes music and voice (v3.0+)"}
+                value={config.duckDb ?? -18} min={-40} max={0} step={1} unit="dB"
+                onChange={v => set('duckDb', v)}/>
             </div>
             {/* The startup-volume slider used to live here and was removed
                 (2026-07-25): volume is persisted device STATE, not a setting.

--- a/controller/tests/test_capabilities.py
+++ b/controller/tests/test_capabilities.py
@@ -85,3 +85,45 @@ def test_shadow_capability_is_surfaced_to_the_dashboard():
     jsx = (ROOT / "controller" / "static" / "dashboard.jsx").read_text()
     assert "owwShadowCapable" in jsx, \
         "the dashboard must gate the on-device toggle on the capability"
+
+
+def test_capabilities_reported_before_the_server_exists_are_not_lost():
+    """
+    A device registers BEFORE its ESPHome server is created — the listener
+    only comes up once the device is present — so the capability push finds
+    no server. Dropping it there built the entity list from an empty set, and
+    that list is a ONE-SHOT at ListEntities time: HA caches it and the sensor
+    is absent for the life of the connection.
+
+    Observed on Retreat, 2026-08-03: connected 05:25:33, server created
+    05:25:34, no ambient light entity in HA afterwards. The same race resolves
+    differently per controller restart, which is why the graph came and went.
+    """
+    import em_esphome
+
+    device_id = "G090LFTESTCAPS"
+    em_esphome._pending_caps.pop(device_id, None)
+    try:
+        # Registration lands first, with no server yet.
+        em_esphome.set_device_capabilities(device_id, ["mic", "ambient_light"])
+        assert device_id not in em_esphome._servers, "precondition: no server yet"
+        assert em_esphome._pending_caps[device_id] == ["mic", "ambient_light"], \
+            "the capabilities must be held until a server exists to take them"
+    finally:
+        em_esphome._pending_caps.pop(device_id, None)
+
+
+def test_the_pending_capabilities_are_what_the_entity_gate_reads():
+    """
+    Guard against the two halves drifting: holding the value is only useful
+    if server creation applies it to the same attribute the ListEntities gate
+    checks (_device_has → srv.capabilities).
+    """
+    import inspect
+    import em_esphome
+
+    src = inspect.getsource(em_esphome._register_device_server)
+    assert "_pending_caps" in src, \
+        "server creation must seed capabilities from the pending map"
+    assert "set_capabilities" in src, \
+        "and must apply them via the same setter the gate reads"

--- a/controller/tests/test_capabilities.py
+++ b/controller/tests/test_capabilities.py
@@ -95,35 +95,39 @@ def test_capabilities_reported_before_the_server_exists_are_not_lost():
     that list is a ONE-SHOT at ListEntities time: HA caches it and the sensor
     is absent for the life of the connection.
 
-    Observed on Retreat, 2026-08-03: connected 05:25:33, server created
+    Observed on Retreat, 2026-08-03: registered 05:25:33, server created
     05:25:34, no ambient light entity in HA afterwards. The same race resolves
-    differently per controller restart, which is why the graph came and went.
+    differently on each controller restart, which is why the graph came and
+    went rather than simply never working.
+
+    Read as source, not imported: em_esphome pulls in zeroconf and aiohttp,
+    which this suite deliberately does without.
     """
-    import em_esphome
+    src = ESPHOME.read_text()
+    setter = re.search(r"def set_device_capabilities\(.*?\n(?=\n\ndef |\Z)", src, re.S)
+    assert setter, "could not find set_device_capabilities"
+    body = setter.group(0)
+    # The store must happen unconditionally — not inside the "if server" arm,
+    # which is exactly what dropped it.
+    store = re.search(r"^\s{4}_pending_caps\[device_id\]\s*=", body, re.M)
+    assert store, (
+        "set_device_capabilities must hold the capabilities unconditionally; "
+        "pushing them only when a server already exists loses them"
+    )
 
-    device_id = "G090LFTESTCAPS"
-    em_esphome._pending_caps.pop(device_id, None)
-    try:
-        # Registration lands first, with no server yet.
-        em_esphome.set_device_capabilities(device_id, ["mic", "ambient_light"])
-        assert device_id not in em_esphome._servers, "precondition: no server yet"
-        assert em_esphome._pending_caps[device_id] == ["mic", "ambient_light"], \
-            "the capabilities must be held until a server exists to take them"
-    finally:
-        em_esphome._pending_caps.pop(device_id, None)
 
-
-def test_the_pending_capabilities_are_what_the_entity_gate_reads():
+def test_the_pending_capabilities_are_applied_when_the_server_is_built():
     """
     Guard against the two halves drifting: holding the value is only useful
     if server creation applies it to the same attribute the ListEntities gate
-    checks (_device_has → srv.capabilities).
+    reads (_device_has → srv.capabilities).
     """
-    import inspect
-    import em_esphome
-
-    src = inspect.getsource(em_esphome._register_device_server)
-    assert "_pending_caps" in src, \
+    src = ESPHOME.read_text()
+    create = re.search(r"async def _register_device_server\(.*?\n(?=\n\nasync def |\n\ndef |\Z)",
+                       src, re.S)
+    assert create, "could not find _register_device_server"
+    body = create.group(0)
+    assert "_pending_caps" in body, \
         "server creation must seed capabilities from the pending map"
-    assert "set_capabilities" in src, \
-        "and must apply them via the same setter the gate reads"
+    assert "set_capabilities" in body, \
+        "and must apply them via the same setter the entity gate reads"

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -658,3 +658,23 @@ def test_support_bundle_redacts_account_names():
         "accounts must carry the role: a name is replaced by <admin>, and a "
         "positional alias would be one-to-one with a real person"
     )
+
+
+def test_the_music_feed_reads_its_lead_per_chunk():
+    """
+    A voice turn lowers the music feed's lead so the response gets the shared
+    data plane (TURN_LEAD_S). That only works if the pacing loop reads the
+    CURRENT lead each time round — capturing LEAD_S once, or referring to the
+    module constant, silently restores the old behaviour and the fix becomes
+    a no-op with every test still passing.
+    """
+    src = (CONTROLLER / "em_player.py").read_text()
+    feed = src.split("async def _feed")[-1]
+    pacing = re.search(r"ahead = sent / BYTES_PER_SEC.*?await asyncio\.sleep\(([^)]*)\)",
+                       feed, re.S)
+    assert pacing, "could not find the feed's pacing sleep"
+    window = feed[:pacing.end()]
+    assert "self.lead_s" in window, (
+        "the pacing loop must read self.lead_s, not the LEAD_S constant — "
+        "otherwise lowering the lead for a voice turn does nothing"
+    )

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -825,3 +825,60 @@ def test_stopping_music_flushes_the_music_plane_not_the_voice_one():
     kinds = [m.get("type") for m in device.control_msgs]
     assert "music_flush" in kinds
     assert "speaker_flush" not in kinds
+
+
+def test_the_music_feed_yields_the_wire_during_a_turn():
+    """
+    Music and TTS share one WebSocket, so a 4s music lead puts ~380KB ahead
+    of the response in the socket. Measured on the first ducked turn: the
+    response waited 2087ms to start and took a 3549ms gap mid-stream. The
+    feed drops its lead for the turn so the response gets the wire.
+    """
+    async def main():
+        device = MixingDevice()
+        _wire(device)
+        s = StubSession("office", periods=3, endless=True)
+        em_player._sessions["office"] = s
+        await s.play("http://radio/stream")
+        await asyncio.sleep(0)
+        before = s.lead_s
+        await em_player.interrupt("office")
+        during = s.lead_s
+        await em_player.resume_interrupted("office")
+        after = s.lead_s
+        await s.stop()
+        return before, during, after
+    before, during, after = asyncio.run(main())
+    assert before == em_player.LEAD_S
+    assert during == em_player.TURN_LEAD_S, "the feed must yield during a turn"
+    assert during < before
+    assert after == em_player.LEAD_S, "and take the wire back afterwards"
+
+
+def test_the_reduced_lead_still_protects_the_music():
+    """
+    Not zero: at zero the music would be sent at the instant it is needed,
+    with no margin against a stall DURING the turn — trading one dropout for
+    another.
+    """
+    assert em_player.TURN_LEAD_S > 0
+
+
+def test_a_pausing_device_does_not_change_its_lead():
+    """
+    On firmware that cannot mix, music is paused for the turn, so there is
+    nothing sharing the wire and nothing to yield.
+    """
+    async def main():
+        device = FakeDevice()
+        _wire(device)
+        s = StubSession("office", periods=3, endless=True)
+        em_player._sessions["office"] = s
+        await s.play("http://radio/stream")
+        await asyncio.sleep(0)
+        await em_player.interrupt("office")
+        during = s.lead_s
+        await em_player.resume_interrupted("office")
+        await s.stop()
+        return during
+    assert asyncio.run(main()) == em_player.LEAD_S

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -700,3 +700,128 @@ def test_an_unseekable_stream_is_only_discovered_once():
         assert s._seekable, "seekability must not leak across URLs"
         await s.stop()
     asyncio.run(main())
+
+
+class MixingDevice(FakeDevice):
+    """A device announcing the audio_mix capability."""
+    audio_mix_capable = True
+
+
+def test_music_rides_its_own_plane_on_a_mixing_device():
+    """
+    0x04/0x05, so the device can hold it separately from voice and mix the
+    two. On 0x02 it would share the voice plane and ducking is impossible.
+    """
+    async def main():
+        device = MixingDevice()
+        _wire(device)
+        s = StubSession("office", periods=3)
+        await s.play("http://radio/stream")
+        await asyncio.wait_for(s._task, 5)
+        return device
+    device = asyncio.run(main())
+    assert [f[0] for f in device.data_frames] == [0x04, 0x04, 0x04, 0x05]
+
+
+def test_music_stays_on_the_voice_plane_for_older_firmware():
+    """
+    Degrade to the old behaviour, never to silence: firmware without the
+    capability would simply never play a 0x04 frame.
+    """
+    async def main():
+        device = FakeDevice()
+        _wire(device)
+        s = StubSession("office", periods=2)
+        await s.play("http://radio/stream")
+        await asyncio.wait_for(s._task, 5)
+        return device
+    device = asyncio.run(main())
+    assert [f[0] for f in device.data_frames] == [0x02, 0x02, 0x03]
+
+
+def test_a_turn_ducks_instead_of_pausing_when_the_device_can_mix():
+    """
+    The whole point. Pausing costs a seek, and a Music Assistant flow stream
+    cannot seek — so a 28s turn cost 28s of the song. Ducking keeps the music
+    playing under the response and loses nothing.
+    """
+    async def main():
+        device = MixingDevice()
+        _wire(device)
+        s = StubSession("office", periods=3, endless=True)
+        em_player._sessions["office"] = s
+        await s.play("http://radio/stream")
+        await asyncio.sleep(0)
+        await em_player.interrupt("office")
+        state_during = s.state
+        await em_player.resume_interrupted("office")
+        await s.stop()
+        return device, s, state_during
+    device, s, state_during = asyncio.run(main())
+
+    assert state_during == PLAYING, "the music must keep playing under the turn"
+    ducks = [m for m in device.control_msgs if m.get("type") == "duck"]
+    assert [m["on"] for m in ducks] == [True, False]
+    assert not any(m.get("type") == "speaker_flush" for m in device.control_msgs), \
+        "ducking must not flush — that discards the buffer that makes it instant"
+    assert s.spawns == [0.0], "no reseek: the stream was never interrupted"
+
+
+def test_a_turn_still_pauses_on_firmware_that_cannot_mix():
+    async def main():
+        device = FakeDevice()
+        _wire(device)
+        s = StubSession("office", periods=3, endless=True)
+        em_player._sessions["office"] = s
+        await s.play("http://radio/stream")
+        await asyncio.sleep(0)
+        await em_player.interrupt("office")
+        paused = s.state
+        await em_player.resume_interrupted("office")
+        await s.stop()
+        return device, paused
+    device, paused = asyncio.run(main())
+    assert paused == PAUSED
+    assert not any(m.get("type") == "duck" for m in device.control_msgs), \
+        "a device that cannot mix must never be told to duck"
+
+
+def test_pausing_during_a_ducked_turn_actually_pauses():
+    """
+    On the pausing path interrupt() had already paused, so the deferred
+    "pause" needed no wire action. When we duck instead, nothing was ever
+    paused — so the user's pause has to actually happen at turn end, or it is
+    silently dropped and the music plays on.
+    """
+    async def main():
+        device = MixingDevice()
+        _wire(device)
+        s = StubSession("office", periods=3, endless=True)
+        em_player._sessions["office"] = s
+        await s.play("http://radio/stream")
+        await asyncio.sleep(0)
+        await em_player.interrupt("office")
+        await em_player.pause("office")          # user speaks: "pause the music"
+        await em_player.resume_interrupted("office")
+        return device, s
+    device, s = asyncio.run(main())
+    assert s.state == PAUSED, "the user's pause must survive a ducked turn"
+
+
+def test_stopping_music_flushes_the_music_plane_not_the_voice_one():
+    """
+    speaker_flush would cut the response and leave the music playing, which
+    is exactly backwards.
+    """
+    async def main():
+        device = MixingDevice()
+        _wire(device)
+        s = StubSession("office", periods=3, endless=True)
+        await s.play("http://radio/stream")
+        await asyncio.sleep(0)
+        await s.stop()
+        return device
+    device = asyncio.run(main())
+    kinds = [m.get("type") for m in device.control_msgs]
+    assert "music_flush" in kinds
+    assert "speaker_flush" not in kinds

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -279,6 +279,23 @@ func main() {
 		pcmSpeaker.Flush()
 	})
 
+	// Music flush — the user genuinely stopped or paused. A voice turn ducks
+	// instead and must never send this.
+	controlClient.OnMusicFlush(func() {
+		pcmSpeaker.FlushMusic()
+	})
+
+	// Duck — music is attenuated under a voice turn and restored at the end.
+	// The depth is read at duck time rather than latched, so a config change
+	// takes effect on the next turn without a restart.
+	controlClient.OnDuck(func(on bool) {
+		if on {
+			pcmSpeaker.SetDuck(config.Get().DuckDb)
+		} else {
+			pcmSpeaker.SetDuck(0)
+		}
+	})
+
 	// Per-stream playback stats — underrun/period counts reported upstream
 	// once per completed TTS stream, persisted against the voice turn.
 	pcmSpeaker.OnStreamStats(func(st speaker.StreamStats) {

--- a/device/internal/bindings/speaker/mix.go
+++ b/device/internal/bindings/speaker/mix.go
@@ -1,0 +1,182 @@
+package speaker
+
+import "math"
+
+// Ducking and mixing for the two playback streams.
+//
+// No build tag and no tinyalsa import, deliberately: this is the arithmetic
+// the ALSA write path runs on every period, and it is the part worth testing
+// on the host. pcm_speaker.go is `//go:build server` and cannot be compiled
+// or tested anywhere but the device.
+//
+// WHY THE DEVICE MIXES AT ALL. Barge-in used to pause the music, answer, and
+// resume. Every assistant people compare us to ducks instead, and pausing
+// carried real bugs with it: a Music Assistant flow stream cannot be seeked,
+// so a 28-second turn cost 28 seconds of the song, and the media_player
+// entity had to report PLAYING while internally paused (#62) or Home
+// Assistant would decline the user's own pause.
+//
+// It has to happen HERE rather than in the controller because of `LEAD_S`:
+// the music feed runs 4 seconds ahead of realtime, so when a wake word fires
+// the next 4 seconds of music are already in this device's buffer. Audio
+// that has left the controller cannot be ducked by the controller. Doing it
+// on the device means the music keeps its full ~5.5s of link-stall
+// protection AND ducking is instant, because the gain is applied to audio we
+// are already holding.
+
+// Q15 fixed point: 32768 == unity. Integer maths on a 32-bit A53 with no
+// FPU pressure on the audio path, and exact at unity — a float multiply
+// would leave a stream that is nominally not ducked very slightly altered.
+const unityGain int32 = 1 << 15
+
+// duckRampPeriods — periods taken to traverse the FULL gain range. A period
+// is ~42.7ms, so 4 gives a ~170ms ramp for a duck from unity to silence, and
+// proportionally less for a shallower one. Fast enough that the duck lands
+// with the wake word, slow enough to be a fade rather than a step: stepping
+// the gain at a period boundary is an audible click, landing on exactly the
+// transition the user is listening to.
+//
+// A CONSTANT SLEW, not a proportional one. `(target-gain)/n` per period is
+// an exponential approach: 4 is then a time constant, not a duration, and
+// the gain crawls the last few percent for over a second — measured at 31
+// periods (1.3s) to settle, against the 170ms this comment used to claim.
+const duckRampPeriods = 4
+
+// rampStep is the most the gain may move in one period.
+const rampStep = unityGain / duckRampPeriods
+
+// Mixer combines the voice and music streams for one output period.
+//
+// Single-consumer by contract: only the ALSA write goroutine touches it, so
+// nothing here is synchronised. The gain TARGET is set from elsewhere and is
+// the one field that needs atomicity — it lives in PcmSpeaker, not here.
+type Mixer struct {
+	gain int32 // current, Q15, ramps toward the target
+}
+
+// DuckGain converts decibels of attenuation to Q15.
+//
+// 0 dB is returned as exactly unity rather than a rounded conversion, so
+// "not ducked" is bit-identical to the input.
+func DuckGain(db float64) int32 {
+	if db >= 0 {
+		return unityGain
+	}
+	g := math.Pow(10, db/20.0) * float64(unityGain)
+	if g < 0 {
+		return 0
+	}
+	return int32(g + 0.5)
+}
+
+// Gain reports the current (ramped) gain, for tests and logging.
+func (m *Mixer) Gain() int32 { return m.gain }
+
+// SetGainImmediate jumps the ramp to a value. Used at stream start, where
+// there is no audio to click.
+func (m *Mixer) SetGainImmediate(g int32) { m.gain = g }
+
+// Mix produces one output period from whichever streams have audio.
+//
+// Both buffers are owned by the caller once dequeued, so mixing happens IN
+// PLACE and the function allocates nothing — this runs ~23 times a second
+// for as long as anything is playing.
+//
+// Returns the buffer to write, or nil when there is nothing to play (the
+// caller pumps silence, which is what paces this loop).
+func (m *Mixer) Mix(voice, music []byte, target int32) []byte {
+	switch {
+	case voice == nil && music == nil:
+		// Still settle the ramp: a duck requested while nothing is playing
+		// must not be waiting, half-applied, for the next period of audio.
+		m.stepGain(target)
+		return nil
+
+	case music == nil:
+		// Voice alone is never ducked — it is the thing being listened to.
+		m.stepGain(target)
+		return voice
+
+	case voice == nil:
+		m.applyGain(music, target)
+		return music
+
+	default:
+		m.applyGain(music, target)
+		mixInto(voice, music)
+		return voice
+	}
+}
+
+// stepGain moves the current gain one period toward the target, by at most
+// rampStep. Clamped rather than divided, so it always arrives exactly.
+func (m *Mixer) stepGain(target int32) {
+	switch {
+	case m.gain < target:
+		if m.gain += rampStep; m.gain > target {
+			m.gain = target
+		}
+	case m.gain > target:
+		if m.gain -= rampStep; m.gain < target {
+			m.gain = target
+		}
+	}
+}
+
+// applyGain scales a period, ramping across it sample by sample.
+//
+// The ramp is per SAMPLE, not per period: a gain change applied at a period
+// boundary is a step discontinuity, which is a click. Interpolating across
+// the period turns the same change into a fade.
+func (m *Mixer) applyGain(buf []byte, target int32) {
+	start := m.gain
+	m.stepGain(target)
+	end := m.gain
+
+	frames := len(buf) / 4 // stereo S16
+	if frames == 0 {
+		return
+	}
+	for i := 0; i < frames; i++ {
+		g := start
+		if end != start {
+			g = start + (end-start)*int32(i)/int32(frames)
+		}
+		// L and R are duplicates on this hardware, but scale both rather
+		// than assuming it — the assumption is one refactor away from being
+		// silently wrong, and the cost is one multiply.
+		for c := 0; c < 2; c++ {
+			off := i*4 + c*2
+			s := int32(int16(uint16(buf[off]) | uint16(buf[off+1])<<8))
+			s = (s * g) >> 15
+			buf[off] = byte(uint16(s) & 0xff)
+			buf[off+1] = byte(uint16(s) >> 8)
+		}
+	}
+}
+
+// mixInto sums music into voice with saturation.
+//
+// Saturating rather than wrapping: an int16 overflow wraps a loud peak to
+// full-scale opposite polarity, which is a far worse noise than the clipping
+// it replaces. With music ducked ~18dB under a response that peaks well
+// below full scale, the sum should not reach this often — but "should not"
+// is not a reason to leave the wrap in.
+func mixInto(dst, src []byte) {
+	n := len(dst)
+	if len(src) < n {
+		n = len(src)
+	}
+	for i := 0; i+1 < n; i += 2 {
+		a := int32(int16(uint16(dst[i]) | uint16(dst[i+1])<<8))
+		b := int32(int16(uint16(src[i]) | uint16(src[i+1])<<8))
+		s := a + b
+		if s > math.MaxInt16 {
+			s = math.MaxInt16
+		} else if s < math.MinInt16 {
+			s = math.MinInt16
+		}
+		dst[i] = byte(uint16(s) & 0xff)
+		dst[i+1] = byte(uint16(s) >> 8)
+	}
+}

--- a/device/internal/bindings/speaker/mix_test.go
+++ b/device/internal/bindings/speaker/mix_test.go
@@ -1,0 +1,193 @@
+package speaker
+
+import (
+	"math"
+	"testing"
+)
+
+// period builds a stereo S16 period where every frame has the same value.
+func period(frames int, v int16) []byte {
+	b := make([]byte, frames*4)
+	for i := 0; i < frames; i++ {
+		for c := 0; c < 2; c++ {
+			off := i*4 + c*2
+			b[off] = byte(uint16(v) & 0xff)
+			b[off+1] = byte(uint16(v) >> 8)
+		}
+	}
+	return b
+}
+
+func sampleAt(b []byte, frame, ch int) int16 {
+	off := frame*4 + ch*2
+	return int16(uint16(b[off]) | uint16(b[off+1])<<8)
+}
+
+func TestDuckGainUnityIsExact(t *testing.T) {
+	// A stream that is not ducked must be bit-identical, not "close".
+	if g := DuckGain(0); g != unityGain {
+		t.Fatalf("0dB should be exactly unity, got %d", g)
+	}
+	m := &Mixer{gain: unityGain}
+	in := period(4, 12345)
+	m.applyGain(in, unityGain)
+	for i := 0; i < 4; i++ {
+		if got := sampleAt(in, i, 0); got != 12345 {
+			t.Fatalf("unity gain altered the sample: %d", got)
+		}
+	}
+}
+
+func TestDuckGainDecibels(t *testing.T) {
+	// -6dB is half amplitude, -18dB is the starting duck depth.
+	for _, tc := range []struct{ db, want float64 }{
+		{-6, 0.5012}, {-18, 0.1259}, {-60, 0.001},
+	} {
+		got := float64(DuckGain(tc.db)) / float64(unityGain)
+		if math.Abs(got-tc.want) > 0.001 {
+			t.Errorf("%gdB: got %.4f want %.4f", tc.db, got, tc.want)
+		}
+	}
+}
+
+func TestVoiceAloneIsNeverAltered(t *testing.T) {
+	// The response is the thing being listened to; ducking applies to the
+	// bed underneath it, never to it.
+	m := &Mixer{gain: DuckGain(-18)}
+	voice := period(4, 8000)
+	out := m.Mix(voice, nil, DuckGain(-18))
+	for i := 0; i < 4; i++ {
+		if got := sampleAt(out, i, 0); got != 8000 {
+			t.Fatalf("voice was attenuated: %d", got)
+		}
+	}
+}
+
+func TestMusicAloneIsDucked(t *testing.T) {
+	m := &Mixer{gain: DuckGain(-6)}
+	music := period(4, 10000)
+	out := m.Mix(nil, music, DuckGain(-6))
+	got := sampleAt(out, 3, 0)
+	if got < 4900 || got > 5100 {
+		t.Fatalf("expected ~5000 (-6dB of 10000), got %d", got)
+	}
+}
+
+func TestNothingPlayingReturnsNil(t *testing.T) {
+	m := &Mixer{gain: unityGain}
+	if out := m.Mix(nil, nil, unityGain); out != nil {
+		t.Fatal("with no audio the caller must pump silence, not a buffer")
+	}
+}
+
+func TestTheRampSettlesEvenWithNoAudio(t *testing.T) {
+	// A duck requested while nothing is playing must not sit half-applied
+	// waiting for the next period — the next thing to play would fade in
+	// from a stale gain.
+	m := &Mixer{gain: unityGain}
+	target := DuckGain(-18)
+	for i := 0; i < 20; i++ {
+		m.Mix(nil, nil, target)
+	}
+	if m.Gain() != target {
+		t.Fatalf("ramp did not settle while idle: %d != %d", m.Gain(), target)
+	}
+}
+
+func TestTheRampReachesItsTargetExactly(t *testing.T) {
+	// Integer division floors, so the last steps round to zero and the gain
+	// would otherwise stop just short of the target forever.
+	m := &Mixer{gain: unityGain}
+	target := DuckGain(-18)
+	for i := 0; i < 200; i++ {
+		m.applyGain(period(2, 1000), target)
+	}
+	if m.Gain() != target {
+		t.Fatalf("gain never reached target: %d != %d", m.Gain(), target)
+	}
+	// And back up again.
+	for i := 0; i < 200; i++ {
+		m.applyGain(period(2, 1000), unityGain)
+	}
+	if m.Gain() != unityGain {
+		t.Fatalf("gain never returned to unity: %d", m.Gain())
+	}
+}
+
+func TestTheRampIsGradualNotAStep(t *testing.T) {
+	// A gain change applied at a period boundary is a click, landing on
+	// exactly the moment the user is listening to.
+	m := &Mixer{gain: unityGain}
+	target := DuckGain(-18)
+	first := period(64, 10000)
+	m.applyGain(first, target)
+
+	start := sampleAt(first, 0, 0)
+	end := sampleAt(first, 63, 0)
+	if start <= end {
+		t.Fatalf("expected a descending ramp across the period, got %d → %d", start, end)
+	}
+	if start < 9000 {
+		t.Fatalf("the ramp should START near the previous gain, got %d", start)
+	}
+	// And it must not have arrived within one period either.
+	if m.Gain() == target {
+		t.Fatal("the whole duck landed in one period — that is the step this avoids")
+	}
+}
+
+func TestMixSumsBothStreams(t *testing.T) {
+	m := &Mixer{gain: unityGain}
+	voice := period(4, 1000)
+	music := period(4, 2000)
+	out := m.Mix(voice, music, unityGain)
+	if got := sampleAt(out, 3, 0); got != 3000 {
+		t.Fatalf("expected 1000+2000, got %d", got)
+	}
+}
+
+func TestMixSaturatesRatherThanWrapping(t *testing.T) {
+	// An int16 overflow wraps a loud peak to full-scale opposite polarity,
+	// which is a much worse noise than the clipping it replaces.
+	m := &Mixer{gain: unityGain}
+	voice := period(2, 30000)
+	music := period(2, 30000)
+	out := m.Mix(voice, music, unityGain)
+	if got := sampleAt(out, 0, 0); got != math.MaxInt16 {
+		t.Fatalf("expected saturation to +32767, got %d", got)
+	}
+
+	m2 := &Mixer{gain: unityGain}
+	out2 := m2.Mix(period(2, -30000), period(2, -30000), unityGain)
+	if got := sampleAt(out2, 0, 0); got != math.MinInt16 {
+		t.Fatalf("expected saturation to -32768, got %d", got)
+	}
+}
+
+func TestMixHandlesMismatchedLengths(t *testing.T) {
+	// The two streams are independent; a short final period on one must not
+	// index past the end of the other.
+	m := &Mixer{gain: unityGain}
+	out := m.Mix(period(8, 100), period(3, 100), unityGain)
+	if len(out) != 32 {
+		t.Fatalf("output should keep the voice period's length, got %d", len(out))
+	}
+	if got := sampleAt(out, 0, 0); got != 200 {
+		t.Fatalf("overlapping region should be summed, got %d", got)
+	}
+	if got := sampleAt(out, 7, 0); got != 100 {
+		t.Fatalf("the tail beyond the shorter buffer should be untouched, got %d", got)
+	}
+}
+
+func TestBothChannelsAreScaled(t *testing.T) {
+	// L and R are duplicates on this hardware, but the code must not depend
+	// on that — the assumption is one refactor away from being wrong.
+	m := &Mixer{gain: DuckGain(-6)}
+	buf := period(4, 10000)
+	m.applyGain(buf, DuckGain(-6))
+	l, r := sampleAt(buf, 3, 0), sampleAt(buf, 3, 1)
+	if l != r {
+		t.Fatalf("channels diverged: L=%d R=%d", l, r)
+	}
+}

--- a/device/internal/bindings/speaker/pcm_speaker.go
+++ b/device/internal/bindings/speaker/pcm_speaker.go
@@ -198,6 +198,14 @@ func (p *PcmSpeaker) silenceLoop() {
 			p.report(p.music.drained(), "music")
 		}
 
+		// The ring's level must be measured BEFORE mixing: Mix sums into the
+		// voice buffer in place, so afterwards there is no voice-only signal
+		// left to measure.
+		var level float64
+		if voice != nil && p.levelTap != nil {
+			level = periodRMS(voice)
+		}
+
 		out := p.mixer.Mix(voice, music, p.duckTarget.Load())
 		if out == nil {
 			out = silencePeriod
@@ -211,12 +219,12 @@ func (p *PcmSpeaker) silenceLoop() {
 		if p.echoTap != nil {
 			p.echoTap(out)
 		}
+		// VOICE only, deliberately — unlike the echo tap above. The meter
+		// ring visualises the RESPONSE; feeding it the mix made the ring
+		// throb along to ducked music before the response had started, which
+		// reads as the device doing something it is not.
 		if p.levelTap != nil {
-			if voice == nil && music == nil {
-				p.levelTap(0)
-			} else {
-				p.levelTap(periodRMS(out))
-			}
+			p.levelTap(level)
 		}
 		if err := p.session.Pump(out); err != nil {
 			log.Printf("silenceLoop: pump error: %v", err)

--- a/device/internal/bindings/speaker/pcm_speaker.go
+++ b/device/internal/bindings/speaker/pcm_speaker.go
@@ -3,7 +3,6 @@
 package speaker
 
 import (
-	"fmt"
 	"log"
 	"math"
 	"os/exec"
@@ -47,58 +46,35 @@ const primePeriods = 24
 var silencePeriod = make([]byte, periodBytes)
 
 type PcmSpeaker struct {
-	session  *tinyalsa.AudioSession
-	audioCh  chan []byte
-	stopCh   chan struct{}
-	// deadCh is closed by silenceLoop on any exit so PumpPeriod can return
+	session *tinyalsa.AudioSession
+	stopCh  chan struct{}
+	// deadCh is closed by silenceLoop on any exit so a pump call can return
 	// an error rather than block indefinitely waiting for a dead consumer.
-	deadCh   chan struct{}
-	// eosPending is set by EndStream (WS reader received 0x03) and consumed
-	// by silenceLoop when audioCh drains, so a drain at natural end of
-	// stream isn't misreported as an underrun.
-	eosPending atomic.Bool
+	deadCh chan struct{}
 
-	// ── per-stream delivery instrumentation ───────────────────────────
-	// Underruns are a rare binary event; these give the *margin* on every
-	// stream, so a link that is merely close to starving is visible before
-	// it audibly breaks (2026-07-20: added after underruns appeared with
-	// no measurable cause — every metric we had timed the wrong thing).
+	// Two independent playback planes, mixed at the ALSA write.
 	//
-	// Written only by PumpPeriod, which the WS read loop calls
-	// sequentially — single writer, so a plain load/compare/store needs no
-	// lock. silenceLoop reads them once per stream at EOS. Cost on the
-	// audio hot path is one time.Now() plus an integer compare per ~42ms
-	// period (~23/s); nothing here allocates or logs.
-	recvFirstNs  atomic.Int64  // arrival of this stream's first 0x02
-	recvLastNs   atomic.Int64  // arrival of the most recent 0x02
-	recvMaxGapNs atomic.Int64  // largest inter-arrival gap this stream
-	recvBytes    atomic.Uint64 // wire bytes received this stream
+	// voice carries TTS and announcements (0x02/0x03); music carries the
+	// media player (0x04/0x05). They are separate so a voice turn can duck
+	// the music instead of pausing it: the music feed runs LEAD_S=4s ahead
+	// of realtime, so by the time a wake word fires the next four seconds
+	// are already in this buffer, and audio that has left the controller
+	// cannot be ducked by the controller. Holding both here means the music
+	// keeps its full ~5.5s of link-stall protection AND the duck is instant.
+	//
+	// All the per-stream machinery — prime gate, discard-until-EOS,
+	// underrun accounting, delivery instrumentation — lives in audioStream,
+	// so both planes get the behaviour that was worked out on the single
+	// one rather than a simplified copy.
+	voice *audioStream
+	music *audioStream
 
-	// stateMu guards streamActive and discarding as one unit. They used to
-	// be independent atomics, but Flush's check-streamActive-then-arm and
-	// EndStream's clear-both are compound transitions: a barge-in Flush
-	// racing a stream's natural EndStream (control and data ride separate
-	// WebSockets) could observe streamActive just before EndStream cleared
-	// it and then arm discarding just after EndStream consumed it — leaving
-	// discard armed with no EOS ever coming, silently swallowing the whole
-	// NEXT response up to its EOS.
-	stateMu sync.Mutex
-	// streamActive tracks whether a 0x02 stream is mid-flight (set by
-	// PumpPeriod, cleared by EndStream — both on the WS read goroutine).
-	// Read by Flush to decide whether to arm discarding.
-	streamActive bool
-	// discarding, when set, makes PumpPeriod drop incoming periods until
-	// the stream's 0x03 EOS arrives. Armed by Flush (barge-in) when a
-	// stream is mid-flight: draining audioCh alone is not enough, because
-	// the rest of the cancelled stream is typically already in flight in
-	// the TCP buffers of both ends — the WS reader would refill the channel
-	// straight after the drain and playback would carry on after a ~1.3s
-	// skip (observed 2026-07-08: barge-in cut the LED but the TTS kept
-	// talking, and the interrupting turn transcribed the device's own
-	// voice). The controller always terminates a stream with 0x03, on the
-	// cancel path included, so discard-until-EOS consumes exactly the
-	// remainder of the cancelled stream no matter how much was buffered.
-	discarding bool
+	// duckTarget is the gain applied to MUSIC while it plays under a voice
+	// turn, Q15. Written from the control plane (SetDuck) and read by the
+	// ALSA goroutine every period, hence atomic; the ramp toward it lives in
+	// the Mixer, which is single-consumer and needs no synchronisation.
+	duckTarget atomic.Int32
+	mixer      Mixer
 
 	// echoTap, when non-nil, receives every period pumped to ALSA — real
 	// audio and silence alike — so an AEC reference stream advances in
@@ -125,32 +101,6 @@ type PcmSpeaker struct {
 	statsCb func(StreamStats)
 }
 
-// StreamStats is the per-stream delivery report, emitted once at EOS.
-//
-// Periods/Underruns answer "did it break". The rest answer "how close did
-// it come, and which side was late" — the questions we could not answer on
-// 2026-07-20 because every available metric measured something else (the
-// controller's "Streaming took 0.0s" times a socket write, not delivery).
-//
-//   - MinDepth: fewest periods left in the buffer at any point mid-stream.
-//     The headline margin number. 0 means it starved (an underrun); a
-//     stream that only ever reached 2 was one hiccup away.
-//   - PrimeWaitMs: first frame arriving → first frame played. Long means
-//     the sender could not fill the prime buffer promptly.
-//   - RecvSpanMs vs audio duration: delivery slower than realtime is the
-//     definitive "the wire could not keep up" signal.
-//   - MaxGapMs: the worst single stall in arrivals, which distinguishes a
-//     uniformly slow link from a briefly stalled one.
-type StreamStats struct {
-	Periods     uint64 `json:"periods"`
-	Underruns   uint64 `json:"underruns"`
-	MinDepth    int    `json:"minDepth"`
-	PrimeWaitMs int64  `json:"primeWaitMs"`
-	RecvSpanMs  int64  `json:"recvSpanMs"`
-	MaxGapMs    int64  `json:"maxGapMs"`
-	BytesRecv   uint64 `json:"bytesRecv"`
-}
-
 // OnStreamStats registers a per-stream stats callback, reported once when a
 // stream reaches its EOS. Invoked on its own goroutine so a slow consumer
 // (network send) can never stall the ALSA pump. Safe to call any time
@@ -163,12 +113,15 @@ func (p *PcmSpeaker) OnStreamStats(cb func(StreamStats)) {
 
 func NewPcmSpeaker(echoTap func([]byte), levelTap func(rms float64)) (*PcmSpeaker, error) {
 	s := &PcmSpeaker{
-		audioCh:  make(chan []byte, audioChanDepth),
 		stopCh:   make(chan struct{}),
 		deadCh:   make(chan struct{}),
 		echoTap:  echoTap,
 		levelTap: levelTap,
 	}
+	s.voice = newAudioStream(audioChanDepth, s.deadCh)
+	s.music = newAudioStream(audioChanDepth, s.deadCh)
+	s.duckTarget.Store(unityGain)
+	s.mixer.SetGainImmediate(unityGain)
 	if err := s.Init(); err != nil {
 		return nil, err
 	}
@@ -212,189 +165,133 @@ func (p *PcmSpeaker) Init() error {
 	return nil
 }
 
-// silenceLoop runs continuously, playing real audio from audioCh when available
-// and silence when the channel is empty. No pause/resume needed — the select
-// naturally yields to real audio. Closes deadCh on any exit so PumpPeriod
-// callers unblock and receive an error rather than hanging.
+// silenceLoop is the ALSA write path: every period, take what each plane has
+// to offer, mix them, and pump. When neither has audio it pumps silence,
+// which is what paces this loop — ALSA blocks in Pump at realtime rate, so
+// there is no timer anywhere and no busy-waiting.
 //
-// audioStreaming tracks whether we are mid-stream. When the channel drains
-// while audioStreaming is true, that's an underrun — a silence period is
-// being injected mid-content. Logged at WARNING so it shows up in server.log
-// against the stutter symptom. Remove once the cause is confirmed and fixed.
+// It replaced a blocking select on a single channel. Two planes cannot be
+// waited on that way without one starving the other, and mixing needs both
+// in hand at the same instant; a non-blocking take from each, with silence
+// as the floor, keeps the pacing property that made the original correct.
+//
+// Closes deadCh on any exit so blocked pump callers unblock with an error
+// rather than hanging.
 func (p *PcmSpeaker) silenceLoop() {
 	defer close(p.deadCh)
-	audioStreaming := false
-	var underruns uint64 // loop-local: only this goroutine drains audioCh
-	// Per-stream accounting for the stats callback: accumulates across
-	// mid-stream drains (a drain flips audioStreaming but the stream isn't
-	// over until its EOS), reported and reset at EOS consume.
-	var streamPeriods, streamUnderruns uint64
-	// Consumption-side instrumentation (see StreamStats). Loop-local: only
-	// this goroutine drains audioCh, so no synchronisation is needed.
-	streamMinDepth := -1     // -1 = nothing consumed yet this stream
-	var firstPumpNs int64    // first period actually played this stream
 	for {
-		// Prime gate: while idle, hold on silence until the buffer has
-		// primePeriods queued or the stream's EOS is already in (short
-		// clip — everything it will ever have is queued). A nil channel
-		// disables the receive case; the silence default then paces the
-		// wait at ALSA rate while the sender fills the buffer. Once
-		// audioStreaming, the gate stays out of the way — mid-stream
-		// drains keep their underrun accounting below. (A stale
-		// eosPending from a barge-in flush can skip one prime — harmless:
-		// the follow-up response just starts eagerly, pre-2026-07-14
-		// behaviour.)
-		audioSrc := p.audioCh
-		if !audioStreaming {
-			if n := len(p.audioCh); n > 0 && n < primePeriods && !p.eosPending.Load() {
-				audioSrc = nil
-			}
-		}
 		select {
 		case <-p.stopCh:
 			return
-		case period := <-audioSrc:
-			audioStreaming = true
-			streamPeriods++
-			// Buffer margin: occupancy remaining *after* taking this
-			// period. len() on a channel is O(1); no allocation, no log.
-			//
-			// Sampled ONLY while the sender still has audio to send. The
-			// last periods of every stream necessarily drain the buffer to
-			// zero, so measuring across the tail made this read 0 on 100%
-			// of streams — healthy ones included — which is how it shipped
-			// in v2.9.6 and told us nothing (caught on first field data,
-			// 2026-07-20). eosPending is set by EndStream the instant the
-			// 0x03 arrives, so !eosPending means "more audio is still
-			// expected" and a low buffer *there* is a real margin warning.
-			if !p.eosPending.Load() {
-				if d := len(p.audioCh); streamMinDepth < 0 || d < streamMinDepth {
-					streamMinDepth = d
-				}
-			}
-			if firstPumpNs == 0 {
-				firstPumpNs = time.Now().UnixNano()
-			}
-			if p.echoTap != nil {
-				p.echoTap(period)
-			}
-			if p.levelTap != nil {
-				p.levelTap(periodRMS(period))
-			}
-			if err := p.session.Pump(period); err != nil {
-				log.Printf("silenceLoop: pump error: %v", err)
-				return
-			}
 		default:
-			if audioStreaming {
-				if p.eosPending.Swap(false) {
-					// Natural end of stream (0x03 received), or a barge-in
-					// flush (Flush sets eosPending so its drain isn't
-					// miscounted as an underrun).
-					firstRecv := p.recvFirstNs.Load()
-					lastRecv := p.recvLastNs.Load()
-					st := StreamStats{
-						Periods:   streamPeriods,
-						Underruns: streamUnderruns,
-						MinDepth:  streamMinDepth,
-						MaxGapMs:  p.recvMaxGapNs.Load() / 1e6,
-						BytesRecv: p.recvBytes.Load(),
-					}
-					if firstRecv > 0 && lastRecv > firstRecv {
-						st.RecvSpanMs = (lastRecv - firstRecv) / 1e6
-					}
-					if firstRecv > 0 && firstPumpNs > firstRecv {
-						st.PrimeWaitMs = (firstPumpNs - firstRecv) / 1e6
-					}
-					log.Printf("[speaker] stream complete — returning to silence "+
-						"(periods=%d underruns=%d minDepth=%d primeWait=%dms recvSpan=%dms maxGap=%dms)",
-						streamPeriods, streamUnderruns, streamMinDepth,
-						st.PrimeWaitMs, st.RecvSpanMs, st.MaxGapMs)
-					p.statsMu.Lock()
-					cb := p.statsCb
-					p.statsMu.Unlock()
-					if cb != nil && streamPeriods > 0 {
-						go cb(st)
-					}
-					streamPeriods, streamUnderruns = 0, 0
-					streamMinDepth, firstPumpNs = -1, 0
-				} else {
-					// Mid-stream drain: the WS sender fell behind real-time
-					// playback and a silence gap is being injected — the
-					// audible stutter on weak WiFi links. One count per
-					// drain event (not per silence period); rate-limited so
-					// a chronically starved link can't flood the log.
-					underruns++
-					streamUnderruns++
-					if underruns == 1 || underruns%16 == 0 {
-						log.Printf("[speaker] UNDERRUN: audio channel drained mid-stream — injecting silence (underruns=%d)", underruns)
-					}
-				}
-				audioStreaming = false
-			}
-			if p.echoTap != nil {
-				p.echoTap(silencePeriod)
-			}
-			if p.levelTap != nil {
+		}
+
+		var voice, music []byte
+		if p.voice.ready(primePeriods) {
+			voice = p.voice.take()
+		} else if p.voice.playing {
+			p.report(p.voice.drained(), "voice")
+		}
+		if p.music.ready(primePeriods) {
+			music = p.music.take()
+		} else if p.music.playing {
+			p.report(p.music.drained(), "music")
+		}
+
+		out := p.mixer.Mix(voice, music, p.duckTarget.Load())
+		if out == nil {
+			out = silencePeriod
+		}
+
+		// Taps see the MIXED output, which is what the speaker actually
+		// emits. That matters for AEC: the far-end reference is what needs
+		// cancelling from the mic, and with music playing under a response
+		// the echo is the sum, not the voice alone. It was already correct
+		// by accident when only one stream existed.
+		if p.echoTap != nil {
+			p.echoTap(out)
+		}
+		if p.levelTap != nil {
+			if voice == nil && music == nil {
 				p.levelTap(0)
+			} else {
+				p.levelTap(periodRMS(out))
 			}
-			if err := p.session.Pump(silencePeriod); err != nil {
-				log.Printf("silenceLoop: silence pump error: %v", err)
-				return
-			}
+		}
+		if err := p.session.Pump(out); err != nil {
+			log.Printf("silenceLoop: pump error: %v", err)
+			return
 		}
 	}
 }
 
-// PumpPeriod queues one period of audio for playback. Called by the WS client
-// for each incoming 0x02 binary frame — MONO S16 on the wire, duplicated to
-// the stereo frames the ALSA device requires here. Blocks until the silence
-// loop has consumed a slot (rate-limiting to ALSA speed), or returns an error
-// if the silence loop has died — preventing an infinite block on a dead
-// consumer.
-func (p *PcmSpeaker) PumpPeriod(data []byte) error {
-	p.stateMu.Lock()
-	if p.discarding {
-		// Flushed stream — swallow the network-buffered remainder without
-		// queueing it (see the discarding field for why draining audioCh
-		// alone can't do this).
-		p.stateMu.Unlock()
-		return nil
+// report logs and forwards a completed stream's stats. A nil st is an
+// underrun, which is counted inside the stream and only logged here.
+func (p *PcmSpeaker) report(st *StreamStats, plane string) {
+	if st == nil {
+		log.Printf("[speaker] UNDERRUN: %s channel drained mid-stream — injecting silence", plane)
+		return
 	}
-	newStream := !p.streamActive
-	p.streamActive = true
-	p.stateMu.Unlock()
-	// Arrival-side instrumentation (see StreamStats). Single writer —
-	// the WS read loop calls this sequentially — so load/compare/store
-	// needs no lock. ~23 calls/s, no allocation, no logging.
-	now := time.Now().UnixNano()
-	if newStream {
-		p.recvFirstNs.Store(now)
-		p.recvMaxGapNs.Store(0)
-		p.recvBytes.Store(0)
-	} else if last := p.recvLastNs.Load(); last > 0 {
-		if gap := now - last; gap > p.recvMaxGapNs.Load() {
-			p.recvMaxGapNs.Store(gap)
-		}
+	log.Printf("[speaker] %s stream complete — returning to silence "+
+		"(periods=%d underruns=%d minDepth=%d primeWait=%dms recvSpan=%dms maxGap=%dms)",
+		plane, st.Periods, st.Underruns, st.MinDepth,
+		st.PrimeWaitMs, st.RecvSpanMs, st.MaxGapMs)
+	// Only the voice plane reports upstream: the controller attaches these
+	// to the turn that produced them (device.last_turn_id), and a music
+	// stream ending would overwrite a turn's delivery figures with a song's.
+	if plane != "voice" || st.Periods == 0 {
+		return
 	}
-	p.recvLastNs.Store(now)
-	p.recvBytes.Add(uint64(len(data)))
-	n := len(data) / 2 // mono S16 samples
+	p.statsMu.Lock()
+	cb := p.statsCb
+	p.statsMu.Unlock()
+	if cb != nil {
+		go cb(*st)
+	}
+}
+
+// toStereo converts a mono S16 wire period into the stereo frames the ALSA
+// device requires. The stereo config is an I2S/codec-path constraint, not a
+// wire one — shipping two identical channels would double bandwidth for
+// nothing on links that are already marginal.
+func toStereo(data []byte) []byte {
+	n := len(data) / 2
 	period := make([]byte, n*4)
 	for i := 0; i < n; i++ {
 		lo, hi := data[i*2], data[i*2+1]
 		period[i*4+0], period[i*4+1] = lo, hi // L
 		period[i*4+2], period[i*4+3] = lo, hi // R
 	}
-	select {
-	case p.audioCh <- period:
-		return nil
-	case <-p.deadCh:
-		return fmt.Errorf("speaker: ALSA loop has died")
-	}
+	return period
 }
 
-// IsStreaming reports whether a 0x02 stream is currently mid-flight.
+// PumpPeriod queues one period of VOICE audio (TTS, announcements). Called by
+// the WS client for each incoming 0x02 frame. Blocks until the ALSA loop has
+// consumed a slot (rate-limiting to playback speed), or returns an error if
+// that loop has died — preventing an infinite block on a dead consumer.
+func (p *PcmSpeaker) PumpPeriod(data []byte) error {
+	_, err := p.voice.pump(toStereo(data), len(data))
+	return err
+}
+
+// PumpMusic queues one period of MUSIC audio (0x04). Identical handling to
+// the voice plane — it is a full stream with its own prime gate, buffer and
+// discard semantics, not a lesser one — but kept separate so a voice turn
+// can duck it rather than stopping it.
+func (p *PcmSpeaker) PumpMusic(data []byte) error {
+	_, err := p.music.pump(toStereo(data), len(data))
+	return err
+}
+
+// SetDuck sets the gain applied to music while it plays under voice, in dB of
+// attenuation (0 = no ducking). The change is ramped by the mixer rather than
+// applied at once, because a gain step at a period boundary is a click — and
+// it would land on exactly the moment the user started speaking.
+func (p *PcmSpeaker) SetDuck(db float64) {
+	p.duckTarget.Store(DuckGain(db))
+}
+
+// IsStreaming reports whether a VOICE stream is currently mid-flight.
 //
 // Added for on-device wake word scoring: while the speaker is playing, the
 // controller lowers its wake threshold to bargeInThreshold, because echo at the
@@ -402,69 +299,47 @@ func (p *PcmSpeaker) PumpPeriod(data []byte) error {
 // The device has to know when it is playing in order to mirror that, or it
 // disagrees with the controller on every barge-in.
 //
-// Reads under stateMu rather than an atomic on purpose: streamActive is one half
-// of a pair guarded together with `discarding` (see the field comment), and
-// reading it outside that lock is what the pairing exists to prevent.
-func (p *PcmSpeaker) IsStreaming() bool {
-	p.stateMu.Lock()
-	defer p.stateMu.Unlock()
-	return p.streamActive
-}
+// Music deliberately does NOT count here. It is a quieter, continuous bed
+// rather than a response the user is talking over, and the controller applies
+// the same rule on its side (wake-over-music scores against bargeInThreshold
+// only when barge-in is enabled). Reporting music as "streaming" would drop
+// the device's bar for as long as a song plays.
+func (p *PcmSpeaker) IsStreaming() bool { return p.voice.isActive() }
 
-// EndStream marks the in-flight stream as complete. Called by the WS client
-// on the 0x03 EOS frame — always after every 0x02 period of that stream has
-// already been handed to PumpPeriod (frames are processed sequentially on
-// the read loop), so by the time silenceLoop drains audioCh the flag is set.
-func (p *PcmSpeaker) EndStream() {
-	p.stateMu.Lock()
-	p.streamActive = false
-	wasDiscarding := p.discarding
-	p.discarding = false
-	p.stateMu.Unlock()
-	if wasDiscarding {
-		log.Printf("[speaker] flush complete — EOS reached, discard disarmed")
-		return
-	}
-	p.eosPending.Store(true)
-}
+// IsPlayingMusic reports whether a music stream is mid-flight.
+func (p *PcmSpeaker) IsPlayingMusic() bool { return p.music.isActive() }
 
-// Flush cuts a playing stream immediately (barge-in). Two parts:
-//   1. Drain audioCh — kills up to ~5.5s already queued on-device.
-//   2. Arm discarding (if a stream is mid-flight) — PumpPeriod then drops
-//      every subsequent period of this stream until its 0x03 EOS arrives.
-//      Necessary because the controller writes the whole response into the
-//      WebSocket ahead of playback: at barge time the rest of the stream
-//      is already in TCP buffers and would refill audioCh right after the
-//      drain (the pre-2026-07-08 version drained only, and playback
-//      resumed after a ~1.3s skip). The controller sends 0x03 on the
-//      cancel path too, so the discard always terminates.
+// EndStream marks the in-flight voice stream complete (0x03). Always arrives
+// after every 0x02 period of that stream has been handed to PumpPeriod —
+// frames are processed sequentially on the read loop — so by the time the
+// ALSA loop drains the buffer the flag is already set.
+func (p *PcmSpeaker) EndStream() { p.voice.endStream() }
+
+// EndMusicStream marks the in-flight music stream complete (0x05).
+func (p *PcmSpeaker) EndMusicStream() { p.music.endStream() }
+
+// Flush cuts a playing VOICE stream immediately (barge-in). Two parts:
+//   1. Drain the buffer — kills up to ~5.5s already queued on-device.
+//   2. Arm discarding (if a stream is mid-flight) — subsequent periods of
+//      this stream are dropped until its EOS arrives. Necessary because the
+//      controller writes the whole response into the WebSocket ahead of
+//      playback: at barge time the rest of the stream is already in TCP
+//      buffers and would refill the channel right after the drain (the
+//      pre-2026-07-08 version drained only, and playback resumed after a
+//      ~1.3s skip). The controller sends the EOS on the cancel path too, so
+//      the discard always terminates.
 //
 // Up to PeriodCount ALSA periods (~170ms) already handed to the hardware
 // still play — cutting those needs a stream restart, which costs more in
-// click/pop than it saves. The streamActive check keeps a flush that races
-// a stream's natural end (control and data travel on separate WebSockets)
-// from arming discard against the *next* stream's audio.
-func (p *PcmSpeaker) Flush() {
-	p.stateMu.Lock()
-	armed := p.streamActive
-	if armed {
-		p.discarding = true
-	}
-	p.stateMu.Unlock()
-	n := 0
-	for {
-		select {
-		case <-p.audioCh:
-			n++
-		default:
-			if n > 0 || armed {
-				p.eosPending.Store(true)
-				log.Printf("[speaker] flushed %d buffered periods (barge-in), discard-until-EOS armed=%v", n, armed)
-			}
-			return
-		}
-	}
-}
+// click/pop than it saves.
+func (p *PcmSpeaker) Flush() { p.voice.flush() }
+
+// FlushMusic stops music the same way. This is now reserved for the user
+// GENUINELY stopping or pausing playback: a voice turn ducks instead, which
+// is the whole point of holding the two planes apart. Flushing here would
+// throw away the buffered audio that makes ducking instant, and on a
+// non-seekable stream that audio cannot be recovered.
+func (p *PcmSpeaker) FlushMusic() { p.music.flush() }
 
 // Close shuts the speaker down in the reverse of Init's bring-up: mute,
 // amp off, then tear the stream down. Muting first makes the PCM-close

--- a/device/internal/bindings/speaker/stream.go
+++ b/device/internal/bindings/speaker/stream.go
@@ -155,12 +155,24 @@ func (s *audioStream) pump(period []byte, wireBytes int) (bool, error) {
 // endStream marks the EOS. Called from the WS read goroutine the instant the
 // frame arrives, so by the time the pump loop drains the channel the flag is
 // already set and the drain is not counted as an underrun.
+//
+// A stream that was being DISCARDED is the exception, and it is load-bearing.
+// flush() already set eosPending and the drain that followed already consumed
+// it, so setting it again here leaves it armed with no stream behind it —
+// and the NEXT stream then reports itself complete at its first buffer dip.
+// Measured after this was briefly wrong: a 2800ms response reported complete
+// after 15 periods (640ms), which ended the turn, cleared the ring and
+// released the duck while the device was still holding most of the audio.
 func (s *audioStream) endStream() {
-	s.eosPending.Store(true)
 	s.mu.Lock()
 	s.active = false
+	wasDiscarding := s.discarding
 	s.discarding = false
 	s.mu.Unlock()
+	if wasDiscarding {
+		return
+	}
+	s.eosPending.Store(true)
 }
 
 // flush drops everything queued and, if a stream is mid-flight, arms discard

--- a/device/internal/bindings/speaker/stream.go
+++ b/device/internal/bindings/speaker/stream.go
@@ -1,0 +1,278 @@
+package speaker
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// errSpeakerDead is returned when the ALSA pump loop has exited, so a caller
+// blocked on a full buffer unblocks with an error instead of hanging forever.
+var errSpeakerDead = errors.New("speaker: ALSA loop has died")
+
+// StreamStats is the per-stream delivery report, emitted once at EOS.
+//
+// Periods/Underruns answer "did it break". The rest answer "how close did it
+// come, and which side was late" — the questions we could not answer on
+// 2026-07-20 because every available metric measured something else (the
+// controller's "Streaming took 0.0s" times a socket write, not delivery).
+//
+//   - MinDepth: fewest periods left in the buffer at any point mid-stream.
+//     The headline margin number. 0 means it starved (an underrun); a stream
+//     that only ever reached 2 was one hiccup away.
+//   - PrimeWaitMs: first frame arriving → first frame played. Long means the
+//     sender could not fill the prime buffer promptly.
+//   - RecvSpanMs vs audio duration: delivery slower than realtime is the
+//     definitive "the wire could not keep up" signal.
+//   - MaxGapMs: the worst single stall in arrivals, which distinguishes a
+//     uniformly slow link from a briefly stalled one.
+type StreamStats struct {
+	Periods     uint64 `json:"periods"`
+	Underruns   uint64 `json:"underruns"`
+	MinDepth    int    `json:"minDepth"`
+	PrimeWaitMs int64  `json:"primeWaitMs"`
+	RecvSpanMs  int64  `json:"recvSpanMs"`
+	MaxGapMs    int64  `json:"maxGapMs"`
+	BytesRecv   uint64 `json:"bytesRecv"`
+}
+
+// audioStream is one buffered playback stream: the voice/TTS plane or the
+// music plane. Both need the same machinery — a prime gate, discard-until-EOS
+// on flush, underrun accounting and delivery instrumentation — so it is
+// extracted rather than duplicated. Every comment here records behaviour that
+// was arrived at the hard way on the single-stream version; none of it is new.
+//
+// Untagged on purpose (pcm_speaker.go is `//go:build server`): this is the
+// buffering state machine, and it is worth being able to test on the host.
+type audioStream struct {
+	ch     chan []byte
+	deadCh <-chan struct{} // closed when the ALSA loop exits
+
+	// eosPending is set by endStream (the WS reader received an EOS frame)
+	// and consumed by the pump loop when the channel drains, so a drain at
+	// the natural end of a stream is not misreported as an underrun.
+	eosPending atomic.Bool
+
+	// mu guards active and discarding as one unit. They used to be
+	// independent atomics, but flush's check-active-then-arm and endStream's
+	// clear-both are compound transitions: a barge-in flush racing a
+	// stream's natural end (control and data ride separate WebSockets) could
+	// observe active just before endStream cleared it and then arm
+	// discarding just after endStream consumed it — leaving discard armed
+	// with no EOS ever coming, silently swallowing the whole NEXT response
+	// up to its EOS.
+	mu sync.Mutex
+	// active tracks whether a stream is mid-flight (set by pump, cleared by
+	// endStream — both on the WS read goroutine). Read by flush to decide
+	// whether to arm discarding.
+	active bool
+	// discarding, when set, makes pump drop incoming periods until the
+	// stream's EOS arrives. Armed by flush when a stream is mid-flight:
+	// draining the channel alone is not enough, because the rest of the
+	// cancelled stream is typically already in flight in the TCP buffers of
+	// both ends — the WS reader would refill the channel straight after the
+	// drain and playback would carry on after a ~1.3s skip (observed
+	// 2026-07-08: barge-in cut the LED but the TTS kept talking, and the
+	// interrupting turn transcribed the device's own voice). The controller
+	// always terminates a stream with an EOS, on the cancel path included,
+	// so discard-until-EOS consumes exactly the remainder of the cancelled
+	// stream no matter how much was buffered.
+	discarding bool
+
+	// ── per-stream delivery instrumentation ───────────────────────────────
+	// Underruns are a rare binary event; these give the *margin* on every
+	// stream, so a link that is merely close to starving is visible before it
+	// audibly breaks (2026-07-20: added after underruns appeared with no
+	// measurable cause — every metric we had timed the wrong thing).
+	//
+	// Written only by pump, which the WS read loop calls sequentially —
+	// single writer, so a plain load/compare/store needs no lock. The pump
+	// loop reads them once per stream at EOS. Cost on the audio hot path is
+	// one time.Now() plus an integer compare per ~42ms period (~23/s);
+	// nothing here allocates or logs.
+	recvFirstNs  atomic.Int64
+	recvLastNs   atomic.Int64
+	recvMaxGapNs atomic.Int64
+	recvBytes    atomic.Uint64
+
+	// ── consumption-side accounting, pump-loop-local by contract ──────────
+	// Only the ALSA goroutine touches these, so they need no synchronisation.
+	playing      bool // mid-stream from the consumer's point of view
+	periods      uint64
+	underruns    uint64
+	minDepth     int   // -1 = nothing consumed yet this stream
+	firstPumpNs  int64 // first period actually played this stream
+}
+
+func newAudioStream(depth int, deadCh <-chan struct{}) *audioStream {
+	return &audioStream{
+		ch:       make(chan []byte, depth),
+		deadCh:   deadCh,
+		minDepth: -1,
+	}
+}
+
+// pump queues one period, or reports that it was swallowed by a flush.
+//
+// Blocks until the ALSA loop has consumed a slot (rate-limiting to playback
+// speed), or returns false with an error if that loop has died — preventing
+// an infinite block on a dead consumer.
+func (s *audioStream) pump(period []byte, wireBytes int) (bool, error) {
+	s.mu.Lock()
+	if s.discarding {
+		// Flushed stream — swallow the network-buffered remainder without
+		// queueing it (see the discarding field for why draining the channel
+		// alone cannot do this).
+		s.mu.Unlock()
+		return false, nil
+	}
+	newStream := !s.active
+	s.active = true
+	s.mu.Unlock()
+
+	now := time.Now().UnixNano()
+	if newStream {
+		s.recvFirstNs.Store(now)
+		s.recvMaxGapNs.Store(0)
+		s.recvBytes.Store(0)
+	} else if last := s.recvLastNs.Load(); last > 0 {
+		if gap := now - last; gap > s.recvMaxGapNs.Load() {
+			s.recvMaxGapNs.Store(gap)
+		}
+	}
+	s.recvLastNs.Store(now)
+	s.recvBytes.Add(uint64(wireBytes))
+
+	select {
+	case s.ch <- period:
+		return true, nil
+	case <-s.deadCh:
+		return false, errSpeakerDead
+	}
+}
+
+// endStream marks the EOS. Called from the WS read goroutine the instant the
+// frame arrives, so by the time the pump loop drains the channel the flag is
+// already set and the drain is not counted as an underrun.
+func (s *audioStream) endStream() {
+	s.eosPending.Store(true)
+	s.mu.Lock()
+	s.active = false
+	s.discarding = false
+	s.mu.Unlock()
+}
+
+// flush drops everything queued and, if a stream is mid-flight, arms discard
+// so the remainder still in TCP buffers is swallowed rather than played.
+//
+// eosPending is set so the drain the pump loop is about to see is accounted
+// as an end of stream rather than an underrun.
+func (s *audioStream) flush() {
+	s.mu.Lock()
+	if s.active {
+		s.discarding = true
+	}
+	s.mu.Unlock()
+	s.eosPending.Store(true)
+	for {
+		select {
+		case <-s.ch:
+		default:
+			return
+		}
+	}
+}
+
+// isActive reports whether a stream is mid-flight on the wire.
+func (s *audioStream) isActive() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.active
+}
+
+// ready reports whether the pump loop should take a period this round.
+//
+// The prime gate: while not yet playing, hold on silence until the buffer has
+// primePeriods queued, or the stream's EOS is already in (a clip shorter than
+// the prime — everything it will ever have is queued). This protects the
+// opening seconds, when the sender's lead is still ~zero and a single WiFi
+// stall used to stutter. Once playing, the gate stays out of the way and
+// mid-stream drains are accounted as underruns instead.
+func (s *audioStream) ready(prime int) bool {
+	n := len(s.ch)
+	if n == 0 {
+		return false
+	}
+	if s.playing {
+		return true
+	}
+	return n >= prime || s.eosPending.Load()
+}
+
+// take removes one period, updating the consumption-side accounting.
+// Only called when ready() said so, and only from the ALSA goroutine.
+func (s *audioStream) take() []byte {
+	select {
+	case period := <-s.ch:
+		s.playing = true
+		s.periods++
+		// Buffer margin: occupancy remaining *after* taking this period.
+		// len() on a channel is O(1); no allocation, no log.
+		//
+		// Sampled ONLY while the sender still has audio to send. The last
+		// periods of every stream necessarily drain the buffer to zero, so
+		// measuring across the tail made this read 0 on 100% of streams —
+		// healthy ones included — which is how it shipped in v2.9.6 and told
+		// us nothing (caught on first field data, 2026-07-20). eosPending is
+		// set the instant the EOS arrives, so !eosPending means "more audio
+		// is still expected" and a low buffer *there* is a real margin
+		// warning.
+		if !s.eosPending.Load() {
+			if d := len(s.ch); s.minDepth < 0 || d < s.minDepth {
+				s.minDepth = d
+			}
+		}
+		if s.firstPumpNs == 0 {
+			s.firstPumpNs = time.Now().UnixNano()
+		}
+		return period
+	default:
+		return nil
+	}
+}
+
+// drained is called when the stream was playing and had nothing to give this
+// round. It reports the completed stream's stats when the drain is an EOS,
+// and counts an underrun when it is not.
+//
+// Returns the stats to report, or nil for an underrun.
+func (s *audioStream) drained() *StreamStats {
+	s.playing = false
+	if !s.eosPending.Swap(false) {
+		// Mid-stream drain: the WS sender fell behind realtime playback and
+		// a silence gap is being injected — the audible stutter on weak WiFi
+		// links. One count per drain event, not per silence period.
+		s.underruns++
+		return nil
+	}
+	// Natural end of stream, or a flush (which sets eosPending so its drain
+	// is not miscounted as an underrun).
+	st := &StreamStats{
+		Periods:   s.periods,
+		Underruns: s.underruns,
+		MinDepth:  s.minDepth,
+		MaxGapMs:  s.recvMaxGapNs.Load() / 1e6,
+		BytesRecv: s.recvBytes.Load(),
+	}
+	firstRecv, lastRecv := s.recvFirstNs.Load(), s.recvLastNs.Load()
+	if firstRecv > 0 && lastRecv > firstRecv {
+		st.RecvSpanMs = (lastRecv - firstRecv) / 1e6
+	}
+	if firstRecv > 0 && s.firstPumpNs > firstRecv {
+		st.PrimeWaitMs = (s.firstPumpNs - firstRecv) / 1e6
+	}
+	s.periods, s.underruns = 0, 0
+	s.minDepth, s.firstPumpNs = -1, 0
+	return st
+}

--- a/device/internal/bindings/speaker/stream_test.go
+++ b/device/internal/bindings/speaker/stream_test.go
@@ -1,0 +1,173 @@
+package speaker
+
+import "testing"
+
+// The buffering state machine, testable on the host because audioStream is
+// untagged. pcm_speaker.go can only be built on the device, which is why
+// every one of these behaviours used to be verifiable only by listening.
+
+func newTestStream(depth int) (*audioStream, chan struct{}) {
+	dead := make(chan struct{})
+	return newAudioStream(depth, dead), dead
+}
+
+func pumpN(t *testing.T, s *audioStream, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if _, err := s.pump([]byte{byte(i)}, 1); err != nil {
+			t.Fatalf("pump %d: %v", i, err)
+		}
+	}
+}
+
+func TestPrimeGateHoldsUntilEnoughIsQueued(t *testing.T) {
+	s, _ := newTestStream(64)
+	pumpN(t, s, 5)
+	if s.ready(24) {
+		t.Fatal("should hold on silence until primed")
+	}
+	pumpN(t, s, 19)
+	if !s.ready(24) {
+		t.Fatal("should start once primed")
+	}
+}
+
+func TestAShortClipDoesNotWaitForThePrime(t *testing.T) {
+	// Everything it will ever have is already queued; waiting for 24 periods
+	// that are never coming would mean it never played.
+	s, _ := newTestStream(64)
+	pumpN(t, s, 3)
+	s.endStream()
+	if !s.ready(24) {
+		t.Fatal("an ended short clip must play without priming")
+	}
+}
+
+func TestOncePlayingTheGateStaysOutOfTheWay(t *testing.T) {
+	s, _ := newTestStream(64)
+	pumpN(t, s, 24)
+	s.ready(24)
+	s.take()
+	if !s.ready(24) {
+		t.Fatal("mid-stream playback must not re-prime on every period")
+	}
+}
+
+func TestANaturalEndReportsStatsRatherThanAnUnderrun(t *testing.T) {
+	s, _ := newTestStream(64)
+	pumpN(t, s, 2)
+	s.endStream()
+	s.ready(24)
+	s.take()
+	s.take()
+	st := s.drained()
+	if st == nil {
+		t.Fatal("a drain after EOS is the end of the stream, not an underrun")
+	}
+	if st.Periods != 2 {
+		t.Fatalf("expected 2 periods, got %d", st.Periods)
+	}
+	if s.underruns != 0 {
+		t.Fatalf("expected no underruns, got %d", s.underruns)
+	}
+}
+
+func TestAMidStreamDrainIsAnUnderrunNotAnEnding(t *testing.T) {
+	s, _ := newTestStream(64)
+	pumpN(t, s, 24)
+	s.ready(24)
+	for i := 0; i < 24; i++ {
+		s.take()
+	}
+	if st := s.drained(); st != nil {
+		t.Fatal("the sender falling behind is an underrun, not a completed stream")
+	}
+	if s.underruns != 1 {
+		t.Fatalf("expected 1 underrun, got %d", s.underruns)
+	}
+}
+
+func TestAFlushedStreamDoesNotLeaveEosArmedForTheNextOne(t *testing.T) {
+	// The regression that shipped on 2026-08-03. flush() sets eosPending and
+	// the drain that follows consumes it; endStream must NOT set it again, or
+	// it stays armed with no stream behind it.
+	//
+	// Measured symptom: a 2800ms response reported complete after 15 periods
+	// (640ms), which ended the turn, cleared the LED ring and released the
+	// music duck while the device still held most of the audio.
+	s, _ := newTestStream(64)
+	pumpN(t, s, 30)
+	s.ready(24)
+	s.take()
+
+	s.flush()                 // barge-in
+	s.drained()               // the pump loop sees the emptied channel
+	s.endStream()             // the cancelled stream's EOS finally arrives
+
+	if s.eosPending.Load() {
+		t.Fatal("eosPending must not survive a flushed stream — the next " +
+			"stream would report itself complete at its first buffer dip")
+	}
+}
+
+func TestTheStreamAfterAFlushBehavesNormally(t *testing.T) {
+	// The consequence of the bug above, from the next stream's point of view.
+	s, _ := newTestStream(64)
+	pumpN(t, s, 30)
+	s.ready(24)
+	s.take()
+	s.flush()
+	s.drained()
+	s.endStream()
+
+	// A fresh response arrives.
+	pumpN(t, s, 56)
+	if !s.ready(24) {
+		t.Fatal("the next stream should prime and play")
+	}
+	for i := 0; i < 15; i++ {
+		s.take()
+	}
+	// It still has 41 periods queued; nothing should claim it is finished.
+	if !s.ready(24) {
+		t.Fatal("still has audio — must keep playing")
+	}
+	if s.eosPending.Load() {
+		t.Fatal("no EOS has arrived for this stream")
+	}
+}
+
+func TestFlushSwallowsTheRestOfTheStreamUntilItsEos(t *testing.T) {
+	s, _ := newTestStream(64)
+	pumpN(t, s, 10)
+	s.flush()
+	// The rest of the cancelled response is already in TCP buffers and keeps
+	// arriving; it must not refill the channel.
+	queued, err := s.pump([]byte{9}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if queued {
+		t.Fatal("post-flush periods must be discarded, not queued")
+	}
+	s.endStream()
+	queued, _ = s.pump([]byte{9}, 1)
+	if !queued {
+		t.Fatal("the EOS disarms the discard; the next stream must play")
+	}
+}
+
+func TestMinDepthIgnoresTheTailOfAStream(t *testing.T) {
+	// Every stream necessarily drains to zero at its end, so sampling across
+	// the tail made this read 0 on 100% of streams, healthy ones included.
+	s, _ := newTestStream(64)
+	pumpN(t, s, 30)
+	s.endStream() // EOS in: everything from here is the tail
+	s.ready(24)
+	for i := 0; i < 30; i++ {
+		s.take()
+	}
+	if s.minDepth != -1 {
+		t.Fatalf("tail periods must not be sampled, got minDepth=%d", s.minDepth)
+	}
+}

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -80,6 +80,8 @@ type ControlClient struct {
 	volumeSetCallback     VolumeSetCallback
 	beamLockCallback      BeamLockCallback
 	speakerFlushCallback  StateCallback
+	musicFlushCallback    StateCallback
+	duckCallback          func(on bool)
 	wifiChangeCallback    WifiChangeCallback
 	wifiCommitCallback    StateCallback
 	wifiScanCallback      StateCallback
@@ -123,6 +125,8 @@ func (c *ControlClient) OnConfigApplied(cb ConfigAppliedCallback) { c.configAppl
 func (c *ControlClient) OnVolumeSet(cb VolumeSetCallback)         { c.volumeSetCallback = cb }
 func (c *ControlClient) OnBeamLock(cb BeamLockCallback)           { c.beamLockCallback = cb }
 func (c *ControlClient) OnSpeakerFlush(cb StateCallback)          { c.speakerFlushCallback = cb }
+func (c *ControlClient) OnMusicFlush(cb StateCallback)            { c.musicFlushCallback = cb }
+func (c *ControlClient) OnDuck(cb func(on bool))                  { c.duckCallback = cb }
 func (c *ControlClient) OnWifiChange(cb WifiChangeCallback)       { c.wifiChangeCallback = cb }
 func (c *ControlClient) OnWifiCommit(cb StateCallback)            { c.wifiCommitCallback = cb }
 func (c *ControlClient) OnWifiScan(cb StateCallback)              { c.wifiScanCallback = cb }
@@ -504,6 +508,28 @@ func (c *ControlClient) connect(ctx context.Context, server *discovery.ServerInf
 				c.speakerFlushCallback()
 			}
 
+		case "music_flush":
+			// The user genuinely stopped or paused. A voice turn must NOT
+			// send this — it ducks instead, which is the whole reason the
+			// music plane is separate. Flushing discards the buffered audio
+			// that makes ducking instant, and on a non-seekable stream that
+			// audio is gone for good.
+			log.Printf("[control] music_flush received — discarding buffered music")
+			if c.musicFlushCallback != nil {
+				c.musicFlushCallback()
+			}
+
+		case "duck":
+			// Duck the music under a voice turn. Sent at turn start and
+			// released at turn end; the DEPTH is config (duckDb), so it can
+			// be tuned by ear in a real room without a firmware push.
+			var msg struct {
+				On bool `json:"on"`
+			}
+			if err := json.Unmarshal(raw, &msg); err == nil && c.duckCallback != nil {
+				c.duckCallback(msg.On)
+			}
+
 		case "ping":
 			// Echo the controller's sequence id so it can pair the reply
 			// with the send it timed. The device deliberately does NOT
@@ -701,8 +727,12 @@ func (c *ControlClient) runShellSession(ctx context.Context, baseURL string, pty
 // off the back of it, and an entity that can never produce a reading is worse
 // than no entity at all.
 func capabilities() []string {
+	// "audio_mix": this firmware holds music on its own plane and mixes it
+	// with voice at the ALSA write, so the controller can duck instead of
+	// pausing. Without it the controller must keep the pause/resume path —
+	// a device that cannot mix would simply never play the 0x04 stream.
 	caps := []string{"mic", "speaker", "leds", "led_anim", "buttons",
-		"oww_shadow", "button_hold"}
+		"oww_shadow", "button_hold", "audio_mix"}
 	if als.Present() {
 		caps = append(caps, "ambient_light")
 	}

--- a/device/internal/client/data.go
+++ b/device/internal/client/data.go
@@ -26,6 +26,12 @@ const (
 	frameTypeMic     = byte(0x01)
 	frameTypeSpeaker = byte(0x02)
 	frameTypeEOS     = byte(0x03)
+	// Music rides its own frame types so the device can hold it on a second
+	// plane and mix it under voice rather than pausing it. An older
+	// controller simply never sends these; a newer one only sends them to a
+	// device announcing "audio_mix".
+	frameTypeMusic    = byte(0x04)
+	frameTypeMusicEOS = byte(0x05)
 	frameTypeVADEnd  = byte(0x04)
 	// frameTypeNoSpeechTimeout signals that the turn ended because no speech
 	// was ever detected — distinct from frameTypeVADEnd (speech detected,
@@ -452,6 +458,17 @@ func (d *DataClient) connect(ctx context.Context, baseURL string) error {
 			log.Println("[data] Speaker: end of stream")
 			if d.spk != nil {
 				d.spk.EndStream()
+			}
+		case frameTypeMusic:
+			if len(data) > 1 && d.spk != nil {
+				if err := d.spk.PumpMusic(data[1:]); err != nil {
+					log.Printf("[data] PumpMusic error: %v", err)
+				}
+			}
+		case frameTypeMusicEOS:
+			log.Println("[data] Music: end of stream")
+			if d.spk != nil {
+				d.spk.EndMusicStream()
 			}
 		default:
 			log.Printf("[data] Unknown binary frame type: 0x%02x", data[0])

--- a/device/internal/config/config.go
+++ b/device/internal/config/config.go
@@ -39,6 +39,12 @@ type Device struct {
 	// barge-in look like an on-device miss.
 	BargeInEnabled   bool
 	BargeInThreshold float64
+	// DuckDb is how far MUSIC is attenuated while a voice turn plays over
+	// it, in dB (negative = quieter). Config rather than a constant because
+	// it is a taste parameter that needs iterating in a real room, the same
+	// reasoning as the LED meter response curve — not something to discover
+	// via a firmware OTA per attempt.
+	DuckDb float64
 	// OwwOnDevice selects on-device wake word scoring: "off" or "shadow".
 	// Shadow mode scores the wake stream locally and reports what it would
 	// have detected, without acting on it, so device and controller can be
@@ -120,6 +126,7 @@ func (d *Device) loadDefaults() {
 	d.OwwModel = envStr("OWW_MODEL", "hey_jarvis_v0.1")
 	d.OwwOnDevice = normaliseOnDevice(envStr("OWW_ON_DEVICE", OnDeviceOff))
 	d.BargeInThreshold = envFloat("BARGE_IN_THRESHOLD", 0.10)
+	d.DuckDb = envFloat("DUCK_DB", -18)
 	d.AdcDigitalGain = envInt("ADC_DIGITAL_GAIN", 88)
 	d.AdcMicpga = envInt("ADC_MICPGA", 40)
 	d.MicGainDb = clampMicGainDb(envInt("MIC_GAIN_DB", 24))
@@ -170,6 +177,12 @@ func (d *Device) Apply(msg ConfigMessage) {
 	}
 	if msg.BargeInThreshold > 0 {
 		d.BargeInThreshold = msg.BargeInThreshold
+	}
+	// Negative-going, so the usual "non-zero means set" rule is inverted:
+	// a duck of 0dB is a legitimate setting ("do not duck at all") and must
+	// be distinguishable from an absent field, hence the pointer.
+	if msg.DuckDb != nil {
+		d.DuckDb = *msg.DuckDb
 	}
 	if msg.StartupVolume > 0 {
 		d.StartupVolume = msg.StartupVolume
@@ -273,6 +286,7 @@ type ConfigMessage struct {
 	OwwOnDevice        string   `json:"owwOnDevice,omitempty"`
 	BargeInEnabled     *bool    `json:"bargeInEnabled,omitempty"`
 	BargeInThreshold   float64  `json:"bargeInThreshold,omitempty"`
+	DuckDb             *float64 `json:"duckDb,omitempty"`
 	BeamAngle          *float64 `json:"beamAngle,omitempty"`
 	BeamformingEnabled *bool    `json:"beamformingEnabled,omitempty"`
 	HasBeamforming     bool     `json:"hasBeamforming,omitempty"`

--- a/device/pkg/speaker/speaker.go
+++ b/device/pkg/speaker/speaker.go
@@ -9,5 +9,21 @@ type Speaker interface {
 	EndStream()
 	// Flush discards queued-but-unplayed audio immediately (barge-in).
 	Flush()
+
+	// ── music plane ───────────────────────────────────────────────────────
+	// A second, independent stream, mixed with the voice plane at the ALSA
+	// write. It exists so a voice turn can DUCK music rather than pausing
+	// it: the controller runs its music feed ~4s ahead of realtime, so the
+	// next four seconds are already on the device when a wake word fires,
+	// and audio that has left the controller cannot be ducked there.
+	PumpMusic(data []byte) error
+	EndMusicStream()
+	// FlushMusic is for the user genuinely stopping or pausing. A voice turn
+	// must duck instead — flushing throws away the buffered audio that makes
+	// ducking instant, and on a non-seekable stream it cannot be recovered.
+	FlushMusic()
+	// SetDuck sets music attenuation in dB while voice plays (0 = none).
+	SetDuck(db float64)
+
 	Close()
 }


### PR DESCRIPTION
Closes #67 by the recommended route: **device-side mixing**.

Music gets its own frame types (`0x04`/`0x05`), its own buffer on the device, and the two planes are mixed at the ALSA write. A voice turn ducks it (`{"type":"duck","on":true}`) instead of pausing.

## Why it cannot be done in the controller

`LEAD_S = 4.0`: the next four seconds of music are already in the device's buffer when a wake word fires, so **audio that has left the controller cannot be ducked by the controller**. Every controller-side option buys ducking by shortening that lead — giving back the stall protection it exists for (raised from 1.5s precisely because measured 1.8–2.6s link stalls caused dropouts), during the seconds the user is listening most closely.

## What this removes, not just improves

Pausing needs a seek to resume, and a Music Assistant flow stream **cannot seek**. A 28-second turn cost 28 seconds of the song; a long one landed in the next track; behaviour differed by source with no way for the user to tell which they had.

## Device side

The per-stream machinery — prime gate, discard-until-EOS, underrun accounting, delivery instrumentation — is extracted into `audioStream` so **both** planes get the behaviour worked out on the single one rather than a simplified copy. It is untagged, so that state machine is host-testable for the first time (`pcm_speaker.go` is `//go:build server` and can only be built for the device).

Mixer notes, each of which is a mistake avoided:

- **The ramp is a constant slew, not proportional.** My first version used `(target-gain)/n` per period, which is an *exponential* approach — "4 periods" was a time constant, not a duration. A test measured it settling in **31 periods (1.3s)** against the 170ms intended.
- Gain is interpolated **per sample** across the period. A step at a period boundary is a click, and it would land on exactly the moment the user started speaking.
- The sum **saturates**; a wrap turns a loud peak into full-scale opposite polarity, far worse than the clipping it replaces.
- **Voice is never attenuated** — only the bed under it.
- Taps now see the **mixed** output, which is more correct: the AEC far-end reference is what needs cancelling from the mic, and with music under a response the echo is the sum.
- Music does **not** count as "streaming" for the device's wake threshold — it is a quiet bed, not a response being talked over, and counting it would drop the wake bar for the length of a song.

## Controller side, and two traps

- A genuine stop/pause must flush the **music** plane. `speaker_flush` would cut the response and leave the music playing, which is exactly backwards.
- `MediaSession.ducked` changes what turn end owes the user. On the pausing path `interrupt()` had already paused, so a deferred "pause the music" needed no wire action. When we duck, **nothing was ever paused** — so that pause has to actually happen at release, or it is silently discarded and the music plays on. Same class of bug as #53, by a different route.

## Compatibility

Negotiated by the `audio_mix` capability, never by version. Firmware without it keeps the pause/resume path unchanged, pinned by a test: music stays on `0x02` there, because a device that cannot mix would never play a `0x04` frame at all — silence rather than degraded behaviour. `reported_state` is kept for that path; on the ducking path it is simply never triggered, since nothing is paused behind HA's back.

## Config

`duckDb`, default **-18dB**, Playback section — a taste parameter that wants tuning by ear in a real room, like the LED meter curve, not a firmware push per attempt. The dashboard slider is disabled with the reason on firmware that cannot mix, which needed `disabled` support adding to `Slider`: it had none, so the prop would have been silently ignored.

## Verification

277 controller tests and the full device suite pass; `go vet` clean; ARM binary cross-compiles. 12 mixer tests plus 5 new controller tests, each verified by reverting the behaviour it covers.

**Not yet verified on hardware** — the open questions in #67 (duck depth by ear, wake score and transcript quality with a bed present) are listening tests, and this has not been on a device yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)