### PR TITLE
fix(docker): select esbuild binary by architecture (unblocks arm64 builds)

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -100,7 +100,7 @@ RUN mkdir -p /app/models/oww_runtime && \
 # Dashboard SPA — placeholder is index.html, full dashboard is dashboard.html
 COPY static/ ./static/
 # Compile JSX dashboard with esbuild
-RUN curl -sfL -o /tmp/esbuild.tar.gz       https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz &&     tar -xz -C /tmp -f /tmp/esbuild.tar.gz &&     install -m755 /tmp/package/bin/esbuild /usr/local/bin/esbuild &&     esbuild /app/static/dashboard.jsx       --bundle=false       --jsx=transform       --jsx-factory=React.createElement       --jsx-fragment=React.Fragment       --outfile=/app/static/dashboard.js &&     rm /tmp/esbuild.tar.gz
+RUN EARCH="$(dpkg --print-architecture)" && case "$EARCH" in amd64) EPKG=linux-x64 ;; arm64) EPKG=linux-arm64 ;; *) echo "unsupported arch: $EARCH" >&2; exit 1 ;; esac && curl -sfL -o /tmp/esbuild.tar.gz "https://registry.npmjs.org/@esbuild/${EPKG}/-/${EPKG}-0.20.2.tgz" &&     tar -xz -C /tmp -f /tmp/esbuild.tar.gz &&     install -m755 /tmp/package/bin/esbuild /usr/local/bin/esbuild &&     esbuild /app/static/dashboard.jsx       --bundle=false       --jsx=transform       --jsx-factory=React.createElement       --jsx-fragment=React.Fragment       --outfile=/app/static/dashboard.js &&     rm /tmp/esbuild.tar.gz
 # Database persisted via volume mount
 # docker run -v ~/EchoMuse/controller/data:/app/data ...
 # Set DB_PATH=/app/data/echomuse.db in environment


### PR DESCRIPTION
## Problem

`controller/Dockerfile` downloads a hard-coded x86-64 esbuild tarball and then executes it:

```
RUN curl -sfL -o /tmp/esbuild.tar.gz https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz && ... esbuild /app/static/dashboard.jsx ...
```

On arm64 the download succeeds and the binary then cannot run, so `docker build` fails with:

```
ERROR: failed to solve: process "/bin/sh -c curl -sfL -o /tmp/esbuild.tar.gz ..." did not complete successfully: exit code: 126
```

Exit 126 is "cannot execute binary format", which is not obvious from the log — it reads like a curl or tar problem.

This matters because the published image is amd64-only. Every tag of `ghcr.io/wilbowes/echomuse-controller` currently on GHCR (`2.8.0`, `2.8.1`, `2.8.2`, `2.9.0`, `2.10.0`, `2.11.0`, `2.12.0`, `2.12.1`, `2.13.0`, `2.14.0`, `latest`) has only a `linux/amd64` manifest. So on a Raspberry Pi — a pretty natural host for this project — `docker-compose.deploy.yml` cannot work, and building locally is the only route. This one line is what blocks it.

## Fix

Detect the architecture and pick the matching esbuild package. `@esbuild/linux-arm64` 0.20.2 is published, so no version bump is needed. Unknown architectures now fail with a clear message rather than a confusing 126 from a foreign binary.

**amd64 behaviour is unchanged.**

## Verification

Built natively on a Raspberry Pi 4 (aarch64, Debian bookworm, Docker 29.7.1). The build completes and the controller runs:

- schema migrates to v16
- dashboard + API on 8768 (`GET /` → 200)
- device WebSocket on 8767, device-link TLS on 8770, CA generated
- mDNS advertises `echomuse._emcontroller._tcp.local`
- `ESPHome servers ready`, `EchoMuse Controller ready — waiting for devices`

Worth noting for a possible follow-up: **nothing else blocks arm64.** Every pinned dependency in `requirements.txt` already ships a cp312 aarch64 manylinux wheel — including `speexdsp-ns`, whose comment says only `python:3.12-slim x86_64` was confirmed — so nothing has to compile from source. With this patch, adding `linux/arm64` to the buildx platforms in the release workflow would produce a working multi-arch image. I have not included that here since CI build time is your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)