### PR TITLE
Measure the no-speech window from the first audio frame

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -77,6 +77,7 @@ COPY em_tap_burst.py .
 COPY em_player.py .
 COPY em_config_sections.py .
 COPY em_recordings.py .
+COPY em_turnclock.py .
 COPY version.py .
 # ESPHome native API subpackage (frame protocol, message registry, vendored protobuf)
 COPY esphome/ ./esphome/

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -71,6 +71,7 @@ import em_ns
 import em_recordings
 import em_oww_models
 import em_player
+import em_turnclock
 
 # ── VAD sentinels ──────────────────────────────────────────────────────────────
 # Queue items marking end-of-speech in mic_queue/voice_queue, in place of
@@ -1078,9 +1079,11 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         # the old device VAD default, for the floor-not-yet-warmed case).
         # This is the noise floor as *measurement*: the threshold adapts per
         # room, the audio itself is untouched.
-        NO_SPEECH_TIMEOUT = 5.0
+        # The decision lives in em_turnclock so it can be tested — see there
+        # for why the window is measured from the first real frame and not
+        # from turn start (#139).
         speech_seen = False
-        first_real_frame_seen = False
+        listening_since = None      # monotonic; set when the first real frame lands
         turn_start = time.monotonic()
 
         def _is_speech(chunk: bytes) -> bool:
@@ -1124,10 +1127,14 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     speech_seen = True
                     log.debug(f"[{self._log_name}] Speech detected (HA VAD start) — no-speech timeout disarmed")
 
-                if not speech_seen and (time.monotonic() - turn_start) > NO_SPEECH_TIMEOUT:
+                give_up, why = em_turnclock.no_speech_verdict(
+                    now=time.monotonic(), turn_start=turn_start,
+                    listening_since=listening_since, speech_seen=speech_seen,
+                )
+                if give_up:
                     log.info(
-                        f"[{self._log_name}] No speech within {NO_SPEECH_TIMEOUT}s — "
-                        f"closing HA pipeline quietly (controller-side no-speech timeout)"
+                        f"[{self._log_name}] {why} — closing HA pipeline "
+                        f"quietly (controller-side no-speech timeout)"
                     )
                     self._send_one(api_pb2.VoiceAssistantAudio(data=b"", end=True))
                     self._no_speech_timeout = True
@@ -1198,8 +1205,10 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     log.debug(f"[{self._log_name}] Preroll discard: skipped frame ({preroll_remaining} remaining)")
                     continue
 
-                if not first_real_frame_seen:
-                    first_real_frame_seen = True
+                if listening_since is None:
+                    # Starts the no-speech window. Until this lands we are
+                    # waiting on the link, not on the user.
+                    listening_since = time.monotonic()
                     log.debug(f"[{self._log_name}] First real audio frame received")
                     if self._trace:
                         self._trace.t_first_frame_ms = self._trace.elapsed_ms()

--- a/controller/em_turnclock.py
+++ b/controller/em_turnclock.py
@@ -1,0 +1,63 @@
+"""When a voice turn should stop waiting, as a pure function.
+
+Split out of `em_esphome._stream_mic_audio` for the reason `em_button.decide`
+and `em_linkauth.decide` were: the test suite does not import em_esphome, so
+this was timing logic with two clocks and two limits and no coverage — and it
+cost a real voice turn (#139) before anyone looked at it.
+
+THE TWO CLOCKS ANSWER DIFFERENT QUESTIONS, and conflating them is the bug this
+module exists to prevent:
+
+  - "Has the user said anything?" can only be asked once their audio is
+    arriving. It is measured from the FIRST REAL FRAME.
+  - "Is any audio coming at all?" is measured from turn start, and is about
+    the device and the link, not the person.
+
+Measured from turn start alone, a slow link masquerades as a silent user. On
+this fleet that is not hypothetical: ordinary WiFi loss (5-7%, on a link whose
+actual latency is 6ms) drives TCP retransmission delays of 400-1400ms, and a
+measured 1373ms gap before the first frame shortened a 5s window to 3.6s and
+answered `no_speech` to someone who had spoken clearly. The device had
+captured that audio perfectly and TCP was holding it.
+"""
+
+# Seconds of quiet, measured from the first real audio frame, before an
+# accidental wake is closed quietly. Matches the device's own noSpeechTimeout.
+NO_SPEECH_TIMEOUT = 5.0
+
+# Seconds to wait for the first real frame before giving up on the turn
+# entirely. Bounds the other side: audio that never arrives must still end the
+# turn, or a device that dies immediately after the wake holds the HA pipeline
+# open until HA's own timeout. A healthy device delivers its first
+# post-preroll frame in ~300ms, so this only elapses on a genuinely stalled
+# link and the ordinary path never reaches it.
+FIRST_AUDIO_GRACE = 5.0
+
+
+def no_speech_verdict(now, turn_start, listening_since, speech_seen,
+                      no_speech_timeout=NO_SPEECH_TIMEOUT,
+                      first_audio_grace=FIRST_AUDIO_GRACE):
+    """Should this turn close quietly as a no-speech?
+
+    All times are monotonic seconds from the same clock.
+
+    `listening_since` is when the first real (post-preroll) frame arrived, or
+    None if none has. `speech_seen` is whether anything above the room's noise
+    floor has been heard — once true this never closes the turn, because HA's
+    VAD owns end-of-turn from that point.
+
+    Returns (close, reason); reason is "" when close is False.
+    """
+    if speech_seen:
+        return False, ""
+
+    if listening_since is not None:
+        waited, limit = now - listening_since, no_speech_timeout
+        why = f"No speech within {limit}s of the first audio frame"
+    else:
+        waited, limit = now - turn_start, first_audio_grace
+        why = f"No audio at all within {limit}s of turn start"
+
+    if waited > limit:
+        return True, why
+    return False, ""

--- a/controller/tests/test_turnclock.py
+++ b/controller/tests/test_turnclock.py
@@ -1,0 +1,75 @@
+"""The no-speech window must measure the user, not the link.
+
+The regression these guard against is #139: a 1373ms delivery gap before the
+first audio frame silently shortened the listening window and answered
+`no_speech` to someone who spoke clearly. `test_late_audio_still_gets_a_full_
+window` fails against the old turn-start-only logic, which is how it was
+verified.
+"""
+import em_turnclock as tc
+
+
+def test_speech_seen_never_closes_the_turn():
+    # Once anything above the noise floor is heard, HA's VAD owns end-of-turn
+    # and this decision must get out of the way — however long it has been.
+    close, _ = tc.no_speech_verdict(now=1000.0, turn_start=0.0,
+                                    listening_since=0.0, speech_seen=True)
+    assert close is False
+
+
+def test_silence_from_a_prompt_device_closes_on_time():
+    # The ordinary accidental wake: audio flowing immediately, nobody speaks.
+    # Behaviour here must be exactly what it always was.
+    close, why = tc.no_speech_verdict(now=5.3, turn_start=0.0,
+                                      listening_since=0.3, speech_seen=False)
+    assert close is False, "5.0s of quiet is not yet over the limit"
+
+    close, why = tc.no_speech_verdict(now=5.4, turn_start=0.0,
+                                      listening_since=0.3, speech_seen=False)
+    assert close is True
+    assert "No speech" in why
+
+
+def test_late_audio_still_gets_a_full_window():
+    # THE #139 REGRESSION. Audio arrives 1.373s late, then the user speaks
+    # 4s in. Measured from turn start that is 5.4s and the turn is already
+    # dead; measured from first audio it is 4.0s and still listening.
+    close, _ = tc.no_speech_verdict(now=5.4, turn_start=0.0,
+                                    listening_since=1.373, speech_seen=False)
+    assert close is False, "a slow link must not shorten the listening window"
+
+    # ...and the window still ENDS, 5s after audio actually started.
+    close, why = tc.no_speech_verdict(now=6.5, turn_start=0.0,
+                                      listening_since=1.373, speech_seen=False)
+    assert close is True
+    assert "No speech" in why
+
+
+def test_audio_that_never_arrives_still_ends_the_turn():
+    # A device that dies right after the wake must not hold the HA pipeline
+    # open. This is the bound on the fix above.
+    close, _ = tc.no_speech_verdict(now=4.9, turn_start=0.0,
+                                    listening_since=None, speech_seen=False)
+    assert close is False
+
+    close, why = tc.no_speech_verdict(now=5.1, turn_start=0.0,
+                                      listening_since=None, speech_seen=False)
+    assert close is True
+    assert "No audio" in why, "must be distinguishable from a silent user"
+
+
+def test_the_two_reasons_are_distinguishable():
+    # They call for opposite investigations — a quiet room versus a dead link
+    # — so the log line must not read the same for both.
+    _, no_audio = tc.no_speech_verdict(now=99.0, turn_start=0.0,
+                                       listening_since=None, speech_seen=False)
+    _, no_speech = tc.no_speech_verdict(now=99.0, turn_start=0.0,
+                                        listening_since=1.0, speech_seen=False)
+    assert no_audio != no_speech
+
+
+def test_limits_are_overridable_for_callers_and_tests():
+    close, _ = tc.no_speech_verdict(now=2.1, turn_start=0.0,
+                                    listening_since=0.0, speech_seen=False,
+                                    no_speech_timeout=2.0)
+    assert close is True


### PR DESCRIPTION
First item of #140, and it converts the worst failure in #139 from a dead turn into a slightly slow one — without touching the transport.

## The bug

The controller's 5s no-speech timeout ran from **turn start**. That conflates two different questions:

- *Did the user say anything?* — only answerable once their audio is arriving.
- *Is any audio coming at all?* — about the device and the link, not the person.

Measured from turn start, a slow link masquerades as a silent user. On Office this morning:

```
11:09:10,638  Voice turn starting
11:09:12,087  First real audio frame received     <- +1449ms
11:09:15,684  No speech within 5.0s — closing HA pipeline quietly
```

Healthy turns in the same session had `first_frame` at +255, +305 and +322ms. This one waited 1373ms for its third preroll frame, leaving 3.6s of actual listening, and closed while the user was still speaking. The saved utterance is **0.32s at −72 dBFS** — silence.

The device was blameless: `[mic] clock: stalls=0, sub_drops=7`, unchanged across the whole episode. It had captured the audio and handed it to the kernel. TCP was holding it, after ordinary WiFi packet loss on a link whose actual latency is 6ms (#139).

## The change

The window now starts at the first real post-preroll frame. `FIRST_AUDIO_GRACE` bounds the other side — audio that never arrives must still end the turn, or a device that dies immediately after the wake holds the HA pipeline open until HA's own timeout.

A healthy device delivers its first frame in ~300ms, so **the ordinary path is unchanged**; the new branch only elapses on a link that has genuinely stalled.

The two outcomes also log differently now. "No audio at all" and "no speech" call for opposite investigations, and they used to read identically.

## Testing

The decision is a pure function in `em_turnclock` for the reason `em_button.decide` and `em_linkauth.decide` are: the suite does not import `em_esphome`, so this was timing logic with two clocks and two limits and zero coverage.

Verified by reintroducing the bug — **four of the six tests fail against the old turn-start-only logic**, including `test_late_audio_still_gets_a_full_window`, which is the exact scenario above.

358 tests pass. The `test_deploy` module-COPY guard caught the missing Dockerfile line, which is a nice demonstration that it works.

## What this does not fix

The loss itself, and the playback side (`min_depth` reached 0 on the same turn) — items 2 and 3 of #140.
