### PR TITLE
wizard: check where the boot image is going before writing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,9 @@ jobs:
       # with no module boundary to import across — so this covers the pure
       # logic that decides what the wizard will and will not attempt.
       - name: Run dashboard tests
-        run: node controller/tests/wifi_scan.test.mjs
+        run: |
+          node controller/tests/wifi_scan.test.mjs
+          node controller/tests/boot_target.test.mjs
 
   device-tests:
     name: Device Go tests

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -2627,6 +2627,89 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     return c;
   }
 
+  // Where the patched kernel is allowed to land, decided from a probe of the
+  // device rather than from trusting a symlink.
+  //
+  // This device has layers below FireOS that EchoMuse does not write: the
+  // preloader, LK, and the partitions holding amonet's unlock payload. The
+  // FireOS kernel and ramdisk live elsewhere, and a kernel written over the
+  // payload costs the unlock and means running amonet again. So the one
+  // partition write the wizard performs is checked against where it is about
+  // to go rather than trusting the symlink to be pointing where it was last
+  // time.
+  //
+  // THE BY-NAME MAP DIFFERS BETWEEN TWRP AND ANDROID, and a rule written
+  // against one is wrong in the other. Measured on hardware 2026-08-08:
+  //
+  //            TWRP    Android
+  //   boot_a          p10        p17
+  //   boot_a_x        p10        p10
+  //   boot_a_amonet   p17          -
+  //
+  // TWRP remaps the bare names onto the kernel partitions and exposes the
+  // payload explicitly as *_amonet, which is the remapping R0rt1z2's thread
+  // describes TWRP as doing for you. So under TWRP `boot_a` is SAFE and under
+  // Android it is the payload. Match on the suffix, never on the bare name
+  // alone, and read every alias of the target rather than one: p10 answers to
+  // both boot_a and boot_a_x, so keeping a single name per partition makes the
+  // verdict depend on glob order.
+  //
+  // An unresolvable target is refused rather than warned about: dd to a name
+  // that is not a block device creates an ordinary file in TWRP's tmpfs, so
+  // nothing reaches flash and the failure surfaces later as a confusing
+  // magiskboot error on a zero-byte image.
+  //
+  // A target with no names at all is allowed through with a warning. Not being
+  // able to read by-name is not evidence of danger, and refusing on it would
+  // block any device whose TWRP lays that directory out differently — the same
+  // reading the OTA free-space check applies to an unreadable df.
+  function classifyBootTarget(probe) {
+    const target = (probe.match(/TARGET=(\S*)/) || [])[1] || '';
+    const isBlock = /ISBLK=yes/.test(probe);
+    const names = [];
+    for (const m of probe.matchAll(/^NAME (\S+) (\S+)$/gm)) {
+      if (m[2] === target && !names.includes(m[1])) names.push(m[1]);
+    }
+    names.sort();
+    const label = names.length ? `${names.join(', ')} (${target})` : target;
+
+    if (!target) {
+      return { ok: false, target, names, reason:
+        '/dev/block/other-boot did not resolve to anything. TWRP normally creates it; '
+        + 'without it there is nothing safe to write to.' };
+    }
+    if (!isBlock) {
+      return { ok: false, target, names, reason:
+        `/dev/block/other-boot resolves to "${target}", which is not a block device. `
+        + 'Writing there would land in TWRP\'s tmpfs and never reach flash.' };
+    }
+    // The payload, named explicitly. Checked before the kernel test because a
+    // partition carrying both names is not one we are willing to guess about.
+    if (names.some(n => n.endsWith('_amonet'))) {
+      return { ok: false, target, names, reason:
+        `/dev/block/other-boot resolves to ${label}, which holds amonet's unlock payload, `
+        + 'not the FireOS kernel. Writing there would cost you the unlock and mean running '
+        + 'amonet again, so nothing has been written. The device is still in TWRP. Please '
+        + 'report this with the line above: it is not a state the wizard has seen.' };
+    }
+    if (names.some(n => n.endsWith('_x'))) {
+      return { ok: true, target, names, reason: label };
+    }
+    // No _x alias and no _amonet alias, but named boot_a/boot_b: this is the
+    // Android-style map, where the bare name IS the payload. The wizard should
+    // never see it, since it runs in TWRP, but being wrong here is expensive
+    // and being cautious costs a re-run.
+    if (names.some(n => n === 'boot_a' || n === 'boot_b')) {
+      return { ok: false, target, names, reason:
+        `/dev/block/other-boot resolves to ${label}, and there is no matching _x partition. `
+        + 'Under that layout the bare name is amonet\'s payload rather than the FireOS '
+        + 'kernel, so this is not somewhere to write a kernel. Refusing.' };
+    }
+    return { ok: true, warn: true, target, names, reason:
+      `could not identify ${target} in by-name — continuing, but it is not a partition this `
+      + 'has been checked against.' };
+  }
+
   async function runPatchBoot(c) {
     addLog('Setting up work directories…');
     await c.shell('mkdir -p /tmp/work /tmp/bin');
@@ -2635,10 +2718,37 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     addLog(unzipOut || '(done)');
     await c.shell('chmod 755 /tmp/bin/magiskboot');
 
+    addLog('Checking which partition the boot image lives in…');
+    const probe = await c.shell(
+      'd=$(readlink -f /dev/block/other-boot 2>/dev/null); echo "TARGET=$d"; '
+      + 'if [ -b "$d" ]; then echo "ISBLK=yes"; else echo "ISBLK=no"; fi; '
+      // Glob every boot_* rather than naming the four we expect: the payload
+      // is only visible under TWRP as boot_a_amonet/boot_b_amonet, and a
+      // fixed list cannot report a name it was not told to look for.
+      + 'for n in /dev/block/platform/*/by-name/boot_*; do '
+      + '[ -e "$n" ] && echo "NAME ${n##*/} $(readlink -f "$n" 2>/dev/null)"; done');
+    const boot = classifyBootTarget(probe);
+    if (!boot.ok) throw new Error(boot.reason);
+    addLog(`  → ${boot.reason}`, boot.warn ? 'warn' : 'ok');
+
     addLog('Pulling boot image from device (10–20s)…');
-    await c.shell('dd if=/dev/block/other-boot of=/tmp/work/boot.img bs=1048576 2>/dev/null');
+    // stderr carried through rather than discarded: dd reports its record
+    // counts there, and a silenced read failure used to reach magiskboot as
+    // an empty file with nothing in the log to say why.
+    const pullOut = await c.shell('dd if=/dev/block/other-boot of=/tmp/work/boot.img bs=1048576 2>&1');
+    addLog(pullOut.trim() || '(done)');
     const bootImg = await c.pull('/tmp/work/boot.img');
     addLog(`Boot image: ${(bootImg.length / 1024 / 1024).toFixed(1)} MB`);
+    // Refuse anything that is not an Android boot image before the byte-offset
+    // cmdline patch below runs against it. That patch writes at a fixed header
+    // offset and would happily corrupt whatever it was handed.
+    const magic = new TextDecoder().decode(bootImg.slice(0, 8));
+    if (magic !== 'ANDROID!') {
+      throw new Error(
+        `Read ${bootImg.length} bytes from ${boot.target} and it does not start with `
+        + `"ANDROID!" (got "${magic.replace(/[^\x20-\x7e]/g, '.')}"). That is not a boot image, `
+        + `so nothing is being patched or flashed.`);
+    }
 
     // Check the CURRENT cmdline before touching anything — magiskboot's
     // own unpack log already echoes CMDLINE [...] for the unmodified
@@ -2697,9 +2807,22 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     const repackOut = await c.shell(`cd /tmp/work && /tmp/bin/magiskboot repack ${workImg} 2>&1`);
     addLog(repackOut || '(done)');
 
-    addLog('Flashing patched boot image…');
-    await c.shell('dd if=/tmp/work/new-boot.img of=/dev/block/other-boot bs=1048576 2>/dev/null');
-    addLog('Boot image flashed.', 'ok');
+    addLog(`Flashing patched boot image to ${boot.names.length ? `${boot.names.join(', ')} (${boot.target})` : boot.target}…`);
+    const flashOut = await c.shell('dd if=/tmp/work/new-boot.img of=/dev/block/other-boot bs=1048576 2>&1');
+    addLog(flashOut.trim() || '(done)');
+
+    // Read the cmdline back off the partition rather than trusting dd's exit.
+    // This is the write the device has to boot from next, and a bad one costs
+    // a rollback and a boot attempt to discover — the same reasoning the OTA
+    // path applies to md5 before it moves a symlink.
+    const readback = await c.shell('dd if=/dev/block/other-boot bs=1 skip=64 count=512 2>/dev/null');
+    if (!readback.includes('androidboot.selinux=permissive')) {
+      throw new Error(
+        `Flashed the patched image to ${boot.target} but reading it back does not show the `
+        + `patched cmdline. The write did not take. Do not reboot the device: it is still in `
+        + `TWRP and recoverable from here.`);
+    }
+    addLog('Boot image flashed and verified.', 'ok');
   }
 
   async function runInstallMagisk(c, file) {
@@ -2899,8 +3022,18 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     // app" as soon as the framework is up, and the earliest we can stop the
     // app itself is the Disable Alexa step — which is on the far side of
     // magiskd attaching, measured at 74s on a cold device. So the app cannot
-    // be silenced in time, but the speaker can: `input` needs only the shell
-    // user, and this runs the moment the framework answers.
+    // be silenced in time, and this is an attempt to silence the speaker
+    // instead: `input` needs only the shell user, and it runs the moment the
+    // framework answers.
+    //
+    // IT DOES NOT RELIABLY WORK. Observed on hardware 2026-08-08: she talks
+    // regardless. Two candidates, not yet separated — OOBE raises the volume
+    // back after we lower it, or it plays on a stream `keyevent 25` does not
+    // address (25 adjusts whichever stream is active, which with nothing
+    // playing is not necessarily the one she uses). `dumpsys audio` while she
+    // is talking settles it. It is left in because turning the volume down
+    // costs nothing and may help, but the log line must not claim more than
+    // that.
     //
     // Safe to leave muted. This moves Android's stream volume; EchoMuse drives
     // the codec itself and seeds its own level from `startupVolume` (85) on
@@ -2914,7 +3047,12 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     addLog('Muting the speaker — Amazon\'s setup assistant starts talking here, and cannot be stopped until root lands…');
     try {
       await c.shell('i=0; while [ $i -lt 15 ]; do input keyevent 25; i=$((i+1)); done');
-      addLog('  → speaker muted for the rest of provisioning (EchoMuse restores volume after the final reboot).', 'ok');
+      // Measured on hardware 2026-08-08: the setup assistant talks anyway. It
+      // either raises the volume back or plays on a stream these keyevents do
+      // not touch, and which of those it is has not been established. Say what
+      // was done, not what was achieved — claiming it is muted for the rest of
+      // provisioning sends someone looking for a fault when they hear her.
+      addLog('  → volume turned down; the setup assistant may raise it again and talk anyway.', 'warn');
     } catch (e) {
       addLog(`  → could not mute (${e.message}) — the setup prompt may talk over the wizard.`, 'warn');
     }

--- a/controller/tests/boot_target.test.mjs
+++ b/controller/tests/boot_target.test.mjs
@@ -1,0 +1,170 @@
+// Tests for classifyBootTarget() in dashboard.jsx — the check that decides
+// where the provisioning wizard is allowed to write a kernel.
+//
+//     node controller/tests/boot_target.test.mjs
+//
+// Source extraction rather than import, for the reason wifi_scan.test.mjs
+// gives: the dashboard compiles to a single classic script with no module
+// boundary, so the alternative is a second copy that drifts.
+//
+// What is under test is the only partition write the wizard performs. The
+// layers below FireOS on this device (preloader, LK, and amonet's unlock
+// payload) are ones EchoMuse does not write. A kernel written over the payload
+// costs the unlock and means running amonet again, which is not a state
+// anyone can be talked out of over an issue thread.
+//
+// Both fixtures below are real output, read off hardware on 2026-08-08. They
+// are here because the first version of this guard was written against the
+// Android map, was therefore inverted for the environment the wizard actually
+// runs in, and passed anyway on the accident that p10 answers to two names
+// and the last one written happened to be the safe one.
+
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const JSX = join(HERE, "..", "static", "dashboard.jsx");
+const src = readFileSync(JSX, "utf8");
+
+function liftFunction(name) {
+  const start = src.indexOf(`function ${name}`);
+  if (start < 0) {
+    throw new Error(`dashboard.jsx no longer defines ${name}() — if it was `
+                  + `renamed or moved, update this test to match`);
+  }
+  let depth = 0;
+  let i = src.indexOf("{", start);
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") { depth--; if (depth === 0) break; }
+  }
+  return src.slice(start, i + 1);
+}
+
+const { classifyBootTarget } = await import(
+  "data:text/javascript;base64," + Buffer.from(
+    liftFunction("classifyBootTarget") + "\nexport { classifyBootTarget };"
+  ).toString("base64"));
+
+// TWRP's map. The bare names are remapped onto the KERNEL partitions and the
+// unlock payload is exposed explicitly as *_amonet. Both by-name directories
+// exist and resolve identically, hence the duplicate lines.
+const TWRP = [
+  ["boot_a", "p10"], ["boot_a_amonet", "p17"], ["boot_a_x", "p10"],
+  ["boot_b", "p11"], ["boot_b_amonet", "p18"], ["boot_b_x", "p11"],
+].flatMap(([n, p]) => [
+  `NAME ${n} /dev/block/mmcblk0${p}`,
+  `NAME ${n} /dev/block/mmcblk0${p}`,
+]).join("\n");
+
+// Android's map, for contrast: no _amonet entries at all, and the bare names
+// point at the payload. The wizard never runs here, but a rule that cannot
+// tell the two apart is a rule that got lucky.
+const ANDROID = [
+  ["boot_a", "p17"], ["boot_a_x", "p10"],
+  ["boot_b", "p18"], ["boot_b_x", "p11"],
+].map(([n, p]) => `NAME ${n} /dev/block/mmcblk0${p}`).join("\n");
+
+const probe = (target, names = TWRP, isBlock = true) =>
+  `TARGET=${target}\nISBLK=${isBlock ? "yes" : "no"}\n${names}`;
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) return;
+  failures++;
+  console.error(`FAIL: ${name}${detail ? `\n      ${detail}` : ""}`);
+}
+
+// The normal case, and the one measured in TWRP: other-boot resolves to p10,
+// which answers to both boot_a and boot_a_x.
+{
+  const r = classifyBootTarget(probe("/dev/block/mmcblk0p10"));
+  check("TWRP p10 is accepted", r.ok === true, JSON.stringify(r));
+  check("TWRP p10 reports both its aliases",
+        r.names.join(",") === "boot_a,boot_a_x", JSON.stringify(r.names));
+  check("TWRP p10 is not warned about", !r.warn, JSON.stringify(r));
+}
+
+// The B slot's kernel, same shape.
+{
+  const r = classifyBootTarget(probe("/dev/block/mmcblk0p11"));
+  check("TWRP p11 is accepted", r.ok === true, JSON.stringify(r));
+  check("TWRP p11 reports both its aliases",
+        r.names.join(",") === "boot_b,boot_b_x", JSON.stringify(r.names));
+}
+
+// The case the guard exists for. Under TWRP the payload is named explicitly.
+for (const [part, dev] of [["boot_a_amonet", "/dev/block/mmcblk0p17"],
+                           ["boot_b_amonet", "/dev/block/mmcblk0p18"]]) {
+  const r = classifyBootTarget(probe(dev));
+  check(`TWRP ${part} is refused`, r.ok === false, JSON.stringify(r));
+  check(`${part} refusal names the partition`, r.reason.includes(part), r.reason);
+  check(`${part} refusal mentions the unlock`, /unlock/i.test(r.reason), r.reason);
+  check(`${part} refusal says nothing was written`,
+        /nothing has been written/.test(r.reason), r.reason);
+}
+
+// Android's map. The bare name is the payload and there is no _x alias on it,
+// so it must be refused despite being called boot_a.
+for (const [part, dev] of [["boot_a", "/dev/block/mmcblk0p17"],
+                           ["boot_b", "/dev/block/mmcblk0p18"]]) {
+  const r = classifyBootTarget(probe(dev, ANDROID));
+  check(`Android ${part} is refused`, r.ok === false, JSON.stringify(r));
+  check(`Android ${part} refusal explains the layout`,
+        /_x/.test(r.reason), r.reason);
+}
+
+// Android's kernel partitions are still fine under Android's map.
+{
+  const r = classifyBootTarget(probe("/dev/block/mmcblk0p10", ANDROID));
+  check("Android p10 is accepted", r.ok === true, JSON.stringify(r));
+  check("Android p10 is named boot_a_x",
+        r.names.join(",") === "boot_a_x", JSON.stringify(r.names));
+}
+
+// No symlink at all. dd would create an ordinary file in TWRP's tmpfs and
+// nothing would reach flash, so this is refused rather than warned about.
+{
+  const r = classifyBootTarget(probe("", TWRP, false));
+  check("an unresolved target is refused", r.ok === false, JSON.stringify(r));
+}
+
+// Resolves to a name, but not to a block device.
+{
+  const r = classifyBootTarget(probe("/dev/block/other-boot", TWRP, false));
+  check("a non-block target is refused", r.ok === false, JSON.stringify(r));
+  check("non-block refusal says so", /not a block device/.test(r.reason), r.reason);
+}
+
+// by-name unreadable, or laid out differently. Not evidence of danger, so it
+// continues with a warning — the same reading the OTA free-space check gives
+// an unreadable df. Refusing here would block a device whose TWRP differs.
+{
+  const r = classifyBootTarget(probe("/dev/block/mmcblk0p10", ""));
+  check("an unidentifiable target continues", r.ok === true, JSON.stringify(r));
+  check("an unidentifiable target warns", r.warn === true, JSON.stringify(r));
+}
+
+// A real block device that is simply not in the boot set.
+{
+  const r = classifyBootTarget(probe("/dev/block/mmcblk0p23"));
+  check("an unrelated block device continues with a warning",
+        r.ok === true && r.warn === true, JSON.stringify(r));
+}
+
+// The verdict must not depend on which alias the probe happened to list last.
+// This is the accident the first version of the guard survived on.
+{
+  const reversed = TWRP.split("\n").reverse().join("\n");
+  const a = classifyBootTarget(probe("/dev/block/mmcblk0p10", reversed));
+  const b = classifyBootTarget(probe("/dev/block/mmcblk0p17", reversed));
+  check("alias order does not change the kernel verdict", a.ok === true, JSON.stringify(a));
+  check("alias order does not change the payload verdict", b.ok === false, JSON.stringify(b));
+}
+
+if (failures) {
+  console.error(`\n${failures} check(s) failed.`);
+  process.exit(1);
+}
+console.log("boot_target: all checks passed.");

--- a/docs/rooting.md
+++ b/docs/rooting.md
@@ -83,9 +83,68 @@ Once those are done, EchoMuse takes over. The provisioning wizard in the
 dashboard handles the rest — see the [Quickstart](quickstart.md). It starts
 from a device already in that state; it does not run the exploit.
 
-The steps the wizard performs — the SELinux patch, Magisk, and the root-grant
-database — happen with TWRP already installed, so a failure can usually be
+The steps the wizard performs (the SELinux patch, Magisk, and the root-grant
+database) happen with TWRP already installed, so a failure can usually be
 re-flashed from recovery.
+
+## What EchoMuse writes, and what it does not
+
+This device has several layers below the operating system, and EchoMuse only
+ever writes the FireOS one. Lowest first:
+
+| Layer | What it is | Written by EchoMuse |
+|---|---|---|
+| Preloader | First stage of boot. Tracks boot attempts per slot. | No |
+| LK (bootloader) | What `lk_build_desc` and `unlock_status` come from. amonet patches this. | No |
+| amonet's unlock payload | Chainloads the real kernel. `mmcblk0p17` / `p18`. | No |
+| TWRP (recovery) | | No, the wizard only runs commands inside it |
+| FireOS kernel and ramdisk | `mmcblk0p10` / `p11`. | **Yes**, one write |
+| `/system`, `/data` | FireOS userspace. | Yes, files only |
+
+The single partition write is in the wizard's Patch Boot Image step, and it
+puts the SELinux permissive cmdline and the `service echomuse` init entry into
+the FireOS kernel. TWRP presents that partition as `/dev/block/other-boot`.
+
+**The by-name directory means different things in TWRP and in Android**, which
+is worth knowing before reading any of it as gospel. Measured on hardware:
+
+| by-name entry | In TWRP | In Android |
+|---|---|---|
+| `boot_a` | `p10`, the kernel | `p17`, the payload |
+| `boot_a_x` | `p10`, the kernel | `p10`, the kernel |
+| `boot_a_amonet` | `p17`, the payload | not present |
+
+TWRP remaps the bare names onto the kernel partitions and exposes the payload
+explicitly as `*_amonet`. So the same name means opposite things depending on
+where you are standing, and `p10` answers to two names at once.
+
+Before writing, the wizard resolves `/dev/block/other-boot`, collects every
+by-name alias of whatever it points at, and refuses if any of them is an
+amonet payload partition. Writing a kernel there would destroy the unlock and
+mean running amonet again, so it is checked rather than assumed. It also
+verifies the image it read is a real boot image before patching it, and reads
+the cmdline back off the partition afterwards rather than trusting that the
+write succeeded.
+
+If any of those checks fail the wizard stops with the device still in TWRP,
+which is a recoverable place to be.
+
+## If a device will not boot
+
+Anything at or below the bootloader is the unlock's territory, and
+[R0rt1z2's thread](https://xdaforums.com/t/unlock-root-twrp-unbrick-amazon-echo-dot-2nd-gen-2016-biscuit.4761416/)
+is the authority on it. One thing from that thread is worth repeating here
+because it is time-critical:
+
+> **Stop trying to boot it.** The preloader tracks boot attempts per slot, and
+> if both slots run out of attempts the device stops booting altogether.
+
+That state is recoverable, but the easy routes are gone: getting back in means
+opening the case and shorting a pin on the board to reach the bootrom, which
+R0rt1z2's thread documents and describes as not especially difficult. A device
+sitting in fastboot or TWRP on the end of a cable needs none of that.
+Repeatedly power cycling one that will not boot is what turns the first
+situation into the second.
 
 ## How well tested is this?
 


### PR DESCRIPTION
Patch Boot Image is the only partition write the wizard performs, and the only
point at which it could reach below FireOS. It read and wrote
`/dev/block/other-boot` with `dd`'s stderr discarded on both sides, checked
nothing about where that symlink pointed, and logged the image size without
acting on it. A bad target or a failed write was invisible until the device
did not boot.

## The check

It now resolves the symlink, collects every by-name alias of the partition it
lands on, and refuses if any of them is an amonet payload partition. Writing a
kernel there costs the unlock and means running amonet again.

**The by-name map differs between TWRP and Android**, measured on hardware:

| by-name entry | In TWRP | In Android |
|---|---|---|
| `boot_a` | `p10`, the kernel | `p17`, the payload |
| `boot_a_x` | `p10`, the kernel | `p10`, the kernel |
| `boot_a_amonet` | `p17`, the payload | not present |

TWRP remaps the bare names onto the kernel partitions and names the payload
explicitly, so a rule written against the Android map is inverted in the
environment the wizard actually runs in. The first version of this guard was
written that way and passed anyway, because `p10` answers to two names and the
last one the glob listed happened to be the safe one. So: match on suffix,
read every alias, and pin the order-independence with a test that reverses the
probe output.

An unresolvable target is refused rather than warned about, because `dd` to a
name that is not a block device creates an ordinary file in TWRP's tmpfs and
never reaches flash. A target with no by-name entries at all continues with a
warning, the same reading the OTA free-space check gives an unreadable `df`.

## Around it

- `dd`'s stderr reaches the log instead of `/dev/null`.
- The pulled image must carry the `ANDROID!` magic before the fixed-offset
  cmdline patch runs against it.
- The cmdline is read back off the partition after flashing rather than
  trusting `dd`'s exit.
- Every failure path leaves the device in TWRP and says so.

## Verification

End to end on hardware against a freshly sideloaded FireOS 5. Resolved to
`boot_a, boot_a_x (/dev/block/mmcblk0p10)`, flashed, read-back held, device
provisioned and connected. `f1r30s.zip` and Magisk's own installer both target
the same partition, which is three independent sources agreeing on it.

`controller/tests/boot_target.test.mjs` covers both maps from real fixtures,
wired into the existing Dashboard logic tests job.

## Also here

`docs/rooting.md` gains a table of what EchoMuse writes and what it does not,
so the boundary is stated rather than implied, plus the TWRP-vs-Android
difference. Its "if a device will not boot" section no longer describes the
preloader brick as permanent: R0rt1z2's thread has BROM USBDL still enabled on
this model, so recovery means opening the case and shorting a pin rather than
being impossible.

The mute step no longer claims the speaker is muted for the rest of
provisioning. Observed on hardware: the setup assistant talks regardless. The
keyevents stay, since turning the volume down costs nothing, but the log line
says what was done rather than what was achieved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
