### PR TITLE
docs: the audio jack, the ALS reason, and tap-as-event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,20 @@ directions.
   **`buttonSingleTapEvent` is gated on `button_hold`** — the event entity is
   only advertised for a hold-capable device, so on older firmware the setting
   is refused rather than leaving the button inert.
+  **Multi-tap repeats the mistake `heldMs` exists to avoid** (#115). The hold
+  is timed on the device; the multi-tap window is timed at the CONTROLLER, on
+  arrival, so the gap it measures is the real gap plus the RTT difference
+  between the two taps. Measured on Test Device: 2566 probes, **26.4% over
+  200ms**, min 1ms, max 9255ms — so a genuine 120ms double-tap routinely
+  arrives >150ms apart and reads as two singles, and a slow-then-fast pair can
+  merge taps that were never a burst. `buttonMultiTapMs: 350` is reliable
+  here for double and triple and 150 is not, but that is a value that clears
+  today's jitter, not one derived from anything. The fix is for the device to
+  report the gap since the previous tap from its own monotonic clock; the
+  expiry timer can stay controller-side, since it only answers "has the burst
+  stopped", where being late costs nothing. **Do not rewrite the coalescer** —
+  per-tap window restart, `enabled()` re-checked at expiry rather than at tap
+  time, and count reset before emit are all correct.
   **Mute blocks the voice TURN, not the gesture.** A hold fires `long` while
   muted; only the tap-starts-a-turn path is refused (`em_button.decide`, with
   the mute state read off the press itself — the device sends `muted` on every
@@ -316,7 +330,8 @@ with no way for the user to tell which they had.
 | `internal/wakeword/ort/` | The `Inferer` implementation: ONNX Runtime via cgo. The library is **dlopen'd at runtime, never linked** (only the MIT C header is vendored) so a device without it boots normally and falls back to controller-side wake word — verified by the ARM binary needing only libdl/liblog/libc with zero undefined `Ort*` symbols. `DefaultOptions` (1 thread, XNNPACK, `allow_spinning=0`) is the measured optimum: 37.7% of one core against 243% for ORT's defaults. Don't "fix" the thread count — more threads lowers latency and *raises* CPU, the wrong trade for duty-cycled work |
 | `internal/wakeword/shadow/` | On-device scoring that reports but never acts (see "On-device wake word"). `Push` must never block: inference runs on its own goroutine and drops frames when behind |
 | `internal/wakeword/fixture/` | Shared golden-fixture parser, tolerance policy and `Verify`. Used by both the host test and `tools/oww_probe`, deliberately — the probe's answer is the trusted one because it runs on hardware, so it must be exactly as strict as the test by construction. Tolerances are relative to the **tensor's** scale, not per element: per-element relative error is meaningless for tensors straddling zero |
-| `internal/bindings/als/` | Ambient light (ams **TSL2540** on i2c). Android does not expose it AT ALL — `dumpsys sensorservice` reports an empty list, nothing under `/sys/class/sensors` or `/sys/bus/iio`, no input device; it is visible only on the raw i2c bus, the same shape as the mute LED being on a different GPIO than the vendor HAL believed. Resolved **by name, not address** (`0-0039` is an enumeration accident; a second ALS, `tsl2584tsv`, is enumerated but undriven). `Lux()` returns **nil, never 0** — a covered sensor reads a genuine 0. `Watch` reports a step change immediately (25% relative, 10-lux floor, measured noise ±1.5%); the steady value rides the ~30s stats tick |
+| `internal/bindings/als/` | Ambient light (ams **TSL2540** on i2c). Android does not expose it AT ALL — `dumpsys sensorservice` reports an empty list, nothing under `/sys/class/sensors` or `/sys/bus/iio`, no input device; it is visible only on the raw i2c bus, the same shape as the mute LED being on a different GPIO than the vendor HAL believed. Resolved **by name, not address** (`0-0039` is an enumeration accident; a second ALS, `tsl2584tsv`, is enumerated but undriven). `Lux()` returns **nil, never 0** — a covered sensor reads a genuine 0. `Watch` reports a step change immediately (25% relative, 10-lux floor, measured noise ±1.5%); the steady value rides the ~30s stats tick. `Report()` says **why** there is no sensor (`ok`/`no_chip`/`no_attribute`/`unknown`, plus every i2c name it saw) and rides the register message as `ambient_light_status` — absence used to be logged only to the device's own stdout, which support bundles do not collect, so two users could not be told apart without a shell session (#90). The whole bus is enumerated **before** matching: returning at the match truncated the list on working devices, which is exactly the side you compare against |
+| `internal/bindings/jack/` | Headphone jack detect (`/sys/class/switch/h2w`, mediatek accdet). Polled, not evented — the ACCDET input node reports no keys on this hardware. Exists for ONE job: accdet mutes `Ext_Speaker_Amp_Switch` on insert (correctly) and **nothing turns it back on**, so the speaker stayed dead until the next boot (#80). Output routing itself is done by the jack's own switch contacts — a response was heard in headphones while the mixer still read `Headphone_Speaker_Mux=Speaker`, so those controls do NOT describe where audio goes and nothing should drive them |
 | `internal/wifi/` | Safe WiFi network change with auto-rollback (wifi_change/wifi_commit/wifi_scan control messages; pending-marker recovery at startup). Reload path is `svc wifi disable/enable` ONLY — see package comment for the hardware-proven constraints |
 | `pkg/led/`, `pkg/mic/`, `pkg/speaker/`, `pkg/buttons/` | Hardware abstractions (interfaces) |
 
@@ -336,6 +351,7 @@ with no way for the user to tell which they had.
 | `em_arbiter.py` | Multi-device wake arbitration — pools same-utterance detections, best SNR answers |
 | `em_player.py` | Media playback sessions — `media_player.play_media` → streaming ffmpeg decode → paced 0x02 feed; pause/resume/stop; voice preempts music (`interrupt`/`resume_interrupted`) |
 | `em_config_sections.py` | Fleet-vs-device config scoping — the six sections, `STATE_KEYS`, and the merge that resolves a device's effective config |
+| `em_tap_burst.py` | Coalesces a burst of action-button taps into one single/double/triple event. The window is restarted per tap and `enabled()` is re-checked at expiry, both correct. **The window is timed at the CONTROLLER, on arrival**, so the gap it measures is the real gap plus the RTT difference between the two taps — 26.4% of probes on this fleet exceed 200ms, which is why double/triple are unreliable below ~350ms (#115). The fix is a device-measured gap, the same reasoning as `heldMs` |
 | `em_recordings.py` | Utterance capture storage — WAVs in `recordings/` beside the DB, per-device file-count retention, ownership-checked path resolution |
 | `em_linkauth.py` | The device-link auth decision as a pure function. Split out of `em_controller._link_auth_ok` so it is testable: the suite does not import em_controller, so this was security logic with no coverage until it orphaned a device |
 | `em_ble_proxy.py` | BLE proxy ESPHome servers — a second, separate ESPHome device per Echo (own port from the shared counter, own mDNS, MAC = serial-derived with the locally-administered bit flipped). Forwards `ble_adverts` control messages from the device's passive scanner (`device/internal/bluetooth`, raw HCI over `/dev/stpbt`; enabling durably disables Android's BT stack) to HA as raw advertisements. Lifecycle = idempotent `reconcile()` driven by `bleProxyEnabled` |
@@ -453,6 +469,67 @@ enabled it and nothing happened" this removes.
 - `DEVICE_DIR`, the shared model names and the classifier stem rule are pinned
   against the firmware constants **by test**. Drift installs assets the device
   never looks for, and the only symptom is shadow mode silently never starting.
+
+## The external audio jack
+
+Three separate faults, all fixed 2026-08-09 (#80), and one non-fault worth
+knowing so nobody builds it.
+
+**Boot with a plug inserted used to strand the whole device.** Android's
+mediaserver claims the speaker PCM when a headset is present, and ALSA parks a
+blocking open behind it with no timeout:
+
+```
+/proc/<pid>/task/<tid>/wchan          -> snd_pcm_open   (parked indefinitely)
+/proc/asound/card0/pcm23p/sub0/status -> PREPARED, owner_pid: 659
+fuser /dev/snd/pcmC0D23p              -> 258 (/system/bin/mediaserver)
+```
+
+`main()` initialises the speaker **before** `SubscribeToButton`, mDNS and the
+control client, so one held device cost everything — no buttons, no wake word,
+no registration. That is the whole of the "no wake word and no working
+buttons" report. `Init()` now runs `stop media` first (the same stock-service
+takeover as `stop mixer` beside it and `stop smarthomewifid` in `main`) and
+waits on the substream status before opening. **The speaker is card 0 device
+23**; the mic is 24. Checking `pcm0p` reads `closed` and proves nothing — that
+is Android's own device, and mistaking it for ours cost a wrong conclusion.
+On timeout it opens anyway, which is the pre-existing behaviour: the wait is
+there to make the common case work and to leave a log line naming the holder.
+
+**The log looks healthy while this happens**, which is most of why it went
+undiagnosed: `[mic] clock` lines keep appearing every 60s from a goroutine
+started before the block. The tell is what is *missing* — `PcmSpeaker
+initialised` never appears.
+
+**Unplugging left the speaker silent until the next reboot.** accdet mutes
+`Ext_Speaker_Amp_Switch` on insert, which is correct — the Dot should not also
+play to the room — and nothing ever turned it back on. `Init()` was the only
+thing that set it, which is exactly why a reboot appeared to fix it.
+`internal/bindings/jack` watches `h2w` and re-enables the amp on removal.
+Insert needs nothing from us.
+
+**Routing is PHYSICAL and needs no code.** The jack's own switch contacts
+divert the signal. A voice response was heard in headphones while the mixer
+still read `Ext_Speaker_Amp_Switch=On`, `Ext_Headphone_Amp_Switch=Off` and
+`Headphone_Speaker_Mux=Speaker` — so those controls do **not** describe where
+audio goes, and driving them would be wrong. Do not build a routing layer.
+
+**Unresolved:** unplugging stalls the mic pipeline for ~35s, long enough that
+the controller drops the device on keepalive timeout. It self-recovers with
+the same pid, no restart. Presumed accdet reconfiguring the codec under the
+SPI capture; not diagnosed.
+
+**Stereo is not supported and the device end is not the blocker.** ALSA is
+already opened with two channels and `PumpPeriod` duplicates L=R; the mono
+downmix happens at the controller, in three ffmpeg calls (`-ac 1`). That was
+right when a mono internal speaker was the only output. With a jack it throws
+information away — see the stereo issue rather than reinventing the analysis.
+
+**`tinymix` IS on these devices** (`/system/bin/tinymix`), and the codec
+regmap is readable at `/sys/kernel/debug/regmap/2-0018/registers`
+(`tlv320aic32x4`). Do not drive `tinyplay` while the server is running: it
+contends for the same PCM and wedged a device hard enough to need a power
+cycle.
 
 ## CPU topology, thermals and why `cpuPct` lies
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1095,3 +1095,119 @@ are **append-only and in ascending date order** — new work goes at the end.
   The button goes completely inert. Two of the five Dots here are still on
   v2.9.11, which is the reminder that "the fleet is current" is a statement
   about the devices you happen to be looking at.
+
+- **2026-08-09 — the jack, and four theories that hardware killed.** Issue #80
+  had two reporters saying the same odd thing: boot an Echo with an aux cable
+  already in and it comes up with no wake word *and no working buttons*, and
+  unplugging never restores the speaker without a reboot. It had been open
+  since 2026-08-03 with a plausible explanation and no evidence.
+
+  The plausible explanation was mine and it was wrong. PR #109 resolved the
+  button input devices by name instead of `event1`/`event2`, arguing that
+  accdet — which probes ahead of both keypads — might enumerate differently
+  with a plug inserted and shift everything after it. It is a real failure
+  mode in general: `evdev.Open` succeeds on any input node, so a device whose
+  numbering moved has working hardware, no error anywhere, and a dead button.
+  It also matched the report exactly. The one thing nobody had done was boot a
+  device with a cable in and dump `/proc/bus/input/devices`. Doing that
+  produced `event0` ACCDET, `event1` mtk-kpd, `event2` keys — identical to a
+  device with nothing plugged in. The theory was dead, and #109 with it.
+
+  Two more died the same way. The mixer state changes on insert
+  (`Ext_Speaker_Amp_Switch` On→Off) looked like a half-completed routing
+  transition, so the next theory was that a mixer write hangs with a plug in —
+  killed by `ps` showing no `tinymix` child, and by the `tinymix` entries in
+  dmesg carrying **lower pids than the server's**, making them init's rather
+  than ours. Then the substream-busy theory pointed at `pcm0p`, which read
+  `closed`. That one was right in mechanism and wrong in target: the speaker
+  is card 0 device **23**. `pcm0p` is Android's own, and checking it proves
+  nothing.
+
+  What actually happens is visible in one file. A thread had been parked in
+  `snd_pcm_open` for eighteen minutes:
+
+  ```
+  /proc/1088/task/1094/wchan            -> snd_pcm_open
+  /proc/asound/card0/pcm23p/sub0/status -> PREPARED, owner_pid: 659
+  fuser /dev/snd/pcmC0D23p              -> 258 (/system/bin/mediaserver)
+  ```
+
+  Android's mediaserver claims the speaker when it sees a headset, and ALSA
+  parks a blocking open behind it with no timeout. `main()` initialises the
+  speaker *before* `SubscribeToButton`, mDNS and the control client, so one
+  held device costs everything. The buttons were never broken; nothing was
+  listening to them. `stop media` on the live stuck device made the parked
+  open return, thread 1094 became the substream's owner, `Init()` finished and
+  the device registered — jack still inserted, no reboot. That is also why
+  unplug/replug "fixed" it for users: Android lets go and our open completes.
+
+  **It hid for so long because the log looks healthy.** `[mic] clock` lines
+  keep arriving every 60s throughout, from a goroutine started before the
+  block. Nothing is missing except a line that never appears, `PcmSpeaker
+  initialised`, and absence is the hardest thing to notice in a log you are
+  scrolling.
+
+  The second fault was simpler and had been hiding behind the first. accdet
+  mutes the internal speaker amp on insert, which is correct — the Dot should
+  not also play to the room — and *nothing* turns it back on. `Init()` was the
+  only thing that ever set it, which is precisely why only a reboot restored
+  it. A `jack` package now watches `h2w` and re-enables the amp on removal.
+
+  The third finding was that a whole planned workstream does not exist.
+  Routing was the item this issue was supposed to be about, and it needs no
+  code: the jack's switch contacts do it in hardware. A response was heard in
+  headphones while the mixer still reported the speaker path selected, so
+  those controls do not describe where audio goes. The plan had this as "the
+  real work and genuinely unknown"; it was neither.
+
+  **I took a device down doing this.** Testing routing by running `tinyplay`
+  and two mixer writes on a live device, while the server owned the PCM,
+  wedged it hard enough to need a physical power cycle — which then wiped
+  `/tmp/server.log`, the RAM-backed file that would have explained it. The
+  correct instrument was already available and free: a real voice turn.
+
+  Wil's summary of the day was that the troubleshooting churn was fine and the
+  carelessness was not — specifically opening PRs on the wrong branch and
+  anything that could lose data. He was right: I wrote the #80 fix onto #109's
+  branch having just proved the two were unrelated, then did it again on
+  `main` for the follow-up. Being wrong about a theory costs a round trip;
+  putting work in the wrong place costs someone else's review.
+
+  **Also this day, and each one turned on a measurement rather than an
+  argument:**
+
+  *#90, the missing light sensor.* Two users, both unfixed by
+  controller-v2.16.1, which had addressed HA's one-shot entity list. Their
+  support bundles showed the capability absent from the device's own
+  registration and `ambientLux` reported as `null` rather than `0` — so the
+  controller never learned the sensor existed and the HA layer never entered
+  into it. `null` versus `0` is only distinguishable because `Lux()` returns
+  nil for "no sensor" and a covered sensor reads a genuine zero; the
+  NULL-not-zero rule paid for itself. Every failing device is a `G090LF096`
+  serial and every working one is not, across two unrelated owners and our own
+  six. **We own none of that revision**, so it cannot be reproduced here. The
+  firmware already knew which of two very different things had happened —
+  chip absent, or driver unbound — and wrote it only to its own log, which
+  support bundles do not collect and a reboot clears. It now reports the
+  reason at registration. A bundle that cannot answer the question it was
+  opened for is the failure mode to watch for; this is the second time.
+
+  That change also demonstrated why flashing before opening a PR is worth the
+  round trip. The tests passed; the field was wrong. `seen` was truncated on
+  the success path because `resolve()` returned the moment it matched, so a
+  *working* device reported only the names sorting before `tsl2540` —
+  dropping three real devices on hardware. Comparing a healthy bus against a
+  broken one is the entire point of the field. No fixture had a device
+  sorting after the match, so nothing could have caught it but a real bus.
+
+  *#115, multi-tap.* PR #107 landed tap-as-an-HA-event from an outside
+  contributor, and it works: `single` and `long` both reach HA. `double` did
+  not, reliably, and the reason is not the code. The multi-tap window is timed
+  at the controller, on arrival, so the gap it measures is the real gap plus
+  the RTT difference between the two taps — and 26.4% of control-plane probes
+  on this fleet exceed 200ms, ranging from 1ms to 9255ms. A genuine 120ms
+  double-tap routinely arrives more than 150ms apart. This is the exact trap
+  `heldMs` exists to avoid, documented for the hold and not carried across to
+  the tap, and no contributor could have known it from the code. 350ms works
+  today; the fix is a device-measured gap.
+

--- a/README.md
+++ b/README.md
@@ -34,12 +34,16 @@ hear the answer through the Dot's speaker. The hardware you already own
 - **Bluetooth proxy** — each Echo doubles as an HA Bluetooth advertisement
   proxy (great with [Bermuda](https://github.com/agittins/bermuda) for room
   presence).
-- **Sensors and buttons in HA** — the Dot has an ambient light sensor that
+- **Sensors and buttons in HA** — most Dots have an ambient light sensor that
   Amazon's software never exposed; it turns up as a lux sensor, reported
-  immediately when a light goes on rather than on a slow poll. Holding the
-  action button fires an event you can trigger automations from, while a
-  normal press still starts a voice turn. The hold keeps working with the
-  mic muted, so a Dot muted for privacy is still a button.
+  immediately when a light goes on rather than on a slow poll. Not every
+  hardware revision has it fitted, and a device without one simply doesn't
+  get the sensor. Holding the action button fires an event you can trigger
+  automations from, while a normal press still starts a voice turn — or fires
+  its own event instead, if you'd rather bind the tap. The hold keeps working
+  with the mic muted, so a Dot muted for privacy is still a button.
+- **Headphones** — plug into the 3.5mm jack and audio moves there, unplug and
+  it comes back, no reboot needed.
 - **Fleet dashboard** — provisioning wizard, per-device or global config
   pushed live (EQ, LED ring scenes, mic tuning), A/B-slot OTA updates with
   automatic fallback, root shell, logs, and per-turn activity analytics

--- a/SETUP.md
+++ b/SETUP.md
@@ -315,6 +315,8 @@ No-speech branch (device's 0x05 sentinel — see WebSocket Protocol below):
 
 A tap on the action button triggers the same pipeline directly, bypassing wake word detection. A second tap cancels at any stage. A *hold* (≥`BUTTON_HOLD_MS`) is a separate gesture that fires an HA event instead of starting a turn, and is measured on the device.
 
+Under `buttonSingleTapEvent` the tap becomes an HA event too, and the button stops starting turns entirely; `buttonMultiTapMs` groups taps into single/double/triple at the cost of delaying every tap by that window. The hold's timing is measured on the device precisely because control-plane RTT here is jittery (26.4% of probes over 200ms on one device, max 9255ms); the multi-tap window is not, which is why it needs ≥350ms to be reliable — see issue #115.
+
 ---
 
 ## On-device wake word (shadow mode)
@@ -609,6 +611,12 @@ done
 **Why device 23?** The biscuit exposes 25+ PCM devices. Device 23 is the TLV320 DAC output path. Most other devices are modem/voice paths or internal DSP routes that hang or error on open.
 
 **Why keep echoaudioservice?** The MediaTek audio DSP requires initialisation that happens inside Amazon's audio HAL (`audio.primary.mt8163.so`). Without `echoaudioservice` running, the I2S clock never starts and `tinyplay` hangs indefinitely. The service is a manifest stub — no Java code — its sole job is to trigger HAL initialisation via the Android audio framework.
+
+**`stop media`, and why the ordering matters.** Since the audio-jack fix (#80), `PcmSpeaker.Init()` also runs `stop media` before opening the PCM. It has to: with a headphone plug inserted at boot, mediaserver claims device 23 and our blocking `snd_pcm_open` waits behind it forever, taking the whole device down with it (no buttons, no wake word, no registration — everything in `main()` is initialised after the speaker).
+
+This depends on the HAL having already initialised by the time we stop it, per the note above. On measured boots it has: mediaserver brings the audio path up at ~15s (visible in dmesg as its `AudioOut_2` thread running open/hw_params/prepare on the codec) and our server starts at ~21s. So the sequence is HAL init → we stop it → we take the device, every boot, in that order. Verified on hardware with and without a plug inserted.
+
+The residual risk is a boot where that ordering reverses — `stop media` landing before the DSP is initialised would give the same symptom the note above describes, an open that hangs with no I2S clock. Nothing observed, and the 6s gap is not marginal, but if a device ever comes up with a silent speaker and a stalled open, this is the first thing to suspect. `echoaudioservice` is untouched and still required.
 
 **The mixer defaults are wrong.** Three mixer controls must be set after every boot — `start_server.sh` handles this automatically. Without them, tinyplay hangs silently on device 23.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -395,6 +395,33 @@ speech detection.
 While the mic is muted a tap does nothing, but a hold still fires its event:
 the mute silences speech, not the button.
 
+### Make the tap an event instead
+
+**Tap fires an event** (`buttonSingleTapEvent`) — turns a tap into a Home
+Assistant event rather than the start of a conversation, so you can bind it to
+anything you like. With it on, the device no longer starts a voice turn from
+the button at all; the wake word is untouched, and a hold still fires `long`.
+A tap fires while muted too, for the same reason a hold does — it's an event,
+not speech.
+
+Needs firmware v2.10.0 or newer. On older firmware the toggle is disabled and
+says so.
+
+**Bind destructive automations to the hold, not the tap.** The button has no
+authentication, and a speaker sitting on a counter is a great deal easier to
+tap by accident than to hold for three quarters of a second.
+
+**Multi-tap window** (`buttonMultiTapMs`) — set it above zero and taps are
+grouped into `single`, `double` or `triple`. The cost is that *every* tap is
+delayed by this window, because a tap can only be called single once no
+second one follows.
+
+**Use 350ms.** Below about 300ms it fights both human timing — double taps
+land roughly 150–400ms apart — and network jitter, because the gap is
+currently measured when the taps reach the controller rather than on the
+device. On a busy or distant device you may need more. Zero disables
+grouping, and a tap fires `single` immediately.
+
 ### Turn processing
 
 **Auto gain (AGC)** — automatically levels your voice volume on button


### PR DESCRIPTION
Catches the docs up with today: #80 and #107 (merged), #114 (merged), #115 (filed, not built).

## CLAUDE.md

- **New section for the external audio jack**, which had none. The mediaserver/`snd_pcm_open` boot hang, the speaker amp nobody re-enables on unplug, and — the part worth stating plainly — **routing needs no code at all**, because the jack's own switch contacts do it. That deletes a planned workstream, so it is written to stop someone building it.
- Records that the speaker is **card 0 device 23** and that checking `pcm0p` reads `closed` and proves nothing. That mistake cost a wrong conclusion during the hunt.
- New rows for `internal/bindings/jack/` and `em_tap_burst.py`; the `als` row now covers `Report()`.
- The Action Button section gains the **multi-tap caveat** with the measured RTT numbers, because "350ms works" is a fact about this link today rather than a derived value.

## SETUP.md

The `stop media` ordering, which is the one genuinely uncomfortable interaction in the jack fix. SETUP.md's own Audio Notes record that the MediaTek DSP is initialised inside Amazon's HAL via the Android audio framework, and that without it the I2S clock never starts and playback hangs. We now stop that framework.

Measured, the ordering is HAL init at ~15s then our `Init()` at ~21s, every boot, verified on hardware both with and without a plug inserted. But someone hitting a silent speaker deserves to find that written down rather than have to deduce it, so the residual risk is named.

## README.md

No longer claims "the Dot has an ambient light sensor". #90 shows some revisions do not have it fitted, and two users chasing a sensor that was never there is the cost of a confident sentence. Headphones get a line, since they now work.

## docs/configuration.md

Both new button settings documented, with **350ms** as the recommendation and the reason it should not be lower. Destructive automations are steered to the hold rather than the tap — the button carries no authentication, and a speaker on a counter is far easier to tap by accident than to hold for 750ms.

## JOURNAL.md

Entry appended in date order: the three theories hardware falsified, the device I took down by testing routing with `tinyplay` on a live server, and the distinction Wil drew between troubleshooting churn (fine) and carelessness with branches and data (not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
