### PR TITLE
Actually add the SQLite ignore rules #156 was meant to add

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ scratchpad/
 # DTLN NS models (vendored into the Docker image at build time; bare-metal
 # dev drops them here or points NS_MODEL_DIR elsewhere)
 controller/models/
+
+# SQLite databases and their sidecars. controller/data/ is already ignored,
+# but DB_PATH defaults to controller/echomuse.db, so a bare-metal run writes
+# a live database there — and merely READING any database creates -wal/-shm
+# beside it, which a `git add -A` then sweeps up. A committed live DB would
+# carry fleet config, device serials, turn history and transcripts.
+*.db
+*.db-wal
+*.db-shm


### PR DESCRIPTION
#156 untracked `controller/echomuse.db` but shipped **none of the ignore rules**. `git rm --cached` stages a deletion, while the `.gitignore` edit beside it stayed unstaged, and the commit went out without it — so that PR delivered half of what its own description claimed.

The result is worse than the starting position: the file is now untracked *and* unignored, so a fresh clone doing `git add -A` would commit it straight back, along with the `-wal`/`-shm` sidecars that any read-only query creates beside it. It stayed invisible because the working copy that made the change still had the edit sitting in it, uncommitted.

No effect on controller-v2.19.0 — `.gitignore` is not part of the image.