### PR TITLE
ci: trivy-action v0.28.0 is unusable, and pins by SHA now

### DIFF
--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -92,7 +92,7 @@ jobs:
       # same base image, and scanning the arm64 variant under QEMU costs
       # runner minutes to restate the answer.
       - name: Generate SBOM
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:${{ steps.version.outputs.version }}
@@ -118,7 +118,7 @@ jobs:
       # (a red tick and a live image). Gating belongs before the push or in
       # the scheduled scan, not here.
       - name: Scan image for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:${{ steps.version.outputs.version }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,7 @@ jobs:
       # image users are pulling today, which is what docker-compose.deploy.yml
       # gives them.
       - name: Scan for fixable HIGH/CRITICAL vulnerabilities
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:latest
@@ -54,7 +54,7 @@ jobs:
       # only the run log, where nobody goes looking.
       - name: Scan again for SARIF
         if: always()
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:latest


### PR DESCRIPTION
Second failure of the `controller-v2.18.0` release, again at **Set up job**, again before the build:

```
Unable to resolve action `aquasecurity/setup-trivy@v0.2.1`
```

`trivy-action@v0.28.0` depends on `setup-trivy@v0.2.1` internally, and **that tag no longer exists upstream** — setup-trivy now publishes only v0.2.6, v0.3.0 and v0.3.1. So v0.28.0 cannot resolve today and never will again, whatever we do at our end. #145 corrected our own ref and hit the version's own broken one immediately behind it.

This is the argument against pinning third-party actions by tag, made by the action we pinned: a tag is a mutable pointer someone else owns, and theirs was deleted. v0.33.1 and v0.36.0 reference setup-trivy **by commit SHA**, which is immune to it — upstream reached the same conclusion.

So this pins trivy-action by SHA with the version in a comment, which is also GitHub's hardening guidance for any action running in a job with credentials. This one holds `packages: write` on GHCR, so it can push images under the project's name. Dependabot updates SHA pins and keeps the comment current, so nothing is lost.

**Inputs checked against v0.36.0's `action.yaml` before moving:** `scan-type`, `image-ref`, `format`, `output`, `severity`, `ignore-unfixed`, `exit-code` all still exist, and `format` is still passed through verbatim as `TRIVY_FORMAT`, so the CycloneDX SBOM step is unaffected.

**What I did not test:** neither workflow runs on a PR, so CI here proves nothing about them. The proof is the release job getting past setup.

**Follow-up, not in this PR:** the remaining eleven actions are still tag-pinned and want the same treatment, together with Dependabot #130 — which has its own problem attached: it bumps `setup-go` 5 → 7, which sets `GOTOOLCHAIN=local`, and `go install govulncheck@latest` then fails because x/vuln v1.6.0 requires go 1.25 while `device/go.mod` pins 1.24.0 to match the firmware toolchain. That `@latest` is the same unpinned-dependency fault as this one and should be pinned in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)