### PR TITLE
ci: trivy-action tags carry a v, so the release job never started

### DIFF
--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -92,7 +92,7 @@ jobs:
       # same base image, and scanning the arm64 variant under QEMU costs
       # runner minutes to restate the answer.
       - name: Generate SBOM
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: image
           image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:${{ steps.version.outputs.version }}
@@ -118,7 +118,7 @@ jobs:
       # (a red tick and a live image). Gating belongs before the push or in
       # the scheduled scan, not here.
       - name: Scan image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: image
           image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:${{ steps.version.outputs.version }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,7 @@ jobs:
       # image users are pulling today, which is what docker-compose.deploy.yml
       # gives them.
       - name: Scan for fixable HIGH/CRITICAL vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: image
           image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:latest
@@ -54,7 +54,7 @@ jobs:
       # only the run log, where nobody goes looking.
       - name: Scan again for SARIF
         if: always()
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           scan-type: image
           image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:latest


### PR DESCRIPTION
`controller-v2.18.0` failed at **Set up job**:

```
Unable to resolve action `aquasecurity/trivy-action@0.28.0`, unable to find version `0.28.0`
```

The action publishes `v0.28.0`. The same typo is why the scheduled **Security scan (published image)** run has failed at the same step since it was added — neither workflow has ever run past setup, so no image was published and no scan has ever reported.

The interesting part is *which* step took the release down. Both trivy steps sit **after** the push and are deliberately report-only, with a comment explaining that failing there would mark a release red without unpublishing anything. That holds for a step that runs and fails. It does not hold for one that cannot be resolved: GitHub resolves every action in a job before executing step 1, so an unresolvable ref in a post-push reporting step blocks the push it was written to never affect. `exit-code: "0"` cannot protect a step that never starts.

Pinned to `v0.28.0` rather than the current `v0.36.0` — the version that was reviewed, changing one character. Bumping the scanner is a separate decision, and this one blocks a release carrying three DoS advisories.

**What I did not test:** neither workflow runs on a PR, so CI passing here proves nothing about them. The proof is re-pointing the `controller-v2.18.0` tag at this commit and watching the release job get past setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)