### PR TITLE
docs: stop media does not stick, and that is what makes it safe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,7 +490,23 @@ control client, so one held device cost everything — no buttons, no wake word,
 no registration. That is the whole of the "no wake word and no working
 buttons" report. `Init()` now runs `stop media` first (the same stock-service
 takeover as `stop mixer` beside it and `stop smarthomewifid` in `main`) and
-waits on the substream status before opening. **The speaker is card 0 device
+waits on the substream status before opening.
+
+**`stop media` does NOT stick, and the fix does not depend on it doing so.**
+Android restarts mediaserver — measured on hardware: `init.svc.media` reads
+`running` again, with a live pid, while our server still owns `pcm23p` in
+`RUNNING` state. What makes this work is winning the race ONCE and then
+holding the device for the life of the process, and `Init()` re-runs
+`stop media` on every start, so an OTA or a supervisor restart gets the same
+treatment. Do not "improve" this into a permanent disable: mediaserver
+returning is what keeps Amazon's audio HAL — and therefore the DSP and the
+I2S clock — initialised, which SETUP.md's Audio Notes describe as load-bearing.
+
+**Android still reacts to jack events.** With mediaserver back, an insert
+makes its `AudioOut_2` thread reconfigure the amp, DAC mux and ramp
+underneath us (`EXTAMP Enable=0`, `Audio_DacMux_Set()`, `set_ignore_ramp`).
+Removal produced no such reaction — only our own `tinymix`. Worth knowing
+before blaming our code for codec state changing without us. **The speaker is card 0 device
 23**; the mic is 24. Checking `pcm0p` reads `closed` and proves nothing — that
 is Android's own device, and mistaking it for ours cost a wrong conclusion.
 On timeout it opens anyway, which is the pre-existing behaviour: the wait is

--- a/SETUP.md
+++ b/SETUP.md
@@ -616,7 +616,11 @@ done
 
 This depends on the HAL having already initialised by the time we stop it, per the note above. On measured boots it has: mediaserver brings the audio path up at ~15s (visible in dmesg as its `AudioOut_2` thread running open/hw_params/prepare on the codec) and our server starts at ~21s. So the sequence is HAL init → we stop it → we take the device, every boot, in that order. Verified on hardware with and without a plug inserted.
 
-The residual risk is a boot where that ordering reverses — `stop media` landing before the DSP is initialised would give the same symptom the note above describes, an open that hangs with no I2S clock. Nothing observed, and the 6s gap is not marginal, but if a device ever comes up with a silent speaker and a stalled open, this is the first thing to suspect. `echoaudioservice` is untouched and still required.
+**`stop media` is temporary, and that is fine — better than fine.** Android restarts mediaserver shortly afterwards: measured on hardware, `init.svc.media` reads `running` again with a live pid, while our server still owns `pcm23p` in `RUNNING` state. So `stop media` is a "get out of the way for a moment" rather than a removal, and what actually makes the fix work is winning the device once and then holding it for the life of the process. `Init()` re-runs it on every start, so an OTA or supervisor restart gets the same treatment.
+
+That also disposes of the worry above: because mediaserver comes back, the HAL, the DSP and the I2S clock stay initialised. Nothing is being permanently deprived. `echoaudioservice` is untouched and still required. **Do not turn this into a permanent disable** — that would remove the very thing the first note says the audio path depends on.
+
+One consequence worth knowing: with mediaserver alive, Android still reacts to jack events. Inserting a plug makes its `AudioOut_2` thread reconfigure the amp, DAC mux and ramp underneath us. Removal produced no such reaction in testing — only our own `tinymix`. If codec state changes with nothing in our logs to explain it, this is why.
 
 **The mixer defaults are wrong.** Three mixer controls must be set after every boot — `start_server.sh` handles this automatically. Without them, tinyplay hangs silently on device 23.
 


### PR DESCRIPTION
Correcting a claim I shipped in the previous docs commit.

`stop media` does **not** stick — Android restarts mediaserver. Measured on hardware after the release: `init.svc.media` reads `running` again with a live pid, while our server still owns `pcm23p` in `RUNNING` state.

So the jack fix does not work by removing mediaserver. It works by **winning the device once and holding it** for the life of the process, with `Init()` re-running `stop media` on every start so an OTA or supervisor restart gets the same treatment.

Both CLAUDE.md and SETUP.md read as though the service stays stopped, which would lead someone to "fix" the apparent flakiness by disabling it permanently. That would be the wrong move, and SETUP.md already says why: Amazon HAL initialises the MediaTek DSP, and without it the I2S clock never starts. mediaserver returning is what keeps that true — so the residual risk I hedged about in the previous commit is not a risk at all, and is now corrected rather than left open.

Also records that with mediaserver alive, Android still reacts to jack events: an insert has its `AudioOut_2` thread reconfigure the amp, DAC mux and ramp underneath us, while removal produced no reaction and only our own `tinymix` acted. If codec state ever changes with nothing in our logs to explain it, that is where to look — and it is the leading suspect for #117 if that ever recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)