### PR TITLE
controller: stop writing every device log line twice

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -2581,7 +2581,16 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                 elif msg_type == "log":
                     level   = msg.get("level", "info")
                     message = msg.get("message", "")
-                    db.log_device(device_id, level, "device", message)
+                    # _push_log_event PERSISTS as well as pushing, so this must
+                    # not also call db.log_device — doing both wrote every
+                    # device log line twice, ~6ms apart, which is how half the
+                    # device_logs table came to be duplicates. It also matters
+                    # for the support bundle: thin_noise keeps the newest three
+                    # [mem] lines per device, so duplication halved the readings
+                    # a leak hunt actually gets.
+                    #
+                    # The removed call was a synchronous DB write on the event
+                    # loop; _push_log_event does it in an executor.
                     await api._push_log_event(device_id, level, "device", message)
 
                 elif msg_type == "pong":

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -795,3 +795,38 @@ def test_tested_firmware_build_matches_the_docs():
         f"the wizard warns against build {build} but docs/rooting.md never "
         f"names it — a reader has nowhere to go"
     )
+
+
+def test_push_log_event_callers_do_not_also_persist():
+    """
+    `_push_log_event` persists AND pushes. A caller that also calls
+    `db.log_device` writes the line twice.
+
+    That is not hypothetical: the device `log` handler did both, so every
+    device log line landed twice about 6ms apart, and roughly half of
+    `device_logs` was duplicates. It stayed invisible because a doubled log
+    line looks like a device that logged twice.
+
+    Two things it cost beyond the wasted rows. `em_support.thin_noise` keeps
+    the newest three `[mem]` lines per device, so duplication halved the
+    distinct readings a leak hunt gets from a bundle. And the redundant call
+    was a synchronous SQLite write on the event loop, which
+    `event_loop_lag_monitor` exists to catch.
+
+    Checked by source shape because the alternative is importing
+    em_controller, which the suite deliberately does not do.
+    """
+    root = Path(__file__).resolve().parent.parent
+    for name in ("em_controller.py", "em_api.py"):
+        lines = (root / name).read_text().splitlines()
+        for i, line in enumerate(lines):
+            if "_push_log_event(" not in line or "async def" in line:
+                continue
+            # The persist would sit just above the push, in the same block.
+            window = lines[max(0, i - 6):i]
+            offenders = [w.strip() for w in window if "db.log_device(" in w]
+            assert not offenders, (
+                f"{name}:{i+1} calls _push_log_event, which already persists, "
+                f"but is preceded by {offenders[0]!r}. That writes the log "
+                f"line twice. Drop the db.log_device call."
+            )


### PR DESCRIPTION
`_push_log_event` persists as well as pushing. The device `log` handler called
`db.log_device` and then called it, so every line the device sent landed in
`device_logs` twice, about 6ms apart.

Measured before the fix, over 6 hours:

| Device | Rows | Immediate repeats |
|---|---|---|
| Lounge | 153 | 71 |
| Office | 158 | 72 |
| Retreat | 153 | 72 |
| Test Device (provisioned 1h earlier) | 24 | 8 |

Gap between the pair: median 6ms, max 11ms. That is the executor round trip.

It stayed invisible because a doubled log line looks like a device that logged
twice, and the only line the firmware sends is the ~5-minutely `[mem]` report,
so nothing looked unreasonable in isolation. Found by @wilbowes noticing the
pairs in the Device Logs tab.

## Why it is worth more than the wasted rows

`em_support.thin_noise` keeps the newest three `[mem]` lines per device in a
support bundle, because those lines were 87% of a real bundle's tail. With
every line doubled, three slots held roughly one and a half distinct readings,
so the one artefact built to carry a leak hunt was quietly carrying half of
what it claimed.

The redundant call was also a synchronous SQLite write on the event loop,
which `event_loop_lag_monitor` exists to catch. `_push_log_event` does it in
an executor.

## Scope

Every other caller of `_push_log_event`, all in `em_api.py`, already relies on
it to persist and was correct. The guard test walks both files and fails on a
`db.log_device` sitting above a `_push_log_event` call, and was verified by
reintroducing the bug.

Existing duplicate rows are left alone; they age out with `LOG_RETENTION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)