### PR TITLE
ci: scan the digest that was pushed, and never fail a shipped release

### DIFF
--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -68,6 +68,7 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#controller-}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: controller
@@ -90,12 +91,29 @@ jobs:
       #
       # amd64 only. The two architectures install the same wheels from the
       # same base image, and scanning the arm64 variant under QEMU costs
-      # runner minutes to restate the answer.
+      # runner minutes to restate the answer. Addressing the index by digest
+      # keeps that: trivy resolves it to the runner's own platform.
+      #
+      # BY DIGEST, never by a reconstructed tag. These steps asked for
+      # :v2.18.0 while metadata-action had published :2.18.0 — the version
+      # output carries the v because it is also EM_CONTROLLER_VERSION for the
+      # dashboard header, while `type=match,pattern=controller-v(.*)` captures
+      # the group after it. The two disagreed from the day the file was
+      # written and nothing noticed, because the steps had never run. The
+      # digest is what build-push-action actually pushed, so there is no
+      # string to get wrong and no chance of scanning something other than
+      # the artifact being released.
+      #
+      # continue-on-error for the same reason the scan below is exit-code 0:
+      # the image is already public by the time this runs, so failing here
+      # marks a release red without unpublishing anything. It did exactly
+      # that on controller-v2.18.0, and took the scan down with it.
       - name: Generate SBOM
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
-          image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:${{ steps.version.outputs.version }}
+          image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller@${{ steps.build.outputs.digest }}
           format: cyclonedx
           output: sbom-controller-${{ steps.version.outputs.version }}.cdx.json
 
@@ -105,11 +123,16 @@ jobs:
       # controller release appearing there would be offered to devices.
       # Retention is long: the useful question is "what was in the version I
       # am running", which is asked months after the release, not days.
+      #
+      # if-no-files-found: warn because the step above may now have failed
+      # without stopping the job — a release missing its SBOM is a gap in the
+      # record, not a reason to report the release itself as broken.
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:
           name: sbom-controller-${{ steps.version.outputs.version }}
           path: sbom-controller-${{ steps.version.outputs.version }}.cdx.json
+          if-no-files-found: warn
           retention-days: 365
 
       # Report-only, and it must stay that way in THIS workflow: the image
@@ -117,11 +140,18 @@ jobs:
       # mark a release red without unpublishing anything — the worst of both
       # (a red tick and a live image). Gating belongs before the push or in
       # the scheduled scan, not here.
+      #
+      # exit-code 0 covers a step that RUNS and finds something. It cannot
+      # cover a step that never starts, so continue-on-error covers the rest:
+      # an unresolvable action reference took this workflow down twice before
+      # the build on controller-v2.18.0, and a failed SBOM skipped this step
+      # entirely on the third attempt.
       - name: Scan image for vulnerabilities
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
-          image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller:${{ steps.version.outputs.version }}
+          image-ref: ghcr.io/${{ github.repository_owner }}/echomuse-controller@${{ steps.build.outputs.digest }}
           format: table
           severity: HIGH,CRITICAL
           ignore-unfixed: true


### PR DESCRIPTION
Third and last fault from the `controller-v2.18.0` release. The image **built and pushed successfully**; the job then went red on the SBOM step, which took the vulnerability scan below it down as `skipped`.

```
FATAL unable to find "ghcr.io/wilbowes/echomuse-controller:v2.18.0"
      remote error: MANIFEST_UNKNOWN: manifest unknown
```

Both scan steps asked for `:v2.18.0` while metadata-action had published `:2.18.0`. The `version` output legitimately carries the `v` — it is also `EM_CONTROLLER_VERSION`, which the dashboard header displays — while `type=match,pattern=controller-v(.*),group=1` captures the group *after* the `v`. The two have disagreed since the file was written and nothing noticed, because these steps had never run.

**They now address the image by digest**, from `build-push-action`'s own output. No string left to get wrong, and it guarantees what is scanned is exactly what was released rather than whatever a tag points at by the time the step runs. The amd64-only intent is preserved: trivy resolves an index digest to the runner's platform.

**Both steps are also `continue-on-error` now.** The scan already carried `exit-code: "0"` and a comment arguing that a post-push failure must never mark a release red, since the image is public by then and nothing here can unpublish it. That argument was right and its implementation was incomplete twice over: `exit-code` covers a step that *runs* and finds something, not one that fails to start, and it says nothing about the SBOM step above it — which is the one that actually fired. The release was complete and correct while the workflow reported failure, which is the exact outcome that comment set out to prevent.

`Upload SBOM` takes `if-no-files-found: warn` to match, since generation can now fail without stopping the job. A release missing its SBOM is a gap in the record, not a broken release.

`security-scan.yml` needs none of this: it scans `:latest` deliberately, to ask what users are pulling today, and is *supposed* to go red on fixable findings.

**What I did not test:** this workflow only runs on a `controller-v*` tag, so CI here proves nothing about it. The next release is the proof. Verified by hand instead: the published index has both `linux/amd64` and `linux/arm64`, `:2.18.0` and `:latest` resolve, and `:v2.18.0` genuinely 404s — matching trivy's error exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)