### PR TITLE
wizard: report the FireOS build, and say which one we test against

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -2314,6 +2314,19 @@ service echomuse /data/local/bin/start_server.sh
 // against the uploaded file's SHA-256 before flashing — catches wrong-
 // version uploads (e.g. a newer Magisk that doesn't support Android 5.1's
 // non-namespaced su, or a corrupted download) before they hit TWRP.
+// The one FireOS 5 build EchoMuse is developed and tested against. R0rt1z2's
+// thread lists five older ones that also boot on an unlocked Dot, and nothing
+// stops someone flashing those — but only this one has ever been through the
+// wizard here, and firmware defaults differ between builds. A device on a
+// different build is the first thing worth knowing when it behaves oddly, and
+// until now the wizard never even looked (see #79).
+//
+// A warning, not a refusal: an older build may well provision fine, we just
+// have no evidence either way, and blocking someone whose device works would
+// be the worse error. Mirrored in docs/rooting.md, pinned by test.
+const _TESTED_FIREOS_BUILD = '272.6.8.0_user_680767620';
+const _TESTED_FIREOS_NAME  = 'Fire OS 5.5.5.4';
+
 const _MAGISK_FILENAME = 'Magisk-v17.3.zip';
 const _MAGISK_SHA256    = '18e46b16b25ebe691c282fe311beccd4811cd533848a64e2efbd754fb85efde7';
 
@@ -2503,9 +2516,17 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     const release = await c.shell('getprop ro.build.version.release');
     const name    = await c.shell('getprop ro.product.name');
     const serial  = await c.shell('getprop ro.serialno') || await c.shell('getprop ro.boot.serialno');
+    const fwBuild = await c.shell('getprop ro.build.version.incremental');
+    const fwName  = await c.shell('getprop ro.build.version.name');
     addLog(`Model: ${model || '(unknown)'}  Build: Android ${release}  Codename: ${name || '(unknown)'}  Serial: ${serial || '(unknown)'}`);
+    addLog(`Firmware: ${fwName || '(unknown)'}  ${fwBuild || ''}`);
     if (!release.startsWith('5.')) {
       throw new Error(`Expected FireOS 5 (Android 5.x), got Android ${release}. Wrong device?`);
+    }
+    if (fwBuild && fwBuild !== _TESTED_FIREOS_BUILD) {
+      addLog(`Untested firmware — EchoMuse is developed against ${_TESTED_FIREOS_NAME} `
+           + `(${_TESTED_FIREOS_BUILD}). Other FireOS 5 builds may behave differently, `
+           + `particularly around USB and ADB.`, 'warn');
     }
     if (model && !model.toLowerCase().includes('amazon') && !name.toLowerCase().includes('biscuit')) {
       addLog('Warning: device may not be an Echo Dot 2nd gen — proceeding anyway.', 'warn');

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -772,3 +772,26 @@ def test_ota_checks_free_space_before_writing_anything():
     assert "free_mb is not None and free_mb <" in ota, (
         "an unknown reading must not be compared as if it were a number"
     )
+
+
+def test_tested_firmware_build_matches_the_docs():
+    """
+    The wizard warns when a device is on a FireOS build other than the one
+    EchoMuse is developed against, and docs/rooting.md tells people which to
+    flash. Those two have to name the same build: a warning pointing at a
+    version the docs do not mention is worse than no warning, because the
+    person reading it has nowhere to go.
+
+    Verified against the fleet 2026-08-07 — all three connected devices report
+    ro.build.version.incremental = 272.6.8.0_user_680767620.
+    """
+    jsx = (CONTROLLER / "static" / "dashboard.jsx").read_text()
+    m = re.search(r"_TESTED_FIREOS_BUILD\s*=\s*'([^']+)'", jsx)
+    assert m, "dashboard.jsx no longer declares _TESTED_FIREOS_BUILD"
+    build = m.group(1)
+
+    rooting = (CONTROLLER.parent / "docs" / "rooting.md").read_text()
+    assert build in rooting, (
+        f"the wizard warns against build {build} but docs/rooting.md never "
+        f"names it — a reader has nowhere to go"
+    )

--- a/controller/tools/README.md
+++ b/controller/tools/README.md
@@ -12,7 +12,12 @@ docker exec echomuse-controller python /tmp/devshell.py "<shell command>" ["<ano
 
 - **devshell.py** — run commands on a device over the `/shell` proxy (PTY
   mode; output includes echoed input — device is mksh + busybox, no
-  tail/sed/head, use `busybox <applet>`). Device ID is hardcoded at the top.
+  tail/sed/head, use `busybox <applet>`). Defaults to the device hardcoded at
+  the top; `-d <serial>` picks another (repeatable) and `--all` runs against
+  every currently-connected device, which is what most diagnostic questions
+  want. **Read-only in practice**: the shell is a child of the server, so
+  stopping the service kills the shell mid-command and takes the device down
+  until it is power cycled.
 - **ota.py** — push a locally built binary: `docker cp device/build/server
   echomuse-controller:/tmp/server-new` first, then
   `python /tmp/ota.py <device_id>` (upload → `/api/devices/{id}/update`).

--- a/controller/tools/devshell.py
+++ b/controller/tools/devshell.py
@@ -1,9 +1,58 @@
-"""One-shot device shell command runner via controller shell proxy."""
+"""One-shot device shell command runner via controller shell proxy.
+
+    devshell.py [-d SERIAL]... [--all] "<cmd>" ["<cmd>" ...]
+
+The device used to be a constant at the top of this file, which meant asking
+the same question of a second device was a file edit — and in practice meant
+writing a throwaway copy of this script instead. Hence -d, and --all for the
+whole fleet, which is what most diagnostic questions actually want.
+
+READ ONLY, in practice: a shell opened here is a CHILD OF THE SERVER, so
+`stop`ping the service kills this shell at the first word and takes the device
+down until it is power cycled. Inspect freely; do not stop the server.
+"""
 import asyncio, json, secrets, sqlite3, sys, time
 import websockets
 
+# Default when neither -d nor --all is given — kept so existing invocations
+# and the README's one-liner behave exactly as before.
 DEVICE = "G090LF11803611NF"
 DB = "/app/data/echomuse.db"
+
+
+def all_devices(max_age_s=300):
+    """Devices seen recently — i.e. ones a shell can actually reach.
+
+    Filtered rather than "every row" because the shell proxy has no fast
+    failure for an absent device: it simply waits, so one retired device turns
+    a fleet-wide question into a minute of nothing. Name an offline device
+    with -d if you really want to wait for it.
+    """
+    con = sqlite3.connect(DB)
+    cutoff = time.time() - max_age_s
+    rows = [r[0] for r in con.execute(
+        "SELECT device_id FROM devices WHERE last_seen > ? ORDER BY last_seen DESC",
+        (cutoff,))]
+    con.close()
+    return rows
+
+
+def parse_args(argv):
+    """Returns (devices, commands). Anything not a flag is a command."""
+    devices, cmds, i = [], [], 0
+    while i < len(argv):
+        a = argv[i]
+        if a in ("-d", "--device"):
+            i += 1
+            if i >= len(argv):
+                raise SystemExit("-d needs a device serial")
+            devices.append(argv[i])
+        elif a == "--all":
+            devices.extend(all_devices())
+        else:
+            cmds.append(a)
+        i += 1
+    return (devices or [DEVICE]), cmds
 
 def make_token():
     tok = secrets.token_hex(32)
@@ -23,10 +72,10 @@ def drop_token(tok):
     con.execute("DELETE FROM sessions WHERE token=?", (tok,))
     con.commit(); con.close()
 
-async def run(cmds):
+async def run(cmds, device=DEVICE):
     tok = make_token()
     try:
-        uri = f"ws://127.0.0.1:8768/api/devices/{DEVICE}/shell?token={tok}"
+        uri = f"ws://127.0.0.1:8768/api/devices/{device}/shell?token={tok}"
         async with websockets.connect(uri, max_size=None) as ws:
             out = bytearray()
             async def read_until(marker, timeout=15):
@@ -51,4 +100,10 @@ async def run(cmds):
         drop_token(tok)
 
 if __name__ == "__main__":
-    asyncio.run(run(sys.argv[1:]))
+    devices, commands = parse_args(sys.argv[1:])
+    if not commands:
+        raise SystemExit(__doc__)
+    for dev in devices:
+        if len(devices) > 1:
+            print(f"\n═══ {dev}")
+        asyncio.run(run(commands, dev))

--- a/docs/rooting.md
+++ b/docs/rooting.md
@@ -25,9 +25,22 @@ For the unlock itself (R0rt1z2's thread has the authoritative list):
 - The following files downloaded and ready:
   - `amonet-biscuit-v1.1.0.zip` — from R0rt1z2's XDA thread
   - `update-kindle-csm_biscuit-272.6.8.0_user_680767620.bin` — FireOS 5 firmware
+    (**this exact build** — see below)
   - `f1r30s.zip` — ADB enablement patch
   - `Magisk-v17.3.zip` — from [GitHub](https://github.com/topjohnwu/Magisk/releases/tag/v17.3)
   - `server` — compiled EchoMuse binary (ARM, API 22)
+
+> **Which FireOS 5 build?** R0rt1z2's thread lists six that boot on an
+> unlocked Dot, and EchoMuse is developed and tested against exactly one:
+> **Fire OS 5.5.5.4**, `272.6.8.0_user_680767620`. Every device in the
+> project's own fleet runs it. The older builds are not known to be broken —
+> they are simply untested here, and firmware defaults differ between builds
+> in ways that reach USB and ADB behaviour. If you are choosing, choose this
+> one. If you already have a device on another build and something behaves
+> oddly, that is the first thing to mention when reporting it.
+>
+> Check what you have with `adb shell getprop ro.build.version.name`. The
+> provisioning wizard reads it at the first step and says so in the log.
 
 > **Why Magisk 17.3?** Newer versions dropped support for Android 5.1 (API 22). 25.x installs but the daemon silently fails. 17.3 is the last version that works reliably on this device.
 


### PR DESCRIPTION
Groundwork for #79.

## What the fleet looks like

All three connected devices, read over the shell proxy:

| | value (identical on all three) |
|---|---|
| `ro.build.version.incremental` | `272.6.8.0_user_680767620` |
| `ro.build.version.name` | `Fire OS 5.5.5.4 (680767620)` |
| `persist.sys.usb.config` | `mtp,adb` |
| `persist.service.adb.enable` | unset |
| file in `/data/property/` matching usb or adb | none |

`/data/property/` is well populated otherwise (wifi settings, audio offsets,
`persist.sys.recovery.batt_level`), just nothing USB related. So on this build
that value is a boot-time default, re-derived every boot, not something
stored.

## What changes

R0rt1z2's thread lists five older FireOS 5 builds that also boot on an
unlocked Dot, and firmware defaults differ between builds. A reporter on a
different build is a plausible explanation for a device behaving differently
on USB, and the wizard never looked at the build at all.

- Step 0 already read `ro.build.version.release` and refused non-5.x. It now
  also reads `ro.build.version.incremental`, logs the firmware, and warns when
  it is not the tested build.
- A warning rather than a refusal. An older build may provision perfectly
  well, we have no evidence either way, and blocking someone whose device
  works is the worse error.
- `docs/rooting.md` now says which build to flash and why. It previously
  listed the `.bin` among "files you need" without saying it was the only one
  tested.
- A test pins those two together, so a warning cannot name a version the docs
  never mention.

The original plan was to write `persist.sys.usb.config` and
`persist.service.adb.enable` into `/data/property/` before the reboot. Dropped:
no device here has those files, so it would add a persisted override that none
of the known-good devices carry.

`controller/tools/devshell.py` also gains `-d`/`--all`, since asking three
devices the same question previously meant editing a constant at the top of
the file and re-copying it each time. `--all` skips devices that are not
connected, because the shell proxy has no fast failure for an absent one.

## Testing

287 controller tests pass and the dashboard JSX compiles. The device values
above were read from the live fleet, bracketed on the wire (`[$(getprop ...)]`)
so stray whitespace would show. There is none, so the exact-match comparison
is safe. The warning path has not been run against a device on a different
build, because we do not have one.
