### PR TITLE
dashboard: show the WiFi band on each device's Status tab

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -413,6 +413,16 @@ function EqCurve({ bands, fs = 22050 }) {
 
 // ─── WiFi signal bars ─────────────────────────────────────────────────────────
 
+// 2.4 or 5GHz from the frequency the device reports, or null when it has not
+// reported one (old firmware, or wpa_cli unavailable when the stat was taken).
+// Null rather than a guess: "2.4GHz" shown for a device we cannot actually
+// see the band of is worse than showing nothing, since the whole point is
+// spotting a device that has quietly landed on the slower radio.
+function wifiBand(freqMhz) {
+  if (!freqMhz) return null;
+  return freqMhz >= 4900 ? '5GHz' : '2.4GHz';
+}
+
 function SignalBars({ rssi }) {
   // 0 bars = no signal / null, 4 bars = excellent
   const level = rssi == null ? 0
@@ -455,7 +465,13 @@ function MicroMeter({ pct, sev }) {
 // StatTile is one cell of the scalar row: label, value, optional glyph, and a
 // headroom meter. `note` carries an exception worth seeing (thermal
 // throttling), which is the only thing here that should ever shout.
-function StatTile({ label, value, unit, sev = 'ok', pct, glyph, note }) {
+//
+// `sub` is the quiet counterpart: context that qualifies the value without
+// being a problem, like which WiFi band a link reading was taken on. It is
+// deliberately a separate prop rather than a second use of `note`, because
+// `note` is red — routing neutral information through it would make every
+// device look like it was in trouble.
+function StatTile({ label, value, unit, sev = 'ok', pct, glyph, note, sub }) {
   const dim = value == null;
   return (
     <div style={{ flex:'1 1 0', minWidth:0 }}>
@@ -482,6 +498,7 @@ function StatTile({ label, value, unit, sev = 'ok', pct, glyph, note }) {
       </div>
       <MicroMeter pct={dim ? null : pct} sev={sev}/>
       {note && <div style={{ fontFamily:"'DM Mono',monospace", fontSize:9, color:SEV.bad, marginTop:3 }}>{note}</div>}
+      {!note && sub && <div style={{ fontFamily:"'DM Mono',monospace", fontSize:9, color:'var(--muted)', marginTop:3 }}>{sub}</div>}
     </div>
   );
 }
@@ -1577,11 +1594,22 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                         when they are not. Each carries a headroom meter so the
                         row rhymes with the capacity bars above it. */}
                     <div style={{ display:'flex', gap:14, marginTop:2 }}>
+                      {/* Band alongside RSSI, because one SSID spanning both
+                          radios lets a device re-associate to the slower one
+                          silently: measured on this fleet, 2.4GHz runs about
+                          60 Mbps against 143 on 5GHz. A device knocked off
+                          5GHz can then sit on 2.4 indefinitely with nothing
+                          on screen to say so. Shown as a note rather than its
+                          own tile — it qualifies the link reading, it is not
+                          a separate health metric. */}
                       <StatTile
                         label="Link" value={s?.wifiRssi != null ? s.wifiRssi : null} unit="dBm"
                         sev={s?.wifiRssi == null ? 'ok' : s.wifiRssi > -70 ? 'ok' : s.wifiRssi > -80 ? 'warn' : 'bad'}
                         pct={s?.wifiRssi == null ? null : Math.max(0, Math.min(100, (s.wifiRssi + 95) / 35 * 100))}
                         glyph={<SignalBars rssi={s?.wifiRssi ?? null}/>}
+                        sub={[wifiBand(s?.wifiFreqMhz),
+                              s?.linkSpeedMbps ? `${s.linkSpeedMbps} Mbps` : null]
+                             .filter(Boolean).join(' · ') || null}
                       />
                       {/* Amber past 200ms, red past 1s — the same thresholds the
                           RTT instrumentation counts excursions against. */}


### PR DESCRIPTION
Shows the WiFi band and negotiated link speed under the Link tile on each
device's Status tab.

One SSID spanning both radios lets a device re-associate to the slower one
with nothing on screen to say so. Measured across this fleet over 440 hours:

| Device | Band | Hours | RSSI avg | Link avg |
|---|---|---|---|---|
| Office | 5GHz | 440 | -30.4 | 148 |
| Lounge | 5GHz | 419 | -52.8 | 143 |
| Lounge | 2.4GHz | 21 | -55.5 | **61** |
| Retreat | 5GHz | 361 | -64.2 | 126 |
| Retreat | 2.4GHz | 79 | -54.8 | **59** |

Not hypothetical: Lounge dropped to the 2.4GHz radio at 08-06 14:00 and has
been there for 21 hours at 61 Mbps, after two weeks on 5GHz at 143. Nothing in
the dashboard showed it.

The device has reported `wifiFreqMhz` since v2.9.6 and it already survives the
stats relay allowlist, so this is display only. No firmware change.

## One design note

Added as a new `sub` prop on `StatTile` rather than reusing `note`. `note`
renders red and is documented as the one thing in that row allowed to shout
(thermal throttling); routing neutral context through it would make every
device look like it was in trouble.

`wifiBand()` returns null rather than guessing when no frequency was reported,
since the point is spotting a device that has quietly landed on the slower
radio, and a wrong band is worse than a blank.

## Not included

A "prefer 5GHz" setting. The same data argues against it as a device-side
feature: Retreat's 5GHz signal is about 10dB worse than its 2.4GHz, so it
changes band for a good reason and forcing it would trade a slow link for an
unreliable one. Band steering belongs at the access point, where it can be
per-client and RSSI-aware.
