### PR TITLE
build: drop esbuild from the runtime image

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -100,7 +100,7 @@ RUN mkdir -p /app/models/oww_runtime && \
 # Dashboard SPA — placeholder is index.html, full dashboard is dashboard.html
 COPY static/ ./static/
 # Compile JSX dashboard with esbuild
-RUN EARCH="$(dpkg --print-architecture)" && case "$EARCH" in amd64) EPKG=linux-x64 ;; arm64) EPKG=linux-arm64 ;; *) echo "unsupported arch: $EARCH" >&2; exit 1 ;; esac && curl -sfL -o /tmp/esbuild.tar.gz "https://registry.npmjs.org/@esbuild/${EPKG}/-/${EPKG}-0.20.2.tgz" &&     tar -xz -C /tmp -f /tmp/esbuild.tar.gz &&     install -m755 /tmp/package/bin/esbuild /usr/local/bin/esbuild &&     esbuild /app/static/dashboard.jsx       --bundle=false       --jsx=transform       --jsx-factory=React.createElement       --jsx-fragment=React.Fragment       --outfile=/app/static/dashboard.js &&     rm /tmp/esbuild.tar.gz
+RUN EARCH="$(dpkg --print-architecture)" && case "$EARCH" in amd64) EPKG=linux-x64 ;; arm64) EPKG=linux-arm64 ;; *) echo "unsupported arch: $EARCH" >&2; exit 1 ;; esac && curl -sfL -o /tmp/esbuild.tar.gz "https://registry.npmjs.org/@esbuild/${EPKG}/-/${EPKG}-0.20.2.tgz" &&     tar -xz -C /tmp -f /tmp/esbuild.tar.gz &&     install -m755 /tmp/package/bin/esbuild /usr/local/bin/esbuild &&     esbuild /app/static/dashboard.jsx       --bundle=false       --jsx=transform       --jsx-factory=React.createElement       --jsx-fragment=React.Fragment       --outfile=/app/static/dashboard.js &&     rm -rf /tmp/esbuild.tar.gz /tmp/package /usr/local/bin/esbuild
 # Database persisted via volume mount
 # docker run -v ~/EchoMuse/controller/data:/app/data ...
 # Set DB_PATH=/app/data/echomuse.db in environment


### PR DESCRIPTION
esbuild is a build-time tool — it compiles `dashboard.jsx` and is never executed at runtime — but two copies ship in the published image:

```
/usr/local/bin/esbuild
/tmp/package/bin/esbuild     # extracted tarball, never cleaned
```

The existing `rm` removes only the `.tar.gz`.

Both are Go 1.20.12 binaries, so a vulnerability scan reports **18 HIGH/CRITICAL per copy**, including `CVE-2024-24790` (CRITICAL, `crypto/x509`) and `CVE-2023-45288`. That's 36 findings on binaries the container never runs.

This adds both paths to the `rm` that already runs after the compile. `dashboard.js` is produced exactly as before — verified byte-identical output and a working controller image (`em_controller` / `em_api` / `em_arbiter` all import, dashboard 248KB).
