### PR TITLE
Report why there is no ambient light sensor (#90)

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -3552,6 +3552,14 @@ async def _get_support_bundle(request: web.Request) -> web.Response:
             # Capabilities decide which HA entities are advertised at all,
             # which is the first thing to check when one is "missing".
             "capabilities": list(getattr(live, "capabilities", []) or []) if live else [],
+            # When ambient_light is missing from the list above, this says
+            # WHY: no_chip (hardware revision without the part), no_attribute
+            # (driver has not bound), or ok. None means firmware too old to
+            # report it — not a fault. Carries the i2c device names it saw,
+            # which is what makes a no_chip answer checkable rather than
+            # merely asserted, and identifies an unfamiliar board revision
+            # the first time one turns up (#90).
+            "ambient_light_status": getattr(live, "ambient_light_status", None) if live else None,
             "muted":        getattr(live, "muted", None) if live else None,
             "rtt_ms":       getattr(live, "rtt_last_ms", None) if live else None,
             "volume":       getattr(live, "volume", None) if live else None,

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -246,6 +246,8 @@ class Device:
         self.ip           = ip
         self.capabilities = capabilities
         self.control_ws   = control_ws
+        # Set from the register message; None on firmware that predates it.
+        self.ambient_light_status: dict | None = None
 
         self.data_ws: WebSocketServerProtocol | None = None
         # Remaining reconnect grace for the speaker stream in flight. Armed by
@@ -2237,6 +2239,13 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
         )
 
         device = Device(device_id, ip, capabilities, ws)
+        # Why the device has no ambient light sensor, when it has none. The
+        # capability list says only that it is absent; without the reason,
+        # an unfitted chip and an unbound driver are indistinguishable
+        # remotely, and #90 needed a shell session on the user's own hardware
+        # to tell them apart. Absent on firmware that does not send it, which
+        # reads as "not reported" rather than as a fault.
+        device.ambient_light_status = msg.get("ambient_light_status")
         # Link-security telemetry for the dashboard: True when this control
         # connection arrived over the TLS listener.
         device.secure = secure

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -830,3 +830,37 @@ def test_push_log_event_callers_do_not_also_persist():
                 f"but is preceded by {offenders[0]!r}. That writes the log "
                 f"line twice. Drop the db.log_device call."
             )
+
+
+# ── Ambient light status reaches a support bundle (#90) ──────────────────────
+#
+# Two users reported no light sensor and the bundle could not say why: the
+# firmware knows whether the chip is absent or the driver simply has not
+# bound, but writes that only to its own log, which the bundle does not
+# collect and a reboot clears. Diagnosing it needed a shell session on their
+# hardware. These pin the three links in the chain that fixes it, because
+# each fails silently — a missing field just looks like an old device.
+
+def test_register_handler_stores_ambient_light_status():
+    """The controller must keep what the device reported at registration."""
+    root = Path(__file__).resolve().parent.parent
+    ctl = (root / "em_controller.py").read_text()
+    assert 'device.ambient_light_status = msg.get("ambient_light_status")' in ctl, (
+        "the register handler must store ambient_light_status off the register "
+        "message — without it the reason is received and dropped"
+    )
+
+
+def test_bundle_live_state_carries_ambient_light_status():
+    """And the support bundle must actually carry it.
+
+    em_support takes live_state wholesale rather than through an allowlist, so
+    the field has to be put there by em_api. A reason that never reaches a
+    bundle leaves us exactly where #90 started.
+    """
+    root = Path(__file__).resolve().parent.parent
+    api = (root / "em_api.py").read_text()
+    assert '"ambient_light_status":' in api, (
+        "em_api's live_state must include ambient_light_status so support "
+        "bundles can answer why a device reports no light sensor"
+    )

--- a/device/internal/bindings/als/als.go
+++ b/device/internal/bindings/als/als.go
@@ -39,11 +39,54 @@ const driverName = "tsl2540"
 // sensor, not about the cost of any single scan.
 const RetryInterval = 30 * time.Second
 
+// i2cGlob is where the bus is enumerated. A variable only so the tests can
+// point it at a fixture directory — nothing reassigns it at runtime.
+var i2cGlob = "/sys/bus/i2c/devices/*/name"
+
+// Status codes. Stable identifiers, because the controller and dashboard key
+// off them; the human-readable part rides in Detail.
+const (
+	// StatusOK — sensor found and readable.
+	StatusOK = "ok"
+	// StatusNoChip — no tsl2540 on the bus at all. Strongly suggests a
+	// hardware revision without the part, in which case nothing here is
+	// broken and the honest answer is to say the device has no sensor.
+	StatusNoChip = "no_chip"
+	// StatusNoAttribute — the chip is on the bus but exposes no als_lux, so
+	// the driver has not bound. Unlike no_chip this is potentially fixable.
+	StatusNoAttribute = "no_attribute"
+	// StatusUnknown — the bus could not be enumerated. Distinct from
+	// "nothing found", which is a positive result.
+	StatusUnknown = "unknown"
+)
+
+// Status is why the sensor is or is not available.
+//
+// This exists because the failure was previously only ever LOGGED, on the
+// device, to a file that a reboot clears and that support bundles do not
+// collect (issue #90). Two users with no sensor could not be told apart from
+// each other, or from a device whose driver simply had not bound, without a
+// shell session on their own hardware. The reason is a hardware fact the
+// device already knows at registration — so it should be reported, not left
+// for someone to go and look for.
+type Status struct {
+	Code string `json:"code"`
+	// Detail is a sentence for a human reading a support bundle.
+	Detail string `json:"detail,omitempty"`
+	// Seen is every i2c device name on the bus, which is what makes a
+	// no_chip answer verifiable rather than merely asserted — and what
+	// identifies an unfamiliar revision the first time one appears.
+	Seen []string `json:"seen,omitempty"`
+	// Path is where the sensor was found, when it was.
+	Path string `json:"path,omitempty"`
+}
+
 var (
 	mu       sync.Mutex
 	path     string    // absolute path to als_lux; empty when unresolved
 	lastScan time.Time // when we last looked, for the retry interval
 	reported bool      // absence logged once, not every retry
+	status   = Status{Code: StatusUnknown, Detail: "i2c bus not scanned yet"}
 )
 
 // resolve finds the sensor BY NAME, not by i2c address.
@@ -72,15 +115,24 @@ func resolve() string {
 	}
 	lastScan = time.Now()
 
-	names, err := filepath.Glob("/sys/bus/i2c/devices/*/name")
+	names, err := filepath.Glob(i2cGlob)
 	if err != nil {
+		status = Status{Code: StatusUnknown, Detail: "could not enumerate the i2c bus"}
 		return ""
 	}
 	// Record what IS on the bus, so an absence can be diagnosed remotely
 	// from a log line instead of a round trip asking someone to run i2c
 	// commands on a device they just flashed.
+	//
+	// The WHOLE bus is enumerated before matching, rather than stopping at
+	// the sensor. Returning early left `Seen` truncated at whatever happened
+	// to sort before tsl2540 — and comparing a working device's bus against
+	// a broken one's is the entire point of the field, so a partial list from
+	// the healthy side defeats it. Caught on hardware; the fixtures could not
+	// see it because none of them had devices sorting after the match.
 	seen := make([]string, 0, len(names))
 	nameMatched := false
+	found := ""
 	for _, n := range names {
 		b, err := os.ReadFile(n)
 		if err != nil {
@@ -98,9 +150,31 @@ func resolve() string {
 		if _, err := os.Stat(p); err != nil {
 			continue
 		}
-		path = p
+		if found == "" {
+			found = p
+		}
+	}
+	if found != "" {
+		path = found
+		status = Status{Code: StatusOK, Path: found, Seen: seen}
 		log.Printf("[als] ambient light sensor at %s", path)
 		return path
+	}
+	// Record the verdict on EVERY scan, not only the first. The log line
+	// below is deliberately once-only, but a status that went stale would
+	// report an old answer for a device whose bus has since changed.
+	if nameMatched {
+		status = Status{
+			Code:   StatusNoAttribute,
+			Detail: driverName + " is on the i2c bus but exposes no als_lux attribute — the driver has not bound",
+			Seen:   seen,
+		}
+	} else {
+		status = Status{
+			Code:   StatusNoChip,
+			Detail: "no " + driverName + " on the i2c bus — this hardware revision appears not to have the sensor fitted",
+			Seen:   seen,
+		}
 	}
 	if !reported {
 		reported = true
@@ -123,6 +197,19 @@ func resolve() string {
 // Used to decide whether to declare the capability at registration, so the
 // controller never advertises an HA entity that could not produce a reading.
 func Present() bool { return resolve() != "" }
+
+// Report returns why the sensor is or is not available, resolving first so the
+// answer reflects the bus as it is now rather than as it was at boot.
+//
+// Sent with the register message: a device that declares no ambient_light
+// capability should be able to say WHY, so the answer reaches a support bundle
+// instead of living in a log file on the user's device (#90).
+func Report() Status {
+	resolve()
+	mu.Lock()
+	defer mu.Unlock()
+	return status
+}
 
 // Lux returns the ambient light level, or nil when there is no sensor or the
 // read fails.

--- a/device/internal/bindings/als/als_test.go
+++ b/device/internal/bindings/als/als_test.go
@@ -1,6 +1,11 @@
 package als
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 // The threshold policy decides what reaches Home Assistant promptly and what
 // waits up to 30s for the stats tick. Too sensitive and a flickering lamp
@@ -54,5 +59,141 @@ func TestSignificant(t *testing.T) {
 func TestSignificantIsSymmetricEnough(t *testing.T) {
 	if !Significant(300, 40) || !Significant(40, 300) {
 		t.Fatal("a lamp must be reportable in both directions")
+	}
+}
+
+// ── Status reporting (issue #90) ─────────────────────────────────────────────
+//
+// Two users' Dots reported no ambient light sensor and there was no way to
+// tell whether the chip was absent or the driver had not bound, because the
+// answer was only ever written to a log file on the device. These pin the
+// three verdicts against a fake i2c bus.
+
+// fakeBus builds an i2c tree and points the package at it. Returns the root.
+// Also resets the package's cached state, which otherwise leaks between tests
+// and makes the second one assert against the first one's scan.
+func fakeBus(t *testing.T, devices map[string]bool) {
+	t.Helper()
+	root := t.TempDir()
+	for name, withAttr := range devices {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "name"), []byte(name+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if withAttr {
+			if err := os.WriteFile(filepath.Join(dir, "als_lux"), []byte("42\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	mu.Lock()
+	path, lastScan, reported = "", time.Time{}, false
+	status = Status{Code: StatusUnknown}
+	mu.Unlock()
+
+	old := i2cGlob
+	i2cGlob = filepath.Join(root, "*", "name")
+	t.Cleanup(func() {
+		i2cGlob = old
+		mu.Lock()
+		path, lastScan, reported = "", time.Time{}, false
+		status = Status{Code: StatusUnknown}
+		mu.Unlock()
+	})
+}
+
+func TestStatusOK(t *testing.T) {
+	fakeBus(t, map[string]bool{"tsl2540": true, "tsl2584tsv": false})
+	got := Report()
+	if got.Code != StatusOK {
+		t.Fatalf("code = %q, want %q (detail %q)", got.Code, StatusOK, got.Detail)
+	}
+	if got.Path == "" {
+		t.Fatal("a resolved sensor must report where it was found")
+	}
+	if !Present() {
+		t.Fatal("Present() must be true when the sensor resolves")
+	}
+}
+
+// Seen must list the WHOLE bus even when the sensor is found early.
+//
+// The first version returned as soon as it matched, so a working device
+// reported only the names sorting before tsl2540 — on real hardware that
+// dropped is31fl3236, tlv320aic32x4 and bq24297. Comparing a healthy bus
+// against a broken one is what this field is for, so a truncated list from
+// the healthy side defeats the purpose. The fixtures missed it because none
+// had a device sorting after the match; `zz_after` is here to guarantee one
+// always does.
+func TestSeenListsWholeBusWhenSensorFound(t *testing.T) {
+	fakeBus(t, map[string]bool{
+		"aa_before": false,
+		"tsl2540":   true,
+		"zz_after":  false,
+	})
+	got := Report()
+	if got.Code != StatusOK {
+		t.Fatalf("code = %q, want %q", got.Code, StatusOK)
+	}
+	if len(got.Seen) != 3 {
+		t.Fatalf("Seen = %v, want all three bus devices", got.Seen)
+	}
+	var sawAfter bool
+	for _, s := range got.Seen {
+		if s == "zz_after" {
+			sawAfter = true
+		}
+	}
+	if !sawAfter {
+		t.Fatalf("Seen = %v, missing the device that sorts after the sensor", got.Seen)
+	}
+}
+
+// The hypothesis for #90: these units carry the second ALS, which is present
+// on working devices too but has no usable driver, and not the tsl2540.
+func TestStatusNoChip(t *testing.T) {
+	fakeBus(t, map[string]bool{"tsl2584tsv": false, "tlv320aic3101": false})
+	got := Report()
+	if got.Code != StatusNoChip {
+		t.Fatalf("code = %q, want %q", got.Code, StatusNoChip)
+	}
+	// Seen is what makes the answer verifiable rather than merely asserted,
+	// and identifies an unfamiliar revision the first time one appears.
+	if len(got.Seen) != 2 {
+		t.Fatalf("Seen = %v, want both bus devices", got.Seen)
+	}
+	if Present() {
+		t.Fatal("Present() must be false with no tsl2540")
+	}
+}
+
+// Distinct from no_chip because the fixes are opposite: this one is ours.
+func TestStatusNoAttribute(t *testing.T) {
+	fakeBus(t, map[string]bool{"tsl2540": false})
+	got := Report()
+	if got.Code != StatusNoAttribute {
+		t.Fatalf("code = %q, want %q", got.Code, StatusNoAttribute)
+	}
+	if got.Detail == "" {
+		t.Fatal("a failure must carry a detail a human can read in a bundle")
+	}
+}
+
+// The absence LOG is deliberately once-only; the status must not be, or a
+// device whose bus changed would keep reporting its first answer forever.
+func TestStatusRefreshesAcrossScans(t *testing.T) {
+	fakeBus(t, map[string]bool{"tsl2584tsv": false})
+	if got := Report(); got.Code != StatusNoChip {
+		t.Fatalf("first scan: code = %q, want %q", got.Code, StatusNoChip)
+	}
+	mu.Lock()
+	lastScan = time.Time{} // allow an immediate re-scan
+	mu.Unlock()
+	if got := Report(); got.Code != StatusNoChip {
+		t.Fatalf("second scan: code = %q, want %q", got.Code, StatusNoChip)
 	}
 }

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -266,6 +266,14 @@ func (c *ControlClient) connect(ctx context.Context, server *discovery.ServerInf
 		// device shows "needs newer firmware" rather than a toggle that
 		// silently does nothing.
 		"capabilities": capabilities(),
+		// Why the ambient light sensor is or is not available. A capability
+		// list says WHAT a device has; when the answer is "nothing", nobody
+		// can tell an absent chip from an unbound driver without a shell
+		// session on the user's own hardware — which is exactly where #90
+		// got stuck, twice, because the reason is written only to a log file
+		// the support bundle does not collect. Costs one small object per
+		// registration.
+		"ambient_light_status": als.Report(),
 	}
 	// Resolved fresh per registration: a cached-at-startup value goes stale
 	// after a WiFi change, and if the process started while the network was


### PR DESCRIPTION
Towards #90. Does not fix it — makes it answerable.

## The problem this solves

Two users' Dots declare no `ambient_light` capability. The firmware already knows which of two very different things happened:

- the `tsl2540` is not on the i2c bus at all (a hardware revision without the part — nothing is broken, and the honest answer is that the device has no sensor), or
- it is on the bus and the driver has not bound (ours, and potentially fixable).

But it only ever wrote that to `/tmp/server.log`, which support bundles do not collect and a reboot clears. So telling those two cases apart needed a shell session on someone else's hardware. #90 has so far cost two support bundles, four comments and a release that fixed a genuinely different layer — HA's one-shot `ListEntities`, which cannot apply here because the controller never learns the sensor exists in the first place.

A capability list says WHAT a device has. When the answer is "not this one", nobody can act on it without the reason.

## What this adds

`als.Report()` returns a `Status`:

| field | meaning |
|---|---|
| `code` | `ok` / `no_chip` / `no_attribute` / `unknown` |
| `detail` | a sentence for whoever is reading the bundle |
| `seen` | every i2c device name on the bus |
| `path` | where the sensor was found, when it was |

`seen` is what makes a `no_chip` answer checkable rather than merely asserted, and it identifies an unfamiliar board revision the first time one turns up. That matters for #90 specifically: every failing device so far is a `G090LF096…` serial, from two unrelated owners, and **we own none of them** — so we cannot reproduce it and every conclusion has to come from user-supplied data.

Sent as `ambient_light_status` on the register message, stored on the `Device`, surfaced in the support bundle's live state. Firmware that does not send it reads as `null` — "not reported", not a fault — per the compatibility rule in CLAUDE.md.

The status refreshes on **every** scan while the log line stays once-only. A stale status would report a device's first answer for the life of the process, and `resolve()` deliberately does not cache a negative result precisely so a bus can change under it.

## Verified on hardware

Flashed to a device before committing. Real support bundle, real device:

```json
{"code": "ok",
 "seen": ["tlv320aic3101", "tlv320aic3101", "tlv320aic3101", "tlv320aic3101",
          "tsl2584tsv", "lp855x-led", "lp55231", "lp55231", "lp55231", "lp55231",
          "tsl2540", "is31fl3236", "sym827-regulator", "tlv320aic32x4",
          "bq24297", "i2c-mt65xx", "i2c-mt65xx", "i2c-mt65xx"],
 "path": "/sys/bus/i2c/devices/0-0039/als_lux"}
```

All 18 devices, matching a manual enumeration of the same bus. Devices on older firmware correctly show `null`.

## A bug the tests could not see

`seen` was **truncated on the success path**. `resolve()` returned as soon as it matched `tsl2540`, so a *working* device reported only the names sorting before it — silently dropping `is31fl3236`, `tlv320aic32x4` and `bq24297` on real hardware.

Comparing a healthy bus against a broken one is the entire point of the field, so a partial list from the healthy side would have quietly undermined the diagnosis this exists for. The bus is now enumerated fully before matching.

The fixtures could not catch it because none had a device sorting *after* the match. `TestSeenListsWholeBusWhenSensorFound` now guarantees one does. This was found by flashing the build and reading a real bundle, which is the argument for doing that before opening a PR rather than after.

## Tests

Five new pure Go tests against a fake i2c bus covering the three verdicts, the whole-bus enumeration, and that the status refreshes across scans. Two shape tests in `test_deploy.py` pin the controller wiring, because every link in that chain fails silently — a dropped field is indistinguishable from old firmware.

`go vet` + `go test ./internal/... ./pkg/...`, `gofmt`, 335 controller tests and pyflakes all pass; ARM build succeeds.

## Note for review

This does not change any behaviour a user sees, and it does not make a missing sensor appear. It makes the *reason* reportable so the next person with this problem is answerable from their first support bundle. Showing it in the dashboard is deliberately not here — that panel is already over-height and is tracked in #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
