### PR TITLE
wizard: say when a reconnect came back in the wrong mode

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -2172,10 +2172,13 @@ const _ADB = (() => {
   let _lastUsbDevice = null;
 
   class Client {
-    constructor(adb, transport, banner) {
+    constructor(adb, transport, banner, serial) {
       this._adb = adb;
       this._transport = transport;
       this.banner = banner;  // product name string, e.g. "omni_biscuit" or "csm_biscuit"
+      // Carried so a WebUSB 'disconnect' event can be matched to this client
+      // rather than to any other USB device the operator happens to unplug.
+      this.serial = serial ?? null;
       this._log = () => {};
     }
 
@@ -2271,7 +2274,7 @@ const _ADB = (() => {
       const banner = adb.banner?.product ?? '(unknown)';
       logFn(`Connected. Banner: ${banner}`);
 
-      return new Client(adb, transport, banner);
+      return new Client(adb, transport, banner, usbDevice.serial ?? null);
     }
   }
 
@@ -2524,6 +2527,11 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   const [checkingRelease, setCheckingRelease] = useState(false);
   const [diagnostics, setDiagnostics] = useState(null);
   const logRef = useRef(null);
+  // Bumped whenever the step in flight is abandoned — by the cable being
+  // pulled, or by the operator cancelling. A step that later settles compares
+  // this against the value it captured and drops its result on the floor
+  // rather than marking a step done that nobody is waiting on any more.
+  const stepEpoch = useRef(0);
 
   function addLog(msg, type = 'info') {
     // 200 lines truncated a normal successful run — the transcript above the
@@ -2535,6 +2543,48 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     setTimeout(() => { if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight; }, 30);
   }
   function markStep(i, st) { setStepState(s => { const n = [...s]; n[i] = st; return n; }); }
+
+  // Abandon whatever step is in flight.
+  //
+  // The ADB calls a step awaits do NOT reliably reject when the device goes
+  // away: `shell` waits on a stream reader that simply never produces, so the
+  // step neither resolves nor throws. `running` stays true, every button here
+  // is gated on `!running`, and the wizard sits there looking busy with no
+  // Retry, no Reconnect and no way out but reloading the page and losing the
+  // transcript. Observed by pulling the cable during Configure WiFi.
+  //
+  // A timeout on `shell` would be the wrong instrument: waitForFramework
+  // budgets ten minutes and `twrp install` takes thirty seconds or more, so
+  // any timeout loose enough to be safe is too loose to be useful.
+  function abandonStep(reason) {
+    stepEpoch.current++;
+    setRunning(false);
+    markStep(step, 'error');
+    addLog(reason, 'error');
+  }
+
+  // The browser knows the cable was pulled; nothing was listening.
+  //
+  // Matched on serial so unplugging an unrelated USB device does not abort a
+  // provision. When either serial is unavailable the event is treated as ours:
+  // a spurious abort costs a Retry, and a missed one costs the hang above.
+  useEffect(() => {
+    if (!navigator.usb) return;
+    const onDisconnect = (e) => {
+      if (!adb && !running) return;
+      const theirs = adb?.serial && e.device?.serialNumber
+                   && e.device.serialNumber !== adb.serial;
+      if (theirs) return;
+      setAdb(null);
+      if (running) {
+        abandonStep('Device disconnected. The step was abandoned — reconnect and retry.');
+      } else {
+        addLog('Device disconnected.', 'warn');
+      }
+    };
+    navigator.usb.addEventListener('disconnect', onDisconnect);
+    return () => navigator.usb.removeEventListener('disconnect', onDisconnect);
+  }, [adb, running, step]);
 
   // What to ask the device when a step fails (#87).
   //
@@ -3880,6 +3930,13 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   }
 
   async function runStep(stepIdx, useLatest) {
+    // Captured up front. If the cable is pulled mid-step the handler above
+    // bumps this and has already set the UI to a usable state, so everything
+    // below must become a no-op — including the failure path, which would
+    // otherwise spend ~100s probing a device that is not there.
+    const epoch = stepEpoch.current;
+    const abandoned = () => epoch !== stepEpoch.current;
+
     setRunning(true);
     markStep(stepIdx, 'running');
     // One banner per step. The transcript is the only record of a provision
@@ -3911,9 +3968,14 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
         case 11: await runInstallEchoMuse(c, binaryFile, useLatest); break;
         case 12: await runInstallOwwAssets(c); break;
       }
+      if (abandoned()) return;
       markStep(stepIdx, 'done');
       if (stepIdx < _WIZARD_STEPS.length - 1) setStep(stepIdx + 1);
     } catch (e) {
+      // A step abandoned mid-flight may still throw on its way out, once the
+      // transport notices. The UI already says what happened; saying it again
+      // in the language of whatever call happened to fail is noise.
+      if (abandoned()) return;
       addLog(`Error: ${e.message}`, 'error');
       markStep(stepIdx, 'error');
       if (e.matchedDeviceId) setDuplicateDeviceId(e.matchedDeviceId);
@@ -3927,7 +3989,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       if (stepIdx === 3) setMagiskFile(null);
       if (stepIdx === 11) setBinaryFile(null);
     }
-    setRunning(false);
+    if (!abandoned()) setRunning(false);
   }
 
   // Auto-advance steps that need no user input once adb is connected.
@@ -4090,6 +4152,19 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
                 onSkip={() => { markStep(10, 'done'); setStep(11); }}
                 onAbort={() => { markStep(10, 'error'); addLog('WiFi skipped — provision incomplete.', 'warn'); }}
               />
+            )}
+
+            {/* The only control available while a step is in flight. The
+                disconnect listener handles the cable being pulled, but a step
+                can stall for reasons the browser does not report — a device
+                that has stopped answering while still enumerated, say — and
+                without this the only way out is reloading the page, which
+                loses the transcript the operator would otherwise paste into
+                an issue. */}
+            {running && (
+              <div style={{ marginBottom: 10, display: 'flex', gap: 8 }}>
+                <Pill danger onClick={() => abandonStep('Step cancelled.')}>Cancel step</Pill>
+              </div>
             )}
 
             {/* Retry button — re-runs the step directly (runStep marks it running).

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -2334,6 +2334,37 @@ const _ALEXA_PKGS = [
 // without a live handle.
 const CONNECT_STEPS = new Set([0, 1, 6]);
 
+// Which mode each step has to run in.
+//
+// This matters because the Dot's only power source is the same micro-USB port
+// carrying data, so pulling the cable POWERS IT OFF, and `reboot recovery` is
+// a one-shot BCB flag. A replug is therefore a cold boot into Android, whatever
+// phase the wizard thinks it is in. Reconnecting during the TWRP phase hands
+// back an Android device that looks perfectly healthy.
+//
+// It is not a cosmetic mismatch. In Android `/dev/block/other-boot` resolves to
+// boot_b, which holds amonet's B-slot unlock payload rather than a kernel, so
+// retrying Patch Boot Image there would write over the unlock. The guard in
+// runPatchBoot refuses that, and this exists so the operator finds out before
+// they get as far as being refused.
+const _STEP_MODE = {
+  0: 'android',
+  1: 'twrp', 2: 'twrp', 3: 'twrp', 4: 'twrp', 5: 'twrp',
+  6: 'android', 7: 'android', 8: 'android', 9: 'android',
+  10: 'android', 11: 'android', 12: 'android',
+};
+
+// TWRP is checked first: its banner is "omni_biscuit", which also contains
+// "biscuit", so an Android-first test would call every TWRP device Android.
+function _bannerMode(banner) {
+  const b = (banner || '').toLowerCase();
+  if (b.includes('omni') || b.includes('twrp') || b.includes('recovery')) return 'twrp';
+  if (b.includes('csm') || b.includes('biscuit')) return 'android';
+  return 'unknown';
+}
+
+const _MODE_NAME = { twrp: 'TWRP recovery', android: 'Android' };
+
 const _INIT_RC_APPEND = `
 service mixer /system/bin/sh
     oneshot
@@ -2963,7 +2994,21 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       // the operator picked the wrong device.
       if (adb) { try { await adb.close(); } catch {} setAdb(null); }
       addLog('Reconnecting to the device…');
-      await runReconnect();
+      const c = await runReconnect();
+      // Say so when the device came back in the wrong mode. Without this the
+      // reconnect looks like a success and the next Retry runs a TWRP step
+      // against Android, or the reverse.
+      const want = _STEP_MODE[step];
+      const got  = _bannerMode(c.banner);
+      if (want && got !== 'unknown' && got !== want) {
+        addLog(`Reconnected in ${_MODE_NAME[got]}, but this step needs ${_MODE_NAME[want]} `
+             + `(banner "${c.banner}").`, 'error');
+        addLog('Pulling the cable powers the Dot off, and a cold boot comes up in Android.', 'warn');
+        if (want === 'twrp') {
+          addLog('To reach TWRP: unplug, plug back in, and hold the mute button for about '
+               + '5 seconds as soon as the blue LED appears.', 'warn');
+        }
+      }
     } catch (e) {
       addLog(`Reconnect failed: ${e.message}`, 'error');
     }

--- a/controller/tests/pm_verdict.test.mjs
+++ b/controller/tests/pm_verdict.test.mjs
@@ -93,3 +93,64 @@ if (failures) {
   process.exit(1);
 }
 console.log("pm_verdict: all checks passed.");
+
+// ─── Step mode / banner classification ────────────────────────────────────────
+//
+// Pulling the cable powers the Dot off, and `reboot recovery` is a one-shot,
+// so a replug is a cold boot into Android whatever phase the wizard is in.
+// Reconnecting during the TWRP phase hands back an Android device that looks
+// healthy. In Android `/dev/block/other-boot` points at boot_b, which holds
+// amonet's unlock payload, so a retried Patch Boot Image there would write
+// over the unlock.
+
+function liftConstObject(name) {
+  const start = src.indexOf(`const ${name} = {`);
+  if (start < 0) throw new Error(`dashboard.jsx no longer defines ${name}`);
+  const end = src.indexOf("};", start);
+  return src.slice(start, end + 2);
+}
+
+function liftFunctionDecl(name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`dashboard.jsx no longer defines ${name}()`);
+  let depth = 0, seen = false, i = src.indexOf("{", start);
+  for (; i < src.length; i++) {
+    if (src[i] === "{") { depth++; seen = true; }
+    else if (src[i] === "}") { depth--; if (seen && depth === 0) break; }
+  }
+  return src.slice(start, i + 1);
+}
+
+const { _bannerMode, _STEP_MODE } = await import(
+  "data:text/javascript;base64," + Buffer.from(
+    liftFunctionDecl("_bannerMode") + "\n" + liftConstObject("_STEP_MODE")
+    + "\nexport { _bannerMode, _STEP_MODE };"
+  ).toString("base64"));
+
+// Real banners, from provisioning transcripts.
+check("TWRP is recognised", _bannerMode("omni_biscuit") === "twrp",
+      _bannerMode("omni_biscuit"));
+check("Android is recognised", _bannerMode("csm_biscuit") === "android",
+      _bannerMode("csm_biscuit"));
+
+// The ordering trap: "omni_biscuit" contains "biscuit", so an Android-first
+// test calls every TWRP device Android — which is the exact direction that
+// lets a TWRP step run against Android.
+check("TWRP is not mistaken for Android", _bannerMode("omni_biscuit") !== "android");
+
+check("an unknown banner is not guessed at",
+      _bannerMode("something_else") === "unknown", _bannerMode("something_else"));
+check("an empty banner is not guessed at", _bannerMode("") === "unknown");
+check("a missing banner is not guessed at", _bannerMode(undefined) === "unknown");
+
+// The boot-image step must be a TWRP step. If this ever flips, the wizard
+// would invite a write to boot_b.
+check("patch boot image is a TWRP step", _STEP_MODE[2] === "twrp", _STEP_MODE[2]);
+check("connect device is an Android step", _STEP_MODE[0] === "android");
+check("verify root is an Android step", _STEP_MODE[7] === "android");
+
+// Every step must have a mode, or the check silently does nothing for it.
+for (let i = 0; i <= 12; i++) {
+  check(`step ${i} has a mode`, _STEP_MODE[i] === "twrp" || _STEP_MODE[i] === "android",
+        String(_STEP_MODE[i]));
+}


### PR DESCRIPTION
Stacked on #99. Order is **#94 → #95 → #99 → this**; do not delete a base
branch before the PR above it has retargeted, or GitHub closes it instead.

Answers @wilbowes's question after the last test: with the device rebooting
when the cable is pulled, how does the wizard confirm where it is?

The Dot's only power source is the micro-USB port carrying the data, so pulling
the cable powers it off, and `reboot recovery` is a one-shot BCB flag. A replug
is a cold boot into **Android**, whatever phase the wizard thinks it is in.
Reconnect handed that back as a success and said nothing, so the next Retry
would run a TWRP step against Android.

## This is the live path for the boot target guard

Not cosmetic. `/dev/block/other-boot` resolves differently by mode, measured on
hardware:

| | TWRP | Android |
|---|---|---|
| `other-boot` | p10 (`boot_a`, `boot_a_x`) | **p18 (`boot_b`)** |

`boot_b` in Android is amonet's B-slot unlock payload, not a kernel. So: pull
cable during the TWRP phase, replug, Reconnect, Retry step 3, and the wizard
writes a FireOS kernel over the unlock. Reachable by unplugging a cable and
clicking two buttons.

The guard from #92 refuses it, via the branch I had assumed was defensive. It
is the live one.

## What this adds

Reconnect compares the ADB banner against the mode the current step needs, and
says so when they disagree, including how to get back to TWRP.

It warns rather than refusing. Reconnecting in the wrong mode deliberately is a
reasonable thing to be doing, and the destructive case is already refused at
the point where it would happen.

The banner test checks TWRP **first** on purpose: `omni_biscuit` contains
`biscuit`, so an Android-first test calls every TWRP device Android, which is
exactly the direction that lets a TWRP step run against Android. A test pins
the ordering, verified by reversing it.

## Not in scope

Working out which step the device is actually up to. Filed as #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)