### PR TITLE
Fire the action-button hold while muted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,20 @@ directions.
   firmware keeps its existing behaviour. Only `long` is emitted — double and
   triple were parked deliberately, because knowing a press was *single*
   requires delaying every single press by the multi-tap window.
+  **Mute blocks the voice TURN, not the gesture.** A hold fires `long` while
+  muted; only the tap-starts-a-turn path is refused (`em_button.decide`, with
+  the mute state read off the press itself — the device sends `muted` on every
+  button event). The device used to drop every dot press while muted, which
+  was right while the button meant one thing and became wrong the day a hold
+  started firing an HA event: a hold bound to something unrelated to speech
+  stopped working whenever the mic was off, with nothing on the device
+  connecting the two. It shipped that way in v2.10.0 and no test noticed,
+  which is why the decision is now a pure function with one.
+  **Moving that check controller-side does not weaken mute**: sovereignty is
+  the device rejecting every `mic_start` while muted plus the hardware ADC
+  mute, not the button filter. A controller with a stale mute view can at
+  worst start a turn that captures silence and ends `no_speech` — keep that
+  rejection in `cmd/server.go` where it is, it is what makes this safe.
   **The evdev reader must filter to `EV_KEY`**: every press is followed by an
   `EV_SYN` whose code and value are both 0, and without the filter that SYN
   read as a release microseconds after the press. The button therefore acted

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -64,6 +64,7 @@ COPY em_ble_proxy.py .
 COPY em_oww_assets.py  ./
 COPY em_oww_models.py .
 COPY em_arbiter.py .
+COPY em_button.py .
 COPY em_player.py .
 COPY em_config_sections.py .
 COPY em_recordings.py .

--- a/controller/em_button.py
+++ b/controller/em_button.py
@@ -1,0 +1,65 @@
+"""
+em_button.py — what an Action-button press means, as a pure decision
+
+Split out of `em_controller.handle_button_event` for the same reason as
+`em_linkauth`: the test suite does not import `em_controller`, so this was
+policy with no coverage — and it silently lost a gesture for the whole life
+of the hold feature (see below).
+
+The rule the device used to enforce, and no longer does:
+
+    While muted, a press must not start a VOICE TURN.
+
+Note what that does not say. It says nothing about which gestures reach Home
+Assistant. The device dropped every dot press while muted
+(`device/cmd/server.go`), which was right when the button meant exactly one
+thing — starting a turn — and became wrong the moment a hold also meant "fire
+an HA event". A hold bound to something unrelated to speech stopped working
+whenever the mic was muted, with nothing on the device to connect the two.
+
+Mute is still sovereign on the DEVICE and that is not weakened by moving this
+here. The guarantee is not the button filter, it is that the device rejects
+every `mic_start` while muted and the ADC is muted in hardware regardless. So
+even a controller with a stale idea of the mute state cannot open the mic; the
+worst it can do is start a turn that captures silence and ends `no_speech`.
+Keep that rejection where it is — it is what makes this file safe.
+"""
+
+from __future__ import annotations
+
+# A hold is forwarded to HA as the `long` event. Fires while muted: it is not
+# speech, so the mute has no opinion about it.
+HOLD = "hold"
+# A tap while muted. Does nothing at all today. This is the branch that grows
+# a tap-as-HA-event outcome (PR #107) — and that outcome belongs BEFORE the
+# mute check, not after: a tap that is an event rather than a turn is in the
+# same position as a hold, and should fire while muted for the same reason.
+BLOCKED = "blocked"
+# A tap during an active turn cancels it.
+CANCEL = "cancel"
+# A tap otherwise starts one.
+TURN = "turn"
+
+
+def decide(
+    *,
+    held_ms: int,
+    hold_ms: int,
+    muted: bool,
+    turn_active: bool,
+) -> str:
+    """
+    Classify a dot-button RELEASE.
+
+    `held_ms` is measured on the device and reported on release; 0 (its value
+    on firmware predating the hold feature, and on any press) reads as a tap,
+    so an unknown hold time can never be promoted to a gesture the user did
+    not make.
+    """
+    if held_ms >= hold_ms:
+        return HOLD
+    if muted:
+        return BLOCKED
+    if turn_active:
+        return CANCEL
+    return TURN

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -73,6 +73,7 @@ import em_eq
 import em_scenes
 import em_shadow
 import em_arbiter
+import em_button
 import em_esphome as esphome
 import em_ble_proxy
 import em_oww_models
@@ -1988,12 +1989,30 @@ async def handle_button_event(device: Device, event: dict):
         # button keeps working exactly as before on devices that have not
         # updated — degrade to old behaviour, never to a wrong answer.
         held_ms = event.get("heldMs") or 0
-        if held_ms >= esphome.BUTTON_HOLD_MS:
+        # Mute is read from the EVENT where the firmware reports it, falling
+        # back to the last mute_state message. The event is authoritative: it
+        # carries the state at the instant of the press, where device.muted is
+        # whatever the last message left behind.
+        muted = bool(event.get("muted", device.muted))
+        action = em_button.decide(
+            held_ms=held_ms,
+            hold_ms=esphome.BUTTON_HOLD_MS,
+            muted=muted,
+            turn_active=device.voice_lock.locked(),
+        )
+
+        if action == em_button.HOLD:
             log.info(f"[{device.device_id}] Dot button held {held_ms}ms → HA event")
             esphome.send_button_event(device.device_id, "long")
             return
 
-        if device.voice_lock.locked():
+        if action == em_button.BLOCKED:
+            # Only the TURN is blocked. The hold above has already been
+            # forwarded, muted or not.
+            log.info(f"[{device.device_id}] Dot button tap ignored — mic is muted")
+            return
+
+        if action == em_button.CANCEL:
             log.info(f"[{device.device_id}] Dot button — cancelling voice turn")
             device.cancel_event.set()
             esphome.cancel_voice_turn(device.device_id)

--- a/controller/tests/test_button.py
+++ b/controller/tests/test_button.py
@@ -1,0 +1,81 @@
+"""
+Action-button gesture policy.
+
+The case this file exists for is `test_hold_fires_while_muted`: a hold bound
+to an HA automation stopped working whenever the mic was muted, from the day
+holds shipped (v2.10.0) until this fix, because the device dropped every dot
+press while muted. Nothing tested it, so nothing said.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import em_button
+
+HOLD_MS = 750
+
+
+def decide(held_ms=0, muted=False, turn_active=False):
+    return em_button.decide(
+        held_ms=held_ms,
+        hold_ms=HOLD_MS,
+        muted=muted,
+        turn_active=turn_active,
+    )
+
+
+# ── The mute rule ────────────────────────────────────────────────────────────
+
+def test_hold_fires_while_muted():
+    """A hold is not speech, so the mute has no opinion about it."""
+    assert decide(held_ms=800, muted=True) == em_button.HOLD
+
+
+def test_hold_fires_while_muted_during_a_turn():
+    """Mute cancels the turn on its own; the hold is still a hold."""
+    assert decide(held_ms=800, muted=True, turn_active=True) == em_button.HOLD
+
+
+def test_tap_starts_no_turn_while_muted():
+    assert decide(held_ms=10, muted=True) == em_button.BLOCKED
+
+
+def test_muted_tap_does_not_cancel_either():
+    """Nothing about a muted press reaches the voice path."""
+    assert decide(held_ms=10, muted=True, turn_active=True) == em_button.BLOCKED
+
+
+# ── Unmuted behaviour is unchanged ───────────────────────────────────────────
+
+def test_tap_starts_a_turn():
+    assert decide(held_ms=10) == em_button.TURN
+
+
+def test_tap_during_a_turn_cancels_it():
+    assert decide(held_ms=10, turn_active=True) == em_button.CANCEL
+
+
+def test_hold_fires_long():
+    assert decide(held_ms=800) == em_button.HOLD
+
+
+# ── The hold threshold ───────────────────────────────────────────────────────
+
+def test_exactly_the_threshold_is_a_hold():
+    assert decide(held_ms=HOLD_MS) == em_button.HOLD
+
+
+def test_one_ms_under_is_a_tap():
+    assert decide(held_ms=HOLD_MS - 1) == em_button.TURN
+
+
+def test_absent_hold_time_reads_as_a_tap():
+    """
+    Firmware predating heldMs reports 0. It must degrade to the old
+    behaviour — a turn — never be promoted to a gesture the user did not
+    make.
+    """
+    assert decide(held_ms=0) == em_button.TURN
+    assert decide(held_ms=0, muted=True) == em_button.BLOCKED

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -156,10 +156,18 @@ func main() {
 	// Button events — forward to controller via control plane
 	_, err = buttonController.SubscribeToButton(func(event pkgbuttons.ButtonClickEvent) {
 		log.Printf("Button event: clickType=%d down=%v", event.ClickType, event.Down)
-		if event.ClickType == pkgbuttons.DotClick && s.IsMuted() {
-			log.Println("Dot button blocked — mic is muted")
-			return
-		}
+		// Muted presses are FORWARDED, with the mute state attached, and the
+		// controller decides what the gesture is allowed to do. Dropping them
+		// here was right while the dot button meant only "start a voice turn";
+		// it became wrong when a hold started firing an HA event, because a
+		// hold bound to something unrelated to speech then stopped working
+		// whenever the mic was muted.
+		//
+		// This does not weaken mute. The mic_start rejection above is what
+		// makes mute sovereign — the controller cannot open the mic while
+		// muted however it reads this event, and the ADC is muted in hardware
+		// regardless.
+		event.Muted = s.IsMuted()
 		// A press outranks the volume arc: adjusting volume and immediately
 		// pressing the button used to leave the arc holding the ring for the
 		// rest of its 2s window, with nothing showing that the device had

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -740,7 +740,7 @@ func capabilities() []string {
 }
 
 func (c *ControlClient) SendButton(event buttons.ButtonClickEvent) {
-	log.Printf("[control] SendButton: clickType=%d down=%v heldMs=%d", event.ClickType, event.Down, event.HeldMs)
+	log.Printf("[control] SendButton: clickType=%d down=%v heldMs=%d muted=%v", event.ClickType, event.Down, event.HeldMs, event.Muted)
 	msg := map[string]interface{}{
 		"type":      "button",
 		"clickType": int(event.ClickType),
@@ -750,6 +750,10 @@ func (c *ControlClient) SendButton(event buttons.ButtonClickEvent) {
 		// long press would silently stop the action button starting voice
 		// turns on older devices.
 		"heldMs": event.HeldMs,
+		// Always sent, never omitempty: absent must mean "this firmware does
+		// not report it" so the controller can fall back to mute_state, and
+		// omitempty would make an unmuted press indistinguishable from that.
+		"muted":  event.Muted,
 		"button": map[string]string{
 			"type": string(event.Button.Type),
 		},

--- a/device/pkg/buttons/subscription.go
+++ b/device/pkg/buttons/subscription.go
@@ -16,6 +16,11 @@ type ButtonClickEvent struct {
 	// excursions past 1600ms, which would make controller-side timing of a
 	// ~750ms gesture report noise as intent.
 	HeldMs int64 `json:"heldMs,omitempty"`
+	// Muted is the mic mute state at the instant of the press. Sent so the
+	// controller judges the gesture against the state it actually happened
+	// in, rather than against whatever the last mute_state message left
+	// behind. Set by the forwarding callback, not by the button driver.
+	Muted bool `json:"muted"`
 }
 
 type EventSubscription struct {


### PR DESCRIPTION
Fixes a hold that stopped working whenever the mic was muted.

`device/cmd/server.go` dropped every dot press while muted. That was correct
while the dot button meant exactly one thing — start a voice turn — and became
wrong in v2.10.0, when a hold also began firing an HA event. A hold bound to
something unrelated to speech (lights, a scene) silently stopped working with
the mic off, and nothing on the device connects the two.

The rule the filter was enforcing is *"while muted, do not start a voice
turn"*. That says nothing about which gestures reach Home Assistant, and only
the controller starts turns — so the policy was in the wrong place.

## What changed

The device forwards muted presses with the mute state attached; the controller
decides. `em_button.decide` refuses the turn and still emits `long`.

Mute is read off the press itself rather than the last `mute_state` message, so
the gesture is judged against the state it actually happened in.

## This does not weaken mute

Sovereignty is **not** the button filter. It is:

- `cmd/server.go` rejecting every `mic_start` while muted, whatever the
  controller believes
- the ADC muted in hardware regardless

Both untouched. A controller with a stale mute view can at worst start a turn
that captures silence and ends `no_speech`; the mic never opens. Those two
guards are now load-bearing for the button path, and the code says so.

## Why a new module for one branch

`tests/` does not import `em_controller`, so this was policy with no coverage —
it shipped broken in v2.10.0 and nothing said. Same reason `em_linkauth` was
split out. 10 tests, no new dependencies.

## Compatibility

| pairing | behaviour |
|---|---|
| old firmware + new controller | device still filters; unchanged |
| new firmware + old controller | muted tap starts an invisible turn that ends `no_speech` — mic stays shut, ring stays red |

The second is the cost of the fix needing both halves. Benign, and OTA is
served by the controller, so the pairing is uncommon.

## Verification

- controller suite: 321 passed
- `go vet` clean on both changed packages
- `./compile.sh` succeeds (`cmd/server.go` is ARM-only and excluded from a host
  build, so the cross-compile is the only thing that checks it)
- not yet exercised on hardware — wants a hold-while-muted on a real Dot before
  it goes out

## Note on #107

Touches the same region of `handle_button_event` and the same CLAUDE.md
paragraph, so expect a conflict. The ordering that matters: with
`buttonSingleTapEvent` on, a tap is an event rather than a turn, so it belongs
**before** the mute check and should fire while muted for the same reason a
hold does. There is a comment in `em_button.py` marking the spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)