### PR TITLE
wizard: make WiFi failures explain themselves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,19 @@ jobs:
           fi
           echo "No undefined names."
 
+  dashboard-tests:
+    name: Dashboard logic tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # No setup-node step: ubuntu-latest ships a node, and this test needs
+      # nothing beyond the standard library. The dashboard is otherwise
+      # untested by construction — it compiles to a single classic script
+      # with no module boundary to import across — so this covers the pure
+      # logic that decides what the wizard will and will not attempt.
+      - name: Run dashboard tests
+        run: node controller/tests/wifi_scan.test.mjs
+
   device-tests:
     name: Device Go tests
     runs-on: ubuntu-latest

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -844,3 +844,84 @@ are **append-only and in ascending date order** — new work goes at the end.
   *explaining* `require_verify` instead of the call *setting* it, and would
   have gone on passing forever. Source-shape assertions must be anchored on
   the call site; prose in the same function will happily satisfy them.
+
+- **2026-08-07 — three things the devices knew and we could not see.** A day
+  of working through reported issues, in which the useful move each time was
+  to stop reasoning and go and measure. Every answer below came off a live
+  device in under a minute, and two of them killed a feature that was already
+  half designed.
+
+  **#79, a Dot dropping off USB after boot.** The plan was to force
+  `persist.sys.usb.config` and `persist.service.adb.enable` into
+  `/data/property/` before the reboot. Then: all three connected devices have
+  **no file in that directory matching usb or adb at all**, while
+  `persist.sys.usb.config` still reads `mtp,adb`. On this firmware it is a
+  boot-time default, not stored. Writing the file would have added a
+  persisted override that none of the known-good devices carry, on a
+  hypothesis the evidence does not support. Dropped.
+
+  What replaced it is duller and probably more useful. R0rt1z2's thread lists
+  six FireOS 5 builds; every device here runs `272.6.8.0_user_680767620` and
+  `docs/rooting.md` listed that .bin among "files you need" without ever
+  saying it was the only one tested. The wizard now reads
+  `ro.build.version.incremental` at step 0, logs it, and warns when it
+  differs. A warning, not a refusal: an older build may be fine, we have no
+  evidence either way, and blocking someone whose device works is the worse
+  error.
+
+  **#82, wifi that never associates.** The log showed config written,
+  verified, no interferers, then twenty identical `wpa_state=SCANNING` lines
+  and an error naming nothing. Asking the radio what it can do:
+
+      key_mgmt:  NONE IEEE8021X WPA-EAP WPA-PSK
+      auth_alg:  OPEN SHARED LEAP
+
+  No SAE. WPA3-Personal is not a configuration problem on this hardware, it
+  is impossible, and the reporter's first network is a Pixel hotspot, which
+  Android 13 and later default to exactly that.
+
+  The wizard could have said so and did not, because `scanWifi` parsed
+  `bssid / frequency / signal / flags / ssid` and threw away two of those.
+  The security flags were in hand the whole time. So: the parser keeps them,
+  the picker shows band and security and greys out what cannot be joined,
+  `key_mgmt` is no longer hardcoded to WPA-PSK (the device reports `NONE`, so
+  open networks always worked and were simply never configurable),
+  `scan_ssid=1` for a typed SSID, and a failed association now rescans and
+  reports whether the network is on the air and with what security. That last
+  one is the point: it turns this class of report into something the log
+  answers by itself.
+
+  This also brought the **first test coverage of `dashboard.jsx`**. Its pure
+  logic is untested by construction, since it compiles to a single classic
+  script with no module boundary to import across, so the test lifts the
+  functions out of the source rather than keeping a copy that would drift.
+  The check worth having is the one in the opposite direction: a mixed
+  WPA2/WPA3 AP advertises both and is joinable through its WPA2 half, so
+  refusing it for mentioning SAE would lock people out of a working network.
+
+  **The 5GHz preference, which we are not building.** The complaint was a
+  microwave knocking a device off the air, and the obvious fix is to prefer
+  5GHz. Per-band signal over 440 hours:
+
+  | Device | Band | Hours | RSSI avg | Link avg |
+  |---|---|---|---|---|
+  | Office | 5GHz | 440 | -30.4 | 148 |
+  | Lounge | 5GHz | 419 | -52.8 | 143 |
+  | Lounge | 2.4GHz | 21 | -55.5 | 61 |
+  | Retreat | 5GHz | 361 | -64.2 | 126 |
+  | Retreat | 2.4GHz | 79 | -54.8 | 59 |
+
+  **Retreat's 5GHz is about 10dB worse than its 2.4GHz.** It changes band for
+  a good reason, and forcing it would trade a slow link for an unreliable one
+  on the device furthest from an AP. Lounge is the opposite. One setting
+  cannot serve both, which is the argument for doing it at the access point
+  where it can be per-client and RSSI-aware. Two further reasons device-side
+  was wrong: Android 5.1 offers a band *lock* rather than a preference, and
+  `internal/wifi/wifi.go` already documents that WifiStateMachine writes its
+  network list back over `wpa_supplicant.conf` on `svc wifi disable`, so a
+  hand-written `freq_list` would work when tested and vanish later.
+
+  What survives is the observation rather than the control: the Status tab
+  now shows band and link speed. Lounge had been sitting on 2.4GHz for 21
+  hours at 61 Mbps after two weeks at 143, and nothing in the dashboard said
+  so.

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -2314,6 +2314,12 @@ service echomuse /data/local/bin/start_server.sh
 // against the uploaded file's SHA-256 before flashing — catches wrong-
 // version uploads (e.g. a newer Magisk that doesn't support Android 5.1's
 // non-namespaced su, or a corrupted download) before they hit TWRP.
+// WiFi security labels, used in the network picker and in error messages.
+// Module scope so WifiPanel and the wizard's step runners share one set.
+const _SECURITY_LABEL = {
+  wpa2: 'WPA2', wpa3: 'WPA3', open: 'Open', wep: 'WEP', enterprise: 'Enterprise',
+};
+
 const _MAGISK_FILENAME = 'Magisk-v17.3.zip';
 const _MAGISK_SHA256    = '18e46b16b25ebe691c282fe311beccd4811cd533848a64e2efbd754fb85efde7';
 
@@ -2389,22 +2395,32 @@ function WifiPanel({ adb, wifiSsid, setWifiSsid, wifiPsk, setWifiPsk, onScan, ne
           border: '1px solid var(--border-soft)', borderRadius: 6, overflow: 'hidden',
           maxHeight: 140, overflowY: 'auto',
         }}>
-          {networks.map(n => (
+          {networks.map(n => {
+            // A network the radio cannot join is shown, greyed, with the
+            // reason. Hiding it would leave someone hunting for a network
+            // they can see on their phone; offering it silently costs them
+            // twenty seconds of SCANNING and no explanation.
+            const blocked = n.blocker;
+            return (
             <div key={n.ssid}
-              onClick={() => setWifiSsid(n.ssid)}
+              onClick={() => { if (!blocked) setWifiSsid(n.ssid); }}
+              title={blocked || ''}
               style={{
                 padding: '6px 10px', display: 'flex', justifyContent: 'space-between', alignItems: 'center',
                 background: wifiSsid === n.ssid ? 'rgba(64,88,120,0.12)' : 'transparent',
-                borderBottom: '1px solid var(--sunken)', cursor: 'pointer',
+                borderBottom: '1px solid var(--sunken)',
+                cursor: blocked ? 'not-allowed' : 'pointer',
+                opacity: blocked ? 0.5 : 1,
               }}>
               <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: wifiSsid === n.ssid ? 'var(--accent)' : 'var(--text)' }}>
                 {n.ssid}
               </span>
               <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 9, color: 'var(--muted)' }}>
-                {n.signal} dBm
+                {[n.securityLabel, (n.bands || []).join('+'), `${n.signal} dBm`]
+                  .filter(Boolean).join(' · ')}
               </span>
             </div>
-          ))}
+          );})}
         </div>
       )}
 
@@ -2907,23 +2923,83 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     await new Promise(r => setTimeout(r, 3000));
     const raw = await c.shell("su -c 'wpa_cli -p /data/misc/wifi/sockets -i wlan0 scan_results'");
     addLog('Scan complete.');
-    // Parse wpa_cli scan_results: bssid / frequency / signal / flags / ssid
+    return parseScanResults(raw);
+  }
+
+  // Parse wpa_cli scan_results: bssid / frequency / signal / flags / ssid.
+  //
+  // The frequency and flags columns used to be read and thrown away, which
+  // is how a WPA3 network came to look identical to a WPA2 one in the picker
+  // and produced twenty seconds of SCANNING with an error that named nothing
+  // (#82). They are the two facts that explain most association failures on
+  // this hardware, so they are kept.
+  function parseScanResults(raw) {
     const networks = [];
-    for (const line of raw.split('\n')) {
+    for (const line of (raw || '').split('\n')) {
       const parts = line.split('\t');
       if (parts.length < 5) continue;
       const ssid = parts[4].trim();
       if (!ssid || ssid === 'SSID') continue;
+      const freq   = parseInt(parts[1], 10);
       const signal = parseInt(parts[2], 10);
+      const flags  = parts[3] || '';
+      const band   = freq >= 4900 ? '5GHz' : (freq > 0 ? '2.4GHz' : '');
+
       const existing = networks.find(n => n.ssid === ssid);
       if (!existing) {
-        networks.push({ ssid, signal });
-      } else if (signal > existing.signal) {
-        existing.signal = signal; // keep strongest AP's signal for duplicate SSIDs (multiple APs/bands)
+        networks.push({ ssid, signal, freq, flags, bands: band ? [band] : [] });
+      } else {
+        // Same SSID on more than one AP or band. Keep the strongest for the
+        // headline numbers, but remember every band it was seen on.
+        if (band && !existing.bands.includes(band)) existing.bands.push(band);
+        if (signal > existing.signal) {
+          existing.signal = signal;
+          existing.freq = freq;
+          existing.flags = flags;
+        }
       }
+    }
+    // Derived here rather than in the panel, so WifiPanel stays presentational
+    // and the same objects can be reused by the failure diagnostics.
+    for (const n of networks) {
+      n.security = classifySecurity(n.flags);
+      n.securityLabel = _SECURITY_LABEL[n.security] || n.security;
+      n.blocker = securityBlocker(n.security);
     }
     networks.sort((a, b) => b.signal - a.signal);
     return networks;
+  }
+
+  // What can this device actually join?
+  //
+  // Measured on hardware (`wpa_cli get_capability key_mgmt`): NONE,
+  // IEEE8021X, WPA-EAP, WPA-PSK. There is no SAE, so WPA3-Personal is not a
+  // configuration problem, it is impossible on this radio — hence 'wpa3'
+  // being refused outright rather than attempted. Mixed WPA2/WPA3 APs
+  // advertise both and are joinable through the WPA2 half.
+  function classifySecurity(flags) {
+    const f = (flags || '').toUpperCase();
+    const hasPsk = f.includes('WPA-PSK') || f.includes('WPA2-PSK') || f.includes('PSK');
+    if (f.includes('EAP')) return 'enterprise';
+    if (f.includes('SAE') && !hasPsk) return 'wpa3';
+    if (hasPsk) return 'wpa2';
+    if (f.includes('WEP')) return 'wep';
+    return 'open';
+  }
+
+  // Why a network cannot be used, or null when it can.
+  function securityBlocker(security) {
+    if (security === 'wpa3') {
+      return 'WPA3 only. This Dot has no SAE support, so it cannot join. '
+           + 'Enable WPA2 compatibility mode on the router or hotspot.';
+    }
+    if (security === 'enterprise') {
+      return 'Enterprise (802.1X). The wizard cannot configure this.';
+    }
+    if (security === 'wep') {
+      return 'WEP. The wizard cannot configure this.';
+    }
+    return null;
   }
 
   // Quote a value for safe embedding inside a wpa_supplicant.conf network
@@ -2937,10 +3013,66 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     return value;
   }
 
+  // Diagnose a failed association from the device's own view of the air.
+  //
+  // Three outcomes worth telling apart, all of which look identical in the
+  // wpa_state log: the network is not on the air at all, it is there but the
+  // radio cannot join it (WPA3), or it is there and joinable, which points at
+  // the password or the AP rather than at us.
+  async function reportWhyNoAssociation(c, ssid) {
+    try {
+      await c.shell("su -c 'wpa_cli -p /data/misc/wifi/sockets -i wlan0 scan'");
+      await new Promise(r => setTimeout(r, 3000));
+      const raw = await c.shell("su -c 'wpa_cli -p /data/misc/wifi/sockets -i wlan0 scan_results'");
+      const seen = parseScanResults(raw);
+      const match = seen.find(n => n.ssid === ssid);
+
+      if (!match) {
+        addLog(`"${ssid}" was not seen in a fresh scan (${seen.length} other network(s) were).`, 'warn');
+        addLog('Either it is out of range, or it is hidden and the SSID is not spelled exactly right.', 'warn');
+        return;
+      }
+      addLog(`"${ssid}" IS on the air: ${_SECURITY_LABEL[match.security] || match.security}`
+           + `, ${match.bands.join(' + ') || match.freq + ' MHz'}, ${match.signal} dBm`, 'warn');
+      addLog(`  flags: ${match.flags}`);
+      const blocker = securityBlocker(match.security);
+      if (blocker) {
+        addLog(`  ${blocker}`, 'error');
+      } else {
+        addLog('  The Dot can join this kind of network, so the likely cause is the '
+             + 'password, or the AP refusing the client.', 'warn');
+      }
+    } catch (e) {
+      addLog(`Could not scan to diagnose: ${e.message || e}`, 'warn');
+    }
+  }
+
   async function runConfigWifi(c, ssid, psk) {
     if (!ssid) throw new Error('No SSID selected.');
     wpaConfEscape(ssid);
     wpaConfEscape(psk);
+
+    // What the scan said about this network, if it was picked from the list.
+    // A typed SSID that no scan saw is treated as hidden, which needs
+    // scan_ssid=1 or wpa_supplicant never probes for it and sits in SCANNING
+    // indefinitely.
+    const known  = (wifiNetworks || []).find(n => n.ssid === ssid);
+    const hidden = !known;
+    const security = known ? known.security : (psk ? 'wpa2' : 'open');
+
+    const blocker = securityBlocker(security);
+    if (blocker) throw new Error(`Cannot join "${ssid}": ${blocker}`);
+
+    if (security === 'wpa2' && !psk) {
+      throw new Error(`"${ssid}" needs a password.`);
+    }
+    if (known) {
+      addLog(`Network: ${_SECURITY_LABEL[security] || security}`
+           + `${known.bands.length ? ', ' + known.bands.join(' + ') : ''}`
+           + `, ${known.signal} dBm`);
+    } else {
+      addLog(`"${ssid}" was not in the last scan — configuring it as a hidden network.`, 'warn');
+    }
 
     addLog('Enabling WiFi radio…');
     await c.shell("su -c 'svc wifi enable'");
@@ -2975,8 +3107,17 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       'wowlan_triggers=disconnect',
       'network={',
       `\tssid="${ssid}"`,
-      `\tpsk="${psk}"`,
-      '\tkey_mgmt=WPA-PSK',
+      // key_mgmt used to be hardcoded to WPA-PSK, which made an open network
+      // unjoinable with no explanation. The device reports NONE among its
+      // supported key_mgmt values, so open networks work, they were just
+      // never configurable.
+      ...(security === 'open'
+            ? ['\tkey_mgmt=NONE']
+            : [`\tpsk="${psk}"`, '\tkey_mgmt=WPA-PSK']),
+      // Without this, wpa_supplicant only ever joins networks that appear in
+      // a passive scan, so a hidden SSID never associates and reports nothing
+      // more useful than SCANNING.
+      ...(hidden ? ['\tscan_ssid=1'] : []),
       '\tpriority=1',
       '}',
       '',
@@ -3121,6 +3262,11 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       if (lastStatus.includes('wpa_state=COMPLETED')) { associated = true; break; }
     }
     if (!associated) {
+      // Say what the radio can actually see. Without this the log ends on
+      // twenty identical SCANNING lines and a status block naming nothing
+      // that would explain them, which is precisely how #82 arrived: correct
+      // config, verified on device, no interferers, and no clue.
+      await reportWhyNoAssociation(c, ssid);
       throw new Error(`Did not associate to "${ssid}" within 20s. Last status:\n${lastStatus}`);
     }
     addLog('Associated.', 'ok');

--- a/controller/tests/wifi_scan.test.mjs
+++ b/controller/tests/wifi_scan.test.mjs
@@ -1,0 +1,118 @@
+// Tests for the WiFi scan parser and security classifier in dashboard.jsx.
+//
+//     node controller/tests/wifi_scan.test.mjs
+//
+// The functions are lifted out of dashboard.jsx by source extraction rather
+// than imported. That is not cleverness for its own sake: the dashboard is
+// compiled with --bundle=false into a single classic script, so it cannot
+// import a module, and the alternative is a second copy of this logic that
+// drifts from the one that actually runs. If extraction fails the test fails
+// loudly, which is the right outcome — it means something was renamed and
+// this file needs to follow.
+//
+// What is under test decides whether a device can join a network at all, so
+// getting it wrong costs someone an evening of "SCANNING" with no
+// explanation (#82).
+
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const JSX = join(HERE, "..", "static", "dashboard.jsx");
+const src = readFileSync(JSX, "utf8");
+
+function liftFunction(name) {
+  const start = src.indexOf(`function ${name}`);
+  if (start < 0) {
+    throw new Error(`dashboard.jsx no longer defines ${name}() — if it was `
+                  + `renamed or moved, update this test to match`);
+  }
+  let depth = 0;
+  let i = src.indexOf("{", start);
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") { depth--; if (depth === 0) break; }
+  }
+  return src.slice(start, i + 1);
+}
+
+function liftConst(name) {
+  const start = src.indexOf(`const ${name}`);
+  if (start < 0) throw new Error(`dashboard.jsx no longer defines ${name}`);
+  const end = src.indexOf("};", start);
+  if (end < 0) throw new Error(`could not find the end of ${name}`);
+  return src.slice(start, end + 2);
+}
+
+const code = [
+  liftConst("_SECURITY_LABEL"),
+  liftFunction("classifySecurity"),
+  liftFunction("securityBlocker"),
+  liftFunction("parseScanResults"),
+  "export { parseScanResults, classifySecurity, securityBlocker };",
+].join("\n");
+
+const { parseScanResults } = await import(
+  "data:text/javascript;base64," + Buffer.from(code).toString("base64"));
+
+// Real wpa_cli output shape: bssid \t frequency \t signal \t flags \t ssid
+const RAW = [
+  "bssid / frequency / signal level / flags / ssid",
+  "aa:bb:cc:00:00:01\t2437\t-45\t[WPA2-PSK-CCMP][ESS]\tHomeNet",
+  "aa:bb:cc:00:00:02\t5180\t-52\t[WPA2-PSK-CCMP][ESS]\tHomeNet",
+  "aa:bb:cc:00:00:03\t5745\t-60\t[SAE-CCMP][ESS]\tPixel_7793",
+  "aa:bb:cc:00:00:04\t2412\t-70\t[ESS]\tCoffeeShop",
+  "aa:bb:cc:00:00:05\t2462\t-66\t[WPA2-EAP-CCMP][ESS]\tCorpWiFi",
+  "aa:bb:cc:00:00:06\t2412\t-80\t[WPA2-PSK-CCMP][SAE-CCMP][ESS]\tMixedMode",
+  "aa:bb:cc:00:00:07\t2437\t-75\t[WEP][ESS]\tOldRouter",
+].join("\n");
+
+let failures = 0;
+function check(label, got, want) {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) {
+    failures++;
+    console.error(`FAIL  ${label}\n      got  ${JSON.stringify(got)}`
+                + `\n      want ${JSON.stringify(want)}`);
+  } else {
+    console.log(`ok    ${label}`);
+  }
+}
+
+const nets = parseScanResults(RAW);
+const by = s => nets.find(n => n.ssid === s);
+
+check("WPA2 network is joinable", by("HomeNet").blocker, null);
+check("one SSID on two bands merges", by("HomeNet").bands.sort(), ["2.4GHz", "5GHz"]);
+check("strongest AP wins the headline signal", by("HomeNet").signal, -45);
+
+// The measured capability of this radio is NONE/IEEE8021X/WPA-EAP/WPA-PSK.
+// No SAE, so a WPA3-only AP can never be joined and must be refused rather
+// than attempted.
+check("WPA3-only is classified", by("Pixel_7793").security, "wpa3");
+check("WPA3-only is refused", typeof by("Pixel_7793").blocker, "string");
+
+// The one that would be easy to get wrong in the other direction: a mixed
+// WPA2/WPA3 AP advertises both, and is perfectly joinable through the WPA2
+// half. Blocking it would lock people out of their own working network.
+check("mixed WPA2/WPA3 uses the WPA2 half", by("MixedMode").security, "wpa2");
+check("mixed WPA2/WPA3 is not refused", by("MixedMode").blocker, null);
+
+check("open network is classified", by("CoffeeShop").security, "open");
+check("open network is joinable", by("CoffeeShop").blocker, null);
+check("enterprise is refused", typeof by("CorpWiFi").blocker, "string");
+check("WEP is refused", typeof by("OldRouter").blocker, "string");
+
+check("header row is skipped", nets.some(n => n.ssid === "ssid"), false);
+check("sorted by signal", nets[0].ssid, "HomeNet");
+check("label attached for the UI", by("Pixel_7793").securityLabel, "WPA3");
+check("empty input", parseScanResults("").length, 0);
+check("garbage input", parseScanResults("nonsense\nlines").length, 0);
+check("null input", parseScanResults(null).length, 0);
+
+if (failures) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall checks passed");


### PR DESCRIPTION
Addresses #82, and the wider class of "it just says SCANNING".

## What the radio can actually do

Measured on a device here, not assumed:

```
key_mgmt:  NONE IEEE8021X WPA-EAP WPA-PSK
auth_alg:  OPEN SHARED LEAP
```

No SAE. WPA3-Personal is not a configuration problem on this hardware, it is
impossible. The reporter's first network is `Pixel_7793`, a Pixel hotspot, and
Android 13 and later default those to WPA3-Personal with a separate
compatibility toggle for older clients. That fits the symptom exactly, though
it is not confirmed yet.

## Changes

1. **The scan parser keeps frequency and flags.** It was already reading
   `bssid / frequency / signal / flags / ssid` and discarding two of those.
   They are the facts that explain most association failures here.

2. **The picker shows security and band**, and greys out networks that cannot
   be joined, with the reason on hover. Shown rather than hidden, because
   someone whose phone can see the network needs to know why the Dot will not
   use it.

3. **`key_mgmt` is no longer hardcoded to `WPA-PSK`.** The device reports
   `NONE` among its capabilities, so open networks always worked, they were
   simply never configurable.

4. **`scan_ssid=1`** when the SSID was typed rather than picked, so a hidden
   network is actively probed for instead of never appearing.

5. **On failure, a fresh scan says what the radio can see**: the network is
   absent, or present but unjoinable with the reason, or present and joinable
   which points at the password or the AP. This is the one that matters most:
   it turns this class of report into something the log answers by itself.

## Testing

286 controller tests pass and the JSX compiles.

This also adds the **first test coverage of `dashboard.jsx`**. Its pure logic
is untested by construction, since it compiles to a single classic script with
no module boundary to import across, so the test lifts the functions out of
the source rather than keeping a second copy that would drift. A new CI job
runs it with the node already on the runner.

Both guards were verified by reintroducing the bug, including the one worth
getting right in the other direction: a mixed WPA2/WPA3 AP advertises both and
is joinable through its WPA2 half, so refusing it for mentioning SAE would
lock people out of a network that works.

Not verified on a device that actually fails, because we do not have one. The
failure path is exercised by the tests, not by hardware.
