### PR TITLE
wizard: stop the disconnect handler crying wolf on our own reboots

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -2172,10 +2172,13 @@ const _ADB = (() => {
   let _lastUsbDevice = null;
 
   class Client {
-    constructor(adb, transport, banner) {
+    constructor(adb, transport, banner, serial) {
       this._adb = adb;
       this._transport = transport;
       this.banner = banner;  // product name string, e.g. "omni_biscuit" or "csm_biscuit"
+      // Carried so a WebUSB 'disconnect' event can be matched to this client
+      // rather than to any other USB device the operator happens to unplug.
+      this.serial = serial ?? null;
       this._log = () => {};
     }
 
@@ -2271,7 +2274,7 @@ const _ADB = (() => {
       const banner = adb.banner?.product ?? '(unknown)';
       logFn(`Connected. Banner: ${banner}`);
 
-      return new Client(adb, transport, banner);
+      return new Client(adb, transport, banner, usbDevice.serial ?? null);
     }
   }
 
@@ -2524,6 +2527,11 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   const [checkingRelease, setCheckingRelease] = useState(false);
   const [diagnostics, setDiagnostics] = useState(null);
   const logRef = useRef(null);
+  // Bumped whenever the step in flight is abandoned — by the cable being
+  // pulled, or by the operator cancelling. A step that later settles compares
+  // this against the value it captured and drops its result on the floor
+  // rather than marking a step done that nobody is waiting on any more.
+  const stepEpoch = useRef(0);
 
   function addLog(msg, type = 'info') {
     // 200 lines truncated a normal successful run — the transcript above the
@@ -2535,6 +2543,48 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     setTimeout(() => { if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight; }, 30);
   }
   function markStep(i, st) { setStepState(s => { const n = [...s]; n[i] = st; return n; }); }
+
+  // Abandon whatever step is in flight.
+  //
+  // The ADB calls a step awaits do NOT reliably reject when the device goes
+  // away: `shell` waits on a stream reader that simply never produces, so the
+  // step neither resolves nor throws. `running` stays true, every button here
+  // is gated on `!running`, and the wizard sits there looking busy with no
+  // Retry, no Reconnect and no way out but reloading the page and losing the
+  // transcript. Observed by pulling the cable during Configure WiFi.
+  //
+  // A timeout on `shell` would be the wrong instrument: waitForFramework
+  // budgets ten minutes and `twrp install` takes thirty seconds or more, so
+  // any timeout loose enough to be safe is too loose to be useful.
+  function abandonStep(reason) {
+    stepEpoch.current++;
+    setRunning(false);
+    markStep(step, 'error');
+    addLog(reason, 'error');
+  }
+
+  // The browser knows the cable was pulled; nothing was listening.
+  //
+  // Matched on serial so unplugging an unrelated USB device does not abort a
+  // provision. When either serial is unavailable the event is treated as ours:
+  // a spurious abort costs a Retry, and a missed one costs the hang above.
+  useEffect(() => {
+    if (!navigator.usb) return;
+    const onDisconnect = (e) => {
+      if (!adb && !running) return;
+      const theirs = adb?.serial && e.device?.serialNumber
+                   && e.device.serialNumber !== adb.serial;
+      if (theirs) return;
+      setAdb(null);
+      if (running) {
+        abandonStep('Device disconnected. The step was abandoned — reconnect and retry.');
+      } else {
+        addLog('Device disconnected.', 'warn');
+      }
+    };
+    navigator.usb.addEventListener('disconnect', onDisconnect);
+    return () => navigator.usb.removeEventListener('disconnect', onDisconnect);
+  }, [adb, running, step]);
 
   // What to ask the device when a step fails (#87).
   //
@@ -3880,6 +3930,13 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   }
 
   async function runStep(stepIdx, useLatest) {
+    // Captured up front. If the cable is pulled mid-step the handler above
+    // bumps this and has already set the UI to a usable state, so everything
+    // below must become a no-op — including the failure path, which would
+    // otherwise spend ~100s probing a device that is not there.
+    const epoch = stepEpoch.current;
+    const abandoned = () => epoch !== stepEpoch.current;
+
     setRunning(true);
     markStep(stepIdx, 'running');
     // One banner per step. The transcript is the only record of a provision
@@ -3911,9 +3968,14 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
         case 11: await runInstallEchoMuse(c, binaryFile, useLatest); break;
         case 12: await runInstallOwwAssets(c); break;
       }
+      if (abandoned()) return;
       markStep(stepIdx, 'done');
       if (stepIdx < _WIZARD_STEPS.length - 1) setStep(stepIdx + 1);
     } catch (e) {
+      // A step abandoned mid-flight may still throw on its way out, once the
+      // transport notices. The UI already says what happened; saying it again
+      // in the language of whatever call happened to fail is noise.
+      if (abandoned()) return;
       addLog(`Error: ${e.message}`, 'error');
       markStep(stepIdx, 'error');
       if (e.matchedDeviceId) setDuplicateDeviceId(e.matchedDeviceId);
@@ -3927,7 +3989,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       if (stepIdx === 3) setMagiskFile(null);
       if (stepIdx === 11) setBinaryFile(null);
     }
-    setRunning(false);
+    if (!abandoned()) setRunning(false);
   }
 
   // Auto-advance steps that need no user input once adb is connected.
@@ -4090,6 +4152,19 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
                 onSkip={() => { markStep(10, 'done'); setStep(11); }}
                 onAbort={() => { markStep(10, 'error'); addLog('WiFi skipped — provision incomplete.', 'warn'); }}
               />
+            )}
+
+            {/* The only control available while a step is in flight. The
+                disconnect listener handles the cable being pulled, but a step
+                can stall for reasons the browser does not report — a device
+                that has stopped answering while still enumerated, say — and
+                without this the only way out is reloading the page, which
+                loses the transcript the operator would otherwise paste into
+                an issue. */}
+            {running && (
+              <div style={{ marginBottom: 10, display: 'flex', gap: 8 }}>
+                <Pill danger onClick={() => abandonStep('Step cancelled.')}>Cancel step</Pill>
+              </div>
             )}
 
             {/* Retry button — re-runs the step directly (runStep marks it running).

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -2334,6 +2334,37 @@ const _ALEXA_PKGS = [
 // without a live handle.
 const CONNECT_STEPS = new Set([0, 1, 6]);
 
+// Which mode each step has to run in.
+//
+// This matters because the Dot's only power source is the same micro-USB port
+// carrying data, so pulling the cable POWERS IT OFF, and `reboot recovery` is
+// a one-shot BCB flag. A replug is therefore a cold boot into Android, whatever
+// phase the wizard thinks it is in. Reconnecting during the TWRP phase hands
+// back an Android device that looks perfectly healthy.
+//
+// It is not a cosmetic mismatch. In Android `/dev/block/other-boot` resolves to
+// boot_b, which holds amonet's B-slot unlock payload rather than a kernel, so
+// retrying Patch Boot Image there would write over the unlock. The guard in
+// runPatchBoot refuses that, and this exists so the operator finds out before
+// they get as far as being refused.
+const _STEP_MODE = {
+  0: 'android',
+  1: 'twrp', 2: 'twrp', 3: 'twrp', 4: 'twrp', 5: 'twrp',
+  6: 'android', 7: 'android', 8: 'android', 9: 'android',
+  10: 'android', 11: 'android', 12: 'android',
+};
+
+// TWRP is checked first: its banner is "omni_biscuit", which also contains
+// "biscuit", so an Android-first test would call every TWRP device Android.
+function _bannerMode(banner) {
+  const b = (banner || '').toLowerCase();
+  if (b.includes('omni') || b.includes('twrp') || b.includes('recovery')) return 'twrp';
+  if (b.includes('csm') || b.includes('biscuit')) return 'android';
+  return 'unknown';
+}
+
+const _MODE_NAME = { twrp: 'TWRP recovery', android: 'Android' };
+
 const _INIT_RC_APPEND = `
 service mixer /system/bin/sh
     oneshot
@@ -2963,7 +2994,21 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       // the operator picked the wrong device.
       if (adb) { try { await adb.close(); } catch {} setAdb(null); }
       addLog('Reconnecting to the device…');
-      await runReconnect();
+      const c = await runReconnect();
+      // Say so when the device came back in the wrong mode. Without this the
+      // reconnect looks like a success and the next Retry runs a TWRP step
+      // against Android, or the reverse.
+      const want = _STEP_MODE[step];
+      const got  = _bannerMode(c.banner);
+      if (want && got !== 'unknown' && got !== want) {
+        addLog(`Reconnected in ${_MODE_NAME[got]}, but this step needs ${_MODE_NAME[want]} `
+             + `(banner "${c.banner}").`, 'error');
+        addLog('Pulling the cable powers the Dot off, and a cold boot comes up in Android.', 'warn');
+        if (want === 'twrp') {
+          addLog('To reach TWRP: unplug, plug back in, and hold the mute button for about '
+               + '5 seconds as soon as the blue LED appears.', 'warn');
+        }
+      }
     } catch (e) {
       addLog(`Reconnect failed: ${e.message}`, 'error');
     }

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -2563,6 +2563,20 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   // this against the value it captured and drops its result on the floor
   // rather than marking a step done that nobody is waiting on any more.
   const stepEpoch = useRef(0);
+  // Set immediately before a teardown WE asked for. Four steps end by rebooting
+  // the device, which drops USB, and without this the disconnect listener races
+  // the rest of the step: observed on a real run, Connect Device succeeded, the
+  // event landed while `running` was still true, and a step that had just
+  // worked was marked failed with "the step was abandoned".
+  const expectDisconnect = useRef(false);
+
+  // Errors thrown by an in-flight transfer when the device goes away. These
+  // race the disconnect event and can arrive first, in which case the catch in
+  // runStep would report a WebUSB internal as though it were a provisioning
+  // failure and then go and probe the absent device for diagnostics.
+  const _isDisconnectError = (e) =>
+    /disconnect|transferOut|transferIn|NetworkError|device was lost/i.test(
+      e?.message || '');
 
   function addLog(msg, type = 'info') {
     // 200 lines truncated a normal successful run — the transcript above the
@@ -2587,10 +2601,13 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   // A timeout on `shell` would be the wrong instrument: waitForFramework
   // budgets ten minutes and `twrp install` takes thirty seconds or more, so
   // any timeout loose enough to be safe is too loose to be useful.
-  function abandonStep(reason) {
+  // `idx` defaults to the step on screen, which is what the disconnect listener
+  // wants. runStep passes its own index explicitly: the two are the same in
+  // practice, but the caller that knows should say so rather than rely on it.
+  function abandonStep(reason, idx = step) {
     stepEpoch.current++;
     setRunning(false);
-    markStep(step, 'error');
+    markStep(idx, 'error');
     addLog(reason, 'error');
   }
 
@@ -2602,6 +2619,12 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   useEffect(() => {
     if (!navigator.usb) return;
     const onDisconnect = (e) => {
+      if (expectDisconnect.current) {
+        // A reboot we asked for. Consumed rather than left set, so the next
+        // unexpected disconnect is still reported.
+        expectDisconnect.current = false;
+        return;
+      }
       if (!adb && !running) return;
       const theirs = adb?.serial && e.device?.serialNumber
                    && e.device.serialNumber !== adb.serial;
@@ -2772,6 +2795,11 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
         // next Transport.authenticate() races a half-torn-down session
         // and hangs at "Authenticating ADB…". Mirrors the clean-exit
         // close()/setAdb(null) a few lines below.
+        //
+        // Closing the transport can surface as a USB disconnect, and this
+        // path is about to throw a message the operator needs to read. The
+        // listener must not overwrite it with "the step was abandoned".
+        expectDisconnect.current = true;
         await c.close();
         setAdb(null);
         const err = new Error(
@@ -2785,6 +2813,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     }
 
     addLog('FireOS 5 confirmed. Rebooting to TWRP recovery…');
+    expectDisconnect.current = true;
     try { await c.shell('reboot recovery'); } catch {}
     await c.close();
     setAdb(null);
@@ -2954,6 +2983,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
 
   async function runReboot(c) {
     addLog('Sending reboot command…');
+    expectDisconnect.current = true;
     try { await c.shell('reboot'); } catch {}
     await c.close();
     setAdb(null);
@@ -3968,6 +3998,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     // the success path (not in a finally) means a failure above leaves the
     // connection alive and the Retry button usable.
     addLog('Rebooting device to finish provisioning…');
+    expectDisconnect.current = true;
     try { await c.shell('su -c reboot'); } catch {}
     await c.close();
     setAdb(null);
@@ -4021,6 +4052,17 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       // transport notices. The UI already says what happened; saying it again
       // in the language of whatever call happened to fail is noise.
       if (abandoned()) return;
+      // The in-flight transfer can also throw BEFORE the disconnect event
+      // arrives — the two race, and on a real run the throw won. That put
+      // "Failed to execute 'transferOut' on 'USBDevice'" in the transcript as
+      // though it were a provisioning failure, and then sent the diagnostics
+      // probes at a device that was no longer plugged in. Take the same exit
+      // the listener would have.
+      if (_isDisconnectError(e)) {
+        abandonStep('Device disconnected. The step was abandoned — reconnect and retry.', stepIdx);
+        setAdb(null);
+        return;
+      }
       addLog(`Error: ${e.message}`, 'error');
       markStep(stepIdx, 'error');
       if (e.matchedDeviceId) setDuplicateDeviceId(e.matchedDeviceId);

--- a/controller/tests/pm_verdict.test.mjs
+++ b/controller/tests/pm_verdict.test.mjs
@@ -154,3 +154,42 @@ for (let i = 0; i <= 12; i++) {
   check(`step ${i} has a mode`, _STEP_MODE[i] === "twrp" || _STEP_MODE[i] === "android",
         String(_STEP_MODE[i]));
 }
+
+// ─── Disconnect-shaped errors ─────────────────────────────────────────────────
+//
+// The in-flight transfer can throw BEFORE the WebUSB disconnect event lands —
+// the two race, and on a real run the throw won. That put "Failed to execute
+// 'transferOut' on 'USBDevice'" in the transcript as though it were a
+// provisioning failure, and then sent the diagnostics probes at a device that
+// was no longer plugged in.
+
+const { _isDisconnectError } = await import(
+  "data:text/javascript;base64," + Buffer.from(
+    liftArrow("_isDisconnectError") + "\nexport { _isDisconnectError };"
+  ).toString("base64"));
+
+// The real one, from the transcript that prompted this.
+check("the observed transferOut error is recognised",
+  _isDisconnectError(new Error(
+    "Failed to execute 'transferOut' on 'USBDevice': The device was disconnected.")));
+check("the transferIn direction is recognised",
+  _isDisconnectError(new Error(
+    "Failed to execute 'transferIn' on 'USBDevice': The device was disconnected.")));
+check("a NetworkError is recognised",
+  _isDisconnectError(new Error("NetworkError: A transfer error has occurred.")));
+
+// Provisioning failures must NOT be swallowed as disconnects: taking the
+// abandon path on a genuine failure hides the real message and skips the
+// diagnostics capture, which is the whole point of #87.
+for (const msg of [
+  "Hash mismatch — expected 18e46b16b25e… (Magisk-v17.3.zip)",
+  "Did not associate to the network within 20s",
+  "The package manager rejected 11 of 11 calls and disabled none.",
+  "Install verification failed: /data/local/bin/server points to \"\"",
+]) {
+  check(`a real failure is not treated as a disconnect: ${msg.slice(0, 34)}`,
+        !_isDisconnectError(new Error(msg)), msg);
+}
+
+check("a missing message does not throw", _isDisconnectError(undefined) === false);
+check("an error with no message does not throw", _isDisconnectError({}) === false);

--- a/controller/tests/pm_verdict.test.mjs
+++ b/controller/tests/pm_verdict.test.mjs
@@ -93,3 +93,64 @@ if (failures) {
   process.exit(1);
 }
 console.log("pm_verdict: all checks passed.");
+
+// ─── Step mode / banner classification ────────────────────────────────────────
+//
+// Pulling the cable powers the Dot off, and `reboot recovery` is a one-shot,
+// so a replug is a cold boot into Android whatever phase the wizard is in.
+// Reconnecting during the TWRP phase hands back an Android device that looks
+// healthy. In Android `/dev/block/other-boot` points at boot_b, which holds
+// amonet's unlock payload, so a retried Patch Boot Image there would write
+// over the unlock.
+
+function liftConstObject(name) {
+  const start = src.indexOf(`const ${name} = {`);
+  if (start < 0) throw new Error(`dashboard.jsx no longer defines ${name}`);
+  const end = src.indexOf("};", start);
+  return src.slice(start, end + 2);
+}
+
+function liftFunctionDecl(name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`dashboard.jsx no longer defines ${name}()`);
+  let depth = 0, seen = false, i = src.indexOf("{", start);
+  for (; i < src.length; i++) {
+    if (src[i] === "{") { depth++; seen = true; }
+    else if (src[i] === "}") { depth--; if (seen && depth === 0) break; }
+  }
+  return src.slice(start, i + 1);
+}
+
+const { _bannerMode, _STEP_MODE } = await import(
+  "data:text/javascript;base64," + Buffer.from(
+    liftFunctionDecl("_bannerMode") + "\n" + liftConstObject("_STEP_MODE")
+    + "\nexport { _bannerMode, _STEP_MODE };"
+  ).toString("base64"));
+
+// Real banners, from provisioning transcripts.
+check("TWRP is recognised", _bannerMode("omni_biscuit") === "twrp",
+      _bannerMode("omni_biscuit"));
+check("Android is recognised", _bannerMode("csm_biscuit") === "android",
+      _bannerMode("csm_biscuit"));
+
+// The ordering trap: "omni_biscuit" contains "biscuit", so an Android-first
+// test calls every TWRP device Android — which is the exact direction that
+// lets a TWRP step run against Android.
+check("TWRP is not mistaken for Android", _bannerMode("omni_biscuit") !== "android");
+
+check("an unknown banner is not guessed at",
+      _bannerMode("something_else") === "unknown", _bannerMode("something_else"));
+check("an empty banner is not guessed at", _bannerMode("") === "unknown");
+check("a missing banner is not guessed at", _bannerMode(undefined) === "unknown");
+
+// The boot-image step must be a TWRP step. If this ever flips, the wizard
+// would invite a write to boot_b.
+check("patch boot image is a TWRP step", _STEP_MODE[2] === "twrp", _STEP_MODE[2]);
+check("connect device is an Android step", _STEP_MODE[0] === "android");
+check("verify root is an Android step", _STEP_MODE[7] === "android");
+
+// Every step must have a mode, or the check silently does nothing for it.
+for (let i = 0; i <= 12; i++) {
+  check(`step ${i} has a mode`, _STEP_MODE[i] === "twrp" || _STEP_MODE[i] === "android",
+        String(_STEP_MODE[i]));
+}


### PR DESCRIPTION
Stacked on #101. Order: **#94 → #95 → #99 → #101 → this.**

Two rough edges in the abandon path from #99, both found in a full
provisioning run by @wilbowes rather than reasoned about.

## Our own reboots looked like failures

Four steps end by rebooting the device, which drops USB. From the transcript:

```
FireOS 5 confirmed. Rebooting to TWRP recovery…
Device is rebooting. Wait for the TWRP menu to appear, then click "Connect to TWRP".
Device disconnected. The step was abandoned — reconnect and retry.
```

Connect Device had just succeeded. The event landed while `running` was still
true and marked the step failed. It recovered, but a green step going red
after it worked is the kind of thing that makes someone start over.

Those teardowns now arm a flag the listener consumes, so an expected
disconnect is silent and the next unexpected one is still reported. The
duplicate-device path arms it too: it closes the transport and then throws a
message the operator needs to read, which "the step was abandoned" must not
overwrite.

## The throw can beat the event

```
Testing su -c id… (magiskd can take a while to attach after boot — retrying if needed)
Error: Failed to execute 'transferOut' on 'USBDevice': The device was disconnected.
Capturing device state for diagnostics…
Device disconnected. The step was abandoned — reconnect and retry.
Device state captured — "Download diagnostics" below.
```

The transfer threw before the disconnect event arrived, so a WebUSB internal
went into the transcript as though it were a provisioning failure, the probes
went at a device that was no longer plugged in, and the operator was offered a
diagnostics file describing a state that no longer existed.

A disconnect-shaped error now takes the same exit the listener would have.

**The pattern is deliberately narrow**, with tests asserting that real
provisioning failures are NOT swallowed as disconnects:

- hash mismatch
- association timeout
- pm rejection
- install verification failure

Treating one of those as a disconnect would hide the real message and skip the
diagnostics capture, which is the point of #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)