### PR TITLE
Correct six shipped defaults against measured field data

### DIFF
--- a/controller/.env.example
+++ b/controller/.env.example
@@ -32,8 +32,8 @@ ESPHOME_PROJECT_VERSION=2.0.0
 # OpenWakeWord model name (without _v0.1.onnx suffix)
 OWW_MODEL=hey_jarvis
 # Detection threshold — lower = more sensitive
-# 0.3 works well for UK accents; default upstream is 0.5
-OWW_THRESHOLD=0.3
+# 0.5 is openwakeword's own default; 0.3 false-woke on ordinary conversation
+OWW_THRESHOLD=0.5
 # ── Database ──────────────────────────────────────────────────────────────────
 # Path to SQLite database file inside the container
 # Mount ~/EchoMuse/controller/data:/app/data in docker-compose.yml

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -59,14 +59,20 @@ DEFAULT_DEVICE_CONFIG = {
     # internally), so this can be tuned without retuning vadThreshold.
     "micGainDb":        24,
     # AEC (speexdsp, device-side, whole mic path incl. wake stream).
-    # Default OFF — enable per-deployment and check the [aec] att= logs.
+    # Default ON, and coupled to bargeInEnabled below: with barge-in the mic
+    # streams throughout playback, and AEC is the only thing stopping the
+    # device waking on its own TTS. Turning one on without the other is the
+    # self-trigger case the barge threshold reasoning assumes away, so if
+    # this goes back to False, bargeInEnabled must go with it.
+    # ~14dB attenuation per response, held across turns since v2.7.8; check
+    # the [aec] att= logs when tuning.
     # aecDelayMs: 0, measured on hardware 2026-07-08 — the mic side reads
     # 160ms ALSA batches, which eats most of the speaker's write-to-ear
     # latency; the filter tail absorbs the remainder. (The original 250
     # guess made the echo arrive *before* its reference — non-causal, zero
     # cancellation.) aecTailMs is the adaptive filter length (residual
     # delay + room reverb). Device clamps: delay 0–1000, tail 50–500.
-    "aecEnabled":       False,
+    "aecEnabled":       True,
     "aecDelayMs":       0,
     "aecTailMs":        300,
     "startupVolume":    85,
@@ -99,18 +105,43 @@ DEFAULT_DEVICE_CONFIG = {
     # delay is only acceptable once a tap is an event rather than speech.
     # 300ms is a reasonable starting point.
     "buttonMultiTapMs": 0,
-    "owwThreshold":     0.3,
+    # owwThreshold: 0.5 — openwakeword's own recommended default, and what
+    # this fleet independently converged on. It was 0.3, which is measurably
+    # too sensitive: of 519 fleet-hours that recorded a near miss while
+    # running 0.5, 212 peaked at >= 0.3, clustered hard against the ceiling
+    # (0.4992, 0.4987, 0.4971, ...). Every one of those would have fired a
+    # spurious turn on a default install — ring up, HA pipeline run, most
+    # likely ending no_speech. Lower it per device if a custom wake model
+    # trades recall for false positives (see oww_forge/README.md).
+    "owwThreshold":     0.5,
     # Barge-in (§3.2, controller-side): wake word spoken during TTS playback
     # cancels it and starts a fresh turn. Requires device AEC (aecEnabled)
     # on — with barge-in the mic streams through playback, and AEC is what
-    # stops the device hearing itself. bargeInThreshold is used as-is,
+    # stops the device hearing itself — so aecEnabled above defaults on with
+    # it, and the two move together. bargeInThreshold is used as-is,
     # deliberately BELOW the normal wake threshold: the echo at the mic is
     # ~25dB louder than the person talking over it, so speech-over-TTS wake
     # scores are inherently depressed (~0.10–0.12 measured), while post-AEC
     # self-echo scores only 0.004 (0.055 worst-case unconverged) — there is
     # no self-trigger risk down to ~0.08.
-    "bargeInEnabled":   False,
-    "bargeInThreshold": 0.10,
+    #
+    # That 0.004 is STALE and the margin is wider than it says: v2.7.8 made
+    # the filter hold convergence across turns, so self-echo measures
+    # 0.002–0.003. 0.10 sat awkwardly close to real speech-over-TTS scores,
+    # which is the wrong way to be wrong — barge-in that never fires is
+    # undiagnosable from the outside ("it just ignores me"), while barge-in
+    # that fires too eagerly is self-evident and adjustable. 0.05 is the
+    # dashboard slider floor, so the only way to tune from here is UP, which
+    # is the direction the visible failure asks for.
+    #
+    # Watch one interaction: the beamformer locks a different mic per turn
+    # and each has its own echo path, so AEC re-converges per turn (per-
+    # channel filter states are the unbuilt fix) — and the one measured
+    # self-echo figure above 0.05 is that unconverged case at 0.055. The
+    # symptom would be a device cutting its own response short. This fleet
+    # runs 0.05 with beamforming and AEC both on and does not do that.
+    "bargeInEnabled":   True,
+    "bargeInThreshold": 0.05,
     # How far music is attenuated while a voice turn plays OVER it, on
     # firmware that can mix the two planes (the "audio_mix" capability).
     # Ducking replaces pausing there: the music feed runs 4s ahead of
@@ -130,17 +161,25 @@ DEFAULT_DEVICE_CONFIG = {
     # owwSpeexNs: openwakeword's built-in speexdsp noise suppressor (Q1,
     # 2026-07-05 review). 16kHz-native, applied controller-side, only to
     # the wake-word detection path — cannot affect STT audio since STT
-    # never sees it. Defaults False: needs the
-    # speexdsp-ns pip package confirmed installable in the Docker build
-    # (see review Q1 fix sequence) before enabling fleet-wide; flip on and
-    # A/B test wake rate in a noisy room once confirmed.
+    # never sees it. Defaults False, but no longer for the original reason:
+    # the packaging blocker cleared (pinned speexdsp-ns==0.1.2 in
+    # requirements.txt, imports cleanly in the image), so the noisy-room
+    # A/B this is waiting on is now actually runnable. Off until someone
+    # runs it — not off because it cannot be turned on.
     "owwSpeexNs":       False,
     # nsAsr: DTLN noise suppression (em_ns.py), controller-side, applied
     # ONLY to the turn audio streamed to HA's STT — the wake stream and
     # all noise-floor measurement stay raw. Helps steady noise (fan, AC,
     # hum) at marginal SNR; does little against competing speech (TV) —
-    # that's the beamformer's job. Default off pending A/B validation
-    # (2026-07-12); models are vendored into the Docker image, so if the
+    # that's the beamformer's job. Default off, and the A/B that was
+    # "pending" has since run with a result that is NOT yet reconciled: with
+    # NS on, recordings showed 8-15% of samples at exact digital zero at a
+    # healthy signal level (the gate chewing speech); with it off, 0.3%.
+    # That is a candidate cause of the choppy-audio reports (#137). This
+    # fleet nonetheless runs it on, with one device explicitly overriding to
+    # off — so treat "on" as unvalidated rather than recommended until
+    # someone listens to a pair of recordings and decides.
+    # Models are vendored into the Docker image, so if the
     # files are missing (bare-metal without NS_MODEL_DIR) the flag
     # degrades to raw streaming with a warning.
     "nsAsr":            False,
@@ -160,13 +199,21 @@ DEFAULT_DEVICE_CONFIG = {
     # Android Bluetooth stack on the device (required — /dev/stpbt is
     # single-owner) and brings up a second ESPHome listener + mDNS entry.
     "bleProxyEnabled":  False,
-    # beamformingEnabled: False — ch6 (centre/omni) for all audio.
-    # beamforming=True was routing OWW audio through a perimeter mic selected
-    # every 32ms frame, injecting channel-splice discontinuities. The SNR
-    # difference between ch6 and the "best" perimeter mic at conversational
-    # distance is negligible; the downside (wrong-mic locks, discontinuities)
-    # is real. Off = ch6 for everything, consistent with what makes OWW work.
-    "beamformingEnabled": False,
+    # beamformingEnabled: True — ch6 (centre/omni) hears the wake word, then
+    # the turn locks to the best perimeter mic. The flag ONLY gates Lock():
+    # unlocked is always ch6 and the wake path never locks, so the wake
+    # stream is ch6 either way (beamformer.go). It cannot splice wake audio.
+    #
+    # This was False, on a comment describing the every-32ms reselection that
+    # be2f16d (v2.6.3 P0-2) had already fixed in the same commit. The real
+    # reason recorded there was that onset discrimination was unreliable at
+    # <=1.5m, "re-enable once P0-3/P0-4 are addressed" — P0-3 closed
+    # 2026-07-12 (DTLN) and v2.7.2's lock-back selection fixed the decayed-
+    # spike picks that caused most of the wrong-lock risk. Nobody went back.
+    # Meanwhile this fleet has run True since the 2026-07-20 config restore
+    # with no reported regression, so True is the value with field evidence
+    # behind it and False is the one that has not been run in months.
+    "beamformingEnabled": True,
     "beamAngle":        -1,
     "eqBands":          [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
     "eqLoudness":       False,

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5125,7 +5125,7 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
             <div style={{ marginTop: 16, ...inputStyle }}>
               <Toggle label="Speex denoise" sub="cleans audio before scoring — try in noisy rooms" value={config.owwSpeexNs ?? false} onChange={v => set('owwSpeexNs', v)}/>
               <Toggle label="Barge-in" sub="wake word interrupts playback — enable AEC first" value={config.bargeInEnabled ?? false} onChange={v => set('bargeInEnabled', v)}/>
-              <Slider label="Barge threshold" sub="wake confidence needed during playback — speech-over-TTS scores low, ~0.10 is typical with AEC" value={config.bargeInThreshold ?? 0.10} min={0.05} max={0.9} step={0.05} onChange={v => set('bargeInThreshold', v)}/>
+              <Slider label="Barge threshold" sub="wake confidence needed during playback — raise it if a response cuts itself short" value={config.bargeInThreshold ?? 0.05} min={0.05} max={0.9} step={0.05} onChange={v => set('bargeInThreshold', v)}/>
               <Slider label="Arbitration window" sub="ms that the first Echo to hear you silences the others — no added delay; 0 disables" value={config.wakeArbitrationMs ?? 700} min={0} max={2000} step={50} unit="ms" onChange={v => set('wakeArbitrationMs', v)}/>
               {/* Three modes, so a select rather than a toggle. Each option is
                   offered only when the device says it can do it — capability,

--- a/device/internal/config/config.go
+++ b/device/internal/config/config.go
@@ -130,10 +130,10 @@ func (d *Device) loadDefaults() {
 	d.VadSpeechMs = envInt("VAD_SPEECH_MS", 80)
 	d.VadSilenceMs = envInt("VAD_SILENCE_MS", 600)
 	d.StartupVolume = envInt("STARTUP_VOLUME", 85)
-	d.OwwThreshold = envFloat("OWW_THRESHOLD", 0.3)
+	d.OwwThreshold = envFloat("OWW_THRESHOLD", 0.5)
 	d.OwwModel = envStr("OWW_MODEL", "hey_jarvis_v0.1")
 	d.OwwOnDevice = normaliseOnDevice(envStr("OWW_ON_DEVICE", OnDeviceOff))
-	d.BargeInThreshold = envFloat("BARGE_IN_THRESHOLD", 0.10)
+	d.BargeInThreshold = envFloat("BARGE_IN_THRESHOLD", 0.05)
 	d.DuckDb = envFloat("DUCK_DB", -18)
 	d.AdcDigitalGain = envInt("ADC_DIGITAL_GAIN", 88)
 	d.AdcMicpga = envInt("ADC_MICPGA", 40)
@@ -142,7 +142,10 @@ func (d *Device) loadDefaults() {
 	d.BeamformingEnabled = envBool("BEAMFORMING_ENABLED", true)
 	agcEnabled := envBool("AGC_ENABLED", true)
 	d.AgcEnabled = &agcEnabled
-	aecEnabled := envBool("AEC_ENABLED", false)
+	// true to match em_db.DEFAULT_DEVICE_CONFIG, which now defaults AEC on
+	// because barge-in does. The controller's value reaches us on the first
+	// config push either way; this only governs the window before it.
+	aecEnabled := envBool("AEC_ENABLED", true)
 	d.AecEnabled = &aecEnabled
 	d.AecDelayMs = envInt("AEC_DELAY_MS", 0)
 	d.AecTailMs = envInt("AEC_TAIL_MS", 300)


### PR DESCRIPTION
Closes #144 (items 1–4), and files the leftovers as #154.

An audit of `DEFAULT_DEVICE_CONFIG` against the device's own env-var defaults and against what this fleet actually stores. The fleet config turned out to be the useful source: **six shipped defaults are values nobody has run in months.**

## Defaults changed

| Key | Was | Now | Why |
|---|---|---|---|
| `owwThreshold` | 0.3 | **0.5** | measured false-wake cost |
| `beamformingEnabled` | False | **True** | comment justified a bug that was already fixed |
| `aecEnabled` | False | **True** | coupled to barge-in |
| `bargeInEnabled` | False | **True** | |
| `bargeInThreshold` | 0.10 | **0.05** | failure asymmetry |

`owwThreshold`, `aecEnabled` and `bargeInThreshold` also move on the device side, so both halves state one intent. The dashboard's barge slider still carried `0.10` as its fallback and in its help text.

### `owwThreshold` 0.3 → 0.5

The one default in the block with no stated reason, and the field data says it costs real false wakes. From `wake_counters` on a three-device fleet running 0.5: **519 hours recorded near misses, 212 of them peaked at ≥ 0.3**, clustered hard against the ceiling (0.4992, 0.4987, 0.4971, …). Every one would have fired a spurious turn on a default install — ring up, HA pipeline run, most likely ending `no_speech`. 0.5 is also openwakeword's own recommended default, and what this fleet independently converged on months ago.

`em_db.py`, `.env.example` and `config.go` all agreed on the wrong value.

### `beamformingEnabled` False → True

**#144 proposed this backwards** — flipping the device to `False` to match the controller. Reading the stored config inverted it: fleet is `True` and has been since the 2026-07-20 config restore, so `False` is the value with no field evidence behind it.

The comment justifying `False` described beamforming "routing OWW audio through a perimeter mic selected every 32ms frame, injecting channel-splice discontinuities". That bug was fixed in `be2f16d` — **the same commit that set the default to False** (v2.6.3, P0-2). Since then the flag only gates `Lock()`: unlocked is always ch6 and the wake path never locks, so the wake stream is ch6 either way and cannot be spliced.

The reason actually recorded in that commit was different: *"onset ratio discrimination unreliable at ≤1.5m … re-enable once the baseline audio quality issues (P0-3, P0-4) are properly addressed."* P0-3 closed 2026-07-12 (DTLN), and v2.7.2's lock-back selection fixed the decayed-spike picks that caused most of the wrong-lock risk. Nobody went back — the same pattern #144 caught for `owwSpeexNs` and `nsAsr`.

### `bargeInEnabled` + `aecEnabled` → True

Coupled, and they have to move together: with barge-in the mic streams throughout playback, and AEC is the only thing stopping the device waking on its own TTS. Enabling one without the other is the self-trigger case the barge threshold reasoning assumes away. The comments now say so in both directions.

### `bargeInThreshold` 0.10 → 0.05

The value this fleet runs, and the dashboard slider floor — so it can only be tuned **up** from here, which is the direction the visible failure asks for. The asymmetry decides it: barge-in that never fires is undiagnosable from the outside ("it just ignores me"), while barge-in that fires too eagerly is self-evident and adjustable.

The comment's `0.004` self-echo figure was stale — v2.7.8 made the filter hold convergence across turns, so it measures 0.002–0.003.

**One interaction is recorded rather than left to be discovered.** Beamforming on means AEC re-converges per turn, because the beamformer locks a different mic each time and each has its own echo path (per-channel filter states are the unbuilt fix). The one measured self-echo figure above 0.05 is exactly that unconverged case, at 0.055. So the symptom to watch is a device cutting its own response short. This fleet runs all three together and does not.

## Comment-only

Two defaults were frozen behind blockers that have since cleared:

- **`owwSpeexNs`** — the packaging blocker cleared (`speexdsp-ns==0.1.2` is pinned and imports cleanly in the image). Off until someone runs the noisy-room A/B, not off because it cannot be turned on.
- **`nsAsr`** — the A/B ran, and the result is *not* reconciled: NS zeroes 8–15% of samples at healthy signal level against 0.3% with it off, which is a candidate cause of #137, while the fleet nonetheless runs it on. Recorded as unreconciled rather than settled, and filed as #154.

## Left alone deliberately

`saveUtterances`, `bleProxyEnabled`, `owwModel`, `eqBands`, `eqLoudness` and `ledScene` all run non-default on this fleet — recordings and the BLE proxy for good reasons that should not become defaults, the rest personal taste.

`bargeInThreshold`'s neighbours in #144 item 4 are addressed; the stale comment is corrected in place.

## Testing

- 358 controller tests pass.
- Go is not available on the machine this was written on, so `go vet` and `go test` for the two `config.go` edits run here for the first time. **Both device edits are literal defaults** (`0.3`→`0.5`, `false`→`true`, `0.10`→`0.05`) plus comments.
- No schema change, no migration.

## Deployment note

These are shipped defaults, not live config. **Nothing changes for an existing install** — this fleet already runs every one of these values, and `DEFAULT_DEVICE_CONFIG` only supplies keys a stored config lacks. The effect is on new devices and fresh installs.
