### PR TITLE
Document that there is no telemetry, and name the one outbound connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ hear the answer through the Dot's speaker. The hardware you already own
   capture quality and tune gain by ear rather than by inference.
 - **Encrypted device link** — TLS with a controller-generated CA plus
   per-device tokens; the wizard installs credentials automatically.
+- **No phone-home** — there is no telemetry, no analytics and no install
+  counter. Nobody, including us, can tell how many people run EchoMuse or
+  which features they use, and that is deliberate. The controller's only
+  outbound connection is an hourly check to GitHub's API for a newer
+  release, so the dashboard can tell you one exists — the same exposure as
+  a `git clone`, and how often it happens is yours to set
+  ([docs/configuration.md](docs/configuration.md#what-leaves-your-network)).
 
 The 7-mic array, LED ring, buttons, and speaker are all driven natively:
 onset-ratio beamforming, +24dB pre-truncation mic gain (the stock capture

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ walkthroughs welcome.
 | Document | What it covers |
 |---|---|
 | [Quickstart](quickstart.md) | Zero to talking to your Dot: controller install, first-run setup, device approval, Home Assistant hookup, everyday use. |
-| [Configuration Guide](configuration.md) | Every dashboard setting explained in plain language — what it does, when to touch it, and how to tune it. |
+| [Configuration Guide](configuration.md) | Every dashboard setting explained in plain language — what it does, when to touch it, and how to tune it. Ends with [what leaves your network](configuration.md#what-leaves-your-network) — there is no telemetry, and the one outbound connection is named. |
 | [The Voice Pipeline, Explained](voice-pipeline.md) | How your voice travels from the microphones to Home Assistant and back, stage by stage, with the benefits and caveats of each design choice. |
 
 Deeper technical references live elsewhere:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -552,3 +552,49 @@ link** button on its Status tab. A device with credentials connects
 encrypted from its next reconnect; the Status tab's **Link** row shows
 which mode each device is using. Once the whole fleet shows `wss (TLS)`,
 set `REQUIRE_DEVICE_TLS=1` to lock out unencrypted connections entirely.
+
+## What leaves your network
+
+EchoMuse has **no telemetry**. There is no usage reporting, no analytics, no
+crash reporting and no install counter. Nothing reports which features you
+use, how many devices you have, or that you installed it at all. This is a
+deliberate decision rather than an omission: the project exists to take a
+cloud voice assistant off your network, and quietly adding a ping home would
+undo the reason to run it.
+
+A consequence worth stating plainly: **nobody, including the maintainers, can
+tell how many people use EchoMuse.** Adoption is guessed at from GitHub stars
+and release download counts, which is the trade being made.
+
+### The one outbound connection
+
+The controller contacts `api.github.com` once an hour to ask what the newest
+release is, so the dashboard can tell you an update is available and show its
+notes. When you choose to update a device, the firmware binary is downloaded
+from `github.com` at that moment.
+
+That is the whole of it. The request carries no identifiers — it is an
+ordinary unauthenticated API call — but like any request it does reveal your
+public IP to GitHub, the same exposure as a `git clone` or opening the repo
+in a browser.
+
+Set `update_check_interval` (seconds, default `3600`) in the system config to
+change how often it runs. A long interval, say `86400`, reduces it to once a
+day. Note that `0` does **not** disable checking — it currently makes the
+poll loop spin without pausing, which is worse than leaving it alone.
+
+### What never leaves
+
+- **Voice audio and transcripts.** Mic audio goes from the device to your
+  controller and on to your Home Assistant, over your LAN. What happens next
+  is whatever your Assist pipeline does — if you have configured HA to use a
+  cloud speech-to-text service, HA sends it there. EchoMuse itself sends it
+  nowhere but HA.
+- **Saved utterance recordings** (`saveUtterances`, off by default) — written
+  to disk beside the database and never uploaded.
+- **Device serials, WiFi credentials, network names and your fleet's
+  configuration.** These live only in the controller's database.
+- **Support bundles** are built only when you ask for one, and sharing the
+  file is your decision. They deliberately exclude speech, transcripts,
+  network names and account names — see
+  [support-bundle.md](support-bundle.md).


### PR DESCRIPTION
The absence of telemetry was previously a property you could only establish by reading the source. Stated plainly it becomes a reason to install this, rather than a thing we happen not to do — and it is the same principle already applied to support bundles, which are opt-in and allowlist-only.

- **README** gains a "No phone-home" bullet in *What you get*.
- **docs/configuration.md** gains a *What leaves your network* section.
- **docs/README.md** points at it from the Configuration Guide row.

## Written to survive someone checking it

The controller **does** poll `api.github.com` hourly for the newest release. A privacy claim that ignored that would be disproved in five minutes and cost more trust than it bought, so the section names it, says what it carries (an unauthenticated call with an `Accept` header — no identifiers, though like any request it reveals a public IP), and says what to set to change the cadence.

It also records that **`update_check_interval: 0` does not disable checking** — the poll loop spins on `sleep(0)` — because a reader who has just been told this is the only outbound connection is precisely the reader who will try to turn it off. Filed separately as #159.

The *what never leaves* list is deliberately careful about the one thing EchoMuse does not control: mic audio goes to the user's Home Assistant, and if their Assist pipeline uses a cloud speech-to-text service, HA sends it on. Claiming "your voice never leaves your network" would be false for a large share of installs.

## Note

The section says nobody, including the maintainers, can tell how many people run EchoMuse. That sentence is accurate today and would need revisiting if opt-in telemetry is ever added.
