### PR TITLE
controller: a deleted device can come back

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -58,6 +58,7 @@ COPY em_support.py .
 COPY em_shadow.py .
 COPY em_ns.py .
 COPY em_pki.py .
+COPY em_linkauth.py .
 COPY em_esphome.py .
 COPY em_ble_proxy.py .
 COPY em_oww_assets.py  ./

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -68,6 +68,7 @@ import em_db as db
 import em_auth as auth
 import em_api as api
 import em_pki
+import em_linkauth
 import em_eq
 import em_scenes
 import em_shadow
@@ -2048,15 +2049,34 @@ async def _link_auth_ok(
     device_id is known.
 
     Rules (rollout-safe by construction):
-      - a presented token that MISMATCHES the stored one always rejects;
+      - a presented token that MISMATCHES a stored one always rejects;
       - a stored token with NO token presented is allowed unless
         REQUIRE_DEVICE_TLS — the DB row is minted before the files land
         on the device, and rejecting in that window would cut off the
         shell plane that the credential push itself rides on;
+      - a presented token for a device with NOTHING on record is ignored,
+        not rejected (see below);
       - REQUIRE_DEVICE_TLS=1 requires TLS + a matching token, full stop.
-    """
-    import hmac as _hmac
 
+    That third rule used to be a rejection, and it made deleting a device a
+    one-way door. Delete removes the row, the token is a column on it, and the
+    device re-reads its credential file on every dial — so it presented a token
+    nothing recognised and was refused on all three planes, INCLUDING the shell
+    plane the controller would otherwise push fresh credentials over. The
+    device retried forever behind a pulsing orange ring, and the dashboard had
+    nothing to show because as far as it was concerned the device did not
+    exist.
+
+    Rejecting there also never bought anything. The rule immediately above
+    admits a connection presenting no token at all, so an unrecognised token
+    was being treated as worse than none while anyone could simply omit the
+    header. A device with a stale credential now comes back as pending and
+    waits for approval, which is the decision a human should be making anyway.
+
+    `REQUIRE_DEVICE_TLS=1` installs are unaffected: the last rule still
+    demands a token that matches a stored one, so a deleted device is refused
+    there regardless and re-provisioning over USB stays the intended path.
+    """
     presented = None
     try:
         presented = ws.request.headers.get("X-EM-Token")
@@ -2066,18 +2086,23 @@ async def _link_auth_ok(
     loop = asyncio.get_event_loop()
     expected = await loop.run_in_executor(None, db.get_device_token, device_id)
 
-    if presented and expected and not _hmac.compare_digest(presented, expected):
-        log.warning(f"[{plane}] {device_id}: token mismatch — rejecting")
+    verdict = em_linkauth.decide(
+        presented=presented,
+        expected=expected,
+        secure=secure,
+        require_tls=REQUIRE_DEVICE_TLS,
+    )
+    if not verdict.ok:
+        log.warning(f"[{plane}] {device_id}: {verdict.reason} — rejecting")
         return False
-    if presented and not expected:
-        log.warning(f"[{plane}] {device_id}: token presented but none on record — rejecting")
-        return False
-    if REQUIRE_DEVICE_TLS and not (secure and presented and expected):
+    if verdict.stale_token:
+        # Allowed, but worth seeing in the log: almost always a device that was
+        # deleted and has come back carrying the credential from its previous
+        # life, which is the answer to "why is this in pending again".
         log.warning(
-            f"[{plane}] {device_id}: REQUIRE_DEVICE_TLS is set and connection "
-            f"is {'plain' if not secure else 'missing a valid token'} — rejecting"
+            f"[{plane}] {device_id}: {verdict.reason}. "
+            f"Treating as an unregistered device; it will need approval."
         )
-        return False
     return True
 
 

--- a/controller/em_linkauth.py
+++ b/controller/em_linkauth.py
@@ -1,0 +1,76 @@
+"""
+The device-link auth decision, as a pure function.
+
+Split out of `em_controller._link_auth_ok` so it can be tested. The rest of
+that function is a websocket header read, a DB lookup and a log call; the part
+worth getting right is the four-way decision below, and it was previously
+unreachable from the test suite because em_controller pulls in the whole
+websockets/openwakeword stack.
+
+It cost an orphaned device to find out. Deleting a device removed its row, and
+the token is a column on that row, so `expected` became None while the device
+carried on presenting the credential it still had on disk. The rule rejected
+that, on all three planes including the shell plane the controller would
+otherwise have used to push a fresh credential, and the device retried forever
+behind a pulsing orange ring.
+"""
+
+import hmac
+from typing import NamedTuple, Optional
+
+
+class Verdict(NamedTuple):
+    ok: bool
+    # Why, for the log. None when there is nothing worth saying.
+    reason: Optional[str] = None
+    # True when the connection is allowed but carried a credential nothing
+    # recognises — worth a log line, since it is almost always a device that
+    # was deleted and has come back.
+    stale_token: bool = False
+
+
+def decide(
+    *,
+    presented: Optional[str],
+    expected: Optional[str],
+    secure: bool,
+    require_tls: bool,
+) -> Verdict:
+    """
+    Whether to admit a device connection.
+
+    `presented` is the X-EM-Token header, `expected` the stored token for this
+    device id, `secure` whether the connection arrived over TLS.
+
+    Four rules:
+
+    1. A presented token that MISMATCHES a stored one always rejects. This is
+       the only case where a credential is actually wrong.
+
+    2. A stored token with NOTHING presented is allowed unless `require_tls`.
+       The DB row is minted before the files reach the device, and rejecting
+       in that window would cut off the shell plane that the credential push
+       itself rides on.
+
+    3. A token presented for a device with nothing on record is IGNORED, not
+       rejected. Rule 2 already admits a connection presenting no token at
+       all, so rejecting an unrecognised one treats it as worse than none
+       while an attacker can simply omit the header: it buys nothing, and it
+       is what made deleting a device a one-way door. Such a device comes back
+       as pending and waits for approval, which is a human decision anyway.
+
+    4. `require_tls` demands TLS AND a token matching a stored one, full stop.
+       A deleted device is still refused there, and re-provisioning over USB
+       stays the intended path.
+    """
+    if presented and expected and not hmac.compare_digest(presented, expected):
+        return Verdict(False, "token mismatch")
+
+    if require_tls and not (secure and presented and expected):
+        return Verdict(False,
+                       "plain connection" if not secure else "missing a valid token")
+
+    if presented and not expected:
+        return Verdict(True, "token presented but none on record", stale_token=True)
+
+    return Verdict(True)

--- a/controller/tests/test_linkauth.py
+++ b/controller/tests/test_linkauth.py
@@ -1,0 +1,117 @@
+"""
+The device-link auth decision.
+
+Untested by construction until now, because the decision lived inside
+em_controller and the suite deliberately does not import that module. What it
+cost: deleting a device removed its row, the token is a column on that row, so
+`expected` went to None while the device carried on presenting the credential
+it still had on disk. That was rejected on all three planes, including the
+shell plane the controller would otherwise push a fresh credential over, and
+the device retried forever behind a pulsing orange ring with nothing in the
+dashboard to explain it (#96).
+"""
+
+import em_linkauth as LA
+
+GOOD = "a" * 40
+STALE = "b" * 40
+
+
+def decide(presented=None, expected=None, secure=True, require_tls=False):
+    return LA.decide(presented=presented, expected=expected,
+                     secure=secure, require_tls=require_tls)
+
+
+# ─── The case that cost a device ──────────────────────────────────────────────
+
+def test_a_token_for_a_device_with_none_on_record_is_admitted():
+    """
+    A deleted device coming back with its old credential. It must be allowed
+    through so it can register as pending, because the shell plane the
+    controller would use to fix it is behind this same gate.
+    """
+    v = decide(presented=STALE, expected=None)
+    assert v.ok is True
+    assert v.stale_token is True, "the log needs to be able to say why"
+
+
+def test_a_stale_token_is_no_stricter_than_no_token_at_all():
+    """
+    The argument for admitting it, as a test rather than a comment: an
+    unrecognised token cannot be treated as worse than an absent one while
+    anyone can simply omit the header. If these two ever disagree, the
+    stricter branch is buying nothing and costing an orphaned device.
+    """
+    for require_tls in (False, True):
+        with_token = decide(presented=STALE, expected=None, require_tls=require_tls)
+        without    = decide(presented=None,  expected=None, require_tls=require_tls)
+        assert with_token.ok == without.ok, (
+            f"require_tls={require_tls}: presenting an unknown token changed "
+            f"the outcome versus presenting nothing")
+
+
+# ─── The cases that must keep rejecting ───────────────────────────────────────
+
+def test_a_mismatched_token_always_rejects():
+    """The only case where a credential is actually wrong."""
+    v = decide(presented=STALE, expected=GOOD)
+    assert v.ok is False
+    assert "mismatch" in v.reason
+
+
+def test_a_mismatched_token_rejects_under_tls_too():
+    assert decide(presented=STALE, expected=GOOD, require_tls=True).ok is False
+
+
+def test_require_tls_refuses_a_plain_connection():
+    assert decide(presented=GOOD, expected=GOOD,
+                  secure=False, require_tls=True).ok is False
+
+
+def test_require_tls_refuses_a_device_with_no_stored_token():
+    """
+    The deleted-device case again, but on an install that has flipped the
+    posture. Re-provisioning over USB is the intended path there, and this
+    fix must not quietly weaken it.
+    """
+    assert decide(presented=STALE, expected=None, require_tls=True).ok is False
+
+
+def test_require_tls_refuses_a_tokenless_connection():
+    assert decide(presented=None, expected=GOOD, require_tls=True).ok is False
+
+
+# ─── The rollout rule that must survive ───────────────────────────────────────
+
+def test_a_stored_token_with_none_presented_is_allowed_by_default():
+    """
+    The DB row is minted before the credential files reach the device, and the
+    push itself rides the shell plane. Rejecting in that window would deadlock
+    the rollout it exists to perform.
+    """
+    v = decide(presented=None, expected=GOOD)
+    assert v.ok is True
+    assert v.stale_token is False
+
+
+def test_a_matching_token_is_allowed_everywhere():
+    for require_tls in (False, True):
+        assert decide(presented=GOOD, expected=GOOD, require_tls=require_tls).ok
+
+
+def test_an_unknown_device_on_a_default_install_is_allowed():
+    """A device that has never been issued a credential, on a default install."""
+    v = decide(presented=None, expected=None)
+    assert v.ok is True
+    assert v.stale_token is False
+
+
+def test_comparison_is_constant_time():
+    """
+    The mismatch branch compares secrets, so it must not use ==. Checked on
+    the source because timing is not observable from a unit test.
+    """
+    import inspect
+    src = inspect.getsource(LA.decide)
+    assert "compare_digest" in src
+    assert "presented == expected" not in src


### PR DESCRIPTION
Closes #96.

Deleting a device removed its row, and the link token is a column on that row,
so `get_device_token` returned None while the device carried on presenting the
credential it still had at `/data/local/etc/echomuse/token`, which it re-reads
on every dial by design.

`_link_auth_ok` rejected that on all three planes. Including the shell plane,
which is the one the controller would otherwise push a fresh credential over,
so there was no way back short of re-running the wizard over USB. From the
outside the device sat pulsing orange and retried forever, and the dashboard
had nothing to show because as far as it was concerned the device did not
exist.

## Why the rule did not earn it

The check beside it admits a connection presenting **no token at all**. So an
unrecognised token was being treated as worse than none, while anyone can
simply omit the header. There is a test asserting exactly that equivalence,
because it is the argument for the change rather than a restatement of it:

```python
def test_a_stale_token_is_no_stricter_than_no_token_at_all():
    for require_tls in (False, True):
        with_token = decide(presented=STALE, expected=None, require_tls=require_tls)
        without    = decide(presented=None,  expected=None, require_tls=require_tls)
        assert with_token.ok == without.ok
```

A device with a stale credential now comes back as **pending** and waits for
approval, which is a human decision anyway. The stale token is still logged,
since it is the answer to "why is this in pending again".

## What is unchanged

`REQUIRE_DEVICE_TLS=1` installs. That rule still demands TLS and a token
matching a stored one, so a deleted device is refused there regardless and
re-provisioning over USB stays the intended path. Pinned by
`test_require_tls_refuses_a_device_with_no_stored_token`, so it cannot be
weakened by accident later.

## em_linkauth.py

The decision moves to a pure function. It was untestable where it was: the
suite deliberately does not import `em_controller`, which pulls in the whole
websockets/openwakeword stack, so this is security logic with no coverage that
had just cost a device.

Eleven tests, verified by reintroducing the bug (two fail, the right two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)