### PR TITLE
wizard: capture device state when a provisioning step fails

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -312,6 +312,7 @@ async def create_app() -> web.Application:
     app.router.add_get("/api/provision/oww_assets",    _get_provision_oww_manifest)
     app.router.add_get("/api/provision/oww_asset/{name}", _get_provision_oww_asset)
     app.router.add_post("/api/provision/tls_credentials", _post_provision_tls_credentials)
+    app.router.add_post("/api/provision/diagnostics",     _post_provision_diagnostics)
     app.router.add_post("/api/devices/{id}/secure_link",  _post_secure_link)
     app.router.add_post("/api/devices/{id}/debloat",      _post_debloat)
 
@@ -3481,6 +3482,43 @@ def _controller_stats() -> dict:
         pass
 
     return stats
+
+
+@auth.require_admin
+async def _post_provision_diagnostics(request: web.Request) -> web.Response:
+    """
+    POST /api/provision/diagnostics
+
+    The wizard collects raw probe output when a step fails and posts it here;
+    this returns the sanitised file to attach to an issue (#87).
+
+    Packaged on the controller rather than in the browser on purpose. The
+    redaction rules and their tests live in em_support, and a second copy in
+    JavaScript would drift from them without anyone noticing until a file
+    carried an SSID. This function only carries; em_support decides.
+
+    Admin-only and a download rather than a display, the same call the support
+    bundle makes: it is meant to be looked at before it is shared.
+    """
+    body = await _json_body(request)
+    diag = em_support.build_provision_diagnostics(
+        step=body.get("step") or "unknown",
+        error=body.get("error") or "",
+        probes=body.get("probes") or {},
+        transcript=body.get("transcript") or None,
+        # The wizard knows which network the operator picked; the file cannot
+        # work it out once the names are gone, and "the one you wanted is
+        # WPA3" is the whole answer on a #82-shaped failure.
+        selected_ssid=body.get("selected_ssid") or None,
+        controller_version=CONTROLLER_VERSION,
+    )
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    return web.Response(
+        body=em_support.to_json(diag).encode(),
+        content_type="application/json",
+        headers={"Content-Disposition":
+                 f'attachment; filename="echomuse-provision-{stamp}.json"'},
+    )
 
 
 @auth.require_admin

--- a/controller/em_support.py
+++ b/controller/em_support.py
@@ -443,3 +443,216 @@ def build(
 
 def to_json(bundle: dict) -> str:
     return json.dumps(bundle, indent=2, default=str)
+
+
+# ─── Provisioning diagnostics ─────────────────────────────────────────────────
+#
+# What the wizard collects when a step fails, packaged here rather than in the
+# browser. The redaction rules and their tests already live in this module, and
+# a second copy in JavaScript would drift from them without anyone noticing
+# until a bundle carried something it should not have.
+#
+# The wizard collects RAW and posts it. Everything below decides what survives.
+# That direction matters: the browser is talking to a device we know nothing
+# about yet, so treating its output as untrusted input is the only safe
+# posture, and it means adding a probe never needs the redaction re-reviewed.
+#
+# THIS IS AN ALLOWLIST, twice over: a probe name nobody listed is dropped whole,
+# and inside the probes that carry key/value output the keys are listed too. A
+# denylist here gets it wrong once, publicly, and cannot be taken back.
+
+# Properties worth having, chosen against failures actually seen. Build
+# identity dominates because firmware defaults differ between the six FireOS 5
+# builds in circulation in ways that reach USB and ADB behaviour (#79), and
+# "which build" was the first question on every provisioning issue so far.
+_PROVISION_PROPS = (
+    "ro.product.model",
+    "ro.product.name",
+    "ro.product.device",
+    "ro.build.version.name",
+    "ro.build.version.incremental",
+    "ro.build.version.release",
+    "ro.build.version.sdk",
+    "ro.build.fingerprint",
+    "ro.serialno",
+    "ro.boot.slot_suffix",
+    "sys.boot_completed",
+    "persist.sys.usb.config",
+    "persist.wifi.migrate.complete",
+)
+
+# `wpa_cli status` keys. The state and the crypto are the diagnostic value;
+# the identifiers are what makes an SSID geolocatable from public wardriving
+# databases, so ssid, bssid, ip_address, address and uuid are simply absent.
+_WPA_STATUS_KEYS = (
+    "wpa_state",
+    "freq",
+    "key_mgmt",
+    "pairwise_cipher",
+    "group_cipher",
+    "mode",
+    "suppPortStatus",
+)
+
+# Probe names the wizard may post. Anything else is dropped.
+_PROVISION_PROBES = (
+    "props",          # getprop, filtered to _PROVISION_PROPS
+    "root",           # su -c id
+    "selinux",        # getenforce
+    "pm_ready",       # pm path android
+    "storage",        # df /data
+    "wpa_status",     # wpa_cli status
+    "wpa_scan",       # wpa_cli scan_results
+    "wpa_caps",       # wpa_cli get_capability key_mgmt
+    "services",       # getprop | grep init.svc
+    "processes",      # wpa_supplicant / SmartHomeWifid counts
+    "packages",       # how many of the disable/hide lists are still visible
+    "data_property",  # filenames only
+    "boot_target",    # what /dev/block/other-boot resolves to (TWRP steps)
+)
+
+_INIT_SVC = re.compile(r"^\[init\.svc\.[a-z0-9_.-]+\]:\s*\[[a-z]+\]$", re.I)
+
+
+def _scrub(text: str) -> list[str]:
+    """
+    Generic backstop applied to every probe, whatever else was done to it.
+
+    Same substitutions as `sanitise_log`, minus the account names, which
+    cannot appear in device shell output. Runs even on probes that have their
+    own parser, because the parser is the thing most likely to be wrong about
+    an output shape nobody has seen: these devices are the ones behaving
+    unusually, by definition.
+    """
+    out = []
+    for ln in (text or "").splitlines():
+        ln = _QUOTED.sub("<redacted>", ln)
+        ln = _URL.sub("<url>", ln)
+        ln = _IPV4.sub("<ip>", ln)
+        ln = _MAC.sub("<mac>", ln)
+        if ln.strip():
+            out.append(ln.rstrip())
+    return out
+
+
+def _probe_props(text: str) -> dict:
+    """`getprop` output projected onto the property allowlist."""
+    found = {}
+    for ln in (text or "").splitlines():
+        m = re.match(r"^\[([^\]]+)\]:\s*\[(.*)\]$", ln.strip())
+        if m and m.group(1) in _PROVISION_PROPS:
+            found[m.group(1)] = m.group(2)
+    return found
+
+
+def _probe_wpa_status(text: str) -> dict:
+    """`wpa_cli status` projected onto the key allowlist."""
+    found = {}
+    for ln in (text or "").splitlines():
+        k, _, v = ln.strip().partition("=")
+        if k in _WPA_STATUS_KEYS:
+            found[k] = v
+    return found
+
+
+def _probe_wpa_scan(text: str, selected: str | None = None) -> list[dict]:
+    """
+    Scan results with the names taken out and the radio left in.
+
+    This is the one probe where the tension is real. The flags and the
+    frequency ARE the diagnosis — a `[SAE-CCMP]` network is one this radio
+    cannot join, and that single fact explains #82 — while the names are the
+    part that locates someone's house. So the row survives and the SSID
+    becomes a positional placeholder.
+
+    The network the operator was trying to join is marked, because "the one
+    you wanted is WPA3" is the whole answer and is otherwise unrecoverable
+    once the names are gone.
+    """
+    rows = []
+    for ln in (text or "").splitlines():
+        parts = ln.rstrip("\n").split("\t")
+        if len(parts) < 4 or parts[0].strip().lower().startswith("bssid"):
+            continue
+        bssid, freq, signal, flags = (p.strip() for p in parts[:4])
+        ssid = parts[4].strip() if len(parts) > 4 else ""
+        if not _MAC.fullmatch(bssid):
+            continue
+        rows.append({
+            "network":  f"network-{len(rows) + 1}",
+            "freq":     freq,
+            "signal":   signal,
+            "flags":    flags,
+            "selected": bool(selected) and ssid == selected,
+        })
+    return rows
+
+
+def _probe_services(text: str) -> list[str]:
+    """`init.svc.*` lines only. Their names and states, nothing else."""
+    return [ln.strip() for ln in (text or "").splitlines()
+            if _INIT_SVC.match(ln.strip())]
+
+
+def build_provision_diagnostics(
+    *,
+    step: str,
+    error: str,
+    probes: dict,
+    transcript: list[str] | None = None,
+    selected_ssid: str | None = None,
+    controller_version: str = "unknown",
+) -> dict:
+    """
+    One file the reporter can attach to a public issue after a failed step.
+
+    Built because diagnosing #79 and #82 each took several rounds of asking
+    someone to run `getprop` and `wpa_cli` by hand, and by the time they
+    answered the device had usually been retried or rebooted, so the state at
+    the moment of failure was gone. Collection is automatic; the download is
+    deliberate.
+
+    `step` and `error` are OURS — the step id comes from a fixed list and the
+    error is our own message — but they are scrubbed anyway rather than
+    trusted, because an error string interpolates device output often enough
+    that the distinction is not worth relying on.
+
+    The transcript is scrubbed line by line and is where a device's own words
+    reach the file, so it gets the same treatment as everything else.
+    """
+    out = {
+        "format": 1,
+        "kind": "provision_diagnostics",
+        "generated": time.time(),
+        "controller_version": controller_version,
+        "step": " ".join(_scrub(str(step))) or "unknown",
+        "error": _scrub(str(error)),
+        "probes": {},
+    }
+
+    raw = probes if isinstance(probes, dict) else {}
+    for name in _PROVISION_PROBES:
+        if name not in raw:
+            continue
+        text = raw.get(name)
+        if not isinstance(text, str):
+            continue
+        if name == "props":
+            value = _probe_props(text)
+        elif name == "wpa_status":
+            value = _probe_wpa_status(text)
+        elif name == "wpa_scan":
+            value = _probe_wpa_scan(text, selected_ssid)
+        elif name == "services":
+            value = _probe_services(text)
+        else:
+            value = _scrub(text)
+        out["probes"][name] = value
+
+    # Named so a reader can tell "the wizard did not ask" from "the device had
+    # nothing to say", which need opposite next questions.
+    out["probes_missing"] = [n for n in _PROVISION_PROBES if n not in out["probes"]]
+
+    if transcript:
+        out["transcript"] = [ln for t in transcript for ln in _scrub(str(t))]
+    return out

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -2517,6 +2517,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   const [progress, setProgress] = useState(null);
   const [latestRelease, setLatestRelease] = useState(null);
   const [checkingRelease, setCheckingRelease] = useState(false);
+  const [diagnostics, setDiagnostics] = useState(null);
   const logRef = useRef(null);
 
   function addLog(msg, type = 'info') {
@@ -2529,6 +2530,99 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     setTimeout(() => { if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight; }, 30);
   }
   function markStep(i, st) { setStepState(s => { const n = [...s]; n[i] = st; return n; }); }
+
+  // What to ask the device when a step fails (#87).
+  //
+  // Diagnosing #79 and #82 each took several rounds of asking the reporter to
+  // run `getprop` and `wpa_cli` by hand, and by the time they answered the
+  // device had usually been retried or rebooted, so the state at the moment of
+  // failure was gone. This collects it while it is still true.
+  //
+  // Everything here is READ-ONLY and cheap. It runs on a device that has just
+  // failed something, which is the worst moment to be issuing commands that
+  // change anything, and it must not turn one failure into two.
+  //
+  // The keys must match `_PROVISION_PROBES` in em_support.py, which drops any
+  // name it does not recognise — a probe added here and not there collects
+  // output that is silently discarded. `tests/test_support.py` pins the pair.
+  //
+  // Sent RAW. The controller does the redaction, because those rules and their
+  // tests live in em_support.py and a second copy here would drift from them
+  // without anyone noticing until a file carried an SSID.
+  const _PROVISION_PROBES = {
+    props:         'getprop',
+    root:          'su -c id 2>&1',
+    selinux:       'getenforce 2>&1',
+    // The two distinct shapes a too-early `pm` produces, which is what the
+    // retry path keys off — worth capturing verbatim rather than as a verdict.
+    pm_ready:      'pm path android 2>&1',
+    storage:       'df /data 2>&1',
+    wpa_status:    "su -c 'wpa_cli -p /data/misc/wifi/sockets -i wlan0 status' 2>&1",
+    wpa_scan:      "su -c 'wpa_cli -p /data/misc/wifi/sockets -i wlan0 scan_results' 2>&1",
+    wpa_caps:      "su -c 'wpa_cli -p /data/misc/wifi/sockets -i wlan0 get_capability key_mgmt' 2>&1",
+    services:      'getprop | grep init.svc',
+    processes:     "ps | grep -E 'wpa_supplicant|SmartHomeWifid' | grep -v grep",
+    // Answers "did the package steps achieve anything", which is the case
+    // that reports success having done nothing. It is also the exact question
+    // #91 had to be asked by hand.
+    packages:      "pm list packages 2>&1 | grep -i amazon",
+    data_property: 'ls /data/property 2>&1',
+    // TWRP steps only, and harmless elsewhere: which partition the boot image
+    // write would have gone to.
+    boot_target:   'readlink -f /dev/block/other-boot 2>&1',
+  };
+
+  async function collectProvisionDiagnostics(c, stepIdx, err) {
+    const probes = {};
+    for (const [name, cmd] of Object.entries(_PROVISION_PROBES)) {
+      try {
+        // Bounded per probe. The device has just failed something and may be
+        // half gone; without this, one unanswered command hangs the whole
+        // collection and the operator gets nothing at all.
+        probes[name] = await Promise.race([
+          c.shell(cmd),
+          new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), 8000)),
+        ]);
+      } catch (e) {
+        probes[name] = `<probe failed: ${e.message}>`;
+      }
+    }
+    return API.post('/api/provision/diagnostics', {
+      step:  _WIZARD_STEPS[stepIdx]?.id || String(stepIdx),
+      error: err?.message || '',
+      probes,
+      transcript: log.map(l => l.msg),
+      selected_ssid: wifiSsid || null,
+    });
+  }
+
+  async function captureDiagnostics(stepIdx, err) {
+    if (!adb) {
+      // No connection means no probes, and a button that downloads a file
+      // containing nothing but the error would be worse than no button.
+      addLog('No ADB connection, so device state could not be captured.', 'warn');
+      return;
+    }
+    addLog('Capturing device state for diagnostics…');
+    try {
+      setDiagnostics(await collectProvisionDiagnostics(adb, stepIdx, err));
+      addLog('Device state captured — "Download diagnostics" below.', 'ok');
+    } catch (e) {
+      // Never let the diagnostic path bury the real failure.
+      addLog(`Could not capture device state: ${e.error || e.message}`, 'warn');
+    }
+  }
+
+  function downloadDiagnostics() {
+    const blob = new Blob([JSON.stringify(diagnostics, null, 2)],
+                          { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `echomuse-provision-${new Date().toISOString().slice(0,19).replace(/[:T]/g,'')}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
 
   async function doCheckRelease() {
     setCheckingRelease(true);
@@ -3730,6 +3824,10 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       addLog(`Error: ${e.message}`, 'error');
       markStep(stepIdx, 'error');
       if (e.matchedDeviceId) setDuplicateDeviceId(e.matchedDeviceId);
+      // Collect device state while it is still the state that failed. A
+      // duplicate-device stop is our own bookkeeping and has nothing to ask
+      // the device about.
+      if (!e.matchedDeviceId) await captureDiagnostics(stepIdx, e);
       // Clear the file selection on failure — forces a deliberate reselect
       // before retry rather than silently re-flashing whatever was picked
       // last time (which, on a hash-mismatch failure, is the wrong file).
@@ -3912,6 +4010,13 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
             {!running && stepState[step] === 'error' && ![3, 10, 11].includes(step) && (
               <div style={{ marginBottom: 10, display: 'flex', gap: 8 }}>
                 <Pill onClick={() => runStep(step)}>Retry</Pill>
+                {/* Collection is automatic on failure; sharing is deliberate.
+                    The file is redacted controller-side (no SSIDs, BSSIDs or
+                    IPs) so it is safe to attach to a public issue, but it is
+                    still the operator's call whether to. */}
+                {diagnostics && (
+                  <Pill onClick={downloadDiagnostics}>Download diagnostics</Pill>
+                )}
                 {step === 0 && duplicateDeviceId && (
                   <Pill danger onClick={async () => {
                     try {

--- a/controller/tests/test_support.py
+++ b/controller/tests/test_support.py
@@ -13,6 +13,7 @@ predicts.
 import inspect
 import json
 import re
+from pathlib import Path
 
 import em_support as S
 
@@ -465,3 +466,191 @@ def test_the_ring_ignores_the_dashboards_own_http_chatter():
                       ("echomuse", "Barge-in: cancelling playback")):
         ring.emit(logging.LogRecord(name, logging.INFO, "f", 1, msg, None, None))
     assert ring.tail() == ["Barge-in: cancelling playback"]
+
+
+# ─── Provisioning diagnostics (#87) ───────────────────────────────────────────
+#
+# Realistic raw probe output, carrying every kind of thing that must not reach
+# a public issue: an SSID, a BSSID, an IP, a MAC, and a home network name.
+
+_RAW_PROPS = """
+[ro.product.model]: [AEOBC]
+[ro.build.version.incremental]: [272.6.8.0_user_680767620]
+[ro.serialno]: [G090LF1180570SPJ]
+[persist.sys.usb.config]: [mtp,adb]
+[net.hostname]: [SamsPhone-Bedroom]
+[wifi.interface]: [wlan0]
+[dhcp.wlan0.ipaddress]: [10.10.1.188]
+""".strip()
+
+_RAW_STATUS = """
+bssid=74:ac:b9:d6:9b:21
+freq=5180
+ssid=Neptune-Media
+id=0
+mode=station
+pairwise_cipher=CCMP
+group_cipher=CCMP
+key_mgmt=WPA2-PSK
+wpa_state=COMPLETED
+ip_address=10.10.1.188
+address=ac:63:be:11:22:33
+uuid=6f1c2b3a-0000-1111-2222-333344445555
+""".strip()
+
+_RAW_SCAN = (
+    "bssid / frequency / signal level / flags / ssid\n"
+    "74:ac:b9:d6:9b:21\t5180\t-52\t[WPA2-PSK-CCMP][ESS]\tNeptune-Media\n"
+    "24:5a:4c:83:7b:e4\t2437\t-71\t[SAE-CCMP][ESS]\tPixel_7793\n"
+    "aa:bb:cc:dd:ee:ff\t2412\t-80\t[ESS]\tSams Room 2.4\n"
+)
+
+
+def _diag(**kw):
+    kw.setdefault("step", "configure_wifi")
+    kw.setdefault("error", "Association failed")
+    kw.setdefault("probes", {})
+    return S.build_provision_diagnostics(**kw)
+
+
+def test_provision_diagnostics_leak_nothing_identifying():
+    """
+    The whole point is that this gets attached to a public issue, so the
+    check is on the SERIALISED output rather than field by field. A leak
+    through a probe nobody thought to parse is the one that gets missed.
+    """
+    out = json.dumps(_diag(
+        probes={
+            "props":      _RAW_PROPS,
+            "wpa_status": _RAW_STATUS,
+            "wpa_scan":   _RAW_SCAN,
+            "storage":    "/dev/block/mmcblk0p23 5.0G 3.1G 1.9G 62% /data",
+        },
+        transcript=["Writing config for \"Neptune-Media\"…",
+                    "Connected! IP: 10.10.1.188"],
+        selected_ssid="Neptune-Media",
+    ))
+    for secret in ("Neptune-Media", "Pixel_7793", "Sams Room",
+                   "SamsPhone-Bedroom", "10.10.1.188",
+                   "74:ac:b9:d6:9b:21", "ac:63:be:11:22:33",
+                   "6f1c2b3a"):
+        assert secret not in out, f"{secret!r} reached the diagnostics file"
+
+
+def test_the_radio_facts_survive_the_scan_redaction():
+    """
+    Names out, radio in. `[SAE-CCMP]` is the entire answer to #82 and the
+    reason scan results are included at all, so a redaction that took the
+    flags with the SSID would leave the probe pointless.
+    """
+    d = _diag(probes={"wpa_scan": _RAW_SCAN}, selected_ssid="Neptune-Media")
+    rows = d["probes"]["wpa_scan"]
+    assert len(rows) == 3, rows
+    assert [r["flags"] for r in rows] == [
+        "[WPA2-PSK-CCMP][ESS]", "[SAE-CCMP][ESS]", "[ESS]"]
+    assert [r["freq"] for r in rows] == ["5180", "2437", "2412"]
+    assert [r["network"] for r in rows] == ["network-1", "network-2", "network-3"]
+    # Which one they were trying to join is unrecoverable once names are gone.
+    assert [r["selected"] for r in rows] == [True, False, False]
+
+
+def test_props_are_allowlisted_not_filtered():
+    """A property nobody listed does not appear, whatever it is called."""
+    d = _diag(probes={"props": _RAW_PROPS})
+    props = d["probes"]["props"]
+    assert props["ro.build.version.incremental"] == "272.6.8.0_user_680767620"
+    assert props["ro.serialno"] == "G090LF1180570SPJ"
+    assert "net.hostname" not in props
+    assert "dhcp.wlan0.ipaddress" not in props
+
+
+def test_serials_are_kept():
+    """
+    Same call as the support bundle: nothing correlates without them, and
+    they identify the reporter's own hardware to them.
+    """
+    assert "G090LF1180570SPJ" in json.dumps(_diag(probes={"props": _RAW_PROPS}))
+
+
+def test_an_unlisted_probe_is_dropped_whole():
+    """
+    The wizard posts from a browser talking to a device we know nothing about
+    yet, so an unrecognised key is untrusted input, not a new feature.
+    """
+    d = _diag(probes={"logcat": "anything at all", "root": "uid=0(root)"})
+    assert "logcat" not in d["probes"]
+    assert d["probes"]["root"] == ["uid=0(root)"]
+
+
+def test_missing_probes_are_named():
+    """
+    "The wizard did not ask" and "the device had nothing to say" need
+    opposite next questions, so they must not look the same in the file.
+    """
+    d = _diag(probes={"root": "uid=0(root)"})
+    assert "wpa_scan" in d["probes_missing"]
+    assert "root" not in d["probes_missing"]
+
+
+def test_a_probe_with_an_unexpected_shape_still_gets_scrubbed():
+    """
+    The parser is the thing most likely to be wrong about output nobody has
+    seen, and these are by definition the devices behaving unusually. So the
+    generic scrub runs regardless of whether a parser matched anything.
+    """
+    d = _diag(probes={"wpa_status": "garbage 10.10.1.188 aa:bb:cc:dd:ee:ff"})
+    assert "10.10.1.188" not in json.dumps(d)
+    assert "aa:bb:cc:dd:ee:ff" not in json.dumps(d)
+
+
+def test_the_error_and_transcript_are_scrubbed_not_trusted():
+    """
+    Both are ours, but our error strings interpolate device output often
+    enough that the distinction is not worth relying on.
+    """
+    d = _diag(error='Staged config does not contain ssid="Neptune-Media"',
+              transcript=["Connected! IP: 10.10.1.188"])
+    blob = json.dumps(d)
+    assert "Neptune-Media" not in blob
+    assert "10.10.1.188" not in blob
+
+
+def test_no_transcripts_parameter_exists():
+    """
+    Same rule the support bundle has: speech must not become an opt-in,
+    because a flag is a thing people tick. `transcript` here is the WIZARD's
+    log, not speech, and there is no path for the latter.
+    """
+    params = set(inspect.signature(S.build_provision_diagnostics).parameters)
+    assert "transcripts" not in params
+    assert "stt_text" not in params
+    assert "recordings" not in params
+
+
+def test_the_wizard_probe_list_matches_the_allowlist():
+    """
+    `dashboard.jsx` collects the probes and `em_support` decides which survive,
+    so the two lists must agree.
+
+    Drift is silent in the direction that matters: a probe added to the wizard
+    and not here is collected, posted, and dropped, so the operator waits for
+    it, the file does not contain it, and nothing anywhere says so. The other
+    direction just leaves a name in `probes_missing` forever.
+
+    Parsed out of the JSX because the dashboard compiles to a single classic
+    script with no module boundary to import across, the same reason
+    CONFIG_SECTIONS is mirror-checked rather than shared.
+    """
+    jsx = (Path(__file__).resolve().parent.parent
+           / "static" / "dashboard.jsx").read_text()
+    block = re.search(r"const _PROVISION_PROBES = \{(.*?)\n  \};", jsx, re.S)
+    assert block, "dashboard.jsx no longer defines _PROVISION_PROBES"
+    in_jsx = set(re.findall(r"^\s*([a-z_]+):", block.group(1), re.M))
+    in_py = set(S._PROVISION_PROBES)
+
+    assert not (in_jsx - in_py), (
+        f"the wizard collects {sorted(in_jsx - in_py)}, which em_support drops "
+        f"on arrival — add them to _PROVISION_PROBES")
+    assert not (in_py - in_jsx), (
+        f"em_support allows {sorted(in_py - in_jsx)}, which the wizard never "
+        f"collects")


### PR DESCRIPTION
Closes #87.

Diagnosing #79 and #82 each took several rounds of asking the reporter to run
`getprop` and `wpa_cli` by hand, and by the time they answered the device had
usually been retried or rebooted, so the state at the moment of failure was
gone. #91 needed the same treatment this morning.

On a step failure the wizard runs a fixed read-only probe set, posts it, and
offers a **Download diagnostics** button next to the error. Collection is
automatic; sharing is deliberate.

## What comes out

Real output, from realistic raw probe input:

```json
{
  "step": "configure_wifi",
  "error": ["Association failed: wpa_state=SCANNING for <redacted>"],
  "probes": {
    "props": {
      "ro.product.model": "AEOBC",
      "ro.build.version.incremental": "272.6.8.0_user_680767620",
      "ro.serialno": "G090LF1180570SPJ"
    },
    "wpa_caps": ["NONE IEEE8021X WPA-EAP WPA-PSK"],
    "wpa_status": { "freq": "5180", "key_mgmt": "WPA2-PSK", "wpa_state": "SCANNING" },
    "wpa_scan": [
      { "network": "network-1", "freq": "5180", "signal": "-52",
        "flags": "[WPA2-PSK-CCMP][ESS]", "selected": true },
      { "network": "network-2", "freq": "2437", "signal": "-71",
        "flags": "[SAE-CCMP][ESS]", "selected": false }
    ]
  },
  "probes_missing": ["selinux", "pm_ready", "storage", "..."]
}
```

The input to that carried an SSID, a BSSID, an IP and a phone hostname. None
survive. `wpa_caps` alone answers #82, and the `packages` probe is the exact
question #91 had to be asked by hand.

## Design

**Packaged on the controller, not in the browser.** The redaction rules and
their tests already live in `em_support.py`, and a second copy in JavaScript
would drift from them without anyone noticing until a file carried an SSID.
The wizard collects raw and posts; `em_support` decides what survives. That
direction also treats the browser as untrusted input, which is the right
posture when it is talking to a device we know nothing about yet.

**An allowlist twice over.** A probe name nobody listed is dropped whole, and
inside the probes carrying key/value output the keys are listed too.

**Scan results are the real tension**, because the flags and frequency ARE the
diagnosis while the names locate someone's house. Rows survive with the SSID
replaced by a positional placeholder, and the network the operator was trying
to join is marked, since "the one you wanted is WPA3" is the whole answer and
is unrecoverable once the names are gone.

**`probes_missing` is explicit**: "the wizard did not ask" and "the device had
nothing to say" need opposite next questions.

## Tests

Assertions are on the SERIALISED output rather than field by field, since a
leak through a probe nobody thought to parse is the one that gets missed. A
drift guard pins the JS probe list against the Python allowlist, verified by
making them disagree. There is also a test that no `transcripts` parameter can
appear, the same rule the support bundle has: speech must not become an
opt-in, because a flag is a thing people tick.

## Not doing

An ADB console in the wizard, requested in #82 and close to #74's third point.
A wizard that hands you a root shell has admitted defeat, and it puts a prompt
in front of someone who mostly wants the thing to work.

The issue's open question was whether this button also belongs on a fielded
device. It does not: the support bundle already covers that case with more
context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)