### PR TITLE
security: zeroconf 0.148.0 -> 0.149.17 (three mDNS DoS advisories)

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -15,7 +15,20 @@ bcrypt==5.0.0
 # published image always ships it.
 cryptography==44.0.1
 # mDNS advertisement (_emcontroller._tcp.local)
-zeroconf==0.148.0
+#
+# Held at >=0.149.12 for three advisories against 0.148.0, all unauthenticated
+# denial of service reachable by anything on the local link — which for this
+# project is the same network segment the devices discover the controller on,
+# so the attack surface is exactly where the dependency is used:
+#   PYSEC-2026-3436  recursion blowup on chained DNS name-compression pointers
+#   PYSEC-2026-3437  unbounded log dedup retaining raw packets, keyed on the
+#                    peer's source port so every packet makes a fresh key
+#   PYSEC-2026-3435  unbounded deferred truncated-query queues, O(N) per arrival
+# None has an in-process workaround; the fix is the upgrade.
+#
+# 0.149.17 rather than 0.150.0: the smallest jump that clears all three, on a
+# dependency the whole fleet's discovery depends on.
+zeroconf==0.149.17
 # Wake word inference — openwakeword deps installed manually to avoid
 # tflite-runtime which has no Python 3.12 x86_64 build.
 # openwakeword itself is installed via --no-deps in the Dockerfile.


### PR DESCRIPTION
Found by the `pip-audit` job from #125 on its first run.

### The advisories

Three against `zeroconf` 0.148.0, all unauthenticated denial of service reachable by anything on the local link. That matters more here than the raw severity suggests: the local link is the same segment devices use to discover the controller, so the exposure sits exactly where the dependency is used. A guest on the same Wi-Fi, a compromised IoT device, or a container on a shared bridge all qualify.

| ID | Fault | Fixed in |
|---|---|---|
| PYSEC-2026-3436 | Recursion blowup on chained DNS name-compression pointers — a ~3kB packet with ~1500 chained pointers exceeds CPython's recursion limit, and `RecursionError` was not in `DECODE_EXCEPTIONS`, so it escaped the decoder | 0.149.5 |
| PYSEC-2026-3437 | Unbounded log dedup retaining the raw packet, keyed on a string containing the peer's ephemeral source port — so every packet mints a fresh key, pinning ~9kB each until exit | 0.149.6 |
| PYSEC-2026-3435 | Unbounded deferred truncated-query queues, plus an O(N) data compare on every arrival | 0.149.12 |

The advisories name Home Assistant on Raspberry-Pi-class hardware as the canonical victim, which describes a fair share of this project's users. There is no in-process workaround for any of them.

### Version choice

`0.149.17`, not `0.150.0` — the smallest jump that clears all three. This is the dependency the whole fleet's discovery rides on, so a minor-version bump is not something to take for free alongside a security fix.

### Verification

Nothing in the test suite imports zeroconf, so passing CI says nothing about this change. I exercised the actual surface instead — the four methods used across `em_controller`, `em_esphome` and `em_ble_proxy` (`async_register_service`, `async_update_service`, `async_unregister_service`, `async_close`) and a `ServiceInfo` built with this project's own arguments, through a live register → update → unregister → close cycle on Python 3.12.

Worth recording one trap: `ServiceInfo` is a Cython class whose `__init__` signature does not introspect, so checking the kwargs by reflection reports every one of them missing and proves nothing. It has to be constructed.

A first attempt also raised `NonUniqueNameException` — because the running controller was already advertising that name on this host. Reassuring rather than otherwise, but it is why the smoke test uses a distinct name.

### Not covered

This is the controller only. The device side is untouched by these advisories — it consumes mDNS through its own Go client.
