### PR TITLE
Resolve button input devices by name, not event number

### DIFF
--- a/device/internal/bindings/buttons/evdev_controller.go
+++ b/device/internal/bindings/buttons/evdev_controller.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 )
 
+// Historical paths, now only the fallback when resolution by name fails.
+// See resolve.go for why the numbering cannot be trusted.
 const dotButton = "/dev/input/event1"
 const volumeButton = "/dev/input/event2"
 
@@ -49,11 +51,11 @@ func (e *EvDevController) SubscribeToButton(callback buttons.ButtonClickCallback
 
 	dotBtn := e.GetDotButton()
 	volBtn := e.GetVolumeButton()
-	dotDevice, err := evdev.Open(dotButton)
+	dotDevice, err := evdev.Open(resolveInputDevice(keypadDeviceName, dotButton))
 	if err != nil {
 		return nil, err
 	}
-	volDevice, err := evdev.Open(volumeButton)
+	volDevice, err := evdev.Open(resolveInputDevice(volumeDeviceName, volumeButton))
 	if err != nil {
 		return nil, err
 	}

--- a/device/internal/bindings/buttons/resolve.go
+++ b/device/internal/bindings/buttons/resolve.go
@@ -1,0 +1,110 @@
+package buttons
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+// Input device NAMES, which are stable, rather than event numbers, which are
+// an enumeration accident.
+//
+// On a Dot with nothing in the jack the order is ACCDET, mtk-kpd, keys, so
+// the buttons land on event1 and event2 and the old hardcoded constants were
+// right. Nothing guarantees that. The MediaTek accessory-detect driver
+// (`soc:accdet@`, which publishes ACCDET) probes ahead of both keypads, so if
+// it probes differently with a jack already inserted, everything after it
+// shifts and the reader opens the wrong device — or opens one that never
+// produces the events it is waiting for.
+//
+// That failure is SILENT, which is what makes it worth removing rather than
+// arguing about: `evdev.Open` succeeds on any of these, so a device whose
+// numbering moved has working hardware, no error anywhere, and a dead action
+// button. It matches issue #80, where booting with an aux cable in left a
+// device with no working buttons and no wake word.
+//
+// Same rule as the ambient light sensor (resolved by driver name, because
+// `0-0039` is an enumeration accident) and the thermal zones (resolved by
+// type). See docs and CLAUDE.md.
+const (
+	// mtk-kpd carries BOTH the action button and mute.
+	keypadDeviceName = "mtk-kpd"
+	// gpio-keys, carrying volume up/down.
+	volumeDeviceName = "keys"
+)
+
+const inputDevicesPath = "/proc/bus/input/devices"
+
+// parseInputDevices maps input device name to its /dev/input/eventN path.
+//
+// Pure, so it is testable on the host against real captured output — the
+// hardware this parses cannot be exercised by `go test`.
+//
+// Format is stanzas separated by blank lines:
+//
+//	N: Name="mtk-kpd"
+//	H: Handlers=gpufreq_ib event1 dynamic_boost
+//
+// Handlers carries unrelated entries (`gpufreq_ib`, `dynamic_boost`) around
+// the one that matters, so the event token is FOUND not indexed.
+func parseInputDevices(content string) map[string]string {
+	out := map[string]string{}
+	name := ""
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case line == "":
+			// Stanza boundary. Drop any name we did not pair with a handler,
+			// so a nameless stanza cannot inherit the previous one's name.
+			name = ""
+		case strings.HasPrefix(line, "N: Name="):
+			name = strings.Trim(strings.TrimPrefix(line, "N: Name="), `"`)
+		case strings.HasPrefix(line, "H: Handlers=") && name != "":
+			for _, f := range strings.Fields(strings.TrimPrefix(line, "H: Handlers=")) {
+				if strings.HasPrefix(f, "event") {
+					out[name] = "/dev/input/" + f
+					break
+				}
+			}
+		}
+	}
+	return out
+}
+
+// resolveInputDevice returns the event path for a named input device, falling
+// back to the historical hardcoded path when the name cannot be found.
+//
+// The fallback is deliberate: an unreadable procfs or a differently-named
+// keypad on some other SKU should leave the device behaving exactly as it did
+// before this existed, not stop the buttons working. Every outcome is logged
+// with what WAS present, so an absence can be diagnosed from a log line
+// instead of a round trip asking someone to run commands on a device they
+// have just flashed.
+func resolveInputDevice(name, fallback string) string {
+	b, err := os.ReadFile(inputDevicesPath)
+	if err != nil {
+		log.Printf("[buttons] %s unreadable (%v) — using %s", inputDevicesPath, err, fallback)
+		return fallback
+	}
+
+	devices := parseInputDevices(string(b))
+	if path, ok := devices[name]; ok {
+		if path != fallback {
+			// The case this whole file exists for. Worth its own line: it is
+			// the difference between a device that works and one whose
+			// buttons are silently dead.
+			log.Printf("[buttons] %q is at %s, not the expected %s — enumeration has shifted", name, path, fallback)
+		} else {
+			log.Printf("[buttons] %q resolved to %s", name, path)
+		}
+		return path
+	}
+
+	seen := make([]string, 0, len(devices))
+	for n := range devices {
+		seen = append(seen, n)
+	}
+	log.Printf("[buttons] %q not found in %s (saw %v) — using %s",
+		name, inputDevicesPath, seen, fallback)
+	return fallback
+}

--- a/device/internal/bindings/buttons/resolve_test.go
+++ b/device/internal/bindings/buttons/resolve_test.go
@@ -1,0 +1,138 @@
+package buttons
+
+import "testing"
+
+// Verbatim from Office (G090LF11803611NF, v2.10.0), nothing in the jack.
+// Kept exactly as the device prints it, trailing spaces in the Handlers
+// lines included, because that whitespace is the sort of thing a parser
+// trips on and a tidied fixture would never catch.
+const officeNoJack = `I: Bus=0019 Vendor=0000 Product=0000 Version=0000
+N: Name="ACCDET"
+P: Phys=
+S: Sysfs=/devices/virtual/input/input0
+U: Uniq=
+H: Handlers=gpufreq_ib event0 dynamic_boost
+B: PROP=0
+B: EV=3
+B: KEY=0
+
+I: Bus=0019 Vendor=2454 Product=6500 Version=0010
+N: Name="mtk-kpd"
+P: Phys=
+S: Sysfs=/devices/soc/10010000.keypad/input/input1
+U: Uniq=
+H: Handlers=gpufreq_ib event1 dynamic_boost
+B: PROP=0
+B: EV=3
+B: KEY=400 6000000000000 0
+
+I: Bus=0019 Vendor=0001 Product=0001 Version=0100
+N: Name="keys"
+P: Phys=gpio-keys/input0
+S: Sysfs=/devices/keys/input/input2
+U: Uniq=
+H: Handlers=gpufreq_ib event2 dynamic_boost
+B: PROP=0
+B: EV=100003
+B: KEY=c000000000000 0
+`
+
+// The hypothesised jack-inserted enumeration from issue #80: accdet claims a
+// second input node, so both keypads shift up by one. Not captured from
+// hardware — nobody has yet booted a device with a cable in and dumped this
+// — so it stands as the shape the parser must survive, not as evidence the
+// shift happens.
+const shiftedByAccdet = `I: Bus=0019 Vendor=0000 Product=0000 Version=0000
+N: Name="ACCDET"
+H: Handlers=event0
+
+I: Bus=0019 Vendor=0000 Product=0000 Version=0000
+N: Name="ACCDET_KEY"
+H: Handlers=event1
+
+I: Bus=0019 Vendor=2454 Product=6500 Version=0010
+N: Name="mtk-kpd"
+H: Handlers=gpufreq_ib event2 dynamic_boost
+
+I: Bus=0019 Vendor=0001 Product=0001 Version=0100
+N: Name="keys"
+H: Handlers=gpufreq_ib event3 dynamic_boost
+`
+
+func TestParsesTheRealDeviceOutput(t *testing.T) {
+	got := parseInputDevices(officeNoJack)
+
+	for name, want := range map[string]string{
+		"ACCDET":  "/dev/input/event0",
+		"mtk-kpd": "/dev/input/event1",
+		"keys":    "/dev/input/event2",
+	} {
+		if got[name] != want {
+			t.Errorf("%q = %q, want %q", name, got[name], want)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("parsed %d devices, want 3: %v", len(got), got)
+	}
+}
+
+// The point of the change: the names still resolve when the numbers move.
+func TestNamesSurviveAShiftedEnumeration(t *testing.T) {
+	got := parseInputDevices(shiftedByAccdet)
+
+	if got["mtk-kpd"] != "/dev/input/event2" {
+		t.Errorf("mtk-kpd = %q, want /dev/input/event2", got["mtk-kpd"])
+	}
+	if got["keys"] != "/dev/input/event3" {
+		t.Errorf("keys = %q, want /dev/input/event3", got["keys"])
+	}
+	// Under the old hardcoded constants this is what the reader would have
+	// opened: ACCDET as the action button, mtk-kpd as volume. Both open
+	// successfully and neither produces the expected events, which is the
+	// silent failure.
+	if got["ACCDET_KEY"] != "/dev/input/event1" {
+		t.Errorf("ACCDET_KEY = %q, want /dev/input/event1", got["ACCDET_KEY"])
+	}
+}
+
+// The event token is found, not indexed — Handlers carries unrelated entries
+// on both sides of it on this hardware.
+func TestEventTokenIsNotPositional(t *testing.T) {
+	got := parseInputDevices(`N: Name="x"
+H: Handlers=gpufreq_ib dynamic_boost event7
+`)
+	if got["x"] != "/dev/input/event7" {
+		t.Errorf("got %q, want /dev/input/event7", got["x"])
+	}
+}
+
+// A stanza with no Handlers line must not let the NEXT stanza's handler be
+// credited to it.
+func TestNameWithoutHandlersDoesNotLeak(t *testing.T) {
+	got := parseInputDevices(`N: Name="nohandler"
+
+N: Name="real"
+H: Handlers=event4
+`)
+	if _, ok := got["nohandler"]; ok {
+		t.Errorf("nohandler should be absent, got %q", got["nohandler"])
+	}
+	if got["real"] != "/dev/input/event4" {
+		t.Errorf("real = %q, want /dev/input/event4", got["real"])
+	}
+}
+
+func TestEmptyInputIsEmptyNotACrash(t *testing.T) {
+	if got := parseInputDevices(""); len(got) != 0 {
+		t.Errorf("want no devices, got %v", got)
+	}
+}
+
+// Resolution runs on the host during `go test`, where /proc/bus/input/devices
+// does not exist. That must degrade to the historical path rather than fail,
+// which is the same behaviour a device with an unreadable procfs gets.
+func TestUnresolvableFallsBackToTheOldPath(t *testing.T) {
+	if got := resolveInputDevice("nothing-has-this-name", dotButton); got != dotButton {
+		t.Errorf("got %q, want the fallback %q", got, dotButton)
+	}
+}


### PR DESCRIPTION
Item 1 of the three in #80. Independent of the routing question, and worth
doing on its own merits.

## The bug

The evdev reader hardcoded its inputs by index:

```go
const dotButton    = "/dev/input/event1"
const volumeButton = "/dev/input/event2"
```

On a Dot with nothing in the jack the enumeration is ACCDET, `mtk-kpd`,
`keys`, so those constants are correct. Nothing guarantees that order. The
MediaTek accessory-detect driver publishes ACCDET and probes ahead of both
keypads, so if it enumerates differently with a jack already inserted,
everything after it shifts by one and the reader opens the wrong device.

**The failure is silent.** `evdev.Open` succeeds on any input node, so the
outcome is working hardware, no error anywhere, and a dead action button.
That matches @nabarge's report in #80: booting with an aux cable in left a
device with no buttons and no wake word, recoverable by unplugging and
replugging.

## What this does not claim

It does not confirm the numbering shifts with a cable in. Nobody has booted a
device that way and dumped `/proc/bus/input/devices`, so that remains a
hypothesis that fits the symptom. This makes the question moot rather than
answering it.

## Behaviour

Names are stable, event numbers are an enumeration accident — the same rule
the ambient light sensor already follows (`0-0039`) and the thermal zones
(resolved by type).

Resolution **falls back to the historical paths** when the name is not found,
so an unreadable procfs or a differently-named keypad on another SKU behaves
exactly as it does today rather than losing its buttons. Every outcome is
logged with what *was* present, so an absence is diagnosable from a log line
instead of a round trip asking someone to run commands on a device they have
just flashed.

On current hardware this resolves to `event1`/`event2` — i.e. it is a no-op
until the day it isn't.

## Tests

6, all pure. The fixture is verbatim from Office including the trailing
whitespace the device actually prints, since a tidied fixture would not catch
a parser that trips on it. Covered: the real output, a shifted enumeration,
the event token being found rather than indexed (`Handlers` carries
`gpufreq_ib` and `dynamic_boost` around it), a nameless stanza not inheriting
the previous name, empty input, and the fallback.

Cross-compiles clean (`./compile.sh`). Not yet run on hardware — on a device
with no jack it should log `"mtk-kpd" resolved to /dev/input/event1` and
behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)