### PR TITLE
fix: a failed OTA no longer empties the rollback slot, and says what failed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -721,6 +721,23 @@ information, and the mismatch must be caught while the device is still
 running happily on its current slot. A failed verification must never reach
 the `ln -sf`; `tests/test_deploy.py` pins that ordering.
 
+**A transfer must never delete its destination before sending.** For firmware
+the destination IS the rollback slot, so an opening `rm -f {dest}` meant every
+failed OTA left a good active slot beside an empty partner — and a later
+crash-loop then flips the symlink onto nothing. It also contradicted the
+message the user was shown, which promised the slot was left untouched. The
+`.part` discipline protects `dest` from a *corrupt* transfer; it cannot
+protect it from being removed before the transfer starts (#121).
+
+**A failed transfer names the STAGE it reached** (`TransferResult`, truthy so
+existing call sites are unchanged). One message covered five outcomes, and the
+two furthest apart — "arrived corrupt" and "no byte was ever sent" — read
+identically; #121 was the second reported in the language of the first, three
+Dots failing 15s after starting, which is far too fast to have attempted 10MB.
+Note a device shell that answers nothing must report as a **link** problem,
+never as "no base64 decoder": one is worth retrying, the other is a property
+of the device that retrying cannot change.
+
 Three things not to undo:
 - Verification rides the **same shell session** as the transfer, and the md5
   tool is detected alongside the base64 decoder in the round trip that was

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -1440,9 +1440,12 @@ async def _run_update(device_id: str, release: dict,
         # reaches the symlink flip below (#76).
         ok = await _stream_binary_to_slot(live, binary, inactive_slot)
         if not ok:
+            # Name the stage. "failed or did not verify" covered everything
+            # from a shell that never opened to a corrupt payload, and #121
+            # was the former reported in the language of the latter.
             await _update_failed(device_id,
-                                 f"Binary transfer to {inactive_slot} failed "
-                                 f"or did not verify — slot left untouched")
+                                 f"Binary transfer to {inactive_slot} failed: "
+                                 f"{ok} — {inactive_slot} left untouched")
             return
 
         # Brief pause so device can cleanly close the transfer shell before
@@ -1717,7 +1720,7 @@ async def _shell_run(live, cmd: str, timeout: float = 30.0) -> str:
         await _release_shell_ws(device_id, live)
 
 
-async def _stream_binary_to_slot(live, binary: bytes, slot: str) -> bool:
+async def _stream_binary_to_slot(live, binary: bytes, slot: str) -> "TransferResult":
     """
     Transfer a firmware binary to /data/local/bin/{slot}.
 
@@ -1731,9 +1734,61 @@ async def _stream_binary_to_slot(live, binary: bytes, slot: str) -> bool:
                                         require_verify=True)
 
 
+class TransferResult:
+    """
+    The outcome of a device file transfer, carrying the STAGE it stopped at.
+
+    Truthy on success, so every existing `if not await _stream_file_to_device(
+    ...)` call site keeps working unchanged.
+
+    The stage exists because one message covered five different outcomes, and
+    the two that matter most are at opposite ends: "the bytes arrived corrupt"
+    and "we never opened a shell, so no byte was ever sent". #121 reported the
+    second and read as the first — three Dots failing with `failed or did not
+    verify`, fifteen seconds after starting, which is far too fast to have
+    attempted a 10MB payload. Nothing short of the controller's own stdout
+    could tell them apart, and a user cannot be asked for that mid-update.
+    """
+
+    __slots__ = ("ok", "stage", "detail")
+
+    def __init__(self, ok: bool, stage: str = "ok", detail: str = ""):
+        self.ok     = ok
+        self.stage  = stage
+        self.detail = detail
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+    def __str__(self) -> str:
+        return self.detail or self.stage
+
+
+# Stage detail text. Phrased for someone reading a device log who is deciding
+# what to try next, so each one says whether any data left the controller —
+# that is the difference between "retry, the link was bad" and "the payload or
+# the device is wrong".
+_TRANSFER_STAGES = {
+    "shell":   "could not open a shell session on the device — no data was sent",
+    "decoder": "no base64 decoder found on the device — no data was sent",
+    "md5tool": "device has no md5 tool, refusing to send unverified",
+    "send":    "timed out part-way through sending",
+    "verify":  "sent, but timed out waiting for md5 verification",
+    "corrupt": "arrived corrupt — md5 did not match what was sent",
+    "error":   "transfer error",
+}
+
+
+def _transfer_failed(stage: str, extra: str = "") -> TransferResult:
+    detail = _TRANSFER_STAGES.get(stage, stage)
+    if extra:
+        detail = f"{detail} ({extra})"
+    return TransferResult(False, stage, detail)
+
+
 async def _stream_file_to_device(live, data: bytes, dest: str,
                                  mode: str = "755",
-                                 require_verify: bool = False) -> bool:
+                                 require_verify: bool = False) -> TransferResult:
     """
     Transfer a file to `dest` on the device via shell heredoc (default mode 755).
 
@@ -1761,11 +1816,23 @@ async def _stream_file_to_device(live, data: bytes, dest: str,
     DETECT_MARKER = "__DETECT_DONE__"
 
     try:
-        ws = await _get_device_shell_ws(live)
+        try:
+            ws = await _get_device_shell_ws(live)
+        except Exception as e:
+            log.error(f"[api] Could not open a shell to {device_id} for "
+                      f"{dest}: {e}")
+            return _transfer_failed("shell", str(e))
 
-        # Remove any previous attempt
-        await ws.send(f"rm -f {dest}\n")
-        await asyncio.sleep(0.2)
+        # `dest` is NOT deleted here, and must not be. This used to open with
+        # `rm -f {dest}` to clear a previous attempt, which for firmware means
+        # deleting /data/local/bin/server_<inactive> — THE ROLLBACK SLOT —
+        # before a single byte of the replacement had been sent. Every failed
+        # OTA therefore left the device with a good active slot and an empty
+        # partner, so a later crash-loop would flip the symlink onto nothing.
+        # It also contradicted the message the user was shown, which promised
+        # the slot was left untouched (#121). Nothing needs the delete: the
+        # heredoc writes with `>`, which truncates, and a verified transfer
+        # arrives by `mv` over whatever was there.
 
         # ── Detect available base64 decoder ──────────────────────────────────
         # Try busybox first (Magisk provides it), then python3/python.
@@ -1806,9 +1873,22 @@ async def _stream_file_to_device(live, data: bytes, dest: str,
                           "'import sys,base64; "
                           "sys.stdout.write(base64.b64decode(sys.stdin.read()))'")
         else:
+            # Two very different things reach here. DETECT_MARKER present means
+            # the device answered and genuinely has no decoder — a property of
+            # that device, which retrying will not change. Absent means the
+            # round trip produced nothing in 15s, i.e. the shell plane is not
+            # carrying output, which is a link problem and IS worth retrying.
+            # Reporting both as "no base64 decoder" sent #121 looking at the
+            # wrong half.
+            if DETECT_MARKER not in detect_buf:
+                log.error(f"[api] Shell produced no output in 15s while probing "
+                          f"{device_id} for a decoder — link problem, not a "
+                          f"missing tool. Output so far: {detect_buf!r}")
+                return _transfer_failed(
+                    "shell", "device shell produced no output within 15s")
             log.error(f"[api] No base64 decoder found on device. "
                       f"Detection output: {detect_buf!r}")
-            return False
+            return _transfer_failed("decoder")
 
         log.info(f"[api] Decoder: {decode_cmd.split()[0]} {decode_cmd.split()[1]}")
 
@@ -1821,7 +1901,7 @@ async def _stream_file_to_device(live, data: bytes, dest: str,
             if require_verify:
                 log.error(f"[api] No md5 tool on device — refusing to transfer "
                           f"{dest} unverified. Detection output: {detect_buf!r}")
-                return False
+                return _transfer_failed("md5tool")
             log.warning(f"[api] No md5 tool on device — {dest} will be "
                         f"transferred WITHOUT verification")
 
@@ -1870,11 +1950,11 @@ async def _stream_file_to_device(live, data: bytes, dest: str,
 
         if not transferred:
             log.error(f"[api] Transfer to {dest} timed out waiting for TRANSFER_OK")
-            return False
+            return _transfer_failed("send")
 
         if md5_cmd is None:
             log.info(f"[api] Transfer to {dest} confirmed (unverified)")
-            return True
+            return TransferResult(True, "unverified")
 
         # ── Verify, then promote ─────────────────────────────────────────────
         # Same shell session, so this is a round trip on an open socket rather
@@ -1901,23 +1981,24 @@ async def _stream_file_to_device(live, data: bytes, dest: str,
                 if "VERIFY_OK" in verify_buf:
                     log.info(f"[api] Transfer to {dest} confirmed "
                              f"({len(data):,} bytes, md5 {want})")
-                    return True
+                    return TransferResult(True)
                 if "VERIFY_BAD" in verify_buf:
                     got = verify_buf.split("VERIFY_BAD:")[-1].strip().split()
                     log.error(f"[api] Transfer to {dest} CORRUPT — md5 {want} "
                               f"expected, device reported {got[0] if got else '(none)'}. "
                               f"{dest} left untouched.")
-                    return False
+                    return _transfer_failed("corrupt",
+                                            f"device reported {got[0] if got else '(none)'}")
             except asyncio.TimeoutError:
                 continue
 
         log.error(f"[api] Transfer to {dest} timed out waiting for md5 verification "
                   f"— {dest} left untouched")
-        return False
+        return _transfer_failed("verify")
 
     except Exception as e:
         log.error(f"[api] File transfer to {dest} failed: {e}")
-        return False
+        return _transfer_failed("error", str(e))
     finally:
         await _release_shell_ws(device_id, live)
 
@@ -1954,9 +2035,10 @@ async def _sync_start_script(live, device_id: str) -> None:
     await _push_log_event(device_id, "info", "controller",
                           "start_server.sh out of date — syncing canonical version")
     tmp = path + ".new"
-    if not await _stream_file_to_device(live, script, tmp):
+    res = await _stream_file_to_device(live, script, tmp)
+    if not res:
         await _push_log_event(device_id, "warn", "controller",
-                              "start_server.sh sync failed (transfer) — continuing OTA")
+                              f"start_server.sh sync failed: {res} — continuing OTA")
         return
     await asyncio.sleep(1.0)
 
@@ -2037,7 +2119,8 @@ async def _sync_debloat(live, device_id: str) -> None:
             await _push_log_event(device_id, "info", "controller",
                                   "debloat script out of date — syncing canonical version")
             tmp = DEBLOAT_SCRIPT_PATH + ".new"
-            if await _stream_file_to_device(live, script, tmp):
+            pushed = await _stream_file_to_device(live, script, tmp)
+            if pushed:
                 await asyncio.sleep(1.0)
                 res = await _shell_run(live,
                     f'NEW=$(busybox md5sum {tmp} | busybox cut -d" " -f1); '
@@ -2053,7 +2136,7 @@ async def _sync_debloat(live, device_id: str) -> None:
                     f"debloat script sync failed ({res.strip() or 'no output'})")
             else:
                 await _push_log_event(device_id, "warn", "controller",
-                                      "debloat script sync failed (transfer)")
+                                      f"debloat script sync failed: {pushed}")
             await asyncio.sleep(1.0)
 
     # ── half 2: the pm-hide list ─────────────────────────────────────────────
@@ -2066,9 +2149,10 @@ async def _sync_debloat(live, device_id: str) -> None:
     # thirty-third package.
     listing = ("\n".join(pkgs) + "\n").encode()
     remote_list = "/data/local/tmp/em_debloat_pkgs.txt"
-    if not await _stream_file_to_device(live, listing, remote_list, mode="644"):
+    pushed = await _stream_file_to_device(live, listing, remote_list, mode="644")
+    if not pushed:
         await _push_log_event(device_id, "warn", "controller",
-                              "debloat hide-list sync failed (transfer)")
+                              f"debloat hide-list sync failed: {pushed}")
         return
     await asyncio.sleep(1.0)
 
@@ -2548,7 +2632,7 @@ async def _run_secure_link(device_id: str) -> None:
                 live, token.encode("ascii"), f"{DEVICE_TLS_DIR}/token", mode="600")
         if not ok:
             await _push_log_event(device_id, "error", "controller",
-                                  "Secure link: credential transfer failed")
+                                  f"Secure link: credential transfer failed: {ok}")
             return
 
         await _push_log_event(
@@ -3233,9 +3317,10 @@ async def _sync_oww_assets(live, device_id: str, progress=None) -> dict:
 
         dest = em_oww_assets.device_path(asset.name)
         part = f"{dest}.part"
-        if not await _stream_file_to_device(live, data, part, mode="644"):
-            await say("error", f"{asset.name} transfer failed")
-            return {"ok": False, "error": f"{asset.name}: transfer failed"}
+        pushed = await _stream_file_to_device(live, data, part, mode="644")
+        if not pushed:
+            await say("error", f"{asset.name} transfer failed: {pushed}")
+            return {"ok": False, "error": f"{asset.name}: {pushed}"}
 
         res = await _shell_run(live, (
             f'GOT=$(busybox md5sum {part} | busybox cut -d" " -f1); '

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -774,6 +774,75 @@ def test_ota_checks_free_space_before_writing_anything():
     )
 
 
+def test_a_transfer_never_deletes_the_destination_before_sending():
+    """
+    For firmware the destination IS the rollback slot, so deleting it up front
+    means a transfer that fails early leaves the device with a good active
+    slot and an empty partner — and a later crash-loop flips the symlink onto
+    nothing. Three Dots hit exactly that in #121, while being told the slot
+    had been left untouched.
+
+    The `.part` discipline only protects `dest` from a CORRUPT transfer. It
+    cannot protect it from being removed before the transfer starts.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+    fn  = _fn_body(src, "_stream_file_to_device")
+    code = "\n".join(l for l in fn.splitlines() if not l.lstrip().startswith("#"))
+
+    assert "rm -f {dest}" not in code, (
+        "deleting dest before sending destroys the rollback slot on any "
+        "transfer that fails early"
+    )
+    # The .part cleanup on a bad md5 must survive — that one is load-bearing.
+    assert "rm -f {landing}" in code or "rm -f {landing};" in code, (
+        "a failed verification must still remove the .part"
+    )
+
+
+def test_a_failed_transfer_says_which_stage_it_failed_at():
+    """
+    One message covered five outcomes, and the two furthest apart are "the
+    bytes arrived corrupt" and "no byte was ever sent". #121 was the second
+    reported in the language of the first, and only the controller's own
+    stdout could tell them apart — which is not something a user can produce
+    mid-update.
+
+    A device shell that answers nothing must NOT read as "no base64 decoder":
+    one is a link problem worth retrying, the other is a property of the
+    device that retrying cannot change.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+
+    assert "class TransferResult" in src and "__bool__" in src, (
+        "the result must stay truthy so `if not await ...` call sites keep "
+        "their meaning"
+    )
+
+    fn = _fn_body(src, "_stream_file_to_device")
+    for stage in ("shell", "decoder", "send", "verify", "corrupt"):
+        assert f'_transfer_failed("{stage}"' in fn, (
+            f"the {stage} failure must be distinguishable from the others"
+        )
+
+    assert "if DETECT_MARKER not in detect_buf" in fn, (
+        "a silent shell must report as a link problem, not a missing decoder"
+    )
+
+    # The OTA message must carry the stage through rather than re-flattening it.
+    ota = src[src.index("_stream_binary_to_slot(live, binary"):]
+    ota = ota[:ota.index("_monitor_reconnect")]
+    assert "{ok}" in ota, (
+        "the update failure message must name the stage the transfer reached"
+    )
+    # Comments stripped first, for the reason the free-space test gives: the
+    # old wording is worth naming in a comment, and a test that reads its own
+    # explanation as the bug can only be silenced by deleting the explanation.
+    ota_code = "\n".join(l for l in ota.splitlines() if not l.lstrip().startswith("#"))
+    assert "failed or did not verify" not in ota_code, (
+        "the flattened message is what made #121 unreadable"
+    )
+
+
 def test_tested_firmware_build_matches_the_docs():
     """
     The wizard warns when a device is on a FireOS build other than the one


### PR DESCRIPTION
Fixes two faults behind #121, where three of five Dots failed v2.10.0 → v2.11.0.

### 1. A failed OTA emptied the rollback slot

`_stream_file_to_device` opened with `rm -f {dest}`. For firmware `dest` is `/data/local/bin/server_<inactive>` — **the slot the device falls back to**. So every failed OTA left a good active slot beside an empty partner, and a later crash-loop would flip the symlink onto nothing.

It also contradicted the message the user was shown, which promised the slot was left untouched. The `.part` discipline from #76 protects `dest` from a *corrupt* transfer; it cannot protect it from being removed before the transfer starts.

Nothing needed the delete — the heredoc writes with `>`, which truncates, and a verified transfer arrives by `mv`.

### 2. One message covered five outcomes

`failed or did not verify` was reported for everything from a shell that never opened to a corrupt payload. In #121's log there are **15 seconds** between `Deploying to slot server_b` and the error — far too fast to have attempted a 10MB base64 heredoc, so no byte was ever sent — while reading as though bytes had arrived bad. Only the controller's own stdout could separate them, which is not something a user can produce mid-update.

`TransferResult` now carries the stage (`shell` / `decoder` / `md5tool` / `send` / `verify` / `corrupt` / `error`) and stays truthy, so all eight `if not await _stream_file_to_device(...)` call sites are unchanged. The OTA failure, both debloat syncs, the `start_server.sh` sync, secure-link credentials and oww asset pushes all name it.

One distinction is load-bearing: **a device shell that answers nothing within 15s reports as a link problem, not as "no base64 decoder"**. One is worth retrying; the other is a property of the device that retrying cannot change. They used to be the same message, which is the half of #121 that sent everyone looking at the wrong thing.

### Tests

Two new guards in `test_deploy.py`, **each verified by reintroducing its bug** — re-adding `rm -f {dest}` fails the first, restoring the flattened message fails the second. 337 pass.

### Scope

This does not make the transfer itself more robust; the shell plane is still the transport, and the same log shows the small payload syncs failing the same way. A device-side fetch over the existing TLS link is the larger change and is deliberately separate. These two are worth landing now because they are what turns the next report into a readable one.
