### PR TITLE
Add buttonSingleTapEvent and buttonMultiTapMs: tap as an HA event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,9 +161,15 @@ directions.
   reported on release), never by timing the down/up messages controller-side:
   RTT excursions past 1600ms have been measured on this fleet, which would
   turn a 750ms gesture into noise. Absent `heldMs` reads as a tap, so old
-  firmware keeps its existing behaviour. Only `long` is emitted — double and
-  triple were parked deliberately, because knowing a press was *single*
-  requires delaying every single press by the multi-tap window.
+  firmware keeps its existing behaviour. A hold always fires `long`; a tap
+  fires `single` only under `buttonSingleTapEvent`, which makes the tap an HA
+  event rather than a voice turn. Double and triple were parked deliberately,
+  because knowing a press was *single* requires delaying every single press by
+  the multi-tap window — a tax on the primary action, which is why they are
+  only available once a tap is no longer the start of speech.
+  **`buttonSingleTapEvent` is gated on `button_hold`** — the event entity is
+  only advertised for a hold-capable device, so on older firmware the setting
+  is refused rather than leaving the button inert.
   **Mute blocks the voice TURN, not the gesture.** A hold fires `long` while
   muted; only the tap-starts-a-turn path is refused (`em_button.decide`, with
   the mute state read off the press itself — the device sends `muted` on every
@@ -178,6 +184,8 @@ directions.
   mute, not the button filter. A controller with a stale mute view can at
   worst start a turn that captures silence and ends `no_speech` — keep that
   rejection in `cmd/server.go` where it is, it is what makes this safe.
+  A tap under `buttonSingleTapEvent` fires while muted too, for the hold's
+  reason: it is an event, not speech.
   **The evdev reader must filter to `EV_KEY`**: every press is followed by an
   `EV_SYN` whose code and value are both 0, and without the filter that SYN
   read as a release microseconds after the press. The button therefore acted
@@ -789,7 +797,7 @@ house, so rows survive with the SSID replaced and the selected network marked.
 
 `config.ConfigMessage` JSON fields (camelCase) are sent from controller to device on connect and on per-device config change. Non-zero fields are applied; zero/nil fields are ignored (partial update). Changes take effect immediately — no restart required.
 
-Configurable parameters: `vadThreshold`, `vadSpeechMs`, `vadSilenceMs`, `owwThreshold`, `owwModel`, `owwSpeexNs`, `adcDigitalGain`, `adcMicpga`, `micGainDb`, `startupVolume`, `beamAngle`, `beamformingEnabled`, `aecEnabled`, `aecDelayMs`, `aecTailMs`, `agcEnabled`, `nsAsr`, `bargeInEnabled`, `bargeInThreshold`, `bleProxyEnabled`, `eqBands`, `eqLoudness`, `ledScene`, `ledListenColor`, `ledThinkColor`, `meterAttack`, `meterDecay`, `meterFloor`, `meterGamma`, `meterRef`, `meterCurve`, `wakeArbitrationMs`, `duckDb`, `owwOnDevice` and `saveUtterances` (the last two are controller-consumed for scoping purposes, though `owwOnDevice` IS acted on by the device; `saveUtterances` and `wakeArbitrationMs` are ignored by it).
+Configurable parameters: `vadThreshold`, `vadSpeechMs`, `vadSilenceMs`, `owwThreshold`, `owwModel`, `owwSpeexNs`, `adcDigitalGain`, `adcMicpga`, `micGainDb`, `startupVolume`, `beamAngle`, `beamformingEnabled`, `aecEnabled`, `aecDelayMs`, `aecTailMs`, `agcEnabled`, `nsAsr`, `bargeInEnabled`, `bargeInThreshold`, `bleProxyEnabled`, `eqBands`, `eqLoudness`, `ledScene`, `ledListenColor`, `ledThinkColor`, `meterAttack`, `meterDecay`, `meterFloor`, `meterGamma`, `meterRef`, `meterCurve`, `wakeArbitrationMs`, `duckDb`, `buttonSingleTapEvent`, `owwOnDevice` and `saveUtterances` (the last two are controller-consumed for scoping purposes, though `owwOnDevice` IS acted on by the device; `saveUtterances`, `wakeArbitrationMs` and `buttonSingleTapEvent` are ignored by it).
 
 ### Fleet vs device scoping (schema v8)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,10 +163,10 @@ directions.
   turn a 750ms gesture into noise. Absent `heldMs` reads as a tap, so old
   firmware keeps its existing behaviour. A hold always fires `long`; a tap
   fires `single` only under `buttonSingleTapEvent`, which makes the tap an HA
-  event rather than a voice turn. Double and triple were parked deliberately,
-  because knowing a press was *single* requires delaying every single press by
-  the multi-tap window — a tax on the primary action, which is why they are
-  only available once a tap is no longer the start of speech.
+  event rather than a voice turn. `double`/`triple` need `buttonMultiTapMs`
+  as well, since knowing a press was *single* means delaying it by the
+  multi-tap window — a cost worth paying only once a tap is an event and not
+  speech.
   **`buttonSingleTapEvent` is gated on `button_hold`** — the event entity is
   only advertised for a hold-capable device, so on older firmware the setting
   is refused rather than leaving the button inert.
@@ -797,7 +797,7 @@ house, so rows survive with the SSID replaced and the selected network marked.
 
 `config.ConfigMessage` JSON fields (camelCase) are sent from controller to device on connect and on per-device config change. Non-zero fields are applied; zero/nil fields are ignored (partial update). Changes take effect immediately — no restart required.
 
-Configurable parameters: `vadThreshold`, `vadSpeechMs`, `vadSilenceMs`, `owwThreshold`, `owwModel`, `owwSpeexNs`, `adcDigitalGain`, `adcMicpga`, `micGainDb`, `startupVolume`, `beamAngle`, `beamformingEnabled`, `aecEnabled`, `aecDelayMs`, `aecTailMs`, `agcEnabled`, `nsAsr`, `bargeInEnabled`, `bargeInThreshold`, `bleProxyEnabled`, `eqBands`, `eqLoudness`, `ledScene`, `ledListenColor`, `ledThinkColor`, `meterAttack`, `meterDecay`, `meterFloor`, `meterGamma`, `meterRef`, `meterCurve`, `wakeArbitrationMs`, `duckDb`, `buttonSingleTapEvent`, `owwOnDevice` and `saveUtterances` (the last two are controller-consumed for scoping purposes, though `owwOnDevice` IS acted on by the device; `saveUtterances`, `wakeArbitrationMs` and `buttonSingleTapEvent` are ignored by it).
+Configurable parameters: `vadThreshold`, `vadSpeechMs`, `vadSilenceMs`, `owwThreshold`, `owwModel`, `owwSpeexNs`, `adcDigitalGain`, `adcMicpga`, `micGainDb`, `startupVolume`, `beamAngle`, `beamformingEnabled`, `aecEnabled`, `aecDelayMs`, `aecTailMs`, `agcEnabled`, `nsAsr`, `bargeInEnabled`, `bargeInThreshold`, `bleProxyEnabled`, `eqBands`, `eqLoudness`, `ledScene`, `ledListenColor`, `ledThinkColor`, `meterAttack`, `meterDecay`, `meterFloor`, `meterGamma`, `meterRef`, `meterCurve`, `wakeArbitrationMs`, `duckDb`, `buttonSingleTapEvent`, `buttonMultiTapMs`, `owwOnDevice` and `saveUtterances` (the last two are controller-consumed for scoping purposes, though `owwOnDevice` IS acted on by the device; `saveUtterances`, `wakeArbitrationMs` and the two `button*` keys are ignored by it).
 
 ### Fleet vs device scoping (schema v8)
 

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -65,6 +65,7 @@ COPY em_oww_assets.py  ./
 COPY em_oww_models.py .
 COPY em_arbiter.py .
 COPY em_button.py .
+COPY em_tap_burst.py .
 COPY em_player.py .
 COPY em_config_sections.py .
 COPY em_recordings.py .

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -802,6 +802,8 @@ async def _apply_live_config(device_id: str, live, effective: dict) -> None:
         live.barge_in_enabled = bool(effective["bargeInEnabled"])
     if "bargeInThreshold" in effective:
         live.barge_threshold = float(effective["bargeInThreshold"])
+    if "buttonSingleTapEvent" in effective:
+        live.button_single_tap_event = bool(effective["buttonSingleTapEvent"])
     if "wakeArbitrationMs" in effective:
         live.wake_arb_ms = int(effective["wakeArbitrationMs"])
     if "eqBands" in effective:
@@ -3905,6 +3907,8 @@ def _merge_device(row) -> dict:
         # than no toggle, because it looks like the feature is broken.
         "owwShadowCapable": getattr(live, "oww_shadow_capable", False) if live else False,
         "audioMixCapable": getattr(live, "audio_mix_capable", False) if live else False,
+        # Gates the tap-as-event toggle — see em_button.decide.
+        "buttonHoldCapable": getattr(live, "button_hold_capable", False) if live else False,
         # Whether the device found its ambient light sensor. Reported so the
         # dashboard can tell "no sensor" apart from "sensor present, no reading
         # yet" — which is the question #90 had to be answered by hand, because

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -804,6 +804,8 @@ async def _apply_live_config(device_id: str, live, effective: dict) -> None:
         live.barge_threshold = float(effective["bargeInThreshold"])
     if "buttonSingleTapEvent" in effective:
         live.button_single_tap_event = bool(effective["buttonSingleTapEvent"])
+    if "buttonMultiTapMs" in effective:
+        live.button_multi_tap_ms = int(effective["buttonMultiTapMs"])
     if "wakeArbitrationMs" in effective:
         live.wake_arb_ms = int(effective["wakeArbitrationMs"])
     if "eqBands" in effective:

--- a/controller/em_button.py
+++ b/controller/em_button.py
@@ -30,10 +30,11 @@ from __future__ import annotations
 # A hold is forwarded to HA as the `long` event. Fires while muted: it is not
 # speech, so the mute has no opinion about it.
 HOLD = "hold"
-# A tap while muted. Does nothing at all today. This is the branch that grows
-# a tap-as-HA-event outcome (PR #107) — and that outcome belongs BEFORE the
-# mute check, not after: a tap that is an event rather than a turn is in the
-# same position as a hold, and should fire while muted for the same reason.
+# A tap forwarded to HA as an event rather than starting a turn
+# (buttonSingleTapEvent). Ordered before the mute check for the same reason a
+# hold is: it is not speech, so the mute has no opinion about it.
+TAP_EVENT = "tap_event"
+# A tap while muted. Does nothing at all.
 BLOCKED = "blocked"
 # A tap during an active turn cancels it.
 CANCEL = "cancel"
@@ -47,6 +48,7 @@ def decide(
     hold_ms: int,
     muted: bool,
     turn_active: bool,
+    tap_event: bool = False,
 ) -> str:
     """
     Classify a dot-button RELEASE.
@@ -55,9 +57,16 @@ def decide(
     on firmware predating the hold feature, and on any press) reads as a tap,
     so an unknown hold time can never be promoted to a gesture the user did
     not make.
+
+    `tap_event` is buttonSingleTapEvent ANDed with `button_hold` capability
+    by the caller: the event entity is only advertised for a hold-capable
+    device, so ungated this would classify taps as events nothing receives —
+    and make TURN and CANCEL unreachable. An inert button.
     """
     if held_ms >= hold_ms:
         return HOLD
+    if tap_event:
+        return TAP_EVENT
     if muted:
         return BLOCKED
     if turn_active:

--- a/controller/em_config_sections.py
+++ b/controller/em_config_sections.py
@@ -52,7 +52,11 @@ SECTIONS: dict[str, dict] = {
     },
     "advanced": {
         "label": "Advanced",
-        "keys": ["agcEnabled", "vadThreshold", "vadSpeechMs", "vadSilenceMs"],
+        "keys": [
+            "agcEnabled", "vadThreshold", "vadSpeechMs", "vadSilenceMs",
+            # Already the button-turn section; this decides whether they happen.
+            "buttonSingleTapEvent",
+        ],
     },
     "bluetooth": {
         "label": "Bluetooth",

--- a/controller/em_config_sections.py
+++ b/controller/em_config_sections.py
@@ -54,8 +54,8 @@ SECTIONS: dict[str, dict] = {
         "label": "Advanced",
         "keys": [
             "agcEnabled", "vadThreshold", "vadSpeechMs", "vadSilenceMs",
-            # Already the button-turn section; this decides whether they happen.
-            "buttonSingleTapEvent",
+            # Already the button-turn section; these decide whether they happen.
+            "buttonSingleTapEvent", "buttonMultiTapMs",
         ],
     },
     "bluetooth": {

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -359,6 +359,9 @@ class Device:
         # turn. _barge_model is a dedicated OWW instance (the main wake
         # listener task is blocked awaiting the turn).
         self.barge_in_enabled = False
+        # False until config is pushed, so a device connecting before then
+        # keeps the historical tap-starts-a-turn behaviour.
+        self.button_single_tap_event = False
         self.barge_threshold  = 0.6
         self.barge_detected   = False
         self._barge_model     = None
@@ -556,6 +559,11 @@ class Device:
         behaviour.
         """
         return "audio_mix" in (self.capabilities or [])
+
+    @property
+    def button_hold_capable(self) -> bool:
+        """Measures hold time — and so was offered the HA event entity."""
+        return "button_hold" in (self.capabilities or [])
 
     @property
     def oww_shadow_capable(self) -> bool:
@@ -1999,6 +2007,10 @@ async def handle_button_event(device: Device, event: dict):
             hold_ms=esphome.BUTTON_HOLD_MS,
             muted=muted,
             turn_active=device.voice_lock.locked(),
+            # ANDed with the capability — see em_button.decide.
+            tap_event=(
+                device.button_single_tap_event and device.button_hold_capable
+            ),
         )
 
         if action == em_button.HOLD:
@@ -2006,9 +2018,14 @@ async def handle_button_event(device: Device, event: dict):
             esphome.send_button_event(device.device_id, "long")
             return
 
+        if action == em_button.TAP_EVENT:
+            log.info(f"[{device.device_id}] Dot button tap → HA event (single)")
+            esphome.send_button_event(device.device_id, "single")
+            return
+
         if action == em_button.BLOCKED:
-            # Only the TURN is blocked. The hold above has already been
-            # forwarded, muted or not.
+            # Only the TURN is blocked. The hold and tap-event above have
+            # already been forwarded, muted or not.
             log.info(f"[{device.device_id}] Dot button tap ignored — mic is muted")
             return
 
@@ -2241,6 +2258,9 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
         device.save_utterances = bool(config.get("saveUtterances", False))
         device.barge_in_enabled = bool(config.get("bargeInEnabled", False))
         device.barge_threshold  = float(config.get("bargeInThreshold", 0.6))
+        device.button_single_tap_event = bool(
+            config.get("buttonSingleTapEvent", False)
+        )
         device.eq_bands      = config.get("eqBands", [0.0] * 8)
         device.eq_loudness   = bool(config.get("eqLoudness", False))
         device.led_scene     = em_scenes.resolve(config)

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -74,6 +74,7 @@ import em_scenes
 import em_shadow
 import em_arbiter
 import em_button
+import em_tap_burst
 import em_esphome as esphome
 import em_ble_proxy
 import em_oww_models
@@ -362,6 +363,12 @@ class Device:
         # False until config is pushed, so a device connecting before then
         # keeps the historical tap-starts-a-turn behaviour.
         self.button_single_tap_event = False
+        self.button_multi_tap_ms = 0
+        self.tap_burst = em_tap_burst.TapCoalescer(
+            lambda name: esphome.send_button_event(self.device_id, name),
+            enabled=lambda: self.button_single_tap_event,
+            on_error=_log_task_exception,
+        )
         self.barge_threshold  = 0.6
         self.barge_detected   = False
         self._barge_model     = None
@@ -2019,8 +2026,17 @@ async def handle_button_event(device: Device, event: dict):
             return
 
         if action == em_button.TAP_EVENT:
-            log.info(f"[{device.device_id}] Dot button tap → HA event (single)")
-            esphome.send_button_event(device.device_id, "single")
+            window_ms = device.button_multi_tap_ms
+            if window_ms <= 0:
+                log.info(f"[{device.device_id}] Dot button tap → HA event (single)")
+                esphome.send_button_event(device.device_id, "single")
+                return
+
+            device.tap_burst.tap(window_ms)
+            log.info(
+                f"[{device.device_id}] Dot button tap "
+                f"{device.tap_burst.count} in burst (window {window_ms}ms)"
+            )
             return
 
         if action == em_button.BLOCKED:
@@ -2261,6 +2277,7 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
         device.button_single_tap_event = bool(
             config.get("buttonSingleTapEvent", False)
         )
+        device.button_multi_tap_ms = int(config.get("buttonMultiTapMs", 0))
         device.eq_bands      = config.get("eqBands", [0.0] * 8)
         device.eq_loudness   = bool(config.get("eqLoudness", False))
         device.led_scene     = em_scenes.resolve(config)
@@ -2696,6 +2713,10 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
 
     finally:
         if device:
+            # Above the stale check on purpose: per-connection state, and
+            # send_button_event resolves by device_id, so an orphaned timer
+            # would fire a phantom tap at the replacement connection.
+            device.tap_burst.cancel()
             if _devices.get(device.device_id) is not device:
                 # A replacement connection has already registered for this
                 # device_id — this socket is stale. Tearing down shared

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -94,6 +94,11 @@ DEFAULT_DEVICE_CONFIG = {
     # True: a tap fires "single" on the HA event entity instead of starting a
     # turn. Gives up cancel-by-tap; mute still cancels. Hold is unaffected.
     "buttonSingleTapEvent": False,
+    # Window (ms) for coalescing taps into double/triple; 0 disables. Delays
+    # every tap by this much, which is why it needs buttonSingleTapEvent — the
+    # delay is only acceptable once a tap is an event rather than speech.
+    # 300ms is a reasonable starting point.
+    "buttonMultiTapMs": 0,
     "owwThreshold":     0.3,
     # Barge-in (§3.2, controller-side): wake word spoken during TTS playback
     # cancels it and starts a fresh turn. Requires device AEC (aecEnabled)

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -91,6 +91,9 @@ DEFAULT_DEVICE_CONFIG = {
     # this closes the DB/UI mismatch. Tune up to 1200 if sentences still
     # get clipped; 600 caused the "must finish quickly" behaviour.
     "vadSilenceMs":     900,
+    # True: a tap fires "single" on the HA event entity instead of starting a
+    # turn. Gives up cancel-by-tap; mute still cancels. Hold is unaffected.
+    "buttonSingleTapEvent": False,
     "owwThreshold":     0.3,
     # Barge-in (§3.2, controller-side): wake word spoken during TTS playback
     # cancels it and starts a fresh turn. Requires device AEC (aecEnabled)

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -213,12 +213,16 @@ MEDIA_PLAYER_KEY = 1
 EVENT_KEY        = 2   # action-button hold, as an HA event entity
 AMBIENT_LUX_KEY  = 3   # TSL2540 ambient light, as an HA sensor
 
-# Press types the event entity advertises. Only "long" is emitted today:
-# double/triple were deliberately parked, because detecting them means
-# delaying the single press by the multi-tap window to know it was single —
-# a latency cost on the primary action for a feature most people will not
-# bind. Adding one later is additive; HA tolerates new event types.
-BUTTON_EVENT_TYPES = ["long"]
+# Press types the event entity advertises. double/triple remain parked,
+# because detecting them means delaying the single press by the multi-tap
+# window to know it was single — a latency cost on the primary action for a
+# feature most people will not bind. Adding one later is additive; HA
+# tolerates new event types.
+#
+# "single" is emitted only when buttonSingleTapEvent is on, but is advertised
+# unconditionally: event_types is sent once at connect, so adding it when the
+# setting flipped would not reach HA until the satellite reconnected.
+BUTTON_EVENT_TYPES = ["long", "single"]
 
 # How long the action button must be held to count as a hold rather than a
 # tap. Measured ON THE DEVICE (heldMs) rather than by timing the down/up
@@ -2151,13 +2155,19 @@ def send_button_event(device_id: str, event_type: str) -> None:
     Fire the action-button event entity in HA.
 
     Fire-and-forget: a button press whose event cannot be delivered is not
-    worth failing a turn over, and HA reconnects on its own.
+    worth failing a turn over, and HA reconnects on its own. Warned rather
+    than dropped silently — with buttonSingleTapEvent on this is the tap's
+    only effect, so a silent drop is indistinguishable from dead hardware.
     """
     server = _servers.get(device_id)
     if server is None:
+        log.warning(f"[esphome] {event_type} dropped — no server for {device_id}")
         return
     satellite = server.get_satellite()
     if satellite is None:
+        log.warning(
+            f"[esphome.{device_id[-8:]}] {event_type} dropped — HA not attached"
+        )
         return
     log.info(f"[esphome.{device_id[-8:]}] action button {event_type} → HA")
     satellite._send_one(api_pb2.EventResponse(

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -213,16 +213,16 @@ MEDIA_PLAYER_KEY = 1
 EVENT_KEY        = 2   # action-button hold, as an HA event entity
 AMBIENT_LUX_KEY  = 3   # TSL2540 ambient light, as an HA sensor
 
-# Press types the event entity advertises. double/triple remain parked,
-# because detecting them means delaying the single press by the multi-tap
-# window to know it was single — a latency cost on the primary action for a
-# feature most people will not bind. Adding one later is additive; HA
-# tolerates new event types.
+# Press types the event entity advertises. double/triple were parked because
+# detecting them means delaying the single press by the multi-tap window to
+# know it was single — a latency cost on the primary action. That cost only
+# lands while a tap starts a turn, so they are emitted under buttonMultiTapMs,
+# which requires buttonSingleTapEvent.
 #
-# "single" is emitted only when buttonSingleTapEvent is on, but is advertised
-# unconditionally: event_types is sent once at connect, so adding it when the
-# setting flipped would not reach HA until the satellite reconnected.
-BUTTON_EVENT_TYPES = ["long", "single"]
+# All are advertised unconditionally: event_types is sent once at connect, so
+# a type added when a setting flipped would not reach HA until reconnect.
+BUTTON_EVENT_TYPES = ["long", "single", "double", "triple"]
+# em_tap_burst decides which of the tap types a given burst becomes.
 
 # How long the action button must be held to count as a hold rather than a
 # tap. Measured ON THE DEVICE (heldMs) rather than by timing the down/up

--- a/controller/em_tap_burst.py
+++ b/controller/em_tap_burst.py
@@ -1,0 +1,80 @@
+"""
+em_tap_burst.py — coalesce a burst of Action-button taps into one event
+
+A tap can only be classified as "single" once no second tap follows it, so
+detecting a double means holding every tap for the length of the window.
+That cost is only acceptable because `buttonSingleTapEvent` has already
+turned a tap into an HA event rather than the start of a voice turn — see
+CLAUDE.md's Action Button section.
+
+Each tap restarts the window; when it finally expires the burst reports
+once as single/double/triple. Anything beyond three reports as triple:
+HA only knows the event types advertised at connect time, so there is no
+"quadruple" to send.
+
+Pure asyncio, no imports from the rest of the controller — unit-tested in
+tests/test_tap_burst.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+MAX_TAP_COUNT = 3
+TAP_EVENT_NAMES = {1: "single", 2: "double", 3: "triple"}
+
+
+class TapCoalescer:
+    """
+    One in-flight tap burst. Owned by a Device, and cancelled when that
+    device's connection ends.
+
+    `emit(name)` sends the finished burst; `enabled()` is re-checked when
+    the window expires, because the setting can be turned off mid-burst
+    and firing then would emit an event for a disabled feature.
+    """
+
+    def __init__(
+        self,
+        emit: Callable[[str], None],
+        enabled: Callable[[], bool] = lambda: True,
+        on_error: Callable[[asyncio.Task], None] | None = None,
+    ) -> None:
+        self._emit = emit
+        self._enabled = enabled
+        self._on_error = on_error
+        self._count = 0
+        self._timer: asyncio.Task | None = None
+
+    @property
+    def count(self) -> int:
+        """Taps recorded so far in the current burst. For tests/diagnostics."""
+        return self._count
+
+    def tap(self, window_ms: int) -> None:
+        """Record a tap and (re)start the window."""
+        self._count += 1
+        if self._timer is not None:
+            self._timer.cancel()
+        self._timer = asyncio.create_task(self._expire(window_ms))
+        if self._on_error is not None:
+            self._timer.add_done_callback(self._on_error)
+
+    def cancel(self) -> None:
+        """Drop any pending burst without emitting."""
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+        self._count = 0
+
+    async def _expire(self, window_ms: int) -> None:
+        await asyncio.sleep(window_ms / 1000)
+        n = min(self._count, MAX_TAP_COUNT)
+        # Reset before emitting: a tap landing during the send would
+        # otherwise join a burst already reported and be lost.
+        self._count = 0
+        self._timer = None
+        if not self._enabled():
+            return
+        self._emit(TAP_EVENT_NAMES[n])

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -4726,7 +4726,7 @@ const CONFIG_SECTIONS = {
   "wakeword": ["owwModel", "owwThreshold", "owwSpeexNs", "bargeInEnabled", "bargeInThreshold", "wakeArbitrationMs", "owwOnDevice"],
   "microphones": ["adcMicpga", "adcDigitalGain", "micGainDb", "beamformingEnabled", "beamAngle", "aecEnabled", "aecDelayMs", "aecTailMs", "nsAsr", "saveUtterances"],
   "ring": ["ledScene", "ledListenColor", "ledThinkColor", "meterAttack", "meterDecay", "meterFloor", "meterGamma", "meterRef", "meterCurve"],
-  "advanced": ["agcEnabled", "vadThreshold", "vadSpeechMs", "vadSilenceMs", "buttonSingleTapEvent"],
+  "advanced": ["agcEnabled", "vadThreshold", "vadSpeechMs", "vadSilenceMs", "buttonSingleTapEvent", "buttonMultiTapMs"],
   "bluetooth": ["bleProxyEnabled"]
 };
 
@@ -5249,6 +5249,7 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
               : 'needs newer firmware on this Echo — it has no action-button event for a tap to fire'}
             value={holdCapable && (config.buttonSingleTapEvent ?? false)}
             onChange={holdCapable ? (v => set('buttonSingleTapEvent', v)) : (() => {})}/>
+          <Slider label="Multi-tap window" sub="0 = off. Coalesces quick taps into double/triple, at the cost of delaying every tap by this much. Needs 'Tap sends an event'" value={config.buttonMultiTapMs ?? 0} min={0} max={600} step={50} unit="ms" disabled={!(holdCapable && (config.buttonSingleTapEvent ?? false))} onChange={v => set('buttonMultiTapMs', v)}/>
         </div>
         {subHeader('Turn processing')}
         <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 24px', ...inputStyle }}>

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1734,6 +1734,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                 sections={sections}
                 shadowCapable={!device.connected || !!device.owwShadowCapable}
                 mixCapable={!device.connected || !!device.audioMixCapable}
+                holdCapable={!device.connected || !!device.buttonHoldCapable}
                 onScopeChange={(id, local) => {
                   setSections(prev => local
                     ? [...prev, id]
@@ -4725,7 +4726,7 @@ const CONFIG_SECTIONS = {
   "wakeword": ["owwModel", "owwThreshold", "owwSpeexNs", "bargeInEnabled", "bargeInThreshold", "wakeArbitrationMs", "owwOnDevice"],
   "microphones": ["adcMicpga", "adcDigitalGain", "micGainDb", "beamformingEnabled", "beamAngle", "aecEnabled", "aecDelayMs", "aecTailMs", "nsAsr", "saveUtterances"],
   "ring": ["ledScene", "ledListenColor", "ledThinkColor", "meterAttack", "meterDecay", "meterFloor", "meterGamma", "meterRef", "meterCurve"],
-  "advanced": ["agcEnabled", "vadThreshold", "vadSpeechMs", "vadSilenceMs"],
+  "advanced": ["agcEnabled", "vadThreshold", "vadSpeechMs", "vadSilenceMs", "buttonSingleTapEvent"],
   "bluetooth": ["bleProxyEnabled"]
 };
 
@@ -4839,7 +4840,8 @@ function StageAdvanced({ open, onToggle, disabledStyle, children }) {
 }
 
 function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
-                            shadowCapable = true, mixCapable = true }) {
+                            shadowCapable = true, mixCapable = true,
+                            holdCapable = true }) {
   // shadowCapable defaults TRUE because this form is also the fleet-config
   // view, where there is no single device whose capability could gate a
   // control. Referencing a `device` here is what blank-screened the Config
@@ -5236,9 +5238,19 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
       {/* 05 ADVANCED — button-turn internals: processing + speech gate */}
       <Stage n="05" title="Advanced"
         chips={<><ScopeChip tone="device">Device</ScopeChip><ScopeChip>Button turns only</ScopeChip></>}
-        desc="Everything here affects only bounded button-press turns. Wake-word turns stream continuously — Home Assistant's VAD endpoints them, and the controller closes accidental wakes after 5s of silence relative to the room's measured noise floor — so none of these settings touch the wake path."
+        desc="Everything here affects only bounded button-press turns — except the action button setting, which decides whether a tap starts one at all. Wake-word turns stream continuously — Home Assistant's VAD endpoints them, and the controller closes accidental wakes after 5s of silence relative to the room's measured noise floor — so none of these settings touch the wake path."
         scope={scopeEl('advanced')} dim={secStyle('advanced')}>
-        {subHeader('Turn processing', true)}
+        {subHeader('Action button', true)}
+        <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 24px', ...inputStyle }}>
+          {/* Offered only when the device says it can measure a hold. */}
+          <Toggle label="Tap sends an event"
+            sub={holdCapable
+              ? "tap fires the HA action-button event instead of starting a turn — hold still fires 'long'; the button can no longer cancel a response. A tap is easy to trigger by accident and the button is unauthenticated — bind destructive automations to 'long' instead"
+              : 'needs newer firmware on this Echo — it has no action-button event for a tap to fire'}
+            value={holdCapable && (config.buttonSingleTapEvent ?? false)}
+            onChange={holdCapable ? (v => set('buttonSingleTapEvent', v)) : (() => {})}/>
+        </div>
+        {subHeader('Turn processing')}
         <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 24px', ...inputStyle }}>
           <Toggle label="Auto gain (AGC)" sub="levels button-turn speech; never the wake stream" value={config.agcEnabled ?? true} onChange={v => set('agcEnabled', v)}/>
         </div>

--- a/controller/tests/test_button.py
+++ b/controller/tests/test_button.py
@@ -17,12 +17,13 @@ import em_button
 HOLD_MS = 750
 
 
-def decide(held_ms=0, muted=False, turn_active=False):
+def decide(held_ms=0, muted=False, turn_active=False, tap_event=False):
     return em_button.decide(
         held_ms=held_ms,
         hold_ms=HOLD_MS,
         muted=muted,
         turn_active=turn_active,
+        tap_event=tap_event,
     )
 
 
@@ -79,3 +80,31 @@ def test_absent_hold_time_reads_as_a_tap():
     """
     assert decide(held_ms=0) == em_button.TURN
     assert decide(held_ms=0, muted=True) == em_button.BLOCKED
+
+
+# ── buttonSingleTapEvent ─────────────────────────────────────────────────────
+
+def test_tap_event_replaces_the_turn():
+    assert decide(held_ms=10, tap_event=True) == em_button.TAP_EVENT
+
+
+def test_tap_event_replaces_the_cancel():
+    """The trade the setting makes: the button stops cancelling responses."""
+    assert decide(held_ms=10, turn_active=True, tap_event=True) == em_button.TAP_EVENT
+
+
+def test_tap_event_fires_while_muted():
+    """Same reason a hold does — an event is not speech."""
+    assert decide(held_ms=10, muted=True, tap_event=True) == em_button.TAP_EVENT
+
+
+def test_hold_still_wins_over_tap_event():
+    assert decide(held_ms=800, tap_event=True) == em_button.HOLD
+
+
+def test_off_by_default_is_the_old_behaviour():
+    """The caller ANDs the setting with button_hold capability, so an
+    incapable device arrives here as tap_event=False and keeps its turn —
+    rather than emitting to an entity HA was never offered."""
+    assert decide(held_ms=10, tap_event=False) == em_button.TURN
+    assert decide(held_ms=10, turn_active=True, tap_event=False) == em_button.CANCEL

--- a/controller/tests/test_tap_burst.py
+++ b/controller/tests/test_tap_burst.py
@@ -1,0 +1,119 @@
+import asyncio
+
+from em_tap_burst import TapCoalescer
+
+WINDOW_MS = 60
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _collector():
+    sent: list[str] = []
+    return sent, sent.append
+
+
+def test_single_tap_emits_single():
+    sent, emit = _collector()
+
+    async def main():
+        c = TapCoalescer(emit)
+        c.tap(WINDOW_MS)
+        await asyncio.sleep(WINDOW_MS / 1000 * 2)
+
+    run(main())
+    assert sent == ["single"]
+
+
+def test_three_taps_inside_window_emit_one_triple():
+    """The point of the feature: a burst reports once, not N times."""
+    sent, emit = _collector()
+
+    async def main():
+        c = TapCoalescer(emit)
+        for _ in range(3):
+            c.tap(WINDOW_MS)
+            await asyncio.sleep(WINDOW_MS / 1000 / 3)
+        await asyncio.sleep(WINDOW_MS / 1000 * 2)
+
+    run(main())
+    assert sent == ["triple"]
+
+
+def test_fourth_tap_still_reports_triple():
+    """HA only knows the event types advertised at connect — there is no
+    "quadruple" to send, so extra taps clamp rather than drop the burst."""
+    sent, emit = _collector()
+
+    async def main():
+        c = TapCoalescer(emit)
+        for _ in range(6):
+            c.tap(WINDOW_MS)
+            await asyncio.sleep(WINDOW_MS / 1000 / 6)
+        await asyncio.sleep(WINDOW_MS / 1000 * 2)
+
+    run(main())
+    assert sent == ["triple"]
+
+
+def test_taps_outside_window_emit_separately():
+    sent, emit = _collector()
+
+    async def main():
+        c = TapCoalescer(emit)
+        c.tap(WINDOW_MS)
+        await asyncio.sleep(WINDOW_MS / 1000 * 2)
+        c.tap(WINDOW_MS)
+        await asyncio.sleep(WINDOW_MS / 1000 * 2)
+
+    run(main())
+    assert sent == ["single", "single"]
+
+
+def test_cancel_drops_the_pending_burst():
+    """The disconnect path: send_button_event resolves by device_id, so an
+    orphaned timer would fire a phantom tap at the replacement connection."""
+    sent, emit = _collector()
+
+    async def main():
+        c = TapCoalescer(emit)
+        c.tap(WINDOW_MS)
+        c.tap(WINDOW_MS)
+        c.cancel()
+        await asyncio.sleep(WINDOW_MS / 1000 * 2)
+        return c.count
+
+    assert run(main()) == 0
+    assert sent == []
+
+
+def test_disabled_mid_burst_emits_nothing():
+    sent, emit = _collector()
+    on = True
+
+    async def main():
+        nonlocal on
+        c = TapCoalescer(emit, enabled=lambda: on)
+        c.tap(WINDOW_MS)
+        on = False
+        await asyncio.sleep(WINDOW_MS / 1000 * 2)
+        return c.count
+
+    assert run(main()) == 0
+    assert sent == []
+
+
+def test_burst_state_resets_between_bursts():
+    sent, emit = _collector()
+
+    async def main():
+        c = TapCoalescer(emit)
+        c.tap(WINDOW_MS)
+        c.tap(WINDOW_MS)
+        await asyncio.sleep(WINDOW_MS / 1000 * 2)
+        c.tap(WINDOW_MS)
+        await asyncio.sleep(WINDOW_MS / 1000 * 2)
+
+    run(main())
+    assert sent == ["double", "single"]


### PR DESCRIPTION
Two opt-in settings, both off by default. With neither set, behaviour is unchanged.

**buttonSingleTapEvent** — a tap fires `single` on the HA event entity instead of
starting a voice turn. Trades cancel-by-tap for a button HA can bind to. Gated on
`button_hold`: without that capability HA was never offered the event entity, so
the setting is refused rather than leaving the button inert.

**buttonMultiTapMs** — taps inside the window coalesce and report once as
single/double/triple. Requires buttonSingleTapEvent, since it delays every tap.
0 disables. The window lives in `em_tap_burst.py` with its own tests, same split
as `em_arbiter.py`.

Also taken from review: the Advanced section copy, and a line in the toggle help
steering destructive automations to `long`.

Rebased onto current main, so the tap branch sits before #108's mute check — a tap
in event mode fires while muted, same reason a hold does. No conflict for you.

Left as follow-ups, both device-side: a ring flash on tap, and the stale volume arc.

Ran on one Dot 2 (FireOS 5.5.5.4) with a 300ms window, on the pre-review build —
the capability gate and the coalescer extraction are tested but not yet on my
hardware.
