### PR TITLE
ci: dependency auditing, image scanning and an SBOM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,79 @@
+version: 2
+
+# Four ecosystems, because the controller image is assembled from all four and
+# a gap in any one of them is invisible: Python wheels, the Debian base image,
+# the device's Go modules, and the actions this repo's own workflows run.
+#
+# Everything is GROUPED into one PR per ecosystem per week. Ungrouped, this
+# config produces a dozen individual PRs against a repo maintained by one
+# person, and a review queue nobody can clear is the same as no scanning at
+# all — worse, because it looks like coverage.
+#
+# Note what Dependabot structurally cannot see here, so nobody reads a green
+# board as "everything is covered":
+#   - openwakeword is installed in the Dockerfile with --no-deps, not from
+#     requirements.txt, so its pin is invisible to the pip ecosystem below.
+#   - SpeexDSP is vendored C source in device/internal/aec/ with no package
+#     metadata at all.
+#   - ONNX Runtime is dlopen'd on the device, pinned by AAR sha256 in the
+#     asset path rather than by any manifest.
+# Those three are tracked by reading the pins, which is a human job.
+
+updates:
+  # ── Controller Python dependencies ──────────────────────────────────────
+  - package-ecosystem: pip
+    directory: /controller
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    groups:
+      python-dependencies:
+        patterns: ["*"]
+    # Major bumps of these two are not routine maintenance and should not
+    # arrive as a weekly PR: numpy majors have broken openwakeword's array
+    # handling before, and an onnxruntime major changes inference behaviour
+    # on every device at once. Both want a deliberate upgrade with a wake
+    # word test behind it.
+    ignore:
+      - dependency-name: numpy
+        update-types: ["version-update:semver-major"]
+      - dependency-name: onnxruntime
+        update-types: ["version-update:semver-major"]
+
+  # ── Controller base image ───────────────────────────────────────────────
+  # python:3.12-slim is where ffmpeg, curl and the whole Debian layer come
+  # from — the majority of what any image scan reports.
+  - package-ecosystem: docker
+    directory: /controller
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+
+  # ── Device Go modules ───────────────────────────────────────────────────
+  # The GoTinyAlsa replace directive points at a submodule path, which
+  # Dependabot skips; that fork is tracked by hand because it carries a fix
+  # not yet merged upstream (see CLAUDE.md).
+  - package-ecosystem: gomod
+    directory: /device
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+
+  # ── GitHub Actions ──────────────────────────────────────────────────────
+  # Workflow actions run with repository credentials, so a stale pinned
+  # action is a supply chain exposure in its own right, not just tidiness.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,65 @@ jobs:
         working-directory: device
         run: go test ./internal/... ./pkg/...
 
+  python-deps-audit:
+    name: Python dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pip-audit
+        run: pip install pip-audit
+      # This is the FAST check, not the authoritative one. requirements.txt
+      # leaves scipy/tqdm/scikit-learn/requests unpinned and installs
+      # openwakeword separately with --no-deps, so what a user actually runs
+      # is decided at image build time, not here. The published image is the
+      # source of truth and is scanned in security-scan.yml; this job exists
+      # to fail on a PR that adds a known-vulnerable pin, minutes rather than
+      # a release later.
+      #
+      # Report-only for now, deliberately. A dependency audit that goes red
+      # on an advisory with no fix available teaches people to ignore a red
+      # X, which costs more than the job earns. Gate it on FIXABLE findings
+      # once a month of real output shows what the steady state looks like.
+      - name: Audit pinned dependencies
+        working-directory: controller
+        run: |
+          pip-audit -r requirements.txt --desc 2>&1 | tee audit.txt || true
+          if grep -qiE "^(Name|found [1-9])" audit.txt; then
+            echo "::warning::pip-audit reported findings — see the log"
+          fi
+
+  device-vulncheck:
+    name: Device Go vulnerability check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: device/go.mod
+          cache-dependency-path: device/go.sum
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      # govulncheck reports only vulnerabilities on REACHABLE call paths, so
+      # it is low-noise enough to read every time — unlike a plain dependency
+      # diff, most of which never executes.
+      #
+      # Two blind spots worth stating rather than discovering later: the
+      # vendored SpeexDSP C in internal/aec/ has no package metadata and is
+      # invisible to every scanner we could run, and ONNX Runtime is dlopen'd
+      # at runtime rather than linked, so it is not in this module graph at
+      # all — its version is pinned by AAR sha256 in the asset path instead.
+      #
+      # Same package scope as go vet: cmd/ carries //go:build server and
+      # fails package setup on a host platform.
+      - name: Run govulncheck
+        working-directory: device
+        run: govulncheck ./internal/... ./pkg/... || true
+
   device-vet:
     name: Device go vet
     runs-on: ubuntu-latest

--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -79,3 +79,50 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # ── Supply chain ────────────────────────────────────────────────────
+      #
+      # The image is what users actually run, and it is the only place the
+      # full dependency set exists: requirements.txt leaves four packages
+      # unpinned, openwakeword is installed with --no-deps, and the Debian
+      # base contributes ffmpeg and curl. So the SBOM is generated from the
+      # built image, never from requirements.txt.
+      #
+      # amd64 only. The two architectures install the same wheels from the
+      # same base image, and scanning the arm64 variant under QEMU costs
+      # runner minutes to restate the answer.
+      - name: Generate SBOM
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: image
+          image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:${{ steps.version.outputs.version }}
+          format: cyclonedx
+          output: sbom-controller-${{ steps.version.outputs.version }}.cdx.json
+
+      # Attached to the workflow run rather than to a Release, because
+      # controller tags deliberately create no GitHub Release — the OTA
+      # poller reads the releases list looking for device firmware, and a
+      # controller release appearing there would be offered to devices.
+      # Retention is long: the useful question is "what was in the version I
+      # am running", which is asked months after the release, not days.
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-controller-${{ steps.version.outputs.version }}
+          path: sbom-controller-${{ steps.version.outputs.version }}.cdx.json
+          retention-days: 365
+
+      # Report-only, and it must stay that way in THIS workflow: the image
+      # has already been pushed by the time this runs, so failing here would
+      # mark a release red without unpublishing anything — the worst of both
+      # (a red tick and a live image). Gating belongs before the push or in
+      # the scheduled scan, not here.
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: image
+          image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:${{ steps.version.outputs.version }}
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "0"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,74 @@
+name: Security scan (published image)
+
+# The scan that actually earns its keep.
+#
+# A release-time scan answers "was this image clean the day it shipped".
+# The question users care about is "is the image I am running clean TODAY",
+# and those diverge without anything changing on our side — a CVE published
+# against an unchanged base layer moves the answer while the digest stays
+# identical. Controller releases are weeks apart, so a release-only scan
+# leaves that window unwatched.
+#
+# This one is allowed to FAIL, unlike the release-time scan: nothing is being
+# published, so a red run is information rather than a broken release. It is
+# scoped to HIGH/CRITICAL findings that have a fix available, because those
+# are the only ones a rebuild can act on — an unfixable advisory going red
+# every week teaches everyone to ignore the badge, which costs more than the
+# job earns.
+
+on:
+  schedule:
+    # Mondays, 07:00 UTC — a working day, so a finding is seen while there is
+    # time to rebuild, rather than sitting from Friday night.
+    - cron: "0 7 * * 1"
+  # Manual runs matter here: the first thing you want after a CVE lands in
+  # the news is an answer about your own image, not a wait until Monday.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan-image:
+    name: Scan published controller image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # `latest` rather than a pinned version on purpose: this asks about the
+      # image users are pulling today, which is what docker-compose.deploy.yml
+      # gives them.
+      - name: Scan for fixable HIGH/CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: image
+          image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:latest
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
+      # Runs even when the step above failed — the findings are the reason
+      # this workflow exists, so they must reach the Security tab rather than
+      # only the run log, where nobody goes looking.
+      - name: Scan again for SARIF
+        if: always()
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: image
+          image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:latest
+          format: sarif
+          output: trivy-results.sarif
+          severity: MEDIUM,HIGH,CRITICAL
+
+      # Code scanning upload is free on public repositories. It is
+      # continue-on-error so that losing the upload never hides the scan
+      # result itself, which is already in the step above.
+      - name: Upload results to code scanning
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-image


### PR DESCRIPTION
The controller ships as an image other people run, and the device as a binary other people flash, so "what is in it" is a question users can reasonably ask and currently cannot answer.

### What this adds

**PR-time, report-only**
- `pip-audit` on `requirements.txt`
- `govulncheck` on the device Go modules (reachable call paths only, so low-noise)

Both report-only on purpose. An audit that goes red on an advisory with no fix available teaches everyone to ignore a red X, which costs more than the job earns. Gate on *fixable* findings once a month of real output shows the steady state.

**Release-time**
- A CycloneDX SBOM generated from the **built image**, not from `requirements.txt` — four packages there are unpinned and openwakeword installs with `--no-deps`, so the image is the only place the full dependency set exists. Attached to the workflow run, since controller tags deliberately create no GitHub Release.
- A Trivy scan, hard-wired report-only: the image is already pushed by that point, so failing there would give a red tick *and* a live image.

**Weekly** (`security-scan.yml`, new)
- Scans the published `:latest`. This is the one that earns its keep — release-time scanning says the image was clean the day it shipped, while the question users have is whether the image they are pulling is clean *today*, and that changes without the digest moving. Allowed to fail, scoped to fixable HIGH/CRITICAL, uploads SARIF to the Security tab. Manual dispatch too, because the first thing you want after a CVE lands in the news is an answer about your own image, not a wait until Monday.

**Dependabot** across pip, docker, gomod and github-actions, grouped into one PR per ecosystem per week. Ungrouped it produces a dozen PRs against a repo one person maintains, and an unclearable queue looks like coverage without being it. `numpy` and `onnxruntime` majors are excluded from the routine sweep — both want a deliberate upgrade with a wake word test behind them.

### What none of this sees

Stated in the configs rather than left to be rediscovered, so a green board is not mistaken for full coverage:

- vendored SpeexDSP C in `device/internal/aec/` has no package metadata
- ONNX Runtime is `dlopen`'d on the device, pinned by AAR sha256 in the asset path
- openwakeword's pin lives in the Dockerfile, not `requirements.txt`

Those stay a human job.

### Settings that go with it

Not in this PR because they are repository settings, not files. The repo is public, so all are free:

- **Dependabot security updates** is currently disabled — this is the biggest single win and it is one toggle
- **CodeQL** — different class of finding from Trivy, and `em_api.py` handles auth, file paths and a shell proxy
- **Private vulnerability reporting** — a way to report a flaw privately on a project that ships root-shell tooling into people's homes
