### PR TITLE
fix: onnxruntime-gpu 1.20.1 no longer exists on PyPI

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -12,10 +12,18 @@ RUN pip install --no-cache-dir -r requirements.txt
 # GPU=1 swaps the CPU onnxruntime from requirements.txt for the CUDA build
 # (both provide the same `onnxruntime` import, so they can't coexist).
 # Local docker-compose.yml sets it; the published GHCR image is CPU-only.
+#
+# The two packages DO NOT share a version line, so this pin cannot be kept
+# in lockstep with requirements.txt by matching the string. onnxruntime
+# publishes 1.20.1 and no 1.20.2; onnxruntime-gpu publishes 1.20.0 and
+# 1.20.2 and no longer publishes 1.20.1 — it was there when this was
+# written and has since gone. The failure only ever surfaces on a fresh
+# local GPU build (the published image is CPU-only and never runs this
+# line), which is why it sat here unnoticed until 2026-08-10.
 ARG GPU=0
 RUN if [ "$GPU" = "1" ]; then \
       pip uninstall -y onnxruntime && \
-      pip install --no-cache-dir onnxruntime-gpu==1.20.1; \
+      pip install --no-cache-dir onnxruntime-gpu==1.20.2; \
     fi
 # Install openwakeword without deps — tflite-runtime has no Python 3.12
 # x86_64 build; onnxruntime handles inference instead


### PR DESCRIPTION
Found while doing a local engineering build off main. A fresh GPU build fails outright:

```
ERROR: Could not find a version that satisfies the requirement onnxruntime-gpu==1.20.1
 (from versions: 1.17.0, ... 1.20.0, 1.20.2, 1.21.0, ...)
```

### Why the pin was never stable

The two packages **do not share a version line**, so this could never be kept in lockstep with `requirements.txt` by matching the string — which is what the existing comment implied by describing it as "the CUDA build" of the same thing:

| version | `onnxruntime` | `onnxruntime-gpu` |
|---|---|---|
| 1.20.0 | yes | yes |
| 1.20.1 | **yes** (our CPU pin) | **gone** |
| 1.20.2 | absent | **yes** |

`onnxruntime-gpu` 1.20.1 existed when the line was written and has since been withdrawn from PyPI.

Pinned to **1.20.2** — the nearest available, and a patch ahead of the CPU build rather than behind it.

### Blast radius: local dev only

The published GHCR image is CPU-only and never executes this line, so no release was affected and nobody pulling the image saw anything. The controller running here predates the withdrawal, which is exactly why it went unnoticed — the failure needs a *fresh* GPU build to appear.

### Verification

Built the image with `GPU: "1"` and checked inside it:

```
zeroconf     0.149.17
onnxruntime  1.20.2
providers    ['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider']
```

### Worth considering separately

Nothing in CI builds the image with `GPU=1`, which is the only thing that would have caught this. A GPU build needs no GPU hardware — it just resolves and downloads a different wheel — so a job gated on changes to `Dockerfile` or `requirements.txt` would cover it for a few minutes of runner time on the rare PR that touches either. Not included here to keep this to the fix.
