### PR TITLE
Capture the audio behind an unmatched on-device wake crossing

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -679,3 +679,40 @@ are **append-only and in ascending date order** — new work goes at the end.
   fix. It was `"will be rejected"` — a substring search on a three-letter
   name. Word-boundary matching showed it absent. The wrong tool made me report
   a leak that was not there, one step after failing to report one that was.
+
+- **2026-08-02 — the number that decides whether the Echo may ever trigger itself.**
+  Asked what on-device wake word still needs, the answer came from the
+  database rather than from memory. Agreement is fine: of 141 turns both
+  detectors saw, **94% agreed** among the 116 that were actually comparable
+  (the rest are turns where the controller used the lower barge-in bar, so the
+  two were not asked the same question). The engine is cheap and stable —
+  6.9M frames, drop rates 0.004–0.028%, worst inference 94ms.
+
+  The gate is the other side. Over 155 device-hours the devices crossed their
+  threshold **26 times with no turn following** — roughly one per device every
+  six hours. On shadow that is a log line. With `owwOnDevice=on` each one is a
+  turn nobody asked for. And **"unmatched" is not "false accept"**: each is
+  either a genuine wake the *controller* missed, which argues for shipping, or
+  a crossing while the controller was not scoring, or a real false trigger,
+  which argues against. Three readings, opposite decisions, and the counters
+  cannot separate them — so the only way through is to listen, and the audio
+  is long gone by the time a counter says anything.
+
+  Building the capture nearly went wrong in the obvious way. The natural check
+  is "did the shadow tracker consume the crossing" — but correlation happens
+  at **turn-persist** time, up to thirty seconds after the wake, so that check
+  calls every genuine wake unmatched and fills the disk with recordings of
+  people using their assistant perfectly successfully. It compares against
+  `last_wake_mono`, set at detection, and waits a second longer than the match
+  window because the controller normally detects *later* than the device: it
+  scores the same frame after a network hop.
+
+  Also recorded here because it will matter when the mode is built: **the
+  arbiter's clock stops being safe**. Today every detection is stamped by the
+  controller as it scores, so network delay never enters the comparison. A
+  device-triggered wake arrives after a hop, and this fleet logs idle RTT
+  excursions of 1.1–2.6s against a 700ms arbitration window — the device that
+  genuinely heard the user first could lose because its message was late, and
+  the wrong room answers. The wake must therefore report how long *ago* it
+  fired, as shadow crossings already do. A granted claim must never be
+  revoked, and the window must be held longer than it is measured.

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -56,6 +56,7 @@ COPY em_eq.py .
 COPY em_scenes.py .
 COPY em_support.py .
 COPY em_shadow.py .
+COPY em_wake_capture.py .
 COPY em_ns.py .
 COPY em_pki.py .
 COPY em_esphome.py .

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -58,6 +58,7 @@ import em_oww_models
 import em_pki
 import em_player
 import em_recordings
+import em_wake_capture
 import em_scenes
 import em_support
 from version import VERSION as CONTROLLER_VERSION
@@ -273,6 +274,8 @@ async def create_app() -> web.Application:
     app.router.add_get("/api/devices/{id}/turns",         _get_device_turns)
     app.router.add_get("/api/devices/{id}/activity",      _get_device_activity)
     app.router.add_get("/api/devices/{id}/turns/{turn}/audio", _get_turn_audio)
+    app.router.add_get("/api/devices/{id}/wake_captures",        _get_wake_captures)
+    app.router.add_get("/api/devices/{id}/wake_captures/{name}", _get_wake_capture_audio)
     app.router.add_post("/api/devices/{id}/wifi",         _post_device_wifi)
     app.router.add_post("/api/devices/{id}/wifi/scan",    _post_device_wifi_scan)
     app.router.add_post("/api/devices/{id}/update",       _post_device_update)
@@ -547,6 +550,57 @@ async def _get_turn_audio(request: web.Request) -> web.Response:
             # Recordings are immutable once written and their names are
             # unique per turn, but the retention window means a name can
             # stop resolving — so cache privately and briefly, never shared.
+            "Cache-Control":       "private, max-age=60",
+        },
+    )
+
+
+@auth.require_auth
+async def _get_wake_captures(request: web.Request) -> web.Response:
+    """
+    GET /api/devices/{id}/wake_captures — on-device wake crossings that
+    matched no turn, newest first.
+
+    These are the evidence for whether owwOnDevice can ever be "on": the
+    counters can say a crossing matched nothing, but not whether it was a
+    false accept or a wake the controller missed, and those want opposite
+    decisions. Only present while captureWakeMisses is on.
+    """
+    device_id = request.match_info["id"]
+    loop = asyncio.get_event_loop()
+    row = await loop.run_in_executor(None, db.get_device, device_id)
+    if row is None:
+        return _error("device_not_found", f"No device: {device_id}", 404)
+    items = await loop.run_in_executor(None, em_wake_capture.list_for, device_id)
+    return _ok({"captures": items})
+
+
+@auth.require_auth
+async def _get_wake_capture_audio(request: web.Request) -> web.Response:
+    """
+    GET /api/devices/{id}/wake_captures/{name} — one capture as a WAV.
+
+    resolve() re-checks that the file belongs to the device in the URL — both
+    come from the path, and one must not be usable to reach the other's
+    audio. Retention is a hard file count, so a 404 is an ordinary outcome.
+    """
+    device_id = request.match_info["id"]
+    name      = request.match_info["name"]
+    loop = asyncio.get_event_loop()
+    row = await loop.run_in_executor(None, db.get_device, device_id)
+    if row is None:
+        return _error("device_not_found", f"No device: {device_id}", 404)
+
+    path = em_wake_capture.resolve(device_id, name)
+    if path is None:
+        return _error("no_capture", "No such capture", 404)
+
+    label = _slug(row["label"] or device_id)
+    return web.FileResponse(
+        path,
+        headers={
+            "Content-Type":        "audio/wav",
+            "Content-Disposition": f'attachment; filename="{label}-{name}"',
             "Cache-Control":       "private, max-age=60",
         },
     )

--- a/controller/em_config_sections.py
+++ b/controller/em_config_sections.py
@@ -30,6 +30,7 @@ SECTIONS: dict[str, dict] = {
         "keys": [
             "owwModel", "owwThreshold", "owwSpeexNs",
             "bargeInEnabled", "bargeInThreshold", "wakeArbitrationMs",
+            "captureWakeMisses",
             "owwOnDevice",
         ],
     },

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -55,6 +55,7 @@ import logging
 import os
 import socket
 import struct
+import time
 
 import numpy as np
 from aiohttp import web

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -71,6 +71,7 @@ import em_pki
 import em_eq
 import em_scenes
 import em_shadow
+import em_wake_capture
 import em_arbiter
 import em_esphome as esphome
 import em_ble_proxy
@@ -333,6 +334,13 @@ class Device:
         # applies a refractory period, so one per utterance) and only the most
         # recent few can ever be within a match window.
         self.shadow: em_shadow.ShadowTracker = em_shadow.ShadowTracker()
+        # Rolling wake-stream buffer, allocated only when the device is
+        # capturing: an unmatched crossing is answered by LISTENING to it,
+        # and the audio is gone by the time we know the crossing matched
+        # nothing. Off by default — this records speech nobody addressed to
+        # the assistant, which is a higher bar than saveUtterances.
+        self.capture_wake_misses: bool = False
+        self.wake_ring: em_wake_capture.AudioRing | None = None
         # Monotonic instant of this controller's most recent wake detection,
         # consumed once by the turn record it belongs to.
         self.last_wake_mono = None  # float | None
@@ -2178,6 +2186,16 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
         device.oww_speex_ns  = bool(config.get("owwSpeexNs", False))
         device.ns_asr        = bool(config.get("nsAsr", False))
         device.save_utterances = bool(config.get("saveUtterances", False))
+        # Arm or disarm the unmatched-crossing buffer. Allocated only while
+        # capturing, and dropped (with its audio) the moment it is turned
+        # off — leaving several seconds of speech in memory after the user
+        # revoked consent is the wrong default.
+        device.capture_wake_misses = bool(config.get("captureWakeMisses", False))
+        if device.capture_wake_misses and device.wake_ring is None:
+            device.wake_ring = em_wake_capture.AudioRing()
+        elif not device.capture_wake_misses and device.wake_ring is not None:
+            device.wake_ring.clear()
+            device.wake_ring = None
         device.barge_in_enabled = bool(config.get("bargeInEnabled", False))
         device.barge_threshold  = float(config.get("bargeInThreshold", 0.6))
         device.eq_bands      = config.get("eqBands", [0.0] * 8)
@@ -2548,6 +2566,8 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                         f"score={msg.get('score')} age={msg.get('ageMs')}ms "
                         f"(shadow — not triggering)"
                     )
+                    if device.wake_ring is not None:
+                        _schedule_wake_capture(device, msg)
 
                 elif msg_type == "ble_adverts":
                     # BLE proxy data path — batched adverts from the
@@ -2634,6 +2654,60 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                 em_player.device_gone(device.device_id)
 
 
+def _schedule_wake_capture(device, msg: dict) -> None:
+    """
+    Decide, a few seconds from now, whether this crossing matched anything —
+    and if it did not, keep the audio around it.
+
+    Deferred rather than immediate because the controller usually detects
+    slightly LATER than the device (it scores the same frame after a network
+    hop), so a crossing arriving first is not yet evidence of anything.
+
+    Deliberately NOT "did the shadow tracker consume it": consumption happens
+    at turn-persist time, which can be 30 seconds after the wake, so asking
+    early would report every genuine wake as unmatched and fill the disk with
+    recordings of people using their assistant perfectly successfully.
+    """
+    try:
+        score = float(msg.get("score") or 0.0)
+        age_s = min(max(float(msg.get("ageMs") or 0) / 1000.0, 0.0),
+                    em_shadow.MAX_AGE_S)
+    except (TypeError, ValueError):
+        return
+    cross_mono = em_shadow.now() - age_s
+    cross_wall = time.time() - age_s
+
+    async def _decide():
+        try:
+            await asyncio.sleep(em_wake_capture.DECIDE_AFTER_S)
+            if em_wake_capture.is_matched(cross_mono, device.last_wake_mono,
+                                          em_shadow.MATCH_WINDOW_S):
+                return
+            ring = device.wake_ring
+            if ring is None:
+                return
+            pcm = ring.extract(cross_mono)
+            if not pcm:
+                log.info(f"[{device.device_id}] unmatched crossing "
+                         f"(score={score:.3f}) — audio already aged out")
+                return
+            name = await asyncio.get_event_loop().run_in_executor(
+                None, em_wake_capture.save, device.device_id, pcm,
+                cross_wall, score)
+            log.info(
+                f"[{device.device_id}] unmatched on-device crossing "
+                f"(score={score:.3f}) — captured "
+                f"{em_wake_capture.duration_ms(len(pcm))}ms as {name}"
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log.warning(f"[{device.device_id}] wake capture failed: {e}")
+
+    task = asyncio.create_task(_decide())
+    task.add_done_callback(_log_task_exception)
+
+
 # ─── Data plane handler ───────────────────────────────────────────────────────
 
 async def handle_data(ws: WebSocketServerProtocol, secure: bool = False):
@@ -2698,6 +2772,11 @@ async def handle_data(ws: WebSocketServerProtocol, secure: bool = False):
                     log.error(f"[{device.device_id}] VAD sentinel lost — queue still full after drain")
                 continue
             payload = raw[MIC_HEADER_LEN:]
+            # Rolling buffer for unmatched-crossing capture. One deque append
+            # when armed, nothing at all when not — this is the data-plane hot
+            # path (~12 frames/s per device).
+            if device.wake_ring is not None:
+                device.wake_ring.append(em_shadow.now(), payload)
             q = device.voice_queue if device.oww_paused.is_set() else device.mic_queue
             try:
                 q.put_nowait(payload)

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -103,6 +103,15 @@ DEFAULT_DEVICE_CONFIG = {
     # no self-trigger risk down to ~0.08.
     "bargeInEnabled":   False,
     "bargeInThreshold": 0.10,
+    # Keep the audio around an on-device wake crossing that matched no turn.
+    # Diagnostic, for one question: are those crossings false accepts, or
+    # wakes the CONTROLLER missed? The counters cannot tell them apart and
+    # the answer decides whether owwOnDevice can ever be "on".
+    #
+    # OFF by default and a higher bar than saveUtterances: this records
+    # speech nobody addressed to the assistant. Meaningless unless
+    # owwOnDevice is "shadow".
+    "captureWakeMisses": False,
     "owwModel":         "hey_jarvis_v0.1",
     # Multi-device wake SUPPRESSION window (ms), not a wait. The first
     # device to detect answers immediately; any other device detecting
@@ -1260,6 +1269,16 @@ def delete_device(device_id: str) -> None:
             log.info(f"[db] Removed {removed} recording(s) for {device_id}")
     except Exception as e:
         log.warning(f"[db] Recording cleanup failed for {device_id}: {e}")
+    # Wake captures are a second store of speech and nothing cascades to the
+    # filesystem, so they need removing explicitly too — deleting a device
+    # must not leave its audio behind.
+    try:
+        import em_wake_capture
+        removed = em_wake_capture.delete_device(device_id)
+        if removed:
+            log.info(f"[db] Removed {removed} wake capture(s) for {device_id}")
+    except Exception as e:
+        log.warning(f"[db] Wake capture cleanup failed for {device_id}: {e}")
     log.info(f"[db] Device deleted: {device_id}")
 
 

--- a/controller/em_wake_capture.py
+++ b/controller/em_wake_capture.py
@@ -1,0 +1,285 @@
+"""
+em_wake_capture.py — audio around on-device wake crossings that matched no turn
+
+Shadow mode tells us the device crossed its wake threshold 26 times, over 155
+device-hours, where no turn followed. That number is the whole gate on
+`owwOnDevice=on`: on the shadow path an unmatched crossing is a log line, but
+a device that TRIGGERS turns them into turns nobody asked for — ring, mic,
+and an utterance sent to Home Assistant.
+
+**"Unmatched" is not the same as "false accept", and the counters cannot tell
+them apart.** Each one is either
+
+  - a genuine wake the CONTROLLER missed, which argues *for* shipping this,
+  - a crossing during a turn or TTS, when the controller was not scoring, or
+  - a real false trigger, which argues against.
+
+Those three want opposite decisions, so the only way through is to listen.
+This module keeps a short rolling buffer of the wake stream per device and,
+when a crossing turns out to have matched nothing, writes the seconds either
+side of it to a WAV.
+
+## Why the check is deferred, and why not by the obvious amount
+
+A crossing is correlated with a turn at TURN-PERSIST time, not at detection —
+the report can land after the wake it belongs to, and by turn end it has had
+seconds to arrive (see em_shadow). So "is it still in the tracker's ring a
+moment later" answers the wrong question: a turn can run for 30 seconds, and
+every genuine wake would look unmatched.
+
+The check instead compares the crossing against the controller's own most
+recent wake instant (`Device.last_wake_mono`), which is set at DETECTION.
+That is the same comparison em_shadow will make later, available immediately,
+and it needs no coordination with turn lifetime.
+
+## Privacy
+
+This writes recognisable speech to disk, and worse than the utterance capture
+does: an unmatched crossing is by definition audio nobody addressed to the
+assistant. It is therefore **opt-in per device and off by default**
+(`captureWakeMisses`), stored separately from `recordings/`, and capped hard
+by file count. It is a diagnostic for answering one question, not a feature.
+"""
+
+from __future__ import annotations
+
+import collections
+import io
+import os
+import re
+import time
+import wave
+from pathlib import Path
+
+# Wire format of the mic stream: mono S16LE at 16kHz, in 80ms frames.
+SAMPLE_RATE = 16000
+SAMPLE_WIDTH = 2
+
+CAPTURES_SUBDIR = "wake_captures"
+
+# Seconds of audio kept either side of the crossing. Enough before it to hear
+# what was said INTO the trigger — a false accept usually has a cause a few
+# syllables earlier — and enough after to hear whether a human carried on
+# talking, which is what distinguishes "the controller missed a real wake"
+# from "the television said something".
+PRE_S = 3.0
+POST_S = 2.0
+
+# The rolling buffer must cover PRE_S plus the age of the report when it
+# arrives plus the wait for the deferred check, with room to spare. 15s of
+# 16kHz mono is ~480KB per device — bounded, and only allocated for devices
+# with the capture switched on.
+RING_S = 15.0
+
+# Hard per-device cap. Small on purpose: this is meant to be reviewed and
+# acted on within days, not to accumulate.
+KEEP_PER_DEVICE = 30
+
+# How long after the crossing to decide. MATCH_WINDOW_S (2.0s) is how far
+# apart the two detectors may be and still be one utterance; the extra second
+# covers the controller detecting slightly later than the device, which is the
+# expected direction — the device scores the frame it just captured, the
+# controller scores it after a network hop.
+DECIDE_AFTER_S = 3.0
+
+_NAME_RE = re.compile(r"^(?P<device>[A-Za-z0-9_.-]{1,64})_(?P<ts>\d{10,19})"
+                      r"_(?P<score>\d{1,4})\.wav$")
+
+
+def captures_dir(db_path: str | None = None) -> Path:
+    """`wake_captures/` beside the SQLite DB. Absolute, so cwd cannot move it."""
+    if db_path is None:
+        db_path = os.environ.get("DB_PATH", "echomuse.db")
+    return Path(db_path).resolve().parent / CAPTURES_SUBDIR
+
+
+def safe_device_id(device_id: str) -> str | None:
+    if device_id and re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", device_id):
+        return device_id
+    return None
+
+
+def filename(device_id: str, at_wall: float, score: float) -> str | None:
+    """
+    Name a capture. The score rides in the filename (×1000, integer) so a
+    directory listing is triageable without opening anything.
+    """
+    safe = safe_device_id(device_id)
+    if safe is None:
+        return None
+    score_i = max(0, min(9999, int(round(float(score) * 1000))))
+    return f"{safe}_{int(at_wall * 1000)}_{score_i}.wav"
+
+
+def parse_filename(name: str) -> tuple[str, float, float] | None:
+    """(device_id, wall seconds, score) — or None if it is not one of ours."""
+    m = _NAME_RE.match(name)
+    if not m:
+        return None
+    return m["device"], int(m["ts"]) / 1000.0, int(m["score"]) / 1000.0
+
+
+class AudioRing:
+    """
+    A bounded rolling buffer of the wake stream, timestamped on arrival.
+
+    Frames are appended on the data-plane hot path (~12/s per device), so this
+    does exactly one deque append and one running-total update per frame — no
+    allocation, no scan, no lock. The deque is trimmed from the left by total
+    DURATION rather than frame count, because a frame is only nominally 80ms
+    and a count-based bound would drift.
+    """
+
+    def __init__(self, seconds: float = RING_S):
+        self._frames: collections.deque = collections.deque()
+        self._bytes = 0
+        self._max_bytes = int(seconds * SAMPLE_RATE * SAMPLE_WIDTH)
+
+    def append(self, at: float, payload: bytes) -> None:
+        if not payload:
+            return
+        self._frames.append((at, payload))
+        self._bytes += len(payload)
+        while self._bytes > self._max_bytes and len(self._frames) > 1:
+            self._bytes -= len(self._frames.popleft()[1])
+
+    def clear(self) -> None:
+        self._frames.clear()
+        self._bytes = 0
+
+    @property
+    def seconds(self) -> float:
+        return self._bytes / (SAMPLE_RATE * SAMPLE_WIDTH)
+
+    def extract(self, centre: float, pre: float = PRE_S,
+                post: float = POST_S) -> bytes:
+        """
+        PCM spanning [centre-pre, centre+post], by frame arrival time.
+
+        Frames are taken whole: a frame is 80ms, and trimming to the exact
+        sample would imply a precision the arrival timestamps do not have.
+        Returns b"" when the window has already aged out of the ring, which
+        is a real outcome rather than an error — a capture is not worth
+        holding the hot path to guarantee.
+        """
+        lo, hi = centre - pre, centre + post
+        return b"".join(p for (at, p) in self._frames if lo <= at <= hi)
+
+
+def save(device_id: str, pcm: bytes, at_wall: float, score: float,
+         db_path: str | None = None, keep: int = KEEP_PER_DEVICE) -> str | None:
+    """
+    Write one capture and prune the device back to `keep` files.
+
+    Returns the filename, or None if there was nothing to write. Blocking —
+    call it in an executor.
+    """
+    name = filename(device_id, at_wall, score)
+    if name is None or not pcm:
+        return None
+    directory = captures_dir(db_path)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    # Write-then-rename: a partially written WAV that the API then serves is
+    # worse than no capture at all.
+    tmp = path.with_suffix(".wav.part")
+    tmp.write_bytes(encode_wav(pcm))
+    tmp.replace(path)
+    prune(device_id, db_path=db_path, keep=keep)
+    return name
+
+
+def encode_wav(pcm: bytes) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(SAMPLE_WIDTH)
+        w.setframerate(SAMPLE_RATE)
+        w.writeframes(pcm)
+    return buf.getvalue()
+
+
+def duration_ms(pcm_len: int) -> int:
+    return int(pcm_len / (SAMPLE_RATE * SAMPLE_WIDTH) * 1000)
+
+
+def list_for(device_id: str, db_path: str | None = None) -> list[dict]:
+    """This device's captures, newest first, with their metadata."""
+    safe = safe_device_id(device_id)
+    if safe is None:
+        return []
+    directory = captures_dir(db_path)
+    if not directory.is_dir():
+        return []
+    out = []
+    for p in directory.iterdir():
+        parsed = parse_filename(p.name)
+        if not parsed or parsed[0] != safe or not p.is_file():
+            continue
+        out.append({
+            "name": p.name,
+            "ts": parsed[1],
+            "score": parsed[2],
+            "bytes": p.stat().st_size,
+            "duration_ms": duration_ms(max(p.stat().st_size - 44, 0)),
+        })
+    out.sort(key=lambda d: d["ts"], reverse=True)
+    return out
+
+
+def prune(device_id: str, db_path: str | None = None,
+          keep: int = KEEP_PER_DEVICE) -> list[str]:
+    """Delete all but the newest `keep`. Returns what was removed."""
+    removed = []
+    for entry in list_for(device_id, db_path)[keep:]:
+        path = captures_dir(db_path) / entry["name"]
+        try:
+            path.unlink()
+            removed.append(entry["name"])
+        except OSError:
+            pass
+    return removed
+
+
+def resolve(device_id: str, name: str, db_path: str | None = None) -> Path | None:
+    """
+    The path for a capture, or None.
+
+    Re-checks that the file belongs to the device in the URL — the endpoint
+    takes both from the path, and one must not be able to name the other's
+    audio. A missing file is an ordinary None, not an error: retention is a
+    hard count, so an older reference is a claim to check rather than trust.
+    """
+    parsed = parse_filename(name)
+    safe = safe_device_id(device_id)
+    if parsed is None or safe is None or parsed[0] != safe:
+        return None
+    path = captures_dir(db_path) / name
+    return path if path.is_file() else None
+
+
+def delete_device(device_id: str, db_path: str | None = None) -> int:
+    """Remove every capture for a device. Nothing cascades to the filesystem."""
+    n = 0
+    for entry in list_for(device_id, db_path):
+        try:
+            (captures_dir(db_path) / entry["name"]).unlink()
+            n += 1
+        except OSError:
+            pass
+    return n
+
+
+def is_matched(cross_mono: float, last_wake_mono: float | None,
+               window_s: float) -> bool:
+    """
+    Whether a crossing lines up with a controller wake.
+
+    Deliberately the same comparison em_shadow.match makes, and deliberately
+    NOT "did the tracker consume it": consumption happens at turn-persist
+    time, which can be 30 seconds after a wake, so asking early would report
+    every genuine wake as unmatched. `last_wake_mono` is set at detection.
+    """
+    if not last_wake_mono:
+        return False
+    return abs(cross_mono - last_wake_mono) <= window_s

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1036,6 +1036,96 @@ function ConnectivityTab({ device, row }) {
 
 // ─── Device detail modal ──────────────────────────────────────────────────────
 
+// ─── WakeCaptures ──────────────────────────────────────────────────────────────
+// On-device wake detections that produced no turn, with their audio.
+//
+// The counters can say a crossing matched nothing but not WHY, and the three
+// possible whys — a wake the controller missed, a crossing during a turn, a
+// genuine false accept — argue for opposite decisions about ever letting the
+// device trigger turns. So the answer is listening, and this is the place to
+// do it.
+function WakeCaptures({ deviceId, deviceLabel }) {
+  const [items, setItems] = useState(null);
+  const [playing, setPlaying] = useState(null);
+  const audioRef = useRef(null);
+  const urlsRef = useRef({});
+
+  useEffect(() => {
+    let live = true;
+    API.get(`/api/devices/${deviceId}/wake_captures`)
+      .then(d => live && setItems(d.captures || []))
+      .catch(() => live && setItems([]));
+    return () => { live = false; };
+  }, [deviceId]);
+
+  // Object URLs pin their blob until revoked; the panel unmounting is the
+  // last chance to let them go.
+  useEffect(() => () => {
+    if (audioRef.current) { audioRef.current.pause(); audioRef.current = null; }
+    Object.values(urlsRef.current).forEach(URL.revokeObjectURL);
+    urlsRef.current = {};
+  }, []);
+
+  const toggle = async c => {
+    const was = playing === c.name;
+    if (audioRef.current) { audioRef.current.pause(); audioRef.current = null; }
+    setPlaying(null);
+    if (was) return;
+    let url = urlsRef.current[c.name];
+    if (!url) {
+      try {
+        // API.blob, not an <a href>: sessions are Bearer-header-only.
+        url = URL.createObjectURL(await API.blob(
+          `/api/devices/${deviceId}/wake_captures/${c.name}`));
+        urlsRef.current[c.name] = url;
+      } catch { return; }
+    }
+    const el = new Audio(url);
+    el.onended = el.onerror = () => setPlaying(p => (p === c.name ? null : p));
+    audioRef.current = el;
+    setPlaying(c.name);
+    el.play().catch(() => setPlaying(p => (p === c.name ? null : p)));
+  };
+
+  if (items === null) return <div className="em-label">Loading…</div>;
+  if (!items.length) {
+    return (
+      <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: 'var(--muted)', lineHeight: 1.7 }}>
+        Nothing captured yet. Each entry here is a detection the Echo made that
+        no voice turn followed — either a wake we missed, or a false alarm.
+      </div>
+    );
+  }
+  return (
+    <div>
+      <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)', marginBottom: 12, lineHeight: 1.6 }}>
+        {items.length} kept · newest first · a false alarm here would become a
+        real turn if the Echo were allowed to trigger
+      </div>
+      {items.map(c => (
+        <div key={c.name} style={{
+          display: 'flex', alignItems: 'center', gap: 12, padding: '8px 0',
+          borderTop: '1px solid var(--track)', minWidth: 0 }}>
+          <button className="em-iconbtn" onClick={() => toggle(c)}
+            title={playing === c.name ? 'Stop' : 'Play'}>
+            {playing === c.name ? '■' : '▶'}
+          </button>
+          <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: 'var(--text2)' }}>
+            {new Date(c.ts * 1000).toLocaleString()}
+          </span>
+          <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: 'var(--muted)' }}>
+            score {c.score.toFixed(3)}
+          </span>
+          <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)', marginLeft: 'auto' }}>
+            {(c.duration_ms / 1000).toFixed(1)}s
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+
 function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDeviceConfigChange }) {
   const [tab, setTab] = useState('status');
   // Seed from the EFFECTIVE config, not the raw stored one — see
@@ -1651,6 +1741,11 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                     stateColor={state.dot}
                   />
                 </Panel>
+                {cfgEff.captureWakeMisses && (
+                  <Panel label="Unmatched on-device crossings" style={{ marginTop: 16 }}>
+                    <WakeCaptures deviceId={device.device_id} deviceLabel={device.label}/>
+                  </Panel>
+                )}
               </div>
             );
           })()}
@@ -4006,7 +4101,7 @@ const STAGE_MONO = "'DM Mono',monospace";
 // be silently wrong.
 const CONFIG_SECTIONS = {
   "playback": ["eqBands", "eqLoudness"],
-  "wakeword": ["owwModel", "owwThreshold", "owwSpeexNs", "bargeInEnabled", "bargeInThreshold", "wakeArbitrationMs", "owwOnDevice"],
+  "wakeword": ["owwModel", "owwThreshold", "owwSpeexNs", "bargeInEnabled", "bargeInThreshold", "wakeArbitrationMs", "owwOnDevice", "captureWakeMisses"],
   "microphones": ["adcMicpga", "adcDigitalGain", "micGainDb", "beamformingEnabled", "beamAngle", "aecEnabled", "aecDelayMs", "aecTailMs", "nsAsr", "saveUtterances"],
   "ring": ["ledScene", "ledListenColor", "ledThinkColor", "meterAttack", "meterDecay", "meterFloor", "meterGamma", "meterRef", "meterCurve"],
   "advanced": ["agcEnabled", "vadThreshold", "vadSpeechMs", "vadSilenceMs"],
@@ -4374,6 +4469,18 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
                 value={(config.owwOnDevice ?? 'off') === 'shadow'}
                 onChange={shadowCapable
                   ? (v => set('owwOnDevice', v ? 'shadow' : 'off'))
+                  : (() => {})}/>
+              {/* Only meaningful while shadow scoring is on, and it records
+                  speech nobody addressed to the assistant — so it is gated on
+                  shadow being enabled AND says plainly what it keeps. */}
+              <Toggle
+                label="Keep audio of unmatched crossings"
+                sub={(config.owwOnDevice ?? 'off') === 'shadow'
+                  ? 'saves a few seconds around each on-device detection that produced no turn, so you can hear whether it was a false alarm or a wake we missed — recognisable speech, kept on this machine, newest 30 per Echo'
+                  : 'needs on-device scoring above'}
+                value={config.captureWakeMisses ?? false}
+                onChange={(config.owwOnDevice ?? 'off') === 'shadow'
+                  ? (v => set('captureWakeMisses', v))
                   : (() => {})}/>
             </div>
           </div>

--- a/controller/tests/test_wake_capture.py
+++ b/controller/tests/test_wake_capture.py
@@ -1,0 +1,172 @@
+"""
+Unmatched wake-crossing capture.
+
+The point of the feature is to answer one question — are the device's
+unmatched crossings false accepts, or wakes the controller missed — so the
+tests are about not destroying the evidence and not writing audio nobody
+asked to be written.
+"""
+
+import em_shadow
+import em_wake_capture as C
+
+
+def _frames(n, at0=0.0, step=0.08, byte=1):
+    """n consecutive 80ms frames, as the mic stream delivers them."""
+    size = int(C.SAMPLE_RATE * step * C.SAMPLE_WIDTH)
+    return [(at0 + i * step, bytes([byte]) * size) for i in range(n)]
+
+
+class TestAudioRing:
+    def test_it_keeps_the_most_recent_audio_and_bounds_itself(self):
+        ring = C.AudioRing(seconds=2.0)
+        for at, p in _frames(100):          # 8 seconds
+            ring.append(at, p)
+        assert 1.8 <= ring.seconds <= 2.0, "ring must stay within its bound"
+
+    def test_it_bounds_by_duration_not_frame_count(self):
+        """
+        A frame is only nominally 80ms; a count-based bound would drift as
+        soon as the device sent a short one.
+        """
+        ring = C.AudioRing(seconds=1.0)
+        ring.append(0.0, b"\x00" * 320)     # 10ms
+        for at, p in _frames(20, at0=0.1):  # 1.6s of full frames
+            ring.append(at, p)
+        assert ring.seconds <= 1.0
+
+    def test_extract_returns_the_window_around_the_crossing(self):
+        ring = C.AudioRing(seconds=20.0)
+        for at, p in _frames(125):          # 10 seconds, t=0..10
+            ring.append(at, p)
+        pcm = ring.extract(centre=5.0, pre=1.0, post=1.0)
+        # 2 seconds either side of centre, frames taken whole
+        assert 1.9 <= C.duration_ms(len(pcm)) / 1000 <= 2.2
+
+    def test_extract_is_empty_when_the_window_has_aged_out(self):
+        """
+        A real outcome, not an error: the hot path is never held up to
+        guarantee a capture.
+        """
+        ring = C.AudioRing(seconds=1.0)
+        for at, p in _frames(50):
+            ring.append(at, p)
+        assert ring.extract(centre=0.5) == b""
+
+    def test_appending_nothing_is_harmless(self):
+        ring = C.AudioRing(seconds=1.0)
+        ring.append(1.0, b"")
+        assert ring.seconds == 0
+
+
+class TestMatching:
+    def test_a_crossing_beside_a_controller_wake_is_matched(self):
+        assert C.is_matched(100.0, 100.3, em_shadow.MATCH_WINDOW_S)
+        assert C.is_matched(100.0, 99.2, em_shadow.MATCH_WINDOW_S)
+
+    def test_a_crossing_with_no_wake_nearby_is_unmatched(self):
+        assert not C.is_matched(100.0, 90.0, em_shadow.MATCH_WINDOW_S)
+        assert not C.is_matched(100.0, None, em_shadow.MATCH_WINDOW_S)
+
+    def test_the_decision_waits_longer_than_the_match_window(self):
+        """
+        The controller usually detects slightly LATER than the device — it
+        scores the same frame after a network hop — so deciding at exactly
+        the match window would call a real wake unmatched.
+        """
+        assert C.DECIDE_AFTER_S > em_shadow.MATCH_WINDOW_S
+
+    def test_it_does_not_ask_whether_the_tracker_consumed_it(self):
+        """
+        The trap this feature could most easily fall into. A crossing is
+        consumed at TURN-PERSIST time, which can be 30s after the wake, so a
+        consumption check a few seconds later reports every genuine wake as
+        unmatched — and would fill the disk with recordings of people
+        talking to their assistant perfectly successfully.
+        """
+        tracker = em_shadow.ShadowTracker()
+        at = em_shadow.now()
+        tracker.record_cross(0.9, 0, at_now=at)
+        # A turn is under way; nothing has been persisted yet, so the
+        # tracker still holds the crossing...
+        assert len(tracker._crossings) == 1
+        # ...but the controller's wake instant already says it matched.
+        assert C.is_matched(at, at + 0.15, em_shadow.MATCH_WINDOW_S)
+
+
+class TestStorage:
+    def test_filenames_carry_the_score_for_triage(self, tmp_path):
+        name = C.filename("G090LF11803611NF", 1785660000.0, 0.734)
+        assert name.endswith("_734.wav")
+        dev, ts, score = C.parse_filename(name)
+        assert dev == "G090LF11803611NF"
+        assert abs(score - 0.734) < 0.001
+        assert abs(ts - 1785660000.0) < 0.01
+
+    def test_a_hostile_device_id_names_no_file(self):
+        assert C.filename("../../etc/passwd", 1.0, 0.5) is None
+        assert C.safe_device_id("a/b") is None
+
+    def test_save_prunes_to_the_cap(self, tmp_path):
+        db = str(tmp_path / "echomuse.db")
+        pcm = b"\x00\x01" * 1600
+        for i in range(8):
+            C.save("dev1", pcm, 1785660000.0 + i, 0.5, db_path=db, keep=3)
+        names = C.list_for("dev1", db_path=db)
+        assert len(names) == 3, "retention is a hard count"
+        # Newest kept, oldest dropped.
+        assert names[0]["ts"] > names[-1]["ts"]
+        assert names[0]["ts"] == 1785660007.0
+
+    def test_save_writes_a_playable_wav(self, tmp_path):
+        import wave
+        db = str(tmp_path / "echomuse.db")
+        pcm = b"\x00\x01" * 8000
+        name = C.save("dev1", pcm, 1785660000.0, 0.5, db_path=db)
+        path = C.captures_dir(db) / name
+        with wave.open(str(path)) as w:
+            assert w.getframerate() == C.SAMPLE_RATE
+            assert w.getnchannels() == 1
+            assert w.getnframes() == len(pcm) // 2
+
+    def test_nothing_is_written_for_empty_audio(self, tmp_path):
+        db = str(tmp_path / "echomuse.db")
+        assert C.save("dev1", b"", 1785660000.0, 0.5, db_path=db) is None
+        assert C.list_for("dev1", db_path=db) == []
+
+    def test_one_device_cannot_read_anothers_capture(self, tmp_path):
+        """
+        The endpoint takes the device and the filename from the path, so the
+        pairing is re-checked rather than trusted.
+        """
+        db = str(tmp_path / "echomuse.db")
+        name = C.save("dev1", b"\x00\x01" * 1600, 1785660000.0, 0.5, db_path=db)
+        assert C.resolve("dev1", name, db_path=db) is not None
+        assert C.resolve("dev2", name, db_path=db) is None
+
+    def test_a_missing_file_resolves_to_none_not_an_error(self, tmp_path):
+        db = str(tmp_path / "echomuse.db")
+        name = C.filename("dev1", 1785660000.0, 0.5)
+        assert C.resolve("dev1", name, db_path=db) is None
+
+    def test_path_traversal_in_the_name_resolves_to_none(self, tmp_path):
+        db = str(tmp_path / "echomuse.db")
+        for bad in ("../../etc/passwd", "dev1_1_1.wav/../../x", "..%2f.."):
+            assert C.resolve("dev1", bad, db_path=db) is None
+
+    def test_deleting_a_device_removes_its_captures(self, tmp_path):
+        db = str(tmp_path / "echomuse.db")
+        C.save("dev1", b"\x00\x01" * 1600, 1785660000.0, 0.5, db_path=db)
+        C.save("dev2", b"\x00\x01" * 1600, 1785660001.0, 0.5, db_path=db)
+        assert C.delete_device("dev1", db_path=db) == 1
+        assert C.list_for("dev1", db_path=db) == []
+        assert len(C.list_for("dev2", db_path=db)) == 1
+
+    def test_captures_live_apart_from_utterance_recordings(self, tmp_path):
+        """
+        Different consent: an utterance was addressed to the assistant, an
+        unmatched crossing was not.
+        """
+        import em_recordings
+        db = str(tmp_path / "echomuse.db")
+        assert C.captures_dir(db) != em_recordings.recordings_dir(db)


### PR DESCRIPTION
Groundwork for deciding whether `owwOnDevice` can ever be `on`.

## The number this exists to explain

From the live database, over **155 device-hours** of shadow scoring:

| device | crossings | matched a turn | **unmatched** |
|---|---|---|---|
| …30NJG | 68 | 50 | **18** |
| …3611NF | 64 | 57 | **7** |
| …71VVV | 23 | 22 | **1** |

About one per device every six hours. On shadow they are a log line. With `owwOnDevice=on` **each one is a turn nobody asked for**.

**"Unmatched" is not "false accept", and the counters cannot tell them apart.** Each is either a genuine wake the *controller* missed (argues **for** shipping), a crossing while the controller was not scoring, or a real false trigger (argues **against**). Those want opposite decisions, so the only way through is to listen — and the audio is long gone by the time a counter says anything.

(For context: agreement on turns both detectors could see is **94%**, n=116. The agreement side is fine; this is the other side.)

## The trap it could most easily have fallen into

Asking whether the shadow tracker still holds the crossing. Correlation happens at **turn-persist** time, which can be thirty seconds after the wake — so that check would call every genuine wake unmatched, and fill the disk with recordings of people using their assistant perfectly successfully.

It compares against `last_wake_mono` instead, which is set at *detection*, and waits a second longer than `MATCH_WINDOW_S` because the controller usually detects **later** than the device: it scores the same frame after a network hop. A test pins both.

## Privacy — a higher bar than saveUtterances, not the same one

This records speech **nobody addressed to the assistant**. So: off by default, opt-in per device, gated in the UI on shadow scoring being on, stored apart from `recordings/`, capped at 30 files per device, deleted with the device, and the buffer is dropped the moment the toggle goes off rather than lingering in memory holding several seconds of audio.

## Cost

One deque append per frame while armed, nothing at all when not (~12 frames/s per device). The ring is bounded by **duration, not frame count** — a frame is only nominally 80ms. ~480KB per capturing device.

## Using it

Config → Wake word → "Keep audio of unmatched crossings", then Activity → *Unmatched on-device crossings* to play them back. `GET /api/devices/{id}/wake_captures` for the list.

## Verification

290 controller tests pass, including 19 new ones. The Dockerfile COPY guard caught the missing line for the new module, which is what it is there for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)