### PR TITLE
ci: publish the controller image for arm64 as well as amd64

### DIFF
--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -12,6 +12,15 @@ name: Controller Release (Docker image)
 #
 # The image is CPU-only (onnxruntime). GPU users build locally with
 # --build-arg GPU=1 (see controller/docker-compose.yml).
+#
+# Built for linux/amd64 AND linux/arm64. A Raspberry Pi is a natural host for
+# this project, and an amd64-only manifest meant docker-compose.deploy.yml
+# could not work on one at all — building locally was the only route, and
+# until #81 even that failed on the hard-coded x86-64 esbuild download.
+# Every Python dependency resolves to a prebuilt aarch64 wheel on this base
+# image, including speexdsp-ns and onnxruntime, so the arm64 build compiles
+# nothing; it is emulated with QEMU, which costs time on the runner and
+# nothing at run time.
 
 on:
   push:
@@ -28,6 +37,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        # arm64 is cross-built on an amd64 runner, so the emulation layer has
+        # to be registered before buildx can target that platform at all.
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -58,7 +72,7 @@ jobs:
         with:
           context: controller
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             EM_CONTROLLER_VERSION=${{ steps.version.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Every published tag of `ghcr.io/wilbowes/echomuse-controller` currently has
an **amd64-only manifest**, so `docker-compose.deploy.yml` cannot work on a
Raspberry Pi at all — which is a natural host for this project. Building
locally was the only route, and until #81 even that failed on a hard-coded
x86-64 esbuild download.

#81 fixed the local build. This makes the *published* image usable there.

## The change

- `platforms: linux/amd64` → `linux/amd64,linux/arm64`
- Adds `docker/setup-qemu-action@v3`, since QEMU has to be registered before
  buildx can target a foreign platform.

## Why this is cheap

Nothing compiles on arm64. Every dependency resolves to a prebuilt aarch64
wheel on `python:3.12-slim` (bookworm, glibc 2.36):

| Package | arm64 wheel |
|---|---|
| `speexdsp-ns` 0.1.2 | `cp312-manylinux_2_28_aarch64` |
| `onnxruntime` 1.20.1 | `cp312-manylinux_2_28_aarch64` |
| `cryptography` 44.0.1 | `cp39-abi3-manylinux_2_28_aarch64` |
| `bcrypt` 5.0.0 | `cp39-abi3-manylinux_2_28_aarch64` |
| `aiohttp`, `zeroconf`, `scipy`, `scikit-learn` | aarch64 wheels |
| `websockets` | pure Python |

The rest of the Dockerfile is arch-neutral: the vendored ONNX Runtime AAR is
the *device's* ARM runtime, extracted with Python's `zipfile`, and the
remaining `x86_64` mentions are a comment and a curl User-Agent string.

So the arm64 build is emulation of package installs and file copies, not a
toolchain run. It costs time on the runner and nothing at run time.

## Verifying it worked

After the next `controller-v*` tag, the manifest should list both platforms:

```
docker buildx imagetools inspect ghcr.io/wilbowes/echomuse-controller:latest
```

Untested beyond the YAML parsing and the wheel availability above — the first
real proof is the next release build.
