### PR TITLE
Pin the add-on to 2.19.0, and fail the release when the pin is wrong

### DIFF
--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -38,6 +38,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # The Home Assistant add-on pulls a PUBLISHED image, pinned by
+      # controller/config.yaml's `version:` — so that file names an image
+      # that has to exist and has to contain the add-on code. Getting it
+      # wrong is not caught by any test and does not fail the release; it
+      # fails on the user's Home Assistant, by silently running whichever
+      # older controller that tag points at. That happened on the first
+      # install: config.yaml pinned 2.18.0, an image built before the
+      # add-on existed, so Supervisor started a controller with no ingress
+      # support — the dashboard answered the LAN with no gate, and the
+      # panel's absolute /api paths hit Home Assistant instead of the
+      # add-on. Both symptoms, one stale pin.
+      #
+      # Checked here rather than in the test suite because this is the only
+      # moment the two can be compared: the tag being released IS the image
+      # tag, and CI on a branch has neither.
+      - name: Add-on version matches the tag
+        run: |
+          want="${GITHUB_REF_NAME#controller-v}"
+          got="$(sed -n 's/^version:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' controller/config.yaml)"
+          if [ "$want" != "$got" ]; then
+            echo "::error::controller/config.yaml pins version '$got' but this release is '$want'."
+            echo "The add-on would pull ghcr.io/.../echomuse-controller:$got — not what is being released here."
+            exit 1
+          fi
+          echo "add-on pins $got, matching the tag"
+
       - name: Set up QEMU
         # arm64 is cross-built on an amd64 runner, so the emulation layer has
         # to be registered before buildx can target that platform at all.

--- a/controller/config.yaml
+++ b/controller/config.yaml
@@ -3,7 +3,7 @@ name: "EchoMuse"
 # derives from the controller-v* tag (controller-v2.18.0 -> 2.18.0). Bump
 # both together: Supervisor pulls `image:version`, so a version with no
 # matching tag on GHCR fails to install.
-version: "2.18.0"
+version: "2.19.0"
 # Pull the published multi-arch image rather than building on the user's
 # machine. Without this Supervisor builds from this directory's Dockerfile,
 # which compiles onnxruntime and ffmpeg on whatever the user runs Home


### PR DESCRIPTION
The add-on pulls a **published** image chosen by `controller/config.yaml`'s `version:`. #122 shipped that pinned to `2.18.0` — an image built from `90c37aa`, *before the add-on existed* — so the first real install started a controller with no ingress support at all. That pin was my change, not natecj's; the original built from source and would have worked.

## Both symptoms were that one pin

- `curl http://<ha>:8768/` returned **200 instead of 403**, because `_ingress_only_middleware` is not in the 2.18.0 image.
- The panel threw `SyntaxError: JSON.parse: unexpected non-whitespace character after JSON data at line 1 column 4`, because the old `dashboard.jsx` fetches absolute `/api/...` paths. Under ingress those never reach the add-on — they hit Home Assistant's own API, which answers `404: Not Found` as plain text. `JSON.parse` reads `404` as a number and trips on the `:` at column 4.

Verified: `git ls-tree 90c37aa` has no `config.yaml`, no `em_start.py`, no `repository.yaml`, and no `INGRESS_ONLY` in `em_api.py`.

## Changes

1. `config.yaml` → `version: "2.19.0"`, to be released from a `main` that actually contains the add-on.
2. `controller-release.yml` refuses to build when the tag and the pin disagree.

The guard lives in the workflow rather than the test suite because that is the only place the two can be compared — the tag being released *is* the image tag, and CI on a branch has neither. Verified both ways: it passes for `controller-v2.19.0` and fails for `controller-v2.18.0` against this config.

Nothing else catches this class of error. It doesn't fail a test, doesn't fail the release, and surfaces only on someone else's Home Assistant as a controller quietly running an older version.

## Order of operations

Merge this **first**, then tag `controller-v2.19.0` from `main`. Tagging first fails the new check, which is the check doing its job.
