### PR TITLE
docs: record the OTA transfer verification, and what actually fixed the Dot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,6 +584,41 @@ The device runs an A/B slot binary system:
 
 OTA is triggered from the dashboard — the controller pushes the new binary via the `/shell` WebSocket.
 
+**md5 decides whether a transfer succeeded, not the shell's exit status.**
+`TRANSFER_OK` only ever proved that the base64 decode pipeline and `chmod`
+exited 0 — never that the bytes on the device match the bytes sent. Bytes
+therefore land in `{dest}.part` and are renamed only on an md5 match
+(`_stream_file_to_device`), the same discipline the asset path has always
+had. **The point is the ordering, not the error message**: a corrupt binary
+and a genuinely broken one produce the *same* observable — three fast exits,
+a symlink flip, a device back on its old version — so an unverified transfer
+costs a reboot and a rollback to arrive at the same place with less
+information, and the mismatch must be caught while the device is still
+running happily on its current slot. A failed verification must never reach
+the `ln -sf`; `tests/test_deploy.py` pins that ordering.
+
+Three things not to undo:
+- Verification rides the **same shell session** as the transfer, and the md5
+  tool is detected alongside the base64 decoder in the round trip that was
+  already happening — so it costs a round trip on an open socket, not a
+  session.
+- **No `cut`.** `md5sum` prints `<hash>  <path>`, and the branch where
+  busybox is absent is exactly the branch where `busybox cut` is absent too.
+  A `case` glob needs no external tool.
+- `require_verify` separates "no md5 tool on this device" from "md5 did not
+  match". Callers default to accepting the former with a warning — their
+  prior behaviour, and the base64 detection already treats a busybox-less
+  device as a contemplated state. **Firmware passes True and refuses**, being
+  the payload we are about to boot.
+
+Free space is checked before anything is written, via
+`em_oww_assets.parse_free_mb` — never an awk field index, for the busybox
+line-wrap reason documented in the asset section. An unreadable `df` reads as
+**carry on**: it is not evidence of a full disk, and refusing on it would
+block updates on any device whose `df` we have not seen. Note binary growth
+is not a plausible cause of a space failure here — v2.9.8 is 10.1MB and
+v2.10.0 is 10.3MB.
+
 Device-side payloads the controller distributes (`start_server.sh` via `/api/provision/start_script`; the debloat pair `debloat_packages.txt`/`echomuse-debloat.sh` via `/api/provision/debloat_packages`+`debloat_script`, applied by the wizard's Debloat step — pm hide list + Magisk service.d daemon stops) live canonically in `controller/device_payloads/` and are read from disk per request — never embed copies in `em_api.py` or `dashboard.jsx`. `device/scripts/start_server.sh` is a symlink into that directory. Every firmware OTA also syncs the device's `/data/local/bin/start_server.sh` against the canonical payload (`_sync_start_script` — md5 compare, heredoc push, rename into place; takes effect on next device reboot), so script drift heals fleet-wide without a separate update path.
 
 **Every payload needs an update path, and `tests/test_deploy.py` enforces it** (a file in `device_payloads/` unreferenced by `em_api.py` fails CI). The debloat pair had none until 2026-07-30 and every fielded device needed a manual push. `_sync_debloat` also rides the OTA and reconciles **both** halves — the boot script by md5, and the `pm hide` list by asking the device which listed packages are still visible — because round 2 added a *package* and a script-only sync would have looked like it worked while changing nothing. It is additionally exposed as `POST /api/devices/{id}/debloat` (Updates tab → Maintenance), which is **required, not a convenience**: the OTA path cannot reach a device already on the latest firmware. Two traps in that reconcile, both of which produced confident wrong answers: match package names with `grep -qx` (whole line) — an unanchored `*package:$p*` also matches `package:$p.client` — and never treat `pm list packages -u` minus `pm list packages` as the hidden count, since it includes uninstalled packages.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -778,3 +778,69 @@ are **append-only and in ascending date order** — new work goes at the end.
   comment on the field claimed a satellite attaching first would "pick them up
   on the next HA reconnect", which was true and was the problem: HA does not
   reconnect on its own.
+
+- **2026-08-03 — a transfer that could only tell you it had finished, not that
+  it had worked.** Someone on Reddit had one Dot that would not leave v2.9.8
+  while the rest of their fleet updated fine. Answering it exposed a gap that
+  was ours, not theirs — though, as it turned out, **not the gap that was
+  causing their problem.** Their Dot had a slot symlink pointing at neither
+  `server_a` nor `server_b`; correcting it and retrying updated the device
+  first time, on a controller predating everything below. Worth stating
+  plainly so the record does not imply the fix and the resolution were the
+  same event.
+
+  That real cause deserves its own note, because it is a failure mode with no
+  natural end. `/data/local/bin/server` pointing anywhere unexpected makes the
+  controller's slot detection return nothing, so the OTA refuses before it
+  transfers a byte — and the device meanwhile runs perfectly on whatever the
+  symlink resolves to. A Dot in that state works indefinitely and can never
+  update, with no symptom other than updates not happening. `start_server.sh`
+  recognises the condition (`Unknown slot ... cannot auto-rollback, giving up`)
+  and the controller reports `Could not determine active slot`, which is
+  accurate and tells the user nothing about what to do. Neither end offers to
+  repair it. `ls -la /data/local/bin/` is what found it, and that it took a
+  human reading a directory listing is the argument for making the OTA say
+  what is wrong in words someone can act on.
+
+  A firmware transfer was confirmed by `TRANSFER_OK`, which the device echoes
+  when the base64 decode pipeline and `chmod` both exit 0. That is a statement
+  about the shell, not about the bytes. Nothing compared what landed against
+  what was sent.
+
+  Which matters because of what a bad binary looks like from outside: three
+  fast exits, `start_server.sh` flips the symlink, the device comes back on
+  its old version. **A corrupt transfer and a genuinely broken build produce
+  exactly that same picture**, and the supervisor log — which records the
+  rollback faithfully — cannot separate them either. So "one Dot won't update,
+  it's fine on the old version" was a question neither end of the system could
+  answer.
+
+  The fix is the one the asset path has had all along: land in `.part`, rename
+  only on an md5 match. What is worth keeping is *where* it sits rather than
+  what it says. A mismatch is now caught while the device is still running
+  happily on its current slot, so it never reaches the symlink flip — where
+  the old path spent a reboot and a rollback to arrive at the same place
+  knowing less. The error message is the small half; the ordering is the
+  point, and it is what the test pins.
+
+  Two details that would be easy to undo. Verification rides the *same* shell
+  session as the transfer and the md5 tool is detected alongside the base64
+  decoder in a round trip that was already happening, so the whole thing costs
+  a round trip on an open socket rather than a session. And it uses no `cut`:
+  `md5sum` prints `<hash>  <path>`, and the branch where busybox is missing is
+  precisely the branch where `busybox cut` would be missing too — a `case`
+  glob needs nothing external. Distinguishing "no md5 tool here" from "md5
+  did not match" is why `require_verify` exists: every other payload keeps its
+  old accept-with-a-warning behaviour, and only firmware refuses.
+
+  Also added the free-space check the OTA path never had, and did **not** add
+  the theory that prompted looking: the binary has barely grown, 10.1MB at
+  v2.9.8 against 10.3MB at v2.10.0. Worth recording as falsified so nobody
+  re-derives it.
+
+  One test lesson, found only because the house rule is to reintroduce the bug
+  rather than trust a green tick. A guard asserting that firmware requires
+  verification passed with the argument deleted — it had matched the docstring
+  *explaining* `require_verify` instead of the call *setting* it, and would
+  have gone on passing forever. Source-shape assertions must be anchored on
+  the call site; prose in the same function will happily satisfy them.


### PR DESCRIPTION
Docs only. Two things the docs did not yet know about, since the freshness pass (#75) merged before the OTA fix (#77).

## CLAUDE.md — the verification invariant

md5 decides whether a transfer succeeded, not the shell's exit status, and **the point is the ordering rather than the error message**: a mismatch has to be caught while the device is still running happily on its current slot, because an unverified transfer spends a reboot and a rollback to arrive at the same place with less information.

Plus the three implementation details that are easy to undo by accident — the verification rides the same shell session, it uses no `cut` (the busybox-less branch is exactly where `busybox cut` is missing too), and `require_verify` separates "no md5 tool" from "md5 mismatch".

## JOURNAL — and a correction

The entry records the Reddit report that prompted the work, **and corrects the impression that the fix and the resolution were the same event.** They were not. Their Dot had a slot symlink pointing at neither `server_a` nor `server_b`; correcting it updated the device first time, on a controller predating all of this. The md5 verification is still worth having — it just did not fix their problem, and the record should not imply it did.

## The cause is worth its own note

It is a failure mode with **no natural end**. A slot symlink pointing anywhere unexpected makes the controller's slot detection return nothing, so the OTA refuses before transferring a byte — while the device runs perfectly on whatever the link resolves to. A Dot in that state works indefinitely and can never update, with no symptom other than updates not happening.

Both ends already recognise the condition — `start_server.sh` logs `Unknown slot ... cannot auto-rollback, giving up`, the controller reports `Could not determine active slot` — and **neither offers to repair it or says anything a user can act on**. A human reading `ls -la /data/local/bin/` is what found it.

That suggests a follow-up worth doing separately: have the OTA name the condition in words someone can act on, and offer the repair. Not in this PR.

286 controller tests pass (unchanged — no code in this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)