### PR TITLE
Native AFE: route device audio through Amazon's own front end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1105,6 +1105,44 @@ Reverting a section **discards** its stored values (`set_device_config_sections`
 
 ### Volume / mute persistence
 
+**The scale stops at the codec's unity gain, and that ceiling is load-bearing.**
+tinymix ctl 61 is the tlv320aic32x4 DAC *digital* volume: 176 steps of 0.5dB
+spanning −63.5…+24dB, with 0dB at index **127**. The firmware shipped
+`volumeMax = 175` — the control's own maximum — so the top 27% of the range
+applied up to +24dB of digital gain to already near-full-scale PCM and
+saturated inside the DAC. Measured on hardware 2026-08-13 (1kHz at −6dBFS,
+recorded through the mic array): THD 1.5% at index 127, 2.3% at 136, **65% at
+153, 89% at 170**, with the output level *flat* from 153 upward because it had
+stopped being able to get louder, and h3 at −1.1dB relative to the fundamental
+(very nearly a square wave). The control that isolates it: index 170 with the
+source scaled down to land at the same acoustic level reads 1.1% — clean — so
+the gain stage is fine and it is purely source × gain exceeding full scale.
+Stock FireOS never writes this control **at all** (absent from
+`/system/etc/audio_device.xml` and from every `/system` binary), leaving the
+DAC at its 0dB reset default and taking user volume from AudioFlinger's
+software attenuation, which only ever attenuates — that is why native Alexa
+has no such distortion.
+
+Two things not to undo: `DEVICE_VOLUME_MAX`/`volumeMax` stay at 127 (both
+pinned by test), and the conversion lives in **one** place — `em_volume.py`,
+because `level / 175` was copy-pasted into `em_controller`, `em_esphome` and
+`em_api` with no test on any of them, which is how the wrong ceiling survived.
+The lost headroom **cannot** be bought back from `Ext_Amp_Gain` (ctl 13): that
+control is inert on this board — sweeping its full 6/12/18/24dB range moves
+the output 0.0dB while still reading its new value back, the same shape as the
+mute LED being on a different GPIO than Amazon's own HAL believed.
+`HP Driver Gain Volume` (ctl 62) *is* live (+18dB commanded → +18.1dB actual,
+THD 2.25%) if more output is ever wanted, but that is a taste call to make by
+ear, and the speaker's behaviour above stock level is unmeasured.
+
+The **physical buttons** traverse `volumeButtonFloor`(47, −40dB)…127 in 4dB
+steps rather than the whole control: the scale is dB-linear, so the bottom
+third is indistinguishable from silence and stepping across it spends presses
+to go nowhere. Silencing the device is the mute button's job. Explicit `Set()`
+calls are deliberately **not** floored — HA's volume 0.0 must still mean
+silent — and a press from below the floor lands *on* it, so one press always
+reaches audible.
+
 Volume is **state, not a setting** — it rides the config channel but has no dashboard control (the slider was removed 2026-07-25: `SeedVolume` ignores later pushes, so moving it did nothing until the device restarted and any real volume change overwrote it). It is listed in `em_config_sections.STATE_KEYS`, exempt from section scoping, and shown read-only on the Status tab.
 
 Volume persists through reboots **controller-side**: every device `volume_state` report is stored into the device's `startupVolume` config, and the device restores it via `Server.SeedVolume` on the **first config push per run only** (later pushes must not stomp live changes). Until seeded (or a local volume change makes the device authoritative), the device suppresses its connect-time `volume_state` report — reporting the boot-default level is what used to clobber the stored value on reboot. Mute is the opposite: **device-sovereign**, persisted locally in `/data/local/etc/echomuse/state.json` (survives OTA slot flips; written on toggle, restored at boot pre-connect — ADC mute immediately, red ring/button LED after LED init).

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -78,6 +78,7 @@ COPY em_player.py .
 COPY em_config_sections.py .
 COPY em_recordings.py .
 COPY em_turnclock.py .
+COPY em_volume.py .
 COPY version.py .
 # ESPHome native API subpackage (frame protocol, message registry, vendored protobuf)
 COPY esphome/ ./esphome/

--- a/controller/device_payloads/start_server.sh
+++ b/controller/device_payloads/start_server.sh
@@ -119,6 +119,30 @@ sup_log() {
 
 sup_log "boot slot=$(readlink /data/local/bin/server 2>/dev/null)"
 
+# ── Native AFE opt-in (docs/native-afe-migration.md) ───────────────────────────
+# EM_NATIVE_AFE is read once by the Go binary at ITS OWN startup — a boot-time
+# choice, not a live config push (cmd/server.go's newAudioBackends: mic/speaker
+# are opened before any controller connection exists to push a config to).
+#
+# A marker FILE, not a hand-export in this script, is what makes the choice
+# durable: this script is re-synced against the canonical payload on every
+# OTA when it drifts (_sync_start_script) and a hand edit here would simply be
+# overwritten. The marker lives in DEVICE_TLS_DIR's directory, not this
+# script, so it survives exactly the syncs that would erase an edit here.
+#
+# Checked once, before the retry loop — `export` here is inherited by every
+# `/data/local/bin/server` launch for the rest of this script's run, so one
+# check covers every restart the retry loop performs. It does NOT take effect
+# on a running device until this script itself re-execs (a real reboot, or
+# `stop`/`start` of the echomuse service from a channel independent of the
+# server's own shell proxy — see the marker's controller-side helper for why
+# the shell proxy must not do this itself).
+NATIVE_AFE_MARKER=/data/local/etc/echomuse/native_afe.enabled
+if [ -f "$NATIVE_AFE_MARKER" ]; then
+    export EM_NATIVE_AFE=1
+    sup_log "native AFE opt-in marker present — EM_NATIVE_AFE=1"
+fi
+
 # ── Amp safety ────────────────────────────────────────────────────────────────
 # Mute + amp off whenever the server is not running. The server does this
 # itself on SIGTERM (PcmSpeaker.Close), but SIGKILL/panic paths skip it —

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -59,6 +59,7 @@ import em_oww_models
 import em_pki
 import em_player
 import em_recordings
+import em_volume
 import em_scenes
 import em_shadow
 import em_support
@@ -4057,7 +4058,11 @@ def _stored_volume(row):
     if level is None:
         return None
     try:
-        return max(0.0, min(1.0, float(level) / 175.0))
+        # float() first, deliberately: em_volume swallows bad input and
+        # returns 0.0, which is the right answer on the audio path and the
+        # wrong one here — this function's None means "not known", and a
+        # corrupt stored value must not report as "silent".
+        return em_volume.device_level_to_ha(float(level))
     except (TypeError, ValueError):
         return None
 

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -4065,6 +4065,12 @@ def _merge_device(row) -> dict:
         # device that never answers.
         "owwTriggerCapable": getattr(live, "oww_trigger_capable", False) if live else False,
         "audioMixCapable": getattr(live, "audio_mix_capable", False) if live else False,
+        # Native AFE (docs/native-afe-migration.md): whether this device's
+        # audio is running through Android's audio HAL right now. Drives the
+        # dashboard disabling the beamformer/AEC/AGC/gain controls that path
+        # bypasses — "disabled with the reason", never a control that
+        # silently does nothing.
+        "nativeAfeCapable": getattr(live, "native_afe_capable", False) if live else False,
         # Gates the tap-as-event toggle — see em_button.decide.
         "buttonHoldCapable": getattr(live, "button_hold_capable", False) if live else False,
         # Whether the device found its ambient light sensor. Reported so the

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -287,6 +287,7 @@ async def create_app() -> web.Application:
     app.router.add_post("/api/devices/{id}/wifi/scan",    _post_device_wifi_scan)
     app.router.add_post("/api/devices/{id}/update",       _post_device_update)
     app.router.add_post("/api/devices/{id}/rollback",     _post_device_rollback)
+    app.router.add_post("/api/devices/{id}/native_afe",   _post_device_native_afe)
     app.router.add_post("/api/releases/upload",           _post_upload_binary)
 
     # Custom wake-word models (oww_forge output → data/oww_models/)
@@ -1206,6 +1207,84 @@ async def _post_device_rollback(request: web.Request) -> web.Response:
 
     asyncio.create_task(_run_rollback(device_id, row["firmware_previous"]))
     return _ok({"status": "started", "rolling_back_to": row["firmware_previous"]}, status=202)
+
+
+# Path start_server.sh checks (docs/native-afe-migration.md's "Opting a
+# device in") — presence exports EM_NATIVE_AFE=1 for that boot. Data, not
+# script, so it survives the OTA-time canonical-payload re-sync that would
+# silently erase a hand-edited export in the script itself.
+NATIVE_AFE_MARKER = "/data/local/etc/echomuse/native_afe.enabled"
+
+
+@auth.require_admin
+async def _post_device_native_afe(request: web.Request) -> web.Response:
+    """
+    POST /api/devices/{id}/native_afe
+
+    Body: {"enabled": bool, "reboot": bool (default false)}
+
+    Writes or removes the on-device native-AFE opt-in marker. This ALONE
+    changes nothing: EM_NATIVE_AFE is read once at the Go binary's own
+    startup (docs/native-afe-migration.md — a boot-time choice, not a live
+    config push), and start_server.sh's own shell keeps its old inode open
+    regardless of anything short of a real restart of THAT script, not just
+    the server it supervises. Pass "reboot": true to also apply it now.
+
+    Gated on native_afe_backend, not native_afe: the backend capability is a
+    fixed fact about this build (compiled-in code + a start_server.sh new
+    enough to have the marker check), where native_afe reflects only whether
+    the AFE path happens to be running right this second — gating on the
+    latter would mean the toggle to turn it ON only appears once it is
+    already on.
+    """
+    device_id = request.match_info["id"]
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    enabled = bool(body.get("enabled"))
+    do_reboot = bool(body.get("reboot"))
+
+    live = _devices.get(device_id)
+    if live is None:
+        return _error("device_offline", "Device is not connected", 409)
+
+    if not getattr(live, "native_afe_backend_capable", False):
+        return _error("not_supported",
+                      "This firmware's start_server.sh predates the native-AFE "
+                      "opt-in marker — OTA it first", 409)
+
+    if device_id in _updates_in_progress:
+        return _error("update_in_progress", "An update is already in progress", 409)
+
+    if enabled:
+        cmd = (f"mkdir -p {DEVICE_TLS_DIR} && touch {NATIVE_AFE_MARKER} && "
+               f"test -f {NATIVE_AFE_MARKER} && echo MARKER_SET")
+    else:
+        cmd = (f"rm -f {NATIVE_AFE_MARKER}; "
+               f"test -f {NATIVE_AFE_MARKER} && echo STILL_PRESENT || echo MARKER_CLEARED")
+    result = await _shell_run(live, cmd)
+
+    want = "MARKER_SET" if enabled else "MARKER_CLEARED"
+    if want not in result:
+        return _error("marker_write_failed",
+                      f"Could not confirm the marker was "
+                      f"{'set' if enabled else 'cleared'} "
+                      f"(device shell reported: {result.strip() or 'nothing'})", 502)
+
+    await _push_log_event(
+        device_id, "info", "controller",
+        f"native AFE opt-in marker {'set' if enabled else 'cleared'} — "
+        f"takes effect on next reboot" + (" (rebooting now)" if do_reboot else ""))
+
+    if do_reboot:
+        # The shell dies the instant `reboot` executes on the device side, so
+        # no response will ever arrive — same shape as the OTA slot-flip's
+        # `kill $PPID` (see _run_update), a short timeout rather than
+        # something to meaningfully await a result from.
+        await _shell_run(live, "reboot", timeout=5.0)
+
+    return _ok({"status": "ok", "marker": enabled, "rebooting": do_reboot})
 
 
 @auth.require_admin
@@ -4071,6 +4150,10 @@ def _merge_device(row) -> dict:
         # bypasses — "disabled with the reason", never a control that
         # silently does nothing.
         "nativeAfeCapable": getattr(live, "native_afe_capable", False) if live else False,
+        # Fixed build property (opt-in mechanism exists at all), distinct
+        # from the runtime state above — gates whether the dashboard offers
+        # the toggle in the first place.
+        "nativeAfeBackendCapable": getattr(live, "native_afe_backend_capable", False) if live else False,
         # Gates the tap-as-event toggle — see em_button.decide.
         "buttonHoldCapable": getattr(live, "button_hold_capable", False) if live else False,
         # Whether the device found its ambient light sensor. Reported so the

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -618,6 +618,24 @@ class Device:
         """
         return "oww_trigger" in (self.capabilities or [])
 
+    @property
+    def native_afe_capable(self) -> bool:
+        """
+        Whether this device's audio is running through Android's audio HAL
+        (OpenSL ES) right now, reaching Amazon's ASP front end — see
+        docs/native-afe-migration.md.
+
+        Unlike most capabilities here, this is NOT a fixed property of the
+        firmware build: it is a boot-time choice (EM_NATIVE_AFE) that falls
+        back to the tinyalsa backends if the OpenSL ES path fails to open, so
+        the device only announces it when that fallback did NOT happen (see
+        internal/client/control.go's capabilities()). Reporting the attempt
+        rather than the outcome would tell the dashboard to disable the
+        beamformer/AEC/AGC/gain controls on a device that silently fell back
+        and still needs them.
+        """
+        return "native_afe" in (self.capabilities or [])
+
     async def send_led_anim(self, anim: dict):
         """
         Hand the ring to the device's local animation engine (led_anim

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -636,6 +636,22 @@ class Device:
         """
         return "native_afe" in (self.capabilities or [])
 
+    @property
+    def native_afe_backend_capable(self) -> bool:
+        """
+        Whether this firmware BUILD supports being opted into native AFE at
+        all — internal/bindings/slmic + slspeaker compiled in, and a
+        start_server.sh with the opt-in marker check. Unlike
+        native_afe_capable above, this is a fixed property of the build, not
+        of what is running right now: a device can have this and still be on
+        the tinyalsa path (marker unset, or not yet rebooted).
+
+        This is what the dashboard's toggle gates on. Writing the marker file
+        to a device that lacks this would be a control that silently does
+        nothing — older firmware's start_server.sh never checks for it.
+        """
+        return "native_afe_backend" in (self.capabilities or [])
+
     async def send_led_anim(self, anim: dict):
         """
         Hand the ring to the device's local animation engine (led_anim

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -79,6 +79,7 @@ import em_esphome as esphome
 import em_ble_proxy
 import em_oww_models
 import em_player
+import em_volume
 
 _LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s — %(message)s"
 
@@ -200,16 +201,11 @@ SPEAKER_FRAME_TYPE = 0x02
 SPEAKER_EOS_TYPE   = 0x03
 MIC_HEADER_LEN     = 3   # [type][seq_hi][seq_lo]
 
-# Volume conversion — device uses integer 0–175, HA expects float 0.0–1.0.
-VOLUME_MAX_DEVICE = 175
-
-def _device_level_to_ha(level: int) -> float:
-    """Convert device volume (0–175) to HA float (0.0–1.0)."""
-    return max(0.0, min(1.0, level / VOLUME_MAX_DEVICE))
-
-def _ha_volume_to_device(volume: float) -> int:
-    """Convert HA volume float (0.0–1.0) to device integer (0–175)."""
-    return max(0, min(VOLUME_MAX_DEVICE, round(volume * VOLUME_MAX_DEVICE)))
+# Volume conversion lives in em_volume so the scale has ONE definition and a
+# test — it used to be spelled `/ 175` in three separate modules.
+VOLUME_MAX_DEVICE = em_volume.DEVICE_VOLUME_MAX
+_device_level_to_ha = em_volume.device_level_to_ha
+_ha_volume_to_device = em_volume.ha_volume_to_device
 
 # ─── Device registry ──────────────────────────────────────────────────────────
 
@@ -2538,7 +2534,7 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                     })
 
                 elif msg_type == "volume_state":
-                    # Device reports current volume level (0–175 int).
+                    # Device reports its current volume level (raw tinymix index).
                     # Convert to HA float, update in-memory state, persist to
                     # config so the value survives controller and device restarts.
                     raw_level = int(msg.get("level", 85))

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -72,6 +72,7 @@ import em_recordings
 import em_oww_models
 import em_player
 import em_turnclock
+import em_volume
 
 # ── VAD sentinels ──────────────────────────────────────────────────────────────
 # Queue items marking end-of-speech in mic_queue/voice_queue, in place of
@@ -491,9 +492,12 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             device_id = (self._owning_server.device_id
                          if self._owning_server is not None else None)
             if msg.has_volume and self._owning_server is not None:
-                # HA set an explicit volume — convert float (0.0–1.0) to device
-                # integer (0–175) and forward to the physical device.
-                level = max(0, min(175, round(msg.volume * 175)))
+                # HA set an explicit volume — convert float (0.0–1.0) to the
+                # device's native level and forward to the physical device.
+                # The conversion is em_volume's, not a local `* 175`: the
+                # ceiling is the codec's unity gain, above which the DAC
+                # clips (see em_volume's docstring).
+                level = em_volume.ha_volume_to_device(msg.volume)
                 log.debug(
                     f"[{self._log_name}] MediaPlayerCommandRequest: "
                     f"volume={msg.volume:.3f} → level={level}"

--- a/controller/em_volume.py
+++ b/controller/em_volume.py
@@ -1,0 +1,47 @@
+"""Volume scale conversion between the device's native level and HA's float.
+
+Split out as pure logic for the reason em_linkauth.py was: the three call
+sites (em_controller, em_esphome, em_api) each had their OWN copy of
+`level / 175`, so the scale lived in three places and none of them were
+covered by a test. Changing the ceiling meant finding all three.
+
+The device level is the raw tinymix ctl 61 index — the tlv320aic32x4 DAC
+digital volume, 0.5dB per step with 0dB (unity) at index 127. The scale is
+therefore dB-linear, which is roughly perceptually linear, so the mapping to
+HA's 0.0–1.0 is a plain proportion and needs no extra taper.
+
+DEVICE_VOLUME_MAX is 127 and NOT the control's own maximum of 175. Indexes
+above 127 apply positive digital gain to near-full-scale PCM and saturate
+inside the DAC — measured at 65% THD by index 153 (see
+device/internal/server/volume.go for the full measurement and why stock
+FireOS never touches this control).
+"""
+
+# Codec unity gain. The mixer control accepts up to 175; everything above
+# this clips. See the module docstring.
+DEVICE_VOLUME_MAX = 127
+
+# 0.5dB per index step, 0dB at DEVICE_VOLUME_MAX.
+DB_PER_STEP = 0.5
+
+
+def level_to_db(level: int) -> float:
+    """Device level as dB relative to unity. Index 127 -> 0.0, index 0 -> -63.5."""
+    return (level - DEVICE_VOLUME_MAX) * DB_PER_STEP
+
+
+def device_level_to_ha(level: int) -> float:
+    """Convert a device volume level to an HA float (0.0–1.0)."""
+    try:
+        return max(0.0, min(1.0, float(level) / DEVICE_VOLUME_MAX))
+    except (TypeError, ValueError, ZeroDivisionError):
+        return 0.0
+
+
+def ha_volume_to_device(volume: float) -> int:
+    """Convert an HA volume float (0.0–1.0) to a device volume level.
+
+    Clamped to the codec's unity gain, so HA asking for full volume can never
+    put the DAC into positive digital gain.
+    """
+    return max(0, min(DEVICE_VOLUME_MAX, round(float(volume) * DEVICE_VOLUME_MAX)))

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1995,8 +1995,16 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                       onClick={() => doNativeAfeToggle(true)}>
                       {nativeAfeBusy ? 'Working…' : 'Enable + restart'}
                     </Pill>
+                    {/* Gated on nativeAfeBackendCapable, not nativeAfeCapable — the
+                        marker can be set with the AFE NOT active (it fell back to
+                        tinyalsa on open failure, exactly the case _pollNativeAfeReconnect
+                        warns about below), and that is precisely the state someone
+                        needs to be able to clear. Gating on the runtime flag would
+                        strand them: Enable no-ops on an already-set marker, Disable
+                        greyed out, no way back short of devshell.py — the workflow
+                        this panel exists to replace. */}
                     <Pill small danger={device.nativeAfeCapable}
-                      disabled={!device.connected || nativeAfeBusy || !device.nativeAfeCapable}
+                      disabled={!device.connected || nativeAfeBusy || !device.nativeAfeBackendCapable}
                       onClick={() => doNativeAfeToggle(false)}>
                       {nativeAfeBusy ? 'Working…' : 'Disable + restart'}
                     </Pill>

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1122,6 +1122,8 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
   const [logsLoading, setLogsLoading] = useState(false);
   const [pushLog, setPushLog] = useState([]);
   const [pushing, setPushing] = useState(false);
+  const [nativeAfeBusy, setNativeAfeBusy] = useState(false);
+  const [nativeAfeLog, setNativeAfeLog] = useState([]);
   const [release, setRelease] = useState(null);
   const [checkingRelease, setCheckingRelease] = useState(false);
   const [approveLabel, setApproveLabel] = useState(device.label || '');
@@ -1388,6 +1390,65 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
           clearInterval(poll); setPushing(false);
         }
       } catch(e) { clearInterval(poll); setPushing(false); }
+    }, 3000);
+  }
+
+  // Native AFE opt-in (docs/native-afe-migration.md) — the marker write
+  // takes effect only on the device's next boot, so this always confirms
+  // (unlike doRollback: that's a well-worn recovery path, this is putting
+  // brand-new, hardware-unverified code — OpenSL ES, HAL routing — directly
+  // in the path of the device's next real voice turn) and always reboots
+  // immediately rather than leaving a marker set with no visible effect,
+  // which would read as the control having silently done nothing.
+  async function doNativeAfeToggle(enable) {
+    const verb = enable ? 'Enable' : 'Disable';
+    if (!confirm(`${verb} native AFE and restart ${device.label || device.device_id} now?\n\n` +
+                 `This replaces the beamformer/AEC/AGC with Android's own audio HAL front end ` +
+                 `for the device's mic and speaker. The device will be briefly unreachable while ` +
+                 `it reboots.`)) return;
+    setNativeAfeBusy(true);
+    setNativeAfeLog([`${verb === 'Enable' ? 'Enabling' : 'Disabling'} — writing the marker and rebooting…`]);
+    try {
+      await API.post(`/api/devices/${device.device_id}/native_afe`, { enabled: enable, reboot: true });
+      setNativeAfeLog(l => [...l, 'Marker set — waiting for the device to come back…']);
+      _pollNativeAfeReconnect(enable);
+    } catch(e) {
+      setNativeAfeLog(l => [...l, `Error: ${e.error || 'Could not write the marker'}`]);
+      setNativeAfeBusy(false);
+    }
+  }
+
+  // Unlike _pollReconnect, completion is "reconnected" — a reboot for this
+  // doesn't change firmware_ver, so that check can't apply. Reports whether
+  // the capability actually came up matching what was requested: the
+  // backend falls back to tinyalsa on any OpenSL ES open failure (default-
+  // off-safe by design), which from here looks like "reconnected but the
+  // toggle didn't take" and is worth saying plainly rather than claiming success.
+  function _pollNativeAfeReconnect(wantActive) {
+    let attempts = 0;
+    let wasDisconnected = false;
+    const poll = setInterval(async () => {
+      attempts++;
+      try {
+        const devices = await API.get('/api/devices');
+        const d = devices.find(x => x.device_id === device.device_id);
+        if (!d?.connected) wasDisconnected = true;
+        if (wasDisconnected && d?.connected) {
+          if (!!d.nativeAfeCapable === wantActive) {
+            setNativeAfeLog(l => [...l, `✓ Reconnected — native AFE is now ${wantActive ? 'active' : 'off'}.`]);
+          } else if (wantActive) {
+            setNativeAfeLog(l => [...l, `⚠ Reconnected, but native AFE did not come up — it fell back ` +
+              `to the tinyalsa path. Check the device's logs (Status tab).`]);
+          } else {
+            setNativeAfeLog(l => [...l, `⚠ Reconnected, but native AFE is still reporting active — ` +
+              `the marker removal or reboot may not have taken. Check the device's logs.`]);
+          }
+          clearInterval(poll); setNativeAfeBusy(false);
+        } else if (attempts > 40) {
+          setNativeAfeLog(l => [...l, 'Timed out waiting for reconnect — check the device.']);
+          clearInterval(poll); setNativeAfeBusy(false);
+        }
+      } catch(e) { clearInterval(poll); setNativeAfeBusy(false); }
     }, 3000);
   }
 
@@ -1907,6 +1968,50 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                   </div>
                 )}
               </Panel>
+
+              {/* Native AFE opt-in (docs/native-afe-migration.md) — only
+                  offered when the firmware build supports it at all
+                  (native_afe_backend: compiled-in backends + a
+                  start_server.sh that checks the marker). Gated on THAT
+                  capability rather than nativeAfeCapable, which reflects
+                  only whether it happens to be running right now — gating
+                  on the latter would mean the control to turn it ON only
+                  ever appeared once it was already on. */}
+              {device.nativeAfeBackendCapable && (
+                <Panel label="Native AFE (experimental)">
+                  <div style={{ fontFamily:"'DM Mono',monospace", fontSize:10, color:'var(--muted)', lineHeight:1.6, marginBottom:14 }}>
+                    Routes this device's mic and speaker through Android's own audio HAL —
+                    Amazon's per-mic AEC, beamformer and SNR beam selection — instead of the
+                    beamformer/AEC/AGC controls under Microphones, which it replaces while active.
+                    Hardware-unverified: run <code>afe_probe</code> on this device before enabling
+                    it for real use. Both directions restart the device to apply.
+                  </div>
+                  <div style={{ display:'flex', alignItems:'center', gap:12, marginBottom: nativeAfeLog.length ? 12 : 0, flexWrap:'wrap' }}>
+                    <span style={{ fontFamily:"'DM Mono',monospace", fontSize:11, color: device.nativeAfeCapable ? 'var(--ok)' : 'var(--muted)' }}>
+                      {device.nativeAfeCapable ? '● Active' : '○ Off (tinyalsa)'}
+                    </span>
+                    <Pill small accent={!device.nativeAfeCapable}
+                      disabled={!device.connected || nativeAfeBusy || device.nativeAfeCapable}
+                      onClick={() => doNativeAfeToggle(true)}>
+                      {nativeAfeBusy ? 'Working…' : 'Enable + restart'}
+                    </Pill>
+                    <Pill small danger={device.nativeAfeCapable}
+                      disabled={!device.connected || nativeAfeBusy || !device.nativeAfeCapable}
+                      onClick={() => doNativeAfeToggle(false)}>
+                      {nativeAfeBusy ? 'Working…' : 'Disable + restart'}
+                    </Pill>
+                  </div>
+                  {nativeAfeLog.map((line, i) => (
+                    <div key={i} style={{
+                      fontFamily:"'DM Mono',monospace", fontSize:10, marginTop:4,
+                      color: line.startsWith('✓') ? 'var(--ok)'
+                           : line.startsWith('⚠') ? 'var(--warn)'
+                           : line.startsWith('Error') ? 'var(--error)'
+                           : 'var(--muted)',
+                    }}>{line}</div>
+                  ))}
+                </Panel>
+              )}
 
               {/* The GitHub Release panel that used to sit here held one
                   button, which now lives beside the version state above.

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1786,6 +1786,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                 triggerCapable={!device.connected || !!device.owwTriggerCapable}
                 mixCapable={!device.connected || !!device.audioMixCapable}
                 holdCapable={!device.connected || !!device.buttonHoldCapable}
+                afeActive={!!device.nativeAfeCapable}
                 onScopeChange={(id, local) => {
                   setSections(prev => local
                     ? [...prev, id]
@@ -4900,11 +4901,18 @@ function onDeviceMode(config) {
 
 function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
                             shadowCapable = true, mixCapable = true,
-                            holdCapable = true, triggerCapable = true }) {
+                            holdCapable = true, triggerCapable = true,
+                            afeActive = false }) {
   // shadowCapable defaults TRUE because this form is also the fleet-config
   // view, where there is no single device whose capability could gate a
   // control. Referencing a `device` here is what blank-screened the Config
   // tab: the prop does not exist, so `device.connected` threw during render.
+  // afeActive defaults FALSE for the same fleet-view reason, but its polarity
+  // is the opposite of the *Capable props above: those mean "can do X, so
+  // enable"; afeActive means "native AFE is running right now, so DISABLE the
+  // beamformer/AEC/AGC/gain controls it replaces" (docs/native-afe-
+  // migration.md's bypass table) — false is the safe default either way
+  // (fleet view, or a device we don't know is running it yet).
   // sections == null means the fleet-config view: nothing to inherit from, so
   // no per-section switches and every control is live.
   const scoped = Array.isArray(sections);
@@ -5213,16 +5221,41 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
         </div>
         <StageAdvanced open={advMics} onToggle={() => setAdvMics(o => !o)} disabledStyle={inputStyle}>
           <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px 24px' }}>
-            <Slider label="MICPGA" sub="analog gain, before the ADC" value={config.adcMicpga ?? 40} min={0} max={59} onChange={v => set('adcMicpga', v)}/>
-            <Slider label="Digital gain" sub="ADC digital gain — affects wake + turns" value={config.adcDigitalGain ?? 88} min={0} max={100} onChange={v => set('adcDigitalGain', v)}/>
-            <Slider label="Mic gain" sub="fixed gain on the 24-bit capture, pre-16-bit stream" value={config.micGainDb ?? 24} min={0} max={42} unit="dB" onChange={v => set('micGainDb', v)}/>
-            <Slider label="Beam angle" sub="-1 = auto (onset-ratio selection)" value={config.beamAngle ?? -1} min={-1} max={359} step={1} onChange={v => set('beamAngle', v)}/>
-            <Toggle label="Beamforming" sub="perimeter mic lock during turns" value={config.beamformingEnabled ?? false} onChange={v => set('beamformingEnabled', v)}/>
-            <Toggle label="Echo cancel (AEC)" sub="subtracts the device's own playback — wake + turns" value={config.aecEnabled ?? false} onChange={v => set('aecEnabled', v)}/>
-            <Toggle label="Noise suppression" sub="DTLN denoise on speech-to-text audio only — helps fans/hum, not TV speech" value={config.nsAsr ?? false} onChange={v => set('nsAsr', v)}/>
-            <Slider label="AEC delay" sub="playback write-to-ear latency compensation" value={config.aecDelayMs ?? 250} min={0} max={1000} step={10} unit="ms" onChange={v => set('aecDelayMs', v)}/>
-            <Slider label="AEC tail" sub="filter length — residual delay error + room reverb" value={config.aecTailMs ?? 300} min={50} max={500} step={10} unit="ms" onChange={v => set('aecTailMs', v)}/>
+            <Slider label="MICPGA" disabled={afeActive}
+              sub={afeActive ? "gain now comes from the AFE (HAL PGA + AFE output gain) — see native AFE below" : "analog gain, before the ADC"}
+              value={config.adcMicpga ?? 40} min={0} max={59} onChange={v => set('adcMicpga', v)}/>
+            <Slider label="Digital gain" disabled={afeActive}
+              sub={afeActive ? "gain now comes from the AFE (HAL PGA + AFE output gain) — see native AFE below" : "ADC digital gain — affects wake + turns"}
+              value={config.adcDigitalGain ?? 88} min={0} max={100} onChange={v => set('adcDigitalGain', v)}/>
+            <Slider label="Mic gain" disabled={afeActive}
+              sub={afeActive ? "gain now comes from the AFE (HAL PGA + AFE output gain) — see native AFE below" : "fixed gain on the 24-bit capture, pre-16-bit stream"}
+              value={config.micGainDb ?? 24} min={0} max={42} unit="dB" onChange={v => set('micGainDb', v)}/>
+            <Slider label="Beam angle" disabled={afeActive || !(config.beamformingEnabled ?? false)}
+              sub={afeActive ? "the AFE selects its own beam — see native AFE below" : "-1 = auto (onset-ratio selection)"}
+              value={config.beamAngle ?? -1} min={-1} max={359} step={1} onChange={v => set('beamAngle', v)}/>
+            <Toggle label="Beamforming" disabled={afeActive}
+              sub={afeActive ? "replaced by the AFE's fixed+adaptive beamformer and SNR beam selection — see native AFE below" : "perimeter mic lock during turns"}
+              value={afeActive ? false : (config.beamformingEnabled ?? false)} onChange={v => set('beamformingEnabled', v)}/>
+            <Toggle label="Echo cancel (AEC)" disabled={afeActive}
+              sub={afeActive ? "replaced by the AFE's own per-mic AEC — see native AFE below" : "subtracts the device's own playback — wake + turns"}
+              value={afeActive ? false : (config.aecEnabled ?? false)} onChange={v => set('aecEnabled', v)}/>
+            <Toggle label="Noise suppression" sub={afeActive ? "the mic stream is already denoised by the AFE — this would be a second pass on top of it" : "DTLN denoise on speech-to-text audio only — helps fans/hum, not TV speech"} value={config.nsAsr ?? false} onChange={v => set('nsAsr', v)}/>
+            <Slider label="AEC delay" disabled={afeActive || !(config.aecEnabled ?? false)}
+              sub={afeActive ? "the AFE times its own reference — see native AFE below" : "playback write-to-ear latency compensation"}
+              value={config.aecDelayMs ?? 250} min={0} max={1000} step={10} unit="ms" onChange={v => set('aecDelayMs', v)}/>
+            <Slider label="AEC tail" disabled={afeActive || !(config.aecEnabled ?? false)}
+              sub={afeActive ? "the AFE runs its own filter — see native AFE below" : "filter length — residual delay error + room reverb"}
+              value={config.aecTailMs ?? 300} min={50} max={500} step={10} unit="ms" onChange={v => set('aecTailMs', v)}/>
             <Toggle label="Save utterances" sub="keeps the last 10 turns' mic audio on the server — play or download from Activity" value={config.saveUtterances ?? false} onChange={v => set('saveUtterances', v)}/>
+            {afeActive && (
+              <div style={{ gridColumn: '1 / -1', marginTop: 4, fontFamily: mono, fontSize: 10, color: 'var(--muted)', lineHeight: 1.6 }}>
+                Native AFE is active on this device (docs/native-afe-migration.md):
+                Android's own audio HAL — Amazon's per-mic AEC, fixed+adaptive
+                beamformer and SNR beam selection — is doing capture instead of
+                the controls above. Recovery is a firmware flag flip and a
+                restart, not a setting here.
+              </div>
+            )}
           </div>
         </StageAdvanced>
       </Stage>
@@ -5328,7 +5361,9 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
         </div>
         {subHeader('Turn processing')}
         <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 24px', ...inputStyle }}>
-          <Toggle label="Auto gain (AGC)" sub="levels button-turn speech; never the wake stream" value={config.agcEnabled ?? true} onChange={v => set('agcEnabled', v)}/>
+          <Toggle label="Auto gain (AGC)" disabled={afeActive}
+            sub={afeActive ? "replaced by the AFE's own AGC (native AFE — see Microphones)" : "levels button-turn speech; never the wake stream"}
+            value={afeActive ? false : (config.agcEnabled ?? true)} onChange={v => set('agcEnabled', v)}/>
         </div>
         {subHeader('Speech gate')}
         <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '4px 20px', ...inputStyle }}>

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1414,8 +1414,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                  (enable
                    ? `Recording and playback move to the Echo's original Amazon audio ` +
                      `software, which does its own beamforming, echo cancellation and auto ` +
-                     `gain in place of EchoMuse's. This has not been measured on real ` +
-                     `hardware yet.`
+                     `gain in place of EchoMuse's.`
                    : `Recording and playback move back to EchoMuse's own pipeline, and its ` +
                      `beamforming, echo cancellation and gain settings take effect again.`) +
                  `\n\nThe Echo will be briefly unreachable while it restarts.`)) return;
@@ -1859,9 +1858,8 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                         sound it played itself.
                       </div>
                       <div style={{ marginTop:8 }}>
-                        Experimental — nothing has been measured through it on real hardware
-                        yet. Run <code>afe_probe</code> on this Echo first. Either direction
-                        restarts the Echo, which is briefly unreachable while it comes back.
+                        Either direction restarts the Echo, which is briefly unreachable
+                        while it comes back.
                       </div>
                     </div>
                     <div style={{ display:'flex', alignItems:'center', gap:12, marginBottom: nativeAfeLog.length ? 12 : 0, flexWrap:'wrap' }}>

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -323,19 +323,26 @@ function Slider({ label, sub, value, min, max, step = 1, unit = '', formatValue,
   );
 }
 
-function Toggle({ label, sub, value, onChange }) {
+function Toggle({ label, sub, value, onChange, disabled = false }) {
   // minWidth: 0 on the flex container and label lets long label/sub text
   // shrink and wrap instead of forcing the row (and the switch with it)
   // wider than the grid column — which pushed the switch past the edge of
   // the config dialog. flexShrink: 0 keeps the switch at full size.
+  //
+  // `disabled` is honoured here, not just styled: callers have passed it
+  // since the native-AFE bypass table landed, but the prop was ignored, so
+  // a control shown as off-and-greyed still WROTE the opposite value on a
+  // click — the exact "silently does something else" that disabled-with-
+  // reason exists to prevent. Slider has always taken the same prop.
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20, minWidth: 0, gap: 10 }}>
       <div style={{ minWidth: 0, flex: 1 }}>
-        <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: 'var(--text2)' }}>{label}</span>
+        <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: disabled ? 'var(--muted)' : 'var(--text2)' }}>{label}</span>
         {sub && <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)', marginLeft: 8 }}>{sub}</span>}
       </div>
-      <div onClick={() => onChange(!value)} style={{
-        width: 36, height: 20, borderRadius: 10, cursor: 'pointer', position: 'relative', flexShrink: 0,
+      <div onClick={() => { if (!disabled) onChange(!value); }} style={{
+        width: 36, height: 20, borderRadius: 10, cursor: disabled ? 'default' : 'pointer',
+        position: 'relative', flexShrink: 0, opacity: disabled ? 0.45 : 1,
         background: value ? 'var(--accent)' : 'var(--muted)',
         border: value ? '1px solid var(--accent-deep)' : '1px solid var(--muted)',
         transition: 'background 0.15s',
@@ -1401,13 +1408,19 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
   // immediately rather than leaving a marker set with no visible effect,
   // which would read as the control having silently done nothing.
   async function doNativeAfeToggle(enable) {
-    const verb = enable ? 'Enable' : 'Disable';
-    if (!confirm(`${verb} native AFE and restart ${device.label || device.device_id} now?\n\n` +
-                 `This replaces the beamformer/AEC/AGC with Android's own audio HAL front end ` +
-                 `for the device's mic and speaker. The device will be briefly unreachable while ` +
-                 `it reboots.`)) return;
+    const who = enable ? "Amazon's" : "EchoMuse's";
+    if (!confirm(`Switch ${device.label || device.device_id} to ${who} audio pipeline ` +
+                 `and restart it now?\n\n` +
+                 (enable
+                   ? `Recording and playback move to the Echo's original Amazon audio ` +
+                     `software, which does its own beamforming, echo cancellation and auto ` +
+                     `gain in place of EchoMuse's. This has not been measured on real ` +
+                     `hardware yet.`
+                   : `Recording and playback move back to EchoMuse's own pipeline, and its ` +
+                     `beamforming, echo cancellation and gain settings take effect again.`) +
+                 `\n\nThe Echo will be briefly unreachable while it restarts.`)) return;
     setNativeAfeBusy(true);
-    setNativeAfeLog([`${verb === 'Enable' ? 'Enabling' : 'Disabling'} — writing the marker and rebooting…`]);
+    setNativeAfeLog([`Switching to ${who} pipeline — writing the marker and restarting…`]);
     try {
       await API.post(`/api/devices/${device.device_id}/native_afe`, { enabled: enable, reboot: true });
       setNativeAfeLog(l => [...l, 'Marker set — waiting for the device to come back…']);
@@ -1435,13 +1448,13 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
         if (!d?.connected) wasDisconnected = true;
         if (wasDisconnected && d?.connected) {
           if (!!d.nativeAfeCapable === wantActive) {
-            setNativeAfeLog(l => [...l, `✓ Reconnected — native AFE is now ${wantActive ? 'active' : 'off'}.`]);
+            setNativeAfeLog(l => [...l, `✓ Back online — now using ${wantActive ? "Amazon's" : "EchoMuse's"} pipeline.`]);
           } else if (wantActive) {
-            setNativeAfeLog(l => [...l, `⚠ Reconnected, but native AFE did not come up — it fell back ` +
-              `to the tinyalsa path. Check the device's logs (Status tab).`]);
+            setNativeAfeLog(l => [...l, `⚠ Back online, but Amazon's pipeline did not start — it fell ` +
+              `back to EchoMuse's. Check the device's logs (Status tab).`]);
           } else {
-            setNativeAfeLog(l => [...l, `⚠ Reconnected, but native AFE is still reporting active — ` +
-              `the marker removal or reboot may not have taken. Check the device's logs.`]);
+            setNativeAfeLog(l => [...l, `⚠ Back online, but it is still reporting Amazon's pipeline — ` +
+              `the marker removal or restart may not have taken. Check the device's logs.`]);
           }
           clearInterval(poll); setNativeAfeBusy(false);
         } else if (attempts > 40) {
@@ -1807,6 +1820,86 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                 <ConnectivityTab device={device} row={row}/>
               </div>
 
+              {/* Audio pipeline / native AFE opt-in (docs/native-afe-migration.md).
+                  Lives here rather than on the Updates tab because it decides what
+                  half the controls below this point even do — but ABOVE the config
+                  form and outside it, for two reasons that both bite if ignored:
+                  it is not a config key (it is a marker file plus a reboot, applied
+                  immediately, never by "Push config"), and it is always per-device,
+                  so it must not sit inside a Stage whose Fleet/Device switch would
+                  grey it out. Same placement argument as the WiFi block above.
+
+                  Offered when the firmware BUILD supports it (native_afe_backend:
+                  compiled-in backends + a start_server.sh that checks the marker),
+                  not when it happens to be running (nativeAfeCapable) — gating on
+                  the latter would mean the control to turn it on only ever appeared
+                  once it was already on.
+
+                  isAdmin is part of the gate and was not needed on the Updates
+                  tab, which admins alone can reach — the Config tab is visible
+                  to everyone (read-only, `disabled={!isAdmin}` on the form
+                  below). The endpoint is admin-only regardless, so without this
+                  a viewer would get buttons that 403. */}
+              {isAdmin && device.nativeAfeBackendCapable && (
+                <div style={{ paddingBottom: 24, marginBottom: 24, borderBottom: '1px solid var(--line, var(--track))' }}>
+                  <Panel label="Audio pipeline">
+                    <div style={{ fontFamily:"'DM Mono',monospace", fontSize:10, color:'var(--muted)', lineHeight:1.7, marginBottom:14 }}>
+                      Which software records from the mics and plays to the speaker.
+                      <div style={{ marginTop:8 }}>
+                        <b style={{ color:'var(--text2)' }}>EchoMuse</b> — the default. Our own
+                        recording and playback, shaped by the beamforming, echo cancellation
+                        and gain settings further down this page.
+                      </div>
+                      <div style={{ marginTop:6 }}>
+                        <b style={{ color:'var(--text2)' }}>Amazon</b> — the Echo&apos;s original
+                        audio software, the one it shipped with for Alexa. It does its own
+                        beamforming, per-mic echo cancellation and auto gain, so the settings
+                        it takes over are greyed out below while it is on. Recording and
+                        playback switch together: Amazon&apos;s echo canceller can only remove
+                        sound it played itself.
+                      </div>
+                      <div style={{ marginTop:8 }}>
+                        Experimental — nothing has been measured through it on real hardware
+                        yet. Run <code>afe_probe</code> on this Echo first. Either direction
+                        restarts the Echo, which is briefly unreachable while it comes back.
+                      </div>
+                    </div>
+                    <div style={{ display:'flex', alignItems:'center', gap:12, marginBottom: nativeAfeLog.length ? 12 : 0, flexWrap:'wrap' }}>
+                      <span style={{ fontFamily:"'DM Mono',monospace", fontSize:11, color: device.nativeAfeCapable ? 'var(--ok)' : 'var(--muted)' }}>
+                        {device.nativeAfeCapable ? '● Using Amazon' : '○ Using EchoMuse'}
+                      </span>
+                      <Pill small accent={!device.nativeAfeCapable}
+                        disabled={!device.connected || nativeAfeBusy || device.nativeAfeCapable}
+                        onClick={() => doNativeAfeToggle(true)}>
+                        {nativeAfeBusy ? 'Working…' : 'Switch to Amazon'}
+                      </Pill>
+                      {/* Gated on nativeAfeBackendCapable, not nativeAfeCapable — the
+                          marker can be set with the AFE NOT active (it fell back to
+                          our own path on an open failure, exactly the case
+                          _pollNativeAfeReconnect warns about), and that is precisely
+                          the state someone needs to be able to clear. Gating on the
+                          runtime flag would strand them: enabling no-ops on an
+                          already-set marker, the way back greyed out, no recovery
+                          short of devshell.py — the workflow this panel replaces. */}
+                      <Pill small danger={device.nativeAfeCapable}
+                        disabled={!device.connected || nativeAfeBusy || !device.nativeAfeBackendCapable}
+                        onClick={() => doNativeAfeToggle(false)}>
+                        {nativeAfeBusy ? 'Working…' : 'Switch to EchoMuse'}
+                      </Pill>
+                    </div>
+                    {nativeAfeLog.map((line, i) => (
+                      <div key={i} style={{
+                        fontFamily:"'DM Mono',monospace", fontSize:10, marginTop:4,
+                        color: line.startsWith('✓') ? 'var(--ok)'
+                             : line.startsWith('⚠') ? 'var(--warn)'
+                             : line.startsWith('Error') ? 'var(--error)'
+                             : 'var(--muted)',
+                      }}>{line}</div>
+                    ))}
+                  </Panel>
+                </div>
+              )}
+
               {/* Scoping summary. Each section below carries its own
                   Fleet/Device switch — this is just the roll-up plus a way
                   back to fully inheriting. */}
@@ -1968,58 +2061,6 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                   </div>
                 )}
               </Panel>
-
-              {/* Native AFE opt-in (docs/native-afe-migration.md) — only
-                  offered when the firmware build supports it at all
-                  (native_afe_backend: compiled-in backends + a
-                  start_server.sh that checks the marker). Gated on THAT
-                  capability rather than nativeAfeCapable, which reflects
-                  only whether it happens to be running right now — gating
-                  on the latter would mean the control to turn it ON only
-                  ever appeared once it was already on. */}
-              {device.nativeAfeBackendCapable && (
-                <Panel label="Native AFE (experimental)">
-                  <div style={{ fontFamily:"'DM Mono',monospace", fontSize:10, color:'var(--muted)', lineHeight:1.6, marginBottom:14 }}>
-                    Routes this device's mic and speaker through Android's own audio HAL —
-                    Amazon's per-mic AEC, beamformer and SNR beam selection — instead of the
-                    beamformer/AEC/AGC controls under Microphones, which it replaces while active.
-                    Hardware-unverified: run <code>afe_probe</code> on this device before enabling
-                    it for real use. Both directions restart the device to apply.
-                  </div>
-                  <div style={{ display:'flex', alignItems:'center', gap:12, marginBottom: nativeAfeLog.length ? 12 : 0, flexWrap:'wrap' }}>
-                    <span style={{ fontFamily:"'DM Mono',monospace", fontSize:11, color: device.nativeAfeCapable ? 'var(--ok)' : 'var(--muted)' }}>
-                      {device.nativeAfeCapable ? '● Active' : '○ Off (tinyalsa)'}
-                    </span>
-                    <Pill small accent={!device.nativeAfeCapable}
-                      disabled={!device.connected || nativeAfeBusy || device.nativeAfeCapable}
-                      onClick={() => doNativeAfeToggle(true)}>
-                      {nativeAfeBusy ? 'Working…' : 'Enable + restart'}
-                    </Pill>
-                    {/* Gated on nativeAfeBackendCapable, not nativeAfeCapable — the
-                        marker can be set with the AFE NOT active (it fell back to
-                        tinyalsa on open failure, exactly the case _pollNativeAfeReconnect
-                        warns about below), and that is precisely the state someone
-                        needs to be able to clear. Gating on the runtime flag would
-                        strand them: Enable no-ops on an already-set marker, Disable
-                        greyed out, no way back short of devshell.py — the workflow
-                        this panel exists to replace. */}
-                    <Pill small danger={device.nativeAfeCapable}
-                      disabled={!device.connected || nativeAfeBusy || !device.nativeAfeBackendCapable}
-                      onClick={() => doNativeAfeToggle(false)}>
-                      {nativeAfeBusy ? 'Working…' : 'Disable + restart'}
-                    </Pill>
-                  </div>
-                  {nativeAfeLog.map((line, i) => (
-                    <div key={i} style={{
-                      fontFamily:"'DM Mono',monospace", fontSize:10, marginTop:4,
-                      color: line.startsWith('✓') ? 'var(--ok)'
-                           : line.startsWith('⚠') ? 'var(--warn)'
-                           : line.startsWith('Error') ? 'var(--error)'
-                           : 'var(--muted)',
-                    }}>{line}</div>
-                  ))}
-                </Panel>
-              )}
 
               {/* The GitHub Release panel that used to sit here held one
                   button, which now lives beside the version state above.
@@ -5335,38 +5376,41 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
         <StageAdvanced open={advMics} onToggle={() => setAdvMics(o => !o)} disabledStyle={inputStyle}>
           <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px 24px' }}>
             <Slider label="MICPGA" disabled={afeActive}
-              sub={afeActive ? "gain now comes from the AFE (HAL PGA + AFE output gain) — see native AFE below" : "analog gain, before the ADC"}
+              sub={afeActive ? "Amazon's pipeline sets its own mic gain" : "analog gain, before the ADC"}
               value={config.adcMicpga ?? 40} min={0} max={59} onChange={v => set('adcMicpga', v)}/>
             <Slider label="Digital gain" disabled={afeActive}
-              sub={afeActive ? "gain now comes from the AFE (HAL PGA + AFE output gain) — see native AFE below" : "ADC digital gain — affects wake + turns"}
+              sub={afeActive ? "Amazon's pipeline sets its own mic gain" : "ADC digital gain — affects wake + turns"}
               value={config.adcDigitalGain ?? 88} min={0} max={100} onChange={v => set('adcDigitalGain', v)}/>
             <Slider label="Mic gain" disabled={afeActive}
-              sub={afeActive ? "gain now comes from the AFE (HAL PGA + AFE output gain) — see native AFE below" : "fixed gain on the 24-bit capture, pre-16-bit stream"}
+              sub={afeActive ? "Amazon's pipeline sets its own mic gain" : "fixed gain on the 24-bit capture, pre-16-bit stream"}
               value={config.micGainDb ?? 24} min={0} max={42} unit="dB" onChange={v => set('micGainDb', v)}/>
             <Slider label="Beam angle" disabled={afeActive || !(config.beamformingEnabled ?? false)}
-              sub={afeActive ? "the AFE selects its own beam — see native AFE below" : "-1 = auto (onset-ratio selection)"}
+              sub={afeActive ? "Amazon's pipeline picks its own direction" : "-1 = auto (onset-ratio selection)"}
               value={config.beamAngle ?? -1} min={-1} max={359} step={1} onChange={v => set('beamAngle', v)}/>
             <Toggle label="Beamforming" disabled={afeActive}
-              sub={afeActive ? "replaced by the AFE's fixed+adaptive beamformer and SNR beam selection — see native AFE below" : "perimeter mic lock during turns"}
+              sub={afeActive ? "Amazon's pipeline does its own beamforming" : "perimeter mic lock during turns"}
               value={afeActive ? false : (config.beamformingEnabled ?? false)} onChange={v => set('beamformingEnabled', v)}/>
             <Toggle label="Echo cancel (AEC)" disabled={afeActive}
-              sub={afeActive ? "replaced by the AFE's own per-mic AEC — see native AFE below" : "subtracts the device's own playback — wake + turns"}
+              sub={afeActive ? "Amazon's pipeline cancels its own echo, on every mic" : "subtracts the device's own playback — wake + turns"}
               value={afeActive ? false : (config.aecEnabled ?? false)} onChange={v => set('aecEnabled', v)}/>
-            <Toggle label="Noise suppression" sub={afeActive ? "the mic stream is already denoised by the AFE — this would be a second pass on top of it" : "DTLN denoise on speech-to-text audio only — helps fans/hum, not TV speech"} value={config.nsAsr ?? false} onChange={v => set('nsAsr', v)}/>
+            {/* Not disabled under the AFE: this one is CONTROLLER-side (DTLN on
+                the speech-to-text stream), so it still runs and still has an
+                effect — just a second denoise on an already-denoised stream,
+                which is a judgement call and not an inert control. */}
+            <Toggle label="Noise suppression" sub={afeActive ? "Amazon's pipeline already denoises the mic — this adds a second pass on top" : "DTLN denoise on speech-to-text audio only — helps fans/hum, not TV speech"} value={config.nsAsr ?? false} onChange={v => set('nsAsr', v)}/>
             <Slider label="AEC delay" disabled={afeActive || !(config.aecEnabled ?? false)}
-              sub={afeActive ? "the AFE times its own reference — see native AFE below" : "playback write-to-ear latency compensation"}
+              sub={afeActive ? "Amazon's pipeline times its own echo canceller" : "playback write-to-ear latency compensation"}
               value={config.aecDelayMs ?? 250} min={0} max={1000} step={10} unit="ms" onChange={v => set('aecDelayMs', v)}/>
             <Slider label="AEC tail" disabled={afeActive || !(config.aecEnabled ?? false)}
-              sub={afeActive ? "the AFE runs its own filter — see native AFE below" : "filter length — residual delay error + room reverb"}
+              sub={afeActive ? "Amazon's pipeline runs its own echo canceller" : "filter length — residual delay error + room reverb"}
               value={config.aecTailMs ?? 300} min={50} max={500} step={10} unit="ms" onChange={v => set('aecTailMs', v)}/>
             <Toggle label="Save utterances" sub="keeps the last 10 turns' mic audio on the server — play or download from Activity" value={config.saveUtterances ?? false} onChange={v => set('saveUtterances', v)}/>
             {afeActive && (
               <div style={{ gridColumn: '1 / -1', marginTop: 4, fontFamily: mono, fontSize: 10, color: 'var(--muted)', lineHeight: 1.6 }}>
-                Native AFE is active on this device (docs/native-afe-migration.md):
-                Android's own audio HAL — Amazon's per-mic AEC, fixed+adaptive
-                beamformer and SNR beam selection — is doing capture instead of
-                the controls above. Recovery is a firmware flag flip and a
-                restart, not a setting here.
+                This Echo is recording through Amazon&apos;s own audio pipeline, so the
+                greyed-out controls above have no effect — it does that work itself.
+                Switch back under <b>Audio pipeline</b> at the top of this tab; it
+                needs a restart, so it is not part of Push config.
               </div>
             )}
           </div>
@@ -5475,7 +5519,7 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
         {subHeader('Turn processing')}
         <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 24px', ...inputStyle }}>
           <Toggle label="Auto gain (AGC)" disabled={afeActive}
-            sub={afeActive ? "replaced by the AFE's own AGC (native AFE — see Microphones)" : "levels button-turn speech; never the wake stream"}
+            sub={afeActive ? "Amazon's pipeline does its own auto gain — see Audio pipeline at the top of this tab" : "levels button-turn speech; never the wake stream"}
             value={afeActive ? false : (config.agcEnabled ?? true)} onChange={v => set('agcEnabled', v)}/>
         </div>
         {subHeader('Speech gate')}

--- a/controller/tests/test_capabilities.py
+++ b/controller/tests/test_capabilities.py
@@ -107,6 +107,24 @@ def test_triggering_is_a_separate_capability_from_scoring():
         "the dashboard must gate the 'On device' option on the capability"
 
 
+def test_native_afe_capability_is_surfaced_to_the_dashboard():
+    """
+    docs/native-afe-migration.md's bypass table: beamformingEnabled,
+    aecEnabled, agcEnabled and the mic gain controls do nothing while the
+    native-AFE backend is running, so the dashboard must be able to tell that
+    apart from an ordinary device — the same "cannot vs off" reasoning as
+    oww_shadow, just with the polarity inverted (this capability being present
+    is what DISABLES controls, not what offers a new one).
+    """
+    assert "native_afe_capable" in CONTROLLER.read_text(), \
+        "em_controller must expose the native-AFE capability as a property"
+    assert "nativeAfeCapable" in API.read_text(), \
+        "/api/devices must surface the native-AFE capability"
+    jsx = (ROOT / "controller" / "static" / "dashboard.jsx").read_text()
+    assert "nativeAfeCapable" in jsx and "afeActive" in jsx, \
+        "the dashboard must gate the beamformer/AEC/AGC/gain controls on the capability"
+
+
 def test_capabilities_reported_before_the_server_exists_are_not_lost():
     """
     A device registers BEFORE its ESPHome server is created — the listener

--- a/controller/tests/test_capabilities.py
+++ b/controller/tests/test_capabilities.py
@@ -125,6 +125,32 @@ def test_native_afe_capability_is_surfaced_to_the_dashboard():
         "the dashboard must gate the beamformer/AEC/AGC/gain controls on the capability"
 
 
+def test_the_toggle_control_actually_honours_disabled():
+    """
+    "Disabled with the reason, never a control that silently does nothing" is
+    the whole rule the bypass table above is enforced by — and for the first
+    release of it, Toggle did not take a `disabled` prop at all (only Slider
+    did). Beamforming, Echo cancel and Auto gain therefore rendered greyed
+    with their reason, read as off, and WROTE THE OPPOSITE VALUE into config
+    when clicked: worse than doing nothing, because the setting silently
+    disagreed with what the control showed.
+
+    Asserted against the component rather than the call sites, because the
+    call sites already looked correct while the bug was live.
+    """
+    jsx = (ROOT / "controller" / "static" / "dashboard.jsx").read_text()
+    m = re.search(r'function Toggle\(\{(.*?)\}\)', jsx, re.S)
+    assert m, "dashboard.jsx must still define a Toggle component"
+    assert "disabled" in m.group(1), \
+        "Toggle must accept a `disabled` prop — every caller that passes one " \
+        "is relying on it to refuse the write, not merely to grey the switch"
+
+    body = jsx[m.end():jsx.index("\n}", m.end())]
+    assert re.search(r'if\s*\(!disabled\)|disabled\s*\?\s*undefined|disabled\s*\|\|', body), \
+        "Toggle's click handler must check `disabled` before calling onChange — " \
+        "styling it grey while still writing the value is the bug this pins"
+
+
 def test_native_afe_toggle_is_gated_on_the_backend_capability_not_the_active_one():
     """
     native_afe_backend is a fixed fact about the BUILD (compiled-in backends

--- a/controller/tests/test_capabilities.py
+++ b/controller/tests/test_capabilities.py
@@ -125,6 +125,24 @@ def test_native_afe_capability_is_surfaced_to_the_dashboard():
         "the dashboard must gate the beamformer/AEC/AGC/gain controls on the capability"
 
 
+def test_native_afe_toggle_is_gated_on_the_backend_capability_not_the_active_one():
+    """
+    native_afe_backend is a fixed fact about the BUILD (compiled-in backends
+    + a start_server.sh new enough to check the marker); native_afe reflects
+    only whether the AFE happens to be running right now. The dashboard's
+    toggle — which offers to turn it ON — has to gate on the former: gating
+    on the latter would mean the control to enable it only appears once it
+    is already enabled.
+    """
+    assert "native_afe_backend" in CONTROLLER.read_text(), \
+        "em_controller must expose the native-AFE backend capability as a property"
+    assert "nativeAfeBackendCapable" in API.read_text(), \
+        "/api/devices must surface the native-AFE backend capability"
+    jsx = (ROOT / "controller" / "static" / "dashboard.jsx").read_text()
+    assert "nativeAfeBackendCapable" in jsx, \
+        "the dashboard must gate the native-AFE toggle on the backend capability"
+
+
 def test_capabilities_reported_before_the_server_exists_are_not_lost():
     """
     A device registers BEFORE its ESPHome server is created — the listener

--- a/controller/tests/test_volume.py
+++ b/controller/tests/test_volume.py
@@ -1,0 +1,48 @@
+"""Volume scale conversion.
+
+The scale existed as `/ 175` copy-pasted into three modules with no test at
+all, which is how it went four releases with a ceiling that put the codec's
+DAC into positive digital gain. These pin the ceiling and the round trip.
+"""
+import pytest
+
+import em_volume
+
+
+def test_ceiling_is_codec_unity_not_the_controls_maximum():
+    # tinymix ctl 61 accepts 0..175. 127 is 0dB; everything above it is
+    # POSITIVE digital gain on near-full-scale PCM and clips inside the DAC
+    # (measured 65% THD at index 153). If this ever reads 175 again, the
+    # distortion above ~73% volume is back.
+    assert em_volume.DEVICE_VOLUME_MAX == 127
+
+
+def test_full_ha_volume_cannot_exceed_unity():
+    assert em_volume.ha_volume_to_device(1.0) == 127
+    # Out-of-range input must clamp, not scale past the ceiling.
+    assert em_volume.ha_volume_to_device(1.5) == 127
+    assert em_volume.ha_volume_to_device(-0.5) == 0
+
+
+def test_level_to_db_anchors():
+    assert em_volume.level_to_db(127) == pytest.approx(0.0)
+    assert em_volume.level_to_db(0) == pytest.approx(-63.5)
+    # The old ceiling was +24dB of digital gain.
+    assert em_volume.level_to_db(175) == pytest.approx(24.0)
+
+
+def test_ha_round_trip_is_stable():
+    for level in range(0, 128):
+        ha = em_volume.device_level_to_ha(level)
+        assert em_volume.ha_volume_to_device(ha) == level
+
+
+def test_device_level_above_the_cap_reports_as_full():
+    # A device still sitting at a pre-cap level must not report >1.0 to HA.
+    assert em_volume.device_level_to_ha(175) == 1.0
+    assert em_volume.device_level_to_ha(140) == 1.0
+
+
+def test_bad_input_does_not_raise():
+    assert em_volume.device_level_to_ha(None) == 0.0
+    assert em_volume.device_level_to_ha("nonsense") == 0.0

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -26,6 +26,8 @@ import (
 	"github.com/wilbowes/EchoMuse/internal/bindings/jack"
 	internalbuttons "github.com/wilbowes/EchoMuse/internal/bindings/buttons"
 	"github.com/wilbowes/EchoMuse/internal/bindings/mic"
+	"github.com/wilbowes/EchoMuse/internal/bindings/slmic"
+	"github.com/wilbowes/EchoMuse/internal/bindings/slspeaker"
 	"github.com/wilbowes/EchoMuse/internal/bindings/speaker"
 	"github.com/wilbowes/EchoMuse/internal/bluetooth"
 	"github.com/wilbowes/EchoMuse/internal/client"
@@ -35,6 +37,8 @@ import (
 	"github.com/wilbowes/EchoMuse/internal/wifi"
 	pkgbuttons "github.com/wilbowes/EchoMuse/pkg/buttons"
 	"github.com/wilbowes/EchoMuse/pkg/led"
+	pkgmic "github.com/wilbowes/EchoMuse/pkg/mic"
+	pkgspeaker "github.com/wilbowes/EchoMuse/pkg/speaker"
 )
 
 func main() {
@@ -68,27 +72,26 @@ func main() {
 		log.Fatalf("Failed to initialize Button controller: %v", err)
 	}
 
-	microphone, err := mic.NewMicrophone()
-	if err != nil {
-		log.Fatalf("Failed to initialize Microphone: %v", err)
-	}
-
 	// AEC canceller — far end fed by the speaker's echo tap, near end run
 	// by the data client on the mono mic stream. Starts disabled; armed by
-	// applyAecConfig from env defaults below and on every config push.
+	// applyAecConfig from env defaults below and on every config push. On
+	// the native-AFE audio path this stays wired up but unused — see
+	// newAudioBackends.
 	canceller := aec.New()
 
 	// The level tap drives the energy-reactive LED ring ("meter" pattern).
 	// The Server doesn't exist yet when the speaker starts its pump loop,
 	// so the tap goes through an atomic pointer armed just below.
 	var srvPtr atomic.Pointer[server.Server]
-	pcmSpeaker, err := speaker.NewPcmSpeaker(canceller.WriteFar, func(rms float64) {
+	levelTap := func(rms float64) {
 		if srv := srvPtr.Load(); srv != nil {
 			srv.SetAudioLevel(rms)
 		}
-	})
+	}
+
+	microphone, pcmSpeaker, err := newAudioBackends(canceller, levelTap)
 	if err != nil {
-		log.Fatalf("Failed to initialize PCM Speaker: %v", err)
+		log.Fatalf("Failed to initialize audio: %v", err)
 	}
 
 	s := server.NewServer(buttonController, microphone, pcmSpeaker)
@@ -500,6 +503,87 @@ func main() {
 	os.Exit(0)
 }
 
+// ─── Audio backend selection ───────────────────────────────────────────────────
+//
+// See docs/native-afe-migration.md. Two backend pairs implement the same
+// pkg/mic and pkg/speaker interfaces:
+//
+//	tinyalsa (default): internal/bindings/mic + internal/bindings/speaker —
+//	  writes PCM directly, our own beamformer/AEC/AGC.
+//	native AFE (opt-in): internal/bindings/slmic + internal/bindings/slspeaker —
+//	  OpenSL ES through Android's audio HAL, reaching Amazon's ASP front end
+//	  (per-mic AEC, beamforming, SNR beam selection) at the cost of no longer
+//	  owning the PCM outright.
+//
+// This is a BOOT-TIME choice, not a live config push — the mic/speaker
+// backends are opened here, before any controller connection exists to push
+// a config to. Per the plan's own "Risks" section, recovery from a bad AFE
+// run in the field is "a firmware flag flip and a restart", deliberately not
+// a config toggle: EM_NATIVE_AFE is read once, at process start.
+//
+// The two backends are ALWAYS chosen together, never independently — an AFE
+// build with only one side converted produces audio that is beamformed but
+// not echo-cancelled, with no error anywhere, which reads as the AFE
+// underperforming rather than as a wiring mistake ("the one rule that
+// matters" in the migration doc).
+type micBackend interface {
+	pkgmic.Microphone
+	pkgmic.Subscribable
+}
+
+// nativeAFERequested reads the boot-time audio backend selection.
+func nativeAFERequested() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("EM_NATIVE_AFE")))
+	return v == "1" || v == "true" || v == "on"
+}
+
+// newAudioBackends opens the mic and speaker backends selected by
+// EM_NATIVE_AFE, falling back to tinyalsa if the native-AFE path fails to
+// open — a device where libOpenSLES.so cannot be dlopen'd, or the HAL
+// refuses the configuration, keeps working exactly as it did before this
+// migration rather than failing to boot. On success on the native path, it
+// also flips the capability control.go's capabilities() reports: unlike
+// "ambient_light" (hardware either has the sensor or it doesn't),
+// "native_afe" reflects the backend actually running right now, not merely
+// what this firmware build supports — the same reasoning that keeps a
+// config control "disabled with the reason" rather than "present but inert"
+// on the controller/dashboard side (see docs/native-afe-migration.md's
+// Phase 2 and CLAUDE.md's capability-negotiation rule).
+func newAudioBackends(canceller *aec.Canceller, levelTap func(rms float64)) (micBackend, pkgspeaker.FullSpeaker, error) {
+	if !nativeAFERequested() {
+		return newTinyalsaBackends(canceller, levelTap)
+	}
+
+	log.Println("[audio] EM_NATIVE_AFE set — attempting the OpenSL ES / native-AFE audio path")
+	m, err := slmic.NewMicrophone()
+	if err != nil {
+		log.Printf("[audio] native AFE microphone unavailable, falling back to tinyalsa: %v", err)
+		return newTinyalsaBackends(canceller, levelTap)
+	}
+	spk, err := slspeaker.NewSpeaker(canceller.WriteFar, levelTap)
+	if err != nil {
+		log.Printf("[audio] native AFE speaker unavailable, falling back to tinyalsa: %v", err)
+		m.Close()
+		return newTinyalsaBackends(canceller, levelTap)
+	}
+
+	client.SetNativeAFEActive(true)
+	log.Println("[audio] native AFE audio path active (OpenSL ES) — beamformer/AEC/AGC bypassed, see docs/native-afe-migration.md")
+	return m, spk, nil
+}
+
+func newTinyalsaBackends(canceller *aec.Canceller, levelTap func(rms float64)) (micBackend, pkgspeaker.FullSpeaker, error) {
+	m, err := mic.NewMicrophone()
+	if err != nil {
+		return nil, nil, fmt.Errorf("tinyalsa microphone: %w", err)
+	}
+	spk, err := speaker.NewPcmSpeaker(canceller.WriteFar, levelTap)
+	if err != nil {
+		return nil, nil, fmt.Errorf("tinyalsa speaker: %w", err)
+	}
+	return m, spk, nil
+}
+
 // ─── Hardware stats collection ────────────────────────────────────────────────
 
 // shadowStats drains the on-device wake word counters for this reporting
@@ -879,7 +963,7 @@ var shadowState struct {
 // rather than on every config push, and the device carries on with
 // controller-side wake word exactly as before.
 func applyShadowConfig(dc *client.DataClient, cc *client.ControlClient,
-	spk *speaker.PcmSpeaker, srv *server.Server) {
+	spk pkgspeaker.FullSpeaker, srv *server.Server) {
 	snap := config.Get().Snapshot()
 	mode, model := snap.OwwOnDevice, snap.OwwModel
 	threshold := float32(snap.OwwThreshold)

--- a/device/internal/bindings/slmic/slmic.go
+++ b/device/internal/bindings/slmic/slmic.go
@@ -1,0 +1,199 @@
+//go:build server
+
+// Package slmic captures through Android's audio HAL via OpenSL ES instead of
+// writing tinyalsa PCM directly, so the capture reaches Amazon's ASP front
+// end (per-mic AEC, fixed+adaptive beamformer, SNR beam selection) instead of
+// bypassing it. See docs/native-afe-migration.md.
+//
+// It implements the same pkg/mic.Microphone (+ Subscribable) contract
+// PcmMicrophone does, with one declared difference: Passthrough() reports
+// true, because the HAL has already reduced the capture to one processed mono
+// channel before this package ever sees it. internal/client's streamMic uses
+// that to skip internal/beamformer entirely rather than feed it a buffer
+// shaped for raw 9-channel capture (see pkg/mic.PassthroughReporter).
+package slmic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+
+	"github.com/wilbowes/EchoMuse/internal/opensl"
+	pkgmic "github.com/wilbowes/EchoMuse/pkg/mic"
+)
+
+const (
+	// defaultLib resolves against /system/lib on the device — the same
+	// library the plan's phase-0 spike confirmed present. Overridable for
+	// bench/emulator use, same idea as EM_OWW_DIR.
+	defaultLib = "libOpenSLES.so"
+
+	// sampleRateHz/periodFrames match the wire format every consumer above
+	// this package already expects: mono S16 16kHz in 80ms frames (see
+	// CLAUDE.md's device audio pipeline section). Nothing downstream needs
+	// to change to accept them.
+	sampleRateHz = 16000
+	periodFrames = 1280 // 80ms @ 16kHz
+
+	// hwBuffers is the OpenSL ES-facing double/triple buffering only — small
+	// by design. It is not the application-level lead buffer; that lives in
+	// each subscriber's own channel, same layering as PcmMicrophone's ALSA
+	// read loop vs. its per-subscriber fan-out.
+	hwBuffers = 4
+
+	// fanoutDepth matches PcmMicrophone.Subscribe's channel depth.
+	fanoutDepth = 32
+)
+
+// Microphone captures mono S16 16kHz through OpenSL ES at the
+// VOICE_RECOGNITION preset and fans it out to subscribers, mirroring
+// internal/bindings/mic.PcmMicrophone's shape.
+type Microphone struct {
+	eng *opensl.Engine
+	rec *opensl.Recorder
+
+	mu   sync.Mutex
+	subs []chan []byte
+}
+
+// NewMicrophone opens the OpenSL ES engine, a recorder at the
+// VOICE_RECOGNITION preset, and starts capture — mirroring
+// mic.PcmMicrophone.NewMicrophone's contract of returning a fully running
+// microphone, so cmd/server.go's backend-selection switch can call either
+// constructor identically. Critically, it runs no `stop mixer` / `stop
+// media`: unlike the tinyalsa backends, this path needs mediaserver to keep
+// owning the PCM, or the HAL's ASP front end is never in the loop at all
+// (docs/native-afe-migration.md, "the one rule that matters").
+func NewMicrophone() (*Microphone, error) {
+	lib := os.Getenv("EM_OPENSL_LIB")
+	if lib == "" {
+		lib = defaultLib
+	}
+	eng, err := opensl.Open(lib)
+	if err != nil {
+		return nil, fmt.Errorf("slmic: %w", err)
+	}
+	rec, err := eng.NewRecorder(opensl.PresetVoiceRecognition, sampleRateHz, periodFrames, hwBuffers)
+	if err != nil {
+		return nil, fmt.Errorf("slmic: %w", err)
+	}
+	m := &Microphone{eng: eng, rec: rec}
+	if err := m.Init(); err != nil {
+		rec.Close()
+		return nil, fmt.Errorf("slmic: %w", err)
+	}
+	return m, nil
+}
+
+// Init starts capture and the permanent fan-out loop, mirroring
+// PcmMicrophone.Init's shape so cmd/server.go's call site does not care which
+// backend it holds.
+func (m *Microphone) Init() error {
+	if err := m.rec.Start(); err != nil {
+		return fmt.Errorf("slmic: start: %w", err)
+	}
+	go m.readLoop()
+	log.Printf("[slmic] recording via OpenSL ES at %s preset (%dHz, %dms periods) — "+
+		"mediaserver keeps the PCM, no stop mixer/stop media on this path",
+		opensl.PresetVoiceRecognition, sampleRateHz, periodFrames*1000/sampleRateHz)
+	return nil
+}
+
+// readLoop reads completed periods forever and fans each out to every
+// current subscriber, exactly like PcmMicrophone.readLoop — down to closing
+// every subscriber channel on exit so callers see EOF rather than hang.
+func (m *Microphone) readLoop() {
+	var drops uint64
+	for {
+		buf, err := m.rec.Read()
+		if err != nil {
+			log.Printf("[slmic] recorder stream ended: %v", err)
+			break
+		}
+		m.mu.Lock()
+		for _, ch := range m.subs {
+			select {
+			case ch <- buf:
+			default:
+				drops++
+				if drops == 1 || drops%64 == 0 {
+					log.Printf("[slmic] subscriber channel full — period dropped (drops=%d)", drops)
+				}
+			}
+		}
+		m.mu.Unlock()
+	}
+
+	m.mu.Lock()
+	log.Printf("[slmic] recorder stream closed — notifying %d subscribers", len(m.subs))
+	for _, ch := range m.subs {
+		close(ch)
+	}
+	m.subs = nil
+	m.mu.Unlock()
+}
+
+// Subscribe registers a new subscriber and returns its channel.
+func (m *Microphone) Subscribe() chan []byte {
+	ch := make(chan []byte, fanoutDepth)
+	m.mu.Lock()
+	m.subs = append(m.subs, ch)
+	m.mu.Unlock()
+	return ch
+}
+
+// Unsubscribe removes a subscriber channel. Safe to call after readLoop has
+// already closed it.
+func (m *Microphone) Unsubscribe(ch chan []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, s := range m.subs {
+		if s == ch {
+			m.subs = append(m.subs[:i], m.subs[i+1:]...)
+			close(ch)
+			return
+		}
+	}
+}
+
+// Listen subscribes to the permanent stream and calls callback for each
+// period until ctx is cancelled. Satisfies pkgmic.Microphone.
+func (m *Microphone) Listen(callback pkgmic.AudioCallback, ctx context.Context) error {
+	if callback == nil {
+		return errors.New("callback can't be nil")
+	}
+	ch := m.Subscribe()
+	defer m.Unsubscribe(ch)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case audio, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			callback(audio)
+		}
+	}
+}
+
+// Passthrough reports that every fanned-out period is already one fully
+// processed mono channel — see pkg/mic.PassthroughReporter.
+func (m *Microphone) Passthrough() bool { return true }
+
+// Close stops capture. The underlying opensl.Engine is process-shared
+// (cached by library path) and outlives any one Microphone, so it is
+// deliberately not closed here.
+func (m *Microphone) Close() {
+	_ = m.rec.Stop()
+	m.rec.Close()
+}
+
+var (
+	_ pkgmic.Microphone          = (*Microphone)(nil)
+	_ pkgmic.Subscribable        = (*Microphone)(nil)
+	_ pkgmic.PassthroughReporter = (*Microphone)(nil)
+)

--- a/device/internal/bindings/slspeaker/mix.go
+++ b/device/internal/bindings/slspeaker/mix.go
@@ -1,0 +1,149 @@
+package slspeaker
+
+import "math"
+
+// Ducking and mixing for the two playback streams, mono variant.
+//
+// This is deliberately the same algorithm as internal/bindings/speaker/mix.go
+// — same ramp, same saturation, same reasoning, ported to mono because the
+// wire is duplicated to stereo only for tinyalsa's I2S/codec path (see
+// CLAUDE.md's speaker plane note); OpenSL ES takes the mono channel directly,
+// so there is nothing to duplicate here. It is a deliberate near-duplicate
+// rather than a shared package: the frame width differs (2 bytes here, 4
+// there) at exactly the one place — applyGain — where that matters, and
+// pulling the rest out for one differing loop was judged not worth new
+// cross-package plumbing during this migration. If both backends end up
+// shipping, extracting the identical parts (Mixer's dispatch, DuckGain,
+// mixInto, the ramp) into a shared internal package is the obvious follow-up.
+//
+// No build tag and no OpenSL import, deliberately — same as the tinyalsa
+// version, this is the arithmetic worth testing on the host.
+
+// unityGain: Q15 fixed point, 32768 == unity. See speaker.unityGain for why
+// (integer maths, exact at unity).
+const unityGain int32 = 1 << 15
+
+// duckRampPeriods / rampStep: identical reasoning to speaker.duckRampPeriods
+// — a CONSTANT SLEW (not proportional), so "N periods" is a duration rather
+// than a time constant. Kept as a period count rather than a wall-clock
+// value because slspeaker's period size is whatever the wire sends (see
+// slspeaker.go), matching the tinyalsa backend's own periods-not-ms framing.
+const duckRampPeriods = 4
+const rampStep = unityGain / duckRampPeriods
+
+// Mixer combines the voice and music streams for one output period.
+//
+// Single-consumer by contract: only the pump goroutine (slspeaker.go) touches
+// it, so nothing here is synchronised. The gain TARGET is set from elsewhere
+// and needs atomicity — it lives in Speaker, not here, same split as
+// speaker.PcmSpeaker/Mixer.
+type Mixer struct {
+	gain int32 // current, Q15, ramps toward the target
+}
+
+// DuckGain converts decibels of attenuation to Q15. 0dB returns exactly
+// unity rather than a rounded conversion, so "not ducked" is bit-identical
+// to the input.
+func DuckGain(db float64) int32 {
+	if db >= 0 {
+		return unityGain
+	}
+	g := math.Pow(10, db/20.0) * float64(unityGain)
+	if g < 0 {
+		return 0
+	}
+	return int32(g + 0.5)
+}
+
+// Gain reports the current (ramped) gain, for tests.
+func (m *Mixer) Gain() int32 { return m.gain }
+
+// SetGainImmediate jumps the ramp to a value, used at stream start where
+// there is no audio to click.
+func (m *Mixer) SetGainImmediate(g int32) { m.gain = g }
+
+// Mix produces one output period from whichever streams have audio. Both
+// buffers are owned by the caller once dequeued; mixing happens IN PLACE.
+// Returns the buffer to write, or nil when there is nothing to play.
+func (m *Mixer) Mix(voice, music []byte, target int32) []byte {
+	switch {
+	case voice == nil && music == nil:
+		// Still settle the ramp: a duck requested while nothing plays must
+		// not be left half-applied for the next period of audio.
+		m.stepGain(target)
+		return nil
+	case music == nil:
+		m.stepGain(target) // voice alone is never ducked
+		return voice
+	case voice == nil:
+		m.applyGain(music, target)
+		return music
+	default:
+		m.applyGain(music, target)
+		mixInto(voice, music)
+		return voice
+	}
+}
+
+func (m *Mixer) stepGain(target int32) {
+	switch {
+	case m.gain < target:
+		if m.gain += rampStep; m.gain > target {
+			m.gain = target
+		}
+	case m.gain > target:
+		if m.gain -= rampStep; m.gain < target {
+			m.gain = target
+		}
+	}
+}
+
+// applyGain scales a mono S16LE period, ramping per SAMPLE across it — a gain
+// step at a period boundary is an audible click, landing on exactly the
+// transition the user is listening to.
+func (m *Mixer) applyGain(buf []byte, target int32) {
+	start := m.gain
+	m.stepGain(target)
+	end := m.gain
+
+	frames := len(buf) / 2 // mono S16
+	if frames == 0 {
+		return
+	}
+	for i := 0; i < frames; i++ {
+		g := start
+		if end != start {
+			g = start + (end-start)*int32(i)/int32(frames)
+		}
+		off := i * 2
+		s := int32(int16(uint16(buf[off]) | uint16(buf[off+1])<<8))
+		s = (s * g) >> 15
+		buf[off] = byte(uint16(s) & 0xff)
+		buf[off+1] = byte(uint16(s) >> 8)
+	}
+}
+
+// mixInto sums music into voice with saturation — identical to
+// speaker.mixInto; this loop was never stereo-specific (it walks raw 2-byte
+// samples regardless of channel layout), so it carries over unchanged.
+//
+// Saturating rather than wrapping: an int16 overflow wraps a loud peak to
+// full-scale opposite polarity, far worse than the clipping it replaces.
+func mixInto(dst, src []byte) {
+	n := len(dst)
+	if len(src) < n {
+		n = len(src)
+	}
+	for i := 0; i+1 < n; i += 2 {
+		a := int32(int16(uint16(dst[i]) | uint16(dst[i+1])<<8))
+		b := int32(int16(uint16(src[i]) | uint16(src[i+1])<<8))
+		s := a + b
+		if s > math.MaxInt16 {
+			s = math.MaxInt16
+		} else if s < math.MinInt16 {
+			s = math.MinInt16
+		}
+		dst[i] = byte(uint16(s) & 0xff)
+		dst[i+1] = byte(uint16(s) >> 8)
+	}
+}

--- a/device/internal/bindings/slspeaker/mix_test.go
+++ b/device/internal/bindings/slspeaker/mix_test.go
@@ -1,0 +1,162 @@
+package slspeaker
+
+import (
+	"math"
+	"testing"
+)
+
+// period builds a mono S16 period where every frame has the same value.
+func period(frames int, v int16) []byte {
+	b := make([]byte, frames*2)
+	for i := 0; i < frames; i++ {
+		off := i * 2
+		b[off] = byte(uint16(v) & 0xff)
+		b[off+1] = byte(uint16(v) >> 8)
+	}
+	return b
+}
+
+func sampleAt(b []byte, frame int) int16 {
+	off := frame * 2
+	return int16(uint16(b[off]) | uint16(b[off+1])<<8)
+}
+
+func TestDuckGainUnityIsExact(t *testing.T) {
+	if g := DuckGain(0); g != unityGain {
+		t.Fatalf("0dB should be exactly unity, got %d", g)
+	}
+	m := &Mixer{gain: unityGain}
+	in := period(4, 12345)
+	m.applyGain(in, unityGain)
+	for i := 0; i < 4; i++ {
+		if got := sampleAt(in, i); got != 12345 {
+			t.Fatalf("unity gain altered the sample: %d", got)
+		}
+	}
+}
+
+func TestDuckGainDecibels(t *testing.T) {
+	for _, tc := range []struct{ db, want float64 }{
+		{-6, 0.5012}, {-18, 0.1259}, {-60, 0.001},
+	} {
+		got := float64(DuckGain(tc.db)) / float64(unityGain)
+		if math.Abs(got-tc.want) > 0.001 {
+			t.Errorf("%gdB: got %.4f want %.4f", tc.db, got, tc.want)
+		}
+	}
+}
+
+func TestVoiceAloneIsNeverAltered(t *testing.T) {
+	m := &Mixer{gain: DuckGain(-18)}
+	voice := period(4, 8000)
+	out := m.Mix(voice, nil, DuckGain(-18))
+	for i := 0; i < 4; i++ {
+		if got := sampleAt(out, i); got != 8000 {
+			t.Fatalf("voice was attenuated: %d", got)
+		}
+	}
+}
+
+func TestMusicAloneIsDucked(t *testing.T) {
+	m := &Mixer{gain: DuckGain(-6)}
+	music := period(4, 10000)
+	out := m.Mix(nil, music, DuckGain(-6))
+	got := sampleAt(out, 3)
+	if got < 4900 || got > 5100 {
+		t.Fatalf("expected ~5000 (-6dB of 10000), got %d", got)
+	}
+}
+
+func TestNothingPlayingReturnsNil(t *testing.T) {
+	m := &Mixer{gain: unityGain}
+	if out := m.Mix(nil, nil, unityGain); out != nil {
+		t.Fatal("with no audio the caller must write nothing, not a buffer")
+	}
+}
+
+func TestTheRampSettlesEvenWithNoAudio(t *testing.T) {
+	m := &Mixer{gain: unityGain}
+	target := DuckGain(-18)
+	for i := 0; i < 20; i++ {
+		m.Mix(nil, nil, target)
+	}
+	if m.Gain() != target {
+		t.Fatalf("ramp did not settle while idle: %d != %d", m.Gain(), target)
+	}
+}
+
+func TestTheRampReachesItsTargetExactly(t *testing.T) {
+	m := &Mixer{gain: unityGain}
+	target := DuckGain(-18)
+	for i := 0; i < 200; i++ {
+		m.applyGain(period(2, 1000), target)
+	}
+	if m.Gain() != target {
+		t.Fatalf("gain never reached target: %d != %d", m.Gain(), target)
+	}
+	for i := 0; i < 200; i++ {
+		m.applyGain(period(2, 1000), unityGain)
+	}
+	if m.Gain() != unityGain {
+		t.Fatalf("gain never returned to unity: %d", m.Gain())
+	}
+}
+
+func TestTheRampIsGradualNotAStep(t *testing.T) {
+	m := &Mixer{gain: unityGain}
+	target := DuckGain(-18)
+	first := period(64, 10000)
+	m.applyGain(first, target)
+
+	start := sampleAt(first, 0)
+	end := sampleAt(first, 63)
+	if start <= end {
+		t.Fatalf("expected a descending ramp across the period, got %d -> %d", start, end)
+	}
+	if start < 9000 {
+		t.Fatalf("the ramp should START near the previous gain, got %d", start)
+	}
+	if m.Gain() == target {
+		t.Fatal("the whole duck landed in one period — that is the step this avoids")
+	}
+}
+
+func TestMixSumsBothStreams(t *testing.T) {
+	m := &Mixer{gain: unityGain}
+	voice := period(4, 1000)
+	music := period(4, 2000)
+	out := m.Mix(voice, music, unityGain)
+	if got := sampleAt(out, 3); got != 3000 {
+		t.Fatalf("expected 1000+2000, got %d", got)
+	}
+}
+
+func TestMixSaturatesRatherThanWrapping(t *testing.T) {
+	m := &Mixer{gain: unityGain}
+	voice := period(2, 30000)
+	music := period(2, 30000)
+	out := m.Mix(voice, music, unityGain)
+	if got := sampleAt(out, 0); got != math.MaxInt16 {
+		t.Fatalf("expected saturation to +32767, got %d", got)
+	}
+
+	m2 := &Mixer{gain: unityGain}
+	out2 := m2.Mix(period(2, -30000), period(2, -30000), unityGain)
+	if got := sampleAt(out2, 0); got != math.MinInt16 {
+		t.Fatalf("expected saturation to -32768, got %d", got)
+	}
+}
+
+func TestMixHandlesMismatchedLengths(t *testing.T) {
+	m := &Mixer{gain: unityGain}
+	out := m.Mix(period(8, 100), period(3, 100), unityGain)
+	if len(out) != 16 {
+		t.Fatalf("output should keep the voice period's length, got %d", len(out))
+	}
+	if got := sampleAt(out, 0); got != 200 {
+		t.Fatalf("overlapping region should be summed, got %d", got)
+	}
+	if got := sampleAt(out, 7); got != 100 {
+		t.Fatalf("the tail beyond the shorter buffer should be untouched, got %d", got)
+	}
+}

--- a/device/internal/bindings/slspeaker/slspeaker.go
+++ b/device/internal/bindings/slspeaker/slspeaker.go
@@ -141,6 +141,29 @@ func NewSpeaker(echoTap func([]byte), levelTap func(rms float64)) (*Speaker, err
 	s.mixer.SetGainImmediate(unityGain)
 
 	go s.pumpLoop()
+
+	// Enable the internal speaker amp, exactly as PcmSpeaker.Init does — this
+	// backend replaces that Init, and the amp is the one piece of its work that
+	// is NOT about owning the ALSA PCM. Ext_Speaker_Amp_Switch is a physical
+	// mixer control that survives across backends, defaults off, and is turned
+	// off by accdet on a headphone insert; Init was historically the only thing
+	// that ever turned it on (issue #80). Dropping it here made the native-AFE
+	// path deliver every period with underruns=0, minDepth healthy and the
+	// controller reporting a clean turn, into a dead amp — audible as nothing
+	// at all, with no failure visible anywhere in the logs. Confirmed on
+	// hardware 2026-08-12: the control read Off with no jack inserted, and
+	// setting it On restored audio with no other change.
+	//
+	// Unlike PcmSpeaker, there is no "amp on onto a clocked, silent DAC" wait
+	// before it: that ordering exists to keep the amp's turn-on transient
+	// inaudible, and it relies on tinyalsa's continuously silence-filled
+	// session, which this path deliberately does not have (an idle OpenSL ES
+	// player queues nothing at all — see NewPlayer). Whether that costs an
+	// audible pop here is unverified on hardware; a pop is strictly better
+	// than silence, and Phase 0/3 owns settling it with measurement rather
+	// than a guess, the same reasoning Close already documents.
+	s.EnableSpeakerAmp()
+
 	log.Printf("[slspeaker] playing via OpenSL ES (%dHz mono) — mediaserver keeps the PCM, no stop media on this path", sampleRateHz)
 	return s, nil
 }

--- a/device/internal/bindings/slspeaker/slspeaker.go
+++ b/device/internal/bindings/slspeaker/slspeaker.go
@@ -1,0 +1,340 @@
+//go:build server
+
+// Package slspeaker renders playback through Android's audio HAL via OpenSL
+// ES instead of writing tinyalsa PCM directly, so it reaches the far-end tap
+// Amazon's ASP front end takes at the HAL's playback side — tinyalsa writes
+// never pass through AudioFlinger, so the AEC in internal/bindings/slmic's
+// capture path would otherwise have nothing to cancel against (see
+// docs/native-afe-migration.md, "the one rule that matters": capture and
+// playback must BOTH go through the framework).
+//
+// The two-plane design (voice ducks music instead of pausing it), the duck
+// ramp, the prime gate and the per-stream delivery stats are unchanged from
+// internal/bindings/speaker.PcmSpeaker — see mix.go and stream.go for the
+// (deliberately near-identical) machinery. What differs is the write point:
+// OpenSL ES's buffer queue is callback-driven rather than a blocking ALSA
+// write, which changes how the pump loop is paced while idle — see pumpLoop.
+package slspeaker
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/wilbowes/EchoMuse/internal/opensl"
+	pkgspeaker "github.com/wilbowes/EchoMuse/pkg/speaker"
+)
+
+const (
+	defaultLib   = "libOpenSLES.so"
+	sampleRateHz = 48000 // matches the wire — nothing resamples
+
+	// periodFrames is nominal, used only to pace the pump loop while idle
+	// (see pumpLoop) — unlike ALSA there is no hardware ring size this must
+	// match exactly. 2048 mono samples ≈ 42.7ms mirrors the tinyalsa
+	// backend's ALSA periodSize, which is what duckRampPeriods (mix.go) was
+	// tuned against.
+	periodFrames = 2048
+
+	// maxPeriodBytes bounds a single Write — generous headroom over the
+	// wire's actual period size (the tinyalsa backend's monoPeriodBytes is
+	// 4096; see pcm_speaker.go's toStereo/periodSize).
+	maxPeriodBytes = 8192
+
+	// hwBuffers is the OpenSL ES-facing double/triple buffering only, not
+	// the lead ring below. A touch deeper than the recorder's: a stall here
+	// is audible, where a dropped capture period is just a missed analysis
+	// window.
+	hwBuffers = 4
+
+	// audioChanDepth / primePeriods mirror the tinyalsa backend's constants
+	// of the same name (internal/bindings/speaker/pcm_speaker.go) as a
+	// starting point, not an independently derived match. Reproducing the
+	// full sizing analysis for THIS backend (link-stall depth vs. hardware
+	// buffer headroom) is explicitly filed in docs/native-afe-migration.md's
+	// "Deferred / filed" section — this ships for Phase 3 measurement, not
+	// as a verified figure.
+	audioChanDepth = 128
+	primePeriods   = 24
+)
+
+// Speaker implements pkg/speaker.FullSpeaker over an OpenSL ES AudioPlayer.
+type Speaker struct {
+	eng  *opensl.Engine
+	play *opensl.Player
+
+	stopCh chan struct{}
+	deadCh chan struct{}
+
+	voice *audioStream
+	music *audioStream
+
+	duckTarget atomic.Int32
+	mixer      Mixer
+
+	// echoTap is accepted for call-site symmetry with
+	// speaker.NewPcmSpeaker (cmd/server.go's backend switch constructs
+	// either with the same two callbacks) but deliberately never invoked:
+	// the HAL takes its own far-end reference internally on this path, so
+	// feeding our Go-side AEC's reference stream would cost CPU for a
+	// cancellation the AEC below never runs (internal/aec is bypassed under
+	// native AFE — see the bypass table in docs/native-afe-migration.md).
+	echoTap func([]byte)
+
+	// levelTap fires at the Write point — VOICE only, pre-mix, matching the
+	// tinyalsa backend's tap (see PcmSpeaker.levelTap). It is MORE accurate
+	// here: tinyalsa's ALSA ring sits ~5.5s ahead of audible, so its tap
+	// leads the meter by that much, where this write point is only as far
+	// ahead as hwBuffers — a few tens of milliseconds.
+	levelTap func(rms float64)
+
+	statsMu sync.Mutex
+	statsCb func(pkgspeaker.StreamStats)
+}
+
+// OnStreamStats registers a per-stream stats callback — same contract as
+// PcmSpeaker.OnStreamStats.
+func (s *Speaker) OnStreamStats(cb func(pkgspeaker.StreamStats)) {
+	s.statsMu.Lock()
+	s.statsCb = cb
+	s.statsMu.Unlock()
+}
+
+// NewSpeaker opens the OpenSL ES engine (shared with slmic's Recorder if one
+// is also open — opensl.Open caches by library path) and an AudioPlayer.
+//
+// It does NOT run `stop media`: unlike PcmSpeaker, this backend needs
+// mediaserver to keep owning the PCM, or the HAL's ASP front end never sees
+// this playback as a far-end reference at all (docs/native-afe-migration.md,
+// "the one rule that matters").
+func NewSpeaker(echoTap func([]byte), levelTap func(rms float64)) (*Speaker, error) {
+	lib := os.Getenv("EM_OPENSL_LIB")
+	if lib == "" {
+		lib = defaultLib
+	}
+	eng, err := opensl.Open(lib)
+	if err != nil {
+		return nil, fmt.Errorf("slspeaker: %w", err)
+	}
+	play, err := eng.NewPlayer(sampleRateHz, maxPeriodBytes, hwBuffers)
+	if err != nil {
+		return nil, fmt.Errorf("slspeaker: %w", err)
+	}
+
+	s := &Speaker{
+		eng:      eng,
+		play:     play,
+		stopCh:   make(chan struct{}),
+		deadCh:   make(chan struct{}),
+		echoTap:  echoTap,
+		levelTap: levelTap,
+	}
+	s.voice = newAudioStream(audioChanDepth, s.deadCh)
+	s.music = newAudioStream(audioChanDepth, s.deadCh)
+	s.duckTarget.Store(unityGain)
+	s.mixer.SetGainImmediate(unityGain)
+
+	go s.pumpLoop()
+	log.Printf("[slspeaker] playing via OpenSL ES (%dHz mono) — mediaserver keeps the PCM, no stop media on this path", sampleRateHz)
+	return s, nil
+}
+
+// Init exists for symmetry with pkg/speaker.Speaker / PcmSpeaker's shape —
+// NewSpeaker already does all the work (opening the OpenSL ES objects starts
+// playback state immediately; see opensl.Engine.NewPlayer), so this is a
+// no-op. Kept as a real method rather than omitted so cmd/server.go's
+// backend-selection switch can treat both constructors identically if a
+// future caller wants an explicit two-phase construct/init split.
+func (s *Speaker) Init() error { return nil }
+
+// pumpLoop drains whichever plane(s) have audio, mixes them, and writes to
+// the OpenSL ES player — the same shape as PcmSpeaker.silenceLoop, with one
+// real difference in how it is paced.
+//
+// ALSA's blocking Pump() call paces silenceLoop even when idle (tinyalsa
+// keeps a continuous, silence-filled stream running once opened), so that
+// loop always has a wait to hang the ramp-settling and level-tap logic off
+// of. OpenSL ES's buffer queue has no such requirement — an AudioPlayer with
+// an empty queue is simply idle, not underrunning (see NewPlayer's doc) — so
+// there is nothing to write and nothing that blocks. This loop instead
+// sleeps one nominal period when idle, and lets Write's own blocking (on a
+// free hardware buffer slot) provide the pacing once something is actually
+// playing, matching realtime the same way ALSA's Pump() did.
+//
+// Whether ASP's own internal AEC wants a continuous (silence-inclusive) far-
+// end reference the way our Go-side speexdsp AEC does — see aec.Process's
+// aecDelayMs comment for why that mattered there — is exactly the kind of
+// question docs/native-afe-migration.md's Phase 0 spike exists to answer on
+// real hardware; nothing here has been verified against it.
+func (s *Speaker) pumpLoop() {
+	defer close(s.deadCh)
+	idlePeriod := time.Duration(periodFrames) * time.Second / time.Duration(sampleRateHz)
+
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		default:
+		}
+
+		var voice, music []byte
+		if s.voice.ready(primePeriods) {
+			voice = s.voice.take()
+		} else if s.voice.playing {
+			s.report(s.voice.drained(), "voice")
+		}
+		if s.music.ready(primePeriods) {
+			music = s.music.take()
+		} else if s.music.playing {
+			s.report(s.music.drained(), "music")
+		}
+
+		var level float64
+		if voice != nil && s.levelTap != nil {
+			level = periodRMS(voice)
+		}
+
+		out := s.mixer.Mix(voice, music, s.duckTarget.Load())
+		if out == nil {
+			time.Sleep(idlePeriod)
+			continue
+		}
+
+		if s.levelTap != nil {
+			s.levelTap(level)
+		}
+		if err := s.play.Write(out); err != nil {
+			log.Printf("[slspeaker] pumpLoop: write error: %v", err)
+			return
+		}
+	}
+}
+
+func (s *Speaker) report(st *pkgspeaker.StreamStats, plane string) {
+	if st == nil {
+		log.Printf("[slspeaker] UNDERRUN: %s channel drained mid-stream — injecting silence", plane)
+		return
+	}
+	log.Printf("[slspeaker] %s stream complete — returning to silence "+
+		"(periods=%d underruns=%d minDepth=%d primeWait=%dms recvSpan=%dms maxGap=%dms)",
+		plane, st.Periods, st.Underruns, st.MinDepth,
+		st.PrimeWaitMs, st.RecvSpanMs, st.MaxGapMs)
+	if plane != "voice" || st.Periods == 0 {
+		return
+	}
+	s.statsMu.Lock()
+	cb := s.statsCb
+	s.statsMu.Unlock()
+	if cb != nil {
+		go cb(*st)
+	}
+}
+
+// PumpPeriod queues one period of VOICE audio. The wire is already mono at
+// this backend's native rate, so — unlike PcmSpeaker.PumpPeriod — there is no
+// toStereo conversion: OpenSL ES takes the mono channel directly (stereo was
+// only ever an I2S/codec-path requirement of the tinyalsa route).
+func (s *Speaker) PumpPeriod(data []byte) error {
+	_, err := s.voice.pump(data, len(data))
+	return err
+}
+
+// PumpMusic queues one period of MUSIC audio (0x04) — identical handling to
+// the voice plane, kept separate so a voice turn can duck it rather than
+// stopping it.
+func (s *Speaker) PumpMusic(data []byte) error {
+	_, err := s.music.pump(data, len(data))
+	return err
+}
+
+// SetDuck sets the gain applied to music while it plays under voice, in dB
+// of attenuation. Ramped, not applied at once — see mix.go's applyGain.
+func (s *Speaker) SetDuck(db float64) { s.duckTarget.Store(DuckGain(db)) }
+
+// IsStreaming reports whether a VOICE stream is mid-flight — see
+// PcmSpeaker.IsStreaming for why music deliberately does not count.
+func (s *Speaker) IsStreaming() bool { return s.voice.isActive() }
+
+// IsPlayingMusic reports whether a music stream is mid-flight.
+func (s *Speaker) IsPlayingMusic() bool { return s.music.isActive() }
+
+// EndStream marks the in-flight voice stream complete (0x03).
+func (s *Speaker) EndStream() { s.voice.endStream() }
+
+// EndMusicStream marks the in-flight music stream complete (0x05).
+func (s *Speaker) EndMusicStream() { s.music.endStream() }
+
+// Flush cuts a playing VOICE stream (barge-in): drains the Go-side channel
+// and arms discard-until-EOS, same contract as PcmSpeaker.Flush. It does NOT
+// clear anything already handed to the OpenSL ES hardware queue — that queue
+// holds already-MIXED periods (voice and music summed, or a bare music
+// period when voice was nil that round), so clearing it indiscriminately
+// could cut real, still-wanted music audio that happened to be queued
+// unmixed. The tinyalsa backend accepts the same kind of tail (its ~170ms of
+// ALSA-ring periods already handed to hardware); this backend's tail is
+// smaller (hwBuffers small buffers), so the trade is at least as good, not
+// worse.
+func (s *Speaker) Flush() { s.voice.flush() }
+
+// FlushMusic stops music the same way, for the user genuinely stopping or
+// pausing (a voice turn ducks instead — see PcmSpeaker.FlushMusic).
+func (s *Speaker) FlushMusic() { s.music.flush() }
+
+// EnableSpeakerAmp re-enables the internal speaker amp after a headphone plug
+// is removed. Unchanged from the tinyalsa backend: accdet mutes this same
+// physical mixer control on insert regardless of which backend owns the PCM,
+// and nothing else turns it back on (issue #80) — that is orthogonal
+// hardware behaviour, not something native AFE changes.
+func (s *Speaker) EnableSpeakerAmp() {
+	if out, err := exec.Command("tinymix", "-D", "0", "5", "On").CombinedOutput(); err != nil {
+		log.Printf("[slspeaker] could not re-enable speaker amp: %v — %s", err, strings.TrimSpace(string(out)))
+		return
+	}
+	log.Println("[slspeaker] speaker amp re-enabled")
+}
+
+// Close stops the pump loop and releases the player.
+//
+// Deliberately does NOT drive the amp/mute tinymix controls the way
+// PcmSpeaker.Close does. Those exist there to make an ALSA session's close
+// transient inaudible while EchoMuse is the sole owner of the PCM; on this
+// path mediaserver owns it, and Android's own audio HAL is already observed
+// to react to hardware events on this same amp/mux (see CLAUDE.md's jack
+// section) — fighting that from here risked a worse click than doing
+// nothing, not a better one, and neither has been verified on hardware. Left
+// for Phase 0/3 to settle with real measurement rather than guessed here.
+func (s *Speaker) Close() {
+	close(s.stopCh)
+	s.play.Clear() // drop anything queued but not yet played
+	s.play.Close()
+	log.Println("[slspeaker] closed")
+}
+
+// periodRMS computes the RMS level of a mono S16LE period, normalized to
+// 0..1 of int16 full-scale. Every sample, unlike PcmSpeaker.periodRMS's
+// every-4th-stereo-frame subsampling — a mono period is a quarter the size
+// to begin with, so the equivalent cost is already paid.
+func periodRMS(period []byte) float64 {
+	if len(period) < 2 {
+		return 0
+	}
+	var sum uint64
+	n := 0
+	for i := 0; i+1 < len(period); i += 2 {
+		v := int64(int16(uint16(period[i]) | uint16(period[i+1])<<8))
+		sum += uint64(v * v)
+		n++
+	}
+	if n == 0 {
+		return 0
+	}
+	return math.Sqrt(float64(sum)/float64(n)) / 32768.0
+}
+
+var _ pkgspeaker.FullSpeaker = (*Speaker)(nil)

--- a/device/internal/bindings/slspeaker/stream.go
+++ b/device/internal/bindings/slspeaker/stream.go
@@ -1,0 +1,195 @@
+package slspeaker
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	pkgspeaker "github.com/wilbowes/EchoMuse/pkg/speaker"
+)
+
+// errSpeakerDead is returned when the pump loop has exited, so a caller
+// blocked on a full buffer unblocks with an error instead of hanging forever.
+var errSpeakerDead = errors.New("slspeaker: pump loop has died")
+
+// StreamStats is a type alias for pkg/speaker.StreamStats, the canonical
+// definition — see that comment. Aliasing rather than redefining means this
+// backend's stats and the tinyalsa backend's are one identical Go type, which
+// is what lets cmd/server.go hold either behind pkg/speaker.FullSpeaker.
+type StreamStats = pkgspeaker.StreamStats
+
+// audioStream is one buffered playback stream (voice/TTS or music), the same
+// state machine as speaker.audioStream — see that file for the full
+// reasoning behind the prime gate, the discard-until-EOS contract and the
+// minDepth sampling rule. It is duplicated here rather than imported because
+// the two backends live in different packages (see the architecture note in
+// docs/native-afe-migration.md); nothing about the logic itself differs.
+//
+// Untagged on purpose — this is the buffering state machine, worth testing on
+// the host independent of OpenSL ES.
+type audioStream struct {
+	ch     chan []byte
+	deadCh <-chan struct{} // closed when the pump loop exits
+
+	eosPending atomic.Bool
+
+	mu         sync.Mutex
+	active     bool
+	discarding bool
+
+	recvFirstNs  atomic.Int64
+	recvLastNs   atomic.Int64
+	recvMaxGapNs atomic.Int64
+	recvBytes    atomic.Uint64
+
+	playing     bool
+	periods     uint64
+	underruns   uint64
+	minDepth    int
+	firstPumpNs int64
+}
+
+func newAudioStream(depth int, deadCh <-chan struct{}) *audioStream {
+	return &audioStream{
+		ch:       make(chan []byte, depth),
+		deadCh:   deadCh,
+		minDepth: -1,
+	}
+}
+
+// pump queues one period, or reports it was swallowed by a flush. Blocks
+// until the pump loop has consumed a slot, or returns an error if that loop
+// has died.
+func (s *audioStream) pump(period []byte, wireBytes int) (bool, error) {
+	s.mu.Lock()
+	if s.discarding {
+		s.mu.Unlock()
+		return false, nil
+	}
+	newStream := !s.active
+	s.active = true
+	s.mu.Unlock()
+
+	now := time.Now().UnixNano()
+	if newStream {
+		s.recvFirstNs.Store(now)
+		s.recvMaxGapNs.Store(0)
+		s.recvBytes.Store(0)
+	} else if last := s.recvLastNs.Load(); last > 0 {
+		if gap := now - last; gap > s.recvMaxGapNs.Load() {
+			s.recvMaxGapNs.Store(gap)
+		}
+	}
+	s.recvLastNs.Store(now)
+	s.recvBytes.Add(uint64(wireBytes))
+
+	select {
+	case s.ch <- period:
+		return true, nil
+	case <-s.deadCh:
+		return false, errSpeakerDead
+	}
+}
+
+// endStream marks the EOS — see speaker.audioStream.endStream for why a
+// discarding stream must NOT re-arm eosPending here.
+func (s *audioStream) endStream() {
+	s.mu.Lock()
+	s.active = false
+	wasDiscarding := s.discarding
+	s.discarding = false
+	s.mu.Unlock()
+	if wasDiscarding {
+		return
+	}
+	s.eosPending.Store(true)
+}
+
+// flush drops everything queued and, if a stream is mid-flight, arms discard
+// so the remainder still in flight from the controller is swallowed rather
+// than played — see speaker.audioStream.flush.
+func (s *audioStream) flush() {
+	s.mu.Lock()
+	if s.active {
+		s.discarding = true
+	}
+	s.mu.Unlock()
+	s.eosPending.Store(true)
+	for {
+		select {
+		case <-s.ch:
+		default:
+			return
+		}
+	}
+}
+
+func (s *audioStream) isActive() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.active
+}
+
+// ready reports whether the pump loop should take a period this round — the
+// prime gate. See speaker.audioStream.ready for the full rationale (protects
+// the opening seconds of playback against link stalls).
+func (s *audioStream) ready(prime int) bool {
+	n := len(s.ch)
+	if n == 0 {
+		return false
+	}
+	if s.playing {
+		return true
+	}
+	return n >= prime || s.eosPending.Load()
+}
+
+// take removes one period, updating consumption-side accounting. Only called
+// when ready() said so, and only from the pump goroutine.
+func (s *audioStream) take() []byte {
+	select {
+	case period := <-s.ch:
+		s.playing = true
+		s.periods++
+		if !s.eosPending.Load() {
+			if d := len(s.ch); s.minDepth < 0 || d < s.minDepth {
+				s.minDepth = d
+			}
+		}
+		if s.firstPumpNs == 0 {
+			s.firstPumpNs = time.Now().UnixNano()
+		}
+		return period
+	default:
+		return nil
+	}
+}
+
+// drained is called when the stream was playing and had nothing to give this
+// round. Returns the stats to report at a natural EOS/flush, or nil for an
+// underrun (mid-stream drain — the audible stutter on a weak link).
+func (s *audioStream) drained() *StreamStats {
+	s.playing = false
+	if !s.eosPending.Swap(false) {
+		s.underruns++
+		return nil
+	}
+	st := &StreamStats{
+		Periods:   s.periods,
+		Underruns: s.underruns,
+		MinDepth:  s.minDepth,
+		MaxGapMs:  s.recvMaxGapNs.Load() / 1e6,
+		BytesRecv: s.recvBytes.Load(),
+	}
+	firstRecv, lastRecv := s.recvFirstNs.Load(), s.recvLastNs.Load()
+	if firstRecv > 0 && lastRecv > firstRecv {
+		st.RecvSpanMs = (lastRecv - firstRecv) / 1e6
+	}
+	if firstRecv > 0 && s.firstPumpNs > firstRecv {
+		st.PrimeWaitMs = (s.firstPumpNs - firstRecv) / 1e6
+	}
+	s.periods, s.underruns = 0, 0
+	s.minDepth, s.firstPumpNs = -1, 0
+	return st
+}

--- a/device/internal/bindings/slspeaker/stream_test.go
+++ b/device/internal/bindings/slspeaker/stream_test.go
@@ -1,0 +1,174 @@
+package slspeaker
+
+import "testing"
+
+// The buffering state machine, testable on the host because audioStream is
+// untagged — same behaviour as internal/bindings/speaker's version (see that
+// package's stream_test.go), ported here because slspeaker.go itself can
+// only be built on the device (//go:build server, cgo against OpenSL ES).
+
+func newTestStream(depth int) (*audioStream, chan struct{}) {
+	dead := make(chan struct{})
+	return newAudioStream(depth, dead), dead
+}
+
+func pumpN(t *testing.T, s *audioStream, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if _, err := s.pump([]byte{byte(i)}, 1); err != nil {
+			t.Fatalf("pump %d: %v", i, err)
+		}
+	}
+}
+
+func TestPrimeGateHoldsUntilEnoughIsQueued(t *testing.T) {
+	s, _ := newTestStream(64)
+	pumpN(t, s, 5)
+	if s.ready(24) {
+		t.Fatal("should hold on silence until primed")
+	}
+	pumpN(t, s, 19)
+	if !s.ready(24) {
+		t.Fatal("should start once primed")
+	}
+}
+
+func TestAShortClipDoesNotWaitForThePrime(t *testing.T) {
+	// Everything it will ever have is already queued; waiting for 24 periods
+	// that are never coming would mean it never played.
+	s, _ := newTestStream(64)
+	pumpN(t, s, 3)
+	s.endStream()
+	if !s.ready(24) {
+		t.Fatal("an ended short clip must play without priming")
+	}
+}
+
+func TestOncePlayingTheGateStaysOutOfTheWay(t *testing.T) {
+	s, _ := newTestStream(64)
+	pumpN(t, s, 24)
+	s.ready(24)
+	s.take()
+	if !s.ready(24) {
+		t.Fatal("mid-stream playback must not re-prime on every period")
+	}
+}
+
+func TestANaturalEndReportsStatsRatherThanAnUnderrun(t *testing.T) {
+	s, _ := newTestStream(64)
+	pumpN(t, s, 2)
+	s.endStream()
+	s.ready(24)
+	s.take()
+	s.take()
+	st := s.drained()
+	if st == nil {
+		t.Fatal("a drain after EOS is the end of the stream, not an underrun")
+	}
+	if st.Periods != 2 {
+		t.Fatalf("expected 2 periods, got %d", st.Periods)
+	}
+	if s.underruns != 0 {
+		t.Fatalf("expected no underruns, got %d", s.underruns)
+	}
+}
+
+func TestAMidStreamDrainIsAnUnderrunNotAnEnding(t *testing.T) {
+	s, _ := newTestStream(64)
+	pumpN(t, s, 24)
+	s.ready(24)
+	for i := 0; i < 24; i++ {
+		s.take()
+	}
+	if st := s.drained(); st != nil {
+		t.Fatal("the sender falling behind is an underrun, not a completed stream")
+	}
+	if s.underruns != 1 {
+		t.Fatalf("expected 1 underrun, got %d", s.underruns)
+	}
+}
+
+func TestAFlushedStreamDoesNotLeaveEosArmedForTheNextOne(t *testing.T) {
+	// The regression that shipped on 2026-08-03. flush() sets eosPending and
+	// the drain that follows consumes it; endStream must NOT set it again, or
+	// it stays armed with no stream behind it.
+	//
+	// Measured symptom: a 2800ms response reported complete after 15 periods
+	// (640ms), which ended the turn, cleared the LED ring and released the
+	// music duck while the device still held most of the audio.
+	s, _ := newTestStream(64)
+	pumpN(t, s, 30)
+	s.ready(24)
+	s.take()
+
+	s.flush()     // barge-in
+	s.drained()   // the pump loop sees the emptied channel
+	s.endStream() // the cancelled stream's EOS finally arrives
+
+	if s.eosPending.Load() {
+		t.Fatal("eosPending must not survive a flushed stream — the next " +
+			"stream would report itself complete at its first buffer dip")
+	}
+}
+
+func TestTheStreamAfterAFlushBehavesNormally(t *testing.T) {
+	// The consequence of the bug above, from the next stream's point of view.
+	s, _ := newTestStream(64)
+	pumpN(t, s, 30)
+	s.ready(24)
+	s.take()
+	s.flush()
+	s.drained()
+	s.endStream()
+
+	// A fresh response arrives.
+	pumpN(t, s, 56)
+	if !s.ready(24) {
+		t.Fatal("the next stream should prime and play")
+	}
+	for i := 0; i < 15; i++ {
+		s.take()
+	}
+	// It still has 41 periods queued; nothing should claim it is finished.
+	if !s.ready(24) {
+		t.Fatal("still has audio — must keep playing")
+	}
+	if s.eosPending.Load() {
+		t.Fatal("no EOS has arrived for this stream")
+	}
+}
+
+func TestFlushSwallowsTheRestOfTheStreamUntilItsEos(t *testing.T) {
+	s, _ := newTestStream(64)
+	pumpN(t, s, 10)
+	s.flush()
+	// The rest of the cancelled response is already in TCP buffers and keeps
+	// arriving; it must not refill the channel.
+	queued, err := s.pump([]byte{9}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if queued {
+		t.Fatal("post-flush periods must be discarded, not queued")
+	}
+	s.endStream()
+	queued, _ = s.pump([]byte{9}, 1)
+	if !queued {
+		t.Fatal("the EOS disarms the discard; the next stream must play")
+	}
+}
+
+func TestMinDepthIgnoresTheTailOfAStream(t *testing.T) {
+	// Every stream necessarily drains to zero at its end, so sampling across
+	// the tail made this read 0 on 100% of streams, healthy ones included.
+	s, _ := newTestStream(64)
+	pumpN(t, s, 30)
+	s.endStream() // EOS in: everything from here is the tail
+	s.ready(24)
+	for i := 0; i < 30; i++ {
+		s.take()
+	}
+	if s.minDepth != -1 {
+		t.Fatalf("tail periods must not be sampled, got minDepth=%d", s.minDepth)
+	}
+}

--- a/device/internal/bindings/speaker/pcm_speaker.go
+++ b/device/internal/bindings/speaker/pcm_speaker.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Binozo/GoTinyAlsa/pkg/pcm"
 	"github.com/Binozo/GoTinyAlsa/pkg/tinyalsa"
+	pkgspeaker "github.com/wilbowes/EchoMuse/pkg/speaker"
 )
 
 // cardNr/deviceNr live in pcmstatus.go so the host test can pin them against
@@ -454,3 +455,9 @@ func periodRMS(period []byte) float64 {
 	}
 	return math.Sqrt(float64(sum)/float64(n)) / 32768.0
 }
+
+// Compile-time proof that this backend and the native-AFE backend
+// (internal/bindings/slspeaker) satisfy the exact same interface, so
+// cmd/server.go's backend-selection switch can hold either behind one
+// variable.
+var _ pkgspeaker.FullSpeaker = (*PcmSpeaker)(nil)

--- a/device/internal/bindings/speaker/stream.go
+++ b/device/internal/bindings/speaker/stream.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	pkgspeaker "github.com/wilbowes/EchoMuse/pkg/speaker"
 )
 
 // errSpeakerDead is returned when the ALSA pump loop has exited, so a caller
@@ -27,15 +29,14 @@ var errSpeakerDead = errors.New("speaker: ALSA loop has died")
 //     definitive "the wire could not keep up" signal.
 //   - MaxGapMs: the worst single stall in arrivals, which distinguishes a
 //     uniformly slow link from a briefly stalled one.
-type StreamStats struct {
-	Periods     uint64 `json:"periods"`
-	Underruns   uint64 `json:"underruns"`
-	MinDepth    int    `json:"minDepth"`
-	PrimeWaitMs int64  `json:"primeWaitMs"`
-	RecvSpanMs  int64  `json:"recvSpanMs"`
-	MaxGapMs    int64  `json:"maxGapMs"`
-	BytesRecv   uint64 `json:"bytesRecv"`
-}
+//
+// A type alias, not a new struct: internal/bindings/slspeaker (the native-AFE
+// backend) has to report this exact same shape (see pkg/speaker.StreamStats,
+// the canonical definition), and aliasing rather than duplicating means every
+// existing reference to speaker.StreamStats in this package and in
+// cmd/server.go keeps compiling unchanged while both backends produce values
+// of one identical type.
+type StreamStats = pkgspeaker.StreamStats
 
 // audioStream is one buffered playback stream: the voice/TTS plane or the
 // music plane. Both need the same machinery — a prime gate, discard-until-EOS

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -728,6 +729,28 @@ func (c *ControlClient) runShellSession(ctx context.Context, baseURL string, pty
 	log.Println("[shell] Session closed")
 }
 
+// nativeAFEActive records whether cmd/server.go selected the OpenSL ES /
+// native-AFE audio backends (internal/bindings/slmic + slspeaker) for THIS
+// run — see cmd/server.go's newAudioBackends. Set at most once, before the
+// control client connects; SetNativeAFEActive is exported for main() to call
+// from outside this package.
+//
+// Unlike "ambient_light" (a fixed property of the hardware, resolved once at
+// als.Present()), this reflects a boot-time CHOICE that can fall back to
+// tinyalsa if libOpenSLES.so fails to open — so the capability must track
+// what actually ended up running, not merely what this firmware build knows
+// how to attempt. Reporting the attempt rather than the outcome would tell
+// the controller/dashboard a device is on the native-AFE path (and so
+// disable the beamformer/AEC/AGC controls that bypass table describes) on a
+// device that silently fell back and still needs them.
+var nativeAFEActive atomic.Bool
+
+// SetNativeAFEActive records which audio backend pair main() actually
+// brought up. Call before Run(), so the very first register message already
+// reports it — capabilities() is read once per connection, same as every
+// other entry in the list.
+func SetNativeAFEActive(active bool) { nativeAFEActive.Store(active) }
+
 // capabilities is what this firmware implements, negotiated by capability
 // rather than by version so the controller needs no knowledge of our release
 // history (see CLAUDE.md). "ambient_light" is conditional on the hardware
@@ -751,6 +774,15 @@ func capabilities() []string {
 		"oww_shadow", "oww_trigger", "button_hold", "audio_mix"}
 	if als.Present() {
 		caps = append(caps, "ambient_light")
+	}
+	// "native_afe": Android's audio HAL front end (per-mic AEC, beamformer,
+	// SNR beam selection) is doing capture/playback for this run, so the
+	// controller/dashboard must show beamformingEnabled, aecEnabled,
+	// agcEnabled, micGainDb/adcDigitalGain/adcMicpga and nsAsr as disabled
+	// with the reason rather than as controls that silently do nothing —
+	// see docs/native-afe-migration.md's bypass table.
+	if nativeAFEActive.Load() {
+		caps = append(caps, "native_afe")
 	}
 	return caps
 }

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -771,7 +771,16 @@ func capabilities() []string {
 	// capability the firmware has, rather than inferring one from a version
 	// string, is the rule the whole registration follows.
 	caps := []string{"mic", "speaker", "leds", "led_anim", "buttons",
-		"oww_shadow", "oww_trigger", "button_hold", "audio_mix"}
+		"oww_shadow", "oww_trigger", "button_hold", "audio_mix",
+		// "native_afe_backend": this binary has internal/bindings/slmic and
+		// slspeaker compiled in AND its start_server.sh has the opt-in
+		// marker check (docs/native-afe-migration.md) — unconditional,
+		// unlike "native_afe" below, because it is a fact about the BUILD,
+		// not about what is running right now. This is the capability the
+		// dashboard's toggle is gated on: writing the marker file on a
+		// device that lacks this would be a control that silently does
+		// nothing, since older firmware's start_server.sh never checks it.
+		"native_afe_backend"}
 	if als.Present() {
 		caps = append(caps, "ambient_light")
 	}

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -428,7 +428,8 @@ func (c *ControlClient) connect(ctx context.Context, server *discovery.ServerInf
 
 		case "volume_set":
 			// Controller forwarding a volume command from HA (MediaPlayerCommandRequest).
-			// level is an integer 0–175 matching the device's native tinymix range.
+			// level is an integer in the device's native tinymix range, capped
+			// at the codec's unity gain — see internal/server/volume.go.
 			var msg struct {
 				Level int `json:"level"`
 			}
@@ -846,7 +847,8 @@ func (c *ControlClient) SendAmbientLight(lux int) {
 	})
 }
 
-// SendVolumeState notifies the controller of the current volume level (0–175).
+// SendVolumeState notifies the controller of the current volume level
+// (0–volumeMax, the raw tinymix ctl 61 index).
 // Called on connect (to sync controller state) and after every local change.
 // Safe for concurrent use — silently drops if not connected.
 func (c *ControlClient) SendVolumeState(level int) {

--- a/device/internal/client/data.go
+++ b/device/internal/client/data.go
@@ -690,7 +690,17 @@ func (d *DataClient) streamMic(conn *websocket.Conn, stopCh <-chan struct{}, loc
 			// are trained level-diverse and don't need AGC. The config
 			// toggle still governs bounded lockMic turns, which get a fresh
 			// ResetAGC each stream.
-			agcEnabled := lockMic && (snap.AgcEnabled == nil || *snap.AgcEnabled)
+			//
+			// Also forced off under native-AFE passthrough: unlike AEC (which
+			// silently no-ops on a size mismatch — see the aec.Process guard
+			// below), processor.Process has no frame-size assumption and
+			// would actually RUN, stacking our own gain control on top of
+			// the AFE's — the bypass table (docs/native-afe-migration.md)
+			// lists AGC as replaced, not merely redundant, and the dashboard
+			// already shows the config toggle as off while active; the
+			// device disagreeing with that would be the exact "control that
+			// silently does something else" CLAUDE.md warns against.
+			agcEnabled := !d.micPassthrough && lockMic && (snap.AgcEnabled == nil || *snap.AgcEnabled)
 
 			// micGainDb is a pre-truncation gain applied to the raw 24-bit
 			// capture (see internal/beamformer's extractChannel) — meaningless

--- a/device/internal/client/data.go
+++ b/device/internal/client/data.go
@@ -168,6 +168,16 @@ type DataClient struct {
 	onDirectionChange func(angle float64)
 	directionMu       sync.Mutex
 
+	// micPassthrough is true when the mic backend already delivers one fully
+	// processed mono channel (internal/bindings/slmic, on the native-AFE
+	// path — see docs/native-afe-migration.md). Decided once, at
+	// construction, from the concrete backend NewDataClient was given: this
+	// mirrors the AFE selection itself, which is a boot-time choice, not a
+	// live config push (see cmd/server.go). When true, streamMic skips
+	// internal/beamformer entirely rather than feed it a buffer shaped for
+	// raw 9-channel capture — see pkg/mic.PassthroughReporter.
+	micPassthrough bool
+
 	// shadowScorer scores the always-on wake stream on the device without
 	// acting on it (internal/wakeword/shadow), nil when off. Guarded because
 	// a config push swaps it from the control goroutine while the mic
@@ -192,14 +202,19 @@ type DataClient struct {
 // runs its near-end side on the mono mic stream. Disabled cancellers pass
 // audio through untouched.
 func NewDataClient(deviceID string, microphone mic.Subscribable, spk speaker.Speaker, canceller *aec.Canceller) *DataClient {
+	passthrough := false
+	if pr, ok := microphone.(mic.PassthroughReporter); ok {
+		passthrough = pr.Passthrough()
+	}
 	return &DataClient{
-		deviceID: deviceID,
-		mic:      microphone,
-		spk:      spk,
-		readyCh:  make(chan string, 1),
-		beam:     beamformer.New(),
-		proc:     processor.New(),
-		aec:      canceller,
+		deviceID:       deviceID,
+		mic:            microphone,
+		spk:            spk,
+		readyCh:        make(chan string, 1),
+		beam:           beamformer.New(),
+		proc:           processor.New(),
+		aec:            canceller,
+		micPassthrough: passthrough,
 	}
 }
 
@@ -677,7 +692,14 @@ func (d *DataClient) streamMic(conn *websocket.Conn, stopCh <-chan struct{}, loc
 			// ResetAGC each stream.
 			agcEnabled := lockMic && (snap.AgcEnabled == nil || *snap.AgcEnabled)
 
-			if snap.MicGainDb != nil && *snap.MicGainDb != gainDb {
+			// micGainDb is a pre-truncation gain applied to the raw 24-bit
+			// capture (see internal/beamformer's extractChannel) — meaningless
+			// on the native-AFE path, where the HAL already hands back 16-bit
+			// audio with its own gain baked in (HAL PGA + AFE output gain; see
+			// the bypass table in docs/native-afe-migration.md). gainLin stays
+			// at its unity default there, so the VAD threshold below is used
+			// as configured rather than scaled by a stage that never runs.
+			if !d.micPassthrough && snap.MicGainDb != nil && *snap.MicGainDb != gainDb {
 				gainDb = *snap.MicGainDb
 				gainLin = math.Pow(10, float64(gainDb)/20.0)
 				log.Printf("[data] mic gain: %ddB (linear %.2f)", gainDb, gainLin)
@@ -697,8 +719,25 @@ func (d *DataClient) streamMic(conn *websocket.Conn, stopCh <-chan struct{}, loc
 				d.beam.Unlock()
 			}
 
-			mono, angle := d.beam.Process(raw, beamAngle, gainLin)
-			clipped := d.beam.ClippedSamples()
+			// On the native-AFE path `raw` IS the processed mono period —
+			// Android's audio HAL already ran per-mic AEC and beamforming
+			// before this ever reached Go (docs/native-afe-migration.md).
+			// Feeding that into internal/beamformer would misinterpret its
+			// bytes as interleaved 9-channel capture, so it must be skipped
+			// outright rather than merely redundant. There is no per-frame
+			// beam angle on this path either (the AFE selects a beam
+			// internally and does not report it per frame — see the
+			// "LED direction arc" deferred item), and clip counting belongs
+			// to the fixed pre-truncation gain stage this path doesn't run.
+			var mono []byte
+			var angle float64
+			var clipped uint64
+			if d.micPassthrough {
+				mono, angle, clipped = raw, -1, 0
+			} else {
+				mono, angle = d.beam.Process(raw, beamAngle, gainLin)
+				clipped = d.beam.ClippedSamples()
+			}
 
 			// AEC — subtract the speaker's own output (reference tapped at
 			// the ALSA write, aligned by aecDelayMs) before anything

--- a/device/internal/client/data.go
+++ b/device/internal/client/data.go
@@ -744,7 +744,21 @@ func (d *DataClient) streamMic(conn *websocket.Conn, stopCh <-chan struct{}, loc
 			// measures or gates the signal. No-op while aecEnabled=false.
 			// (Has its own mutex — inside pipeMu only for lock ordering
 			// simplicity; aec.mu is a leaf lock, no inversion possible.)
-			mono = d.aec.Process(mono)
+			//
+			// Skipped outright on the native-AFE path: internal/aec is
+			// replaced there by the AFE's own per-mic subband AEC (bypass
+			// table, docs/native-afe-migration.md), and it is not merely
+			// redundant — its FrameSize is tuned to the tinyalsa raw batch
+			// cadence (2560 samples/160ms), not slmic's periodFrames
+			// (1280 samples/80ms), so feeding it here is a permanent no-op
+			// caught by its own size guard (aec.sizeWarned) rather than a
+			// harmless pass-through. Confirmed on hardware 2026-08-12: an
+			// aecEnabled=true device left over from the tinyalsa path logged
+			// "AEC BYPASSED" once and silently did nothing on every period
+			// from then on.
+			if !d.micPassthrough {
+				mono = d.aec.Process(mono)
+			}
 
 			// ── Processing pipeline ──────────────────────────────────────
 			// VAD on raw beamformed output — pre-NS/AGC so threshold is

--- a/device/internal/opensl/opensl.go
+++ b/device/internal/opensl/opensl.go
@@ -1,0 +1,439 @@
+//go:build server
+
+// Package opensl is a minimal Go binding to Android's OpenSL ES, used to
+// reach the audio HAL's ASP front end (see docs/native-afe-migration.md) —
+// tinyalsa's direct pcm23p/pcm24c writes never pass through AudioFlinger, so
+// they never reach it.
+//
+// The library is dlopen'd at RUNTIME (see shim.h), not linked, so this
+// package builds and the firmware boots on a device — or a plain Linux host
+// running `go build ./...` without -tags server, which excludes this package
+// entirely — where libOpenSLES.so was never resolved. Open just returns an
+// error and the caller (slmic/slspeaker) falls back to the tinyalsa backends.
+//
+// Both Recorder and Player present a BLOCKING API — Read()/Write() — even
+// though OpenSL ES itself is callback-driven (a buffer queue completion fires
+// on a thread OpenSL ES owns, not one Go created). That asymmetry is
+// deliberate: it lets slmic/slspeaker read almost like the tinyalsa backends
+// they replace — a read loop, a pump loop — rather than every caller having
+// to become callback-shaped. The channel-based bridging between the two
+// models lives entirely in this package.
+package opensl
+
+/*
+#cgo CFLAGS: -O2
+#cgo LDFLAGS: -ldl
+
+#include <string.h>
+#include "shim.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+// ErrClosed is returned by Read/Write after the Recorder/Player (or the
+// Engine that owns it) has been closed.
+var ErrClosed = errors.New("opensl: closed")
+
+// Preset selects the Android input_source via SL_ANDROID_KEY_RECORDING_PRESET,
+// which is what picks the ASP pipeline the audio HAL runs — see
+// docs/native-afe-migration.md's table. The mapping to the real
+// SL_ANDROID_RECORDING_PRESET_* value is resolved in C (shim.h's em_preset)
+// against the real header, not guessed here.
+type Preset int
+
+const (
+	// PresetMic is AUDIO_SOURCE_MIC -> ASP pipeline 2, an empty algorithm
+	// list (passthrough). Useful as the phase-0 CONTROL: any difference
+	// between this and PresetVoiceRecognition is the AFE, not the codec path.
+	PresetMic Preset = 0
+	// PresetVoiceRecognition is AUDIO_SOURCE_VOICE_RECOGNITION -> ASP
+	// pipeline 0 — per-mic AEC, fixed+adaptive beamformer, SNR beam
+	// selection. This is the pipeline the whole migration is for.
+	PresetVoiceRecognition Preset = 1
+	// PresetVoiceCommunication is AUDIO_SOURCE_VOICE_COMMUNICATION -> ASP
+	// pipeline 1 (VoIP-tuned AEC/RES/NR/CNG/AGC). Recorded for comparison
+	// only — nothing in this migration is expected to use it.
+	PresetVoiceCommunication Preset = 2
+)
+
+func (p Preset) String() string {
+	switch p {
+	case PresetMic:
+		return "MIC"
+	case PresetVoiceRecognition:
+		return "VOICE_RECOGNITION"
+	case PresetVoiceCommunication:
+		return "VOICE_COMMUNICATION"
+	default:
+		return fmt.Sprintf("Preset(%d)", int(p))
+	}
+}
+
+// Engine is a dlopen'd libOpenSLES.so instance, its SLEngineItf and a single
+// shared OutputMix that every Player routes into.
+//
+// Opening the SAME path twice returns the same Engine rather than a second
+// one — some Android versions only tolerate a single OpenSL ES engine per
+// process, and the ort.Runtime precedent (same reasoning, different library)
+// makes this the expected shape in this codebase.
+type Engine struct {
+	eng C.em_engine
+}
+
+var (
+	openMu  sync.Mutex
+	engines = map[string]*Engine{}
+)
+
+// Open loads libOpenSLES.so from libPath (an absolute path, or a soname to be
+// resolved by the dynamic linker — "libOpenSLES.so" resolves against
+// /system/lib on the device) and creates the engine and output mix.
+func Open(libPath string) (*Engine, error) {
+	openMu.Lock()
+	defer openMu.Unlock()
+
+	if e := engines[libPath]; e != nil {
+		return e, nil
+	}
+
+	cPath := C.CString(libPath)
+	defer C.free(unsafe.Pointer(cPath))
+
+	e := &Engine{}
+	if err := goErr(C.em_sl_open(cPath, &e.eng)); err != nil {
+		return nil, fmt.Errorf("opensl: open %s: %w", libPath, err)
+	}
+	engines[libPath] = e
+	return e, nil
+}
+
+// Close releases the engine and every object it owns. Not part of the normal
+// server path — the engine lives for the process there — but used by
+// afe_probe, which opens and closes across several recordings.
+func (e *Engine) Close() {
+	openMu.Lock()
+	for path, eng := range engines {
+		if eng == e {
+			delete(engines, path)
+		}
+	}
+	openMu.Unlock()
+	C.em_engine_close(&e.eng)
+}
+
+// ─── shared callback registry ───────────────────────────────────────────────
+//
+// Every Recorder and Player registers under a small int64 handle so the
+// exported callbacks below — invoked from a thread OpenSL ES owns, which may
+// not be one the Go runtime has seen before — can find the right Go object.
+// One registry for both rather than two: the handle space is shared, so a
+// stray callback after Close can never be misattributed to an unrelated
+// object that happened to reuse a small integer.
+
+var (
+	regMu     sync.Mutex
+	nextID    int64
+	recorders = map[int64]*Recorder{}
+	players   = map[int64]*Player{}
+)
+
+func newHandle() int64 {
+	return atomic.AddInt64(&nextID, 1)
+}
+
+//export em_go_recorder_cb
+func em_go_recorder_cb(ctx C.longlong) {
+	regMu.Lock()
+	r := recorders[int64(ctx)]
+	regMu.Unlock()
+	if r != nil {
+		r.onComplete()
+	}
+}
+
+//export em_go_player_cb
+func em_go_player_cb(ctx C.longlong) {
+	regMu.Lock()
+	p := players[int64(ctx)]
+	regMu.Unlock()
+	if p != nil {
+		p.onComplete()
+	}
+}
+
+// ─── recorder ────────────────────────────────────────────────────────────────
+
+// Recorder captures mono S16LE PCM at a fixed rate through a chosen
+// input_source. Read blocks for the next completed period.
+type Recorder struct {
+	rec      C.em_recorder
+	handle   int64
+	bufBytes int
+
+	// inflight is the FIFO of buffer slots currently enqueued with OpenSL
+	// ES, in the exact order they were enqueued — priming and every
+	// re-enqueue in onComplete push in that order, and OpenSL ES's simple
+	// buffer queue completes callbacks in enqueue order (the one ordering
+	// guarantee this whole design leans on), so popping this FIFO on each
+	// completion always names the right slot without OpenSL ES having to
+	// say so.
+	inflight chan int
+	frames   chan []byte
+	drops    atomic.Uint64
+	closed   atomic.Bool
+}
+
+// NewRecorder opens a recorder at rateHz through preset, with nbuf hardware
+// buffers of periodFrames mono samples each.
+//
+// nbuf is the HAL-facing double/triple buffering only — small by design (2-4
+// is typical). The application-level lead buffer (matching the tinyalsa
+// backends' subscriber channel depth) belongs in the caller, same layering as
+// PcmMicrophone's ALSA read loop vs. its per-subscriber channels.
+func (e *Engine) NewRecorder(preset Preset, rateHz, periodFrames, nbuf int) (*Recorder, error) {
+	if periodFrames <= 0 {
+		return nil, fmt.Errorf("opensl: NewRecorder: periodFrames must be positive, got %d", periodFrames)
+	}
+	if nbuf < 2 {
+		return nil, fmt.Errorf("opensl: NewRecorder: nbuf must be at least 2, got %d", nbuf)
+	}
+
+	bufBytes := periodFrames * 2 // mono S16LE
+	r := &Recorder{
+		bufBytes: bufBytes,
+		inflight: make(chan int, nbuf),
+		// Frame queue depth: a handful of periods of slack for Read()'s
+		// caller to fall behind before frames start dropping — the OpenSL
+		// ES callback thread must never block, so a full channel drops
+		// rather than waits (mirrors PcmMicrophone's subscriber drop).
+		frames: make(chan []byte, nbuf*4),
+	}
+	r.handle = newHandle()
+	regMu.Lock()
+	recorders[r.handle] = r
+	regMu.Unlock()
+
+	err := goErr(C.em_recorder_open(&e.eng, C.int(preset), C.int(rateHz),
+		C.int(bufBytes), C.int(nbuf), C.longlong(r.handle), &r.rec))
+	if err != nil {
+		regMu.Lock()
+		delete(recorders, r.handle)
+		regMu.Unlock()
+		return nil, fmt.Errorf("opensl: NewRecorder(%s, %dHz): %w", preset, rateHz, err)
+	}
+	if err := goErr(C.em_recorder_prime(&r.rec)); err != nil {
+		r.Close()
+		return nil, fmt.Errorf("opensl: prime recorder: %w", err)
+	}
+	for i := 0; i < nbuf; i++ {
+		r.inflight <- i // mirrors em_recorder_prime's enqueue order exactly
+	}
+	return r, nil
+}
+
+// FrameSize is the byte length of every period Read returns.
+func (r *Recorder) FrameSize() int { return r.bufBytes }
+
+// Start begins recording. Buffers must already be primed (NewRecorder does
+// this), or there is nothing for the hardware to fill.
+func (r *Recorder) Start() error { return goErr(C.em_recorder_start(&r.rec)) }
+
+// Stop halts recording. The recorder can be Start()ed again.
+func (r *Recorder) Stop() error { return goErr(C.em_recorder_stop(&r.rec)) }
+
+// Read blocks for the next completed period and returns a copy the caller
+// owns. Returns ErrClosed once Close has run.
+func (r *Recorder) Read() ([]byte, error) {
+	buf, ok := <-r.frames
+	if !ok {
+		return nil, ErrClosed
+	}
+	return buf, nil
+}
+
+// Drops counts periods dropped because Read fell behind the audio thread —
+// the OpenSL ES analogue of PcmMicrophone's sub_drops counter.
+func (r *Recorder) Drops() uint64 { return r.drops.Load() }
+
+// Close stops delivering frames and releases the recorder. Safe to call once;
+// a second call is a no-op.
+func (r *Recorder) Close() {
+	if r.closed.Swap(true) {
+		return
+	}
+	regMu.Lock()
+	delete(recorders, r.handle)
+	regMu.Unlock()
+	C.em_recorder_close(&r.rec)
+	close(r.frames)
+}
+
+// onComplete runs on the OpenSL ES callback thread every time one queued
+// buffer has been filled. It must be fast and must not block: copy the
+// finished buffer out, hand it to the reader (or drop it, counted, if the
+// reader is behind), and re-enqueue the same slot immediately so the
+// recorder is never starved of somewhere to write.
+func (r *Recorder) onComplete() {
+	var idx int
+	select {
+	case idx = <-r.inflight:
+	default:
+		// Nothing was inflight — should not happen (every completion pairs
+		// with an earlier enqueue), but a closed/racing recorder must not
+		// hang the audio thread waiting on an empty channel.
+		return
+	}
+
+	ptr := C.em_recorder_bufptr(&r.rec, C.int(idx))
+	buf := C.GoBytes(ptr, C.int(r.bufBytes))
+	select {
+	case r.frames <- buf:
+	default:
+		r.drops.Add(1)
+	}
+
+	// Best-effort: a failure here means the recorder is on its way down: the
+	// object was already destroyed under us, or is about to be. There is no
+	// caller to report it to from the audio thread, same reasoning as
+	// echoTap/levelTap being fire-and-forget in the tinyalsa backend.
+	_ = goErr(C.em_recorder_enqueue(&r.rec, C.int(idx)))
+	select {
+	case r.inflight <- idx:
+	default:
+	}
+}
+
+// ─── player ──────────────────────────────────────────────────────────────────
+
+// Player renders mono S16LE PCM at a fixed rate through the shared output
+// mix. Combined with a Recorder from the same Engine, both capture and
+// playback route through AudioFlinger and the HAL — the "one rule that
+// matters" in docs/native-afe-migration.md: without that, the ASP echo
+// canceller has no far-end reference to cancel against.
+type Player struct {
+	play     C.em_player
+	handle   int64
+	bufBytes int
+
+	free     chan int // hardware buffer slots available to Write into
+	inflight chan int // slots enqueued, awaiting their completion callback (FIFO)
+	closed   atomic.Bool
+}
+
+// NewPlayer opens a player at rateHz with nbuf hardware buffers, each able to
+// hold up to maxBufBytes. Playback starts immediately (see shim.h's
+// em_player_open for why); with nothing written yet, the queue is simply
+// empty and no callback fires until the first Write.
+func (e *Engine) NewPlayer(rateHz, maxBufBytes, nbuf int) (*Player, error) {
+	if maxBufBytes <= 0 {
+		return nil, fmt.Errorf("opensl: NewPlayer: maxBufBytes must be positive, got %d", maxBufBytes)
+	}
+	if nbuf < 2 {
+		return nil, fmt.Errorf("opensl: NewPlayer: nbuf must be at least 2, got %d", nbuf)
+	}
+
+	p := &Player{
+		bufBytes: maxBufBytes,
+		free:     make(chan int, nbuf),
+		inflight: make(chan int, nbuf),
+	}
+	p.handle = newHandle()
+	regMu.Lock()
+	players[p.handle] = p
+	regMu.Unlock()
+
+	err := goErr(C.em_player_open(&e.eng, C.int(rateHz), C.int(maxBufBytes),
+		C.int(nbuf), C.longlong(p.handle), &p.play))
+	if err != nil {
+		regMu.Lock()
+		delete(players, p.handle)
+		regMu.Unlock()
+		return nil, fmt.Errorf("opensl: NewPlayer(%dHz): %w", rateHz, err)
+	}
+	for i := 0; i < nbuf; i++ {
+		p.free <- i // nothing queued yet — every slot starts free
+	}
+	return p, nil
+}
+
+// MaxFrameBytes is the largest period Write will accept.
+func (p *Player) MaxFrameBytes() int { return p.bufBytes }
+
+// Write copies data into the next free hardware buffer and enqueues it,
+// blocking until a slot is free — the same backpressure contract
+// PumpPeriod/PumpMusic give callers today (rate-limits the caller to playback
+// speed). Returns ErrClosed once Close has run.
+func (p *Player) Write(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if len(data) > p.bufBytes {
+		return fmt.Errorf("opensl: period of %d bytes exceeds the %d-byte buffer", len(data), p.bufBytes)
+	}
+	idx, ok := <-p.free
+	if !ok {
+		return ErrClosed
+	}
+	ptr := C.em_player_bufptr(&p.play, C.int(idx))
+	C.memcpy(ptr, unsafe.Pointer(&data[0]), C.size_t(len(data)))
+	if err := goErr(C.em_player_enqueue(&p.play, C.int(idx), C.int(len(data)))); err != nil {
+		p.free <- idx // failed to enqueue — return the slot rather than leak it
+		return err
+	}
+	p.inflight <- idx
+	return nil
+}
+
+// Clear drops everything queued but not yet played (barge-in / user stop).
+// Buffers already handed to the HAL and mid-flight are unaffected — the
+// OpenSL ES analogue of tinyalsa's Flush leaving up to PeriodCount periods
+// still playing.
+func (p *Player) Clear() error { return goErr(C.em_player_clear(&p.play)) }
+
+// Close stops accepting writes and releases the player. Safe to call once; a
+// second call is a no-op.
+func (p *Player) Close() {
+	if p.closed.Swap(true) {
+		return
+	}
+	regMu.Lock()
+	delete(players, p.handle)
+	regMu.Unlock()
+	C.em_player_close(&p.play)
+	close(p.free)
+}
+
+// onComplete runs on the OpenSL ES callback thread every time one enqueued
+// buffer has finished playing. It must be fast: pop the slot that completed
+// (FIFO — see the Recorder.onComplete comment for why this is safe without
+// OpenSL ES naming the slot) and return it to the free pool so a blocked
+// Write can proceed.
+func (p *Player) onComplete() {
+	select {
+	case idx := <-p.inflight:
+		select {
+		case p.free <- idx:
+		default:
+		}
+	default:
+		// Spurious callback with nothing inflight — see the matching comment
+		// on Recorder.onComplete.
+	}
+}
+
+// goErr converts the shim's malloc'd char* convention into a Go error,
+// freeing the message. NULL means success.
+func goErr(msg *C.char) error {
+	if msg == nil {
+		return nil
+	}
+	defer C.free(unsafe.Pointer(msg))
+	return errors.New(C.GoString(msg))
+}

--- a/device/internal/opensl/shim.h
+++ b/device/internal/opensl/shim.h
@@ -1,0 +1,494 @@
+/*
+ * shim.h — the C half of the OpenSL ES binding.
+ *
+ * Same two reasons this exists as internal/wakeword/ort/shim.h:
+ *
+ *  1. Every OpenSL ES object (SLObjectItf, SLEngineItf, SLRecordItf, ...) is a
+ *     struct of function pointers, and cgo cannot call a function pointer held
+ *     in a C struct. Every call needs a C-side wrapper.
+ *
+ *  2. libOpenSLES.so is dlopen'd at runtime, not linked. Nothing in the build
+ *     references an OpenSL ES symbol directly, so the firmware links and boots
+ *     on a device (or a Go host build) where the library was never resolved at
+ *     link time — em_sl_open simply fails and the caller falls back to the
+ *     tinyalsa backends. Unlike the ORT shim, this package needs no vendored
+ *     header: the NDK toolchain this repo cross-compiles with already ships
+ *     the real Khronos/AOSP OpenSL ES headers (SLES/OpenSLES*.h) under its own
+ *     sysroot, so `#include`ing them costs nothing extra to vendor and can't
+ *     drift from what the device actually implements.
+ *
+ * Unlike ORT's OrtApi, OpenSL ES's interface IDs (SL_IID_ENGINE and friends)
+ * are exported as DATA symbols, not looked up through a version-negotiated
+ * "get me the API" entry point — the headers declare them
+ * `extern SL_API const SLInterfaceID SL_IID_ENGINE;` for a caller that links
+ * against libOpenSLES.so normally. Referencing that extern directly here would
+ * force the Go linker to resolve it at BUILD time, defeating the whole point
+ * of dlopen. So every interface ID this file needs is resolved with dlsym
+ * instead (em_resolve_iid) and the header is included only for its type
+ * definitions and #define constants (SL_DATAFORMAT_PCM, SL_BOOLEAN_TRUE, the
+ * struct layouts, ...), never for a symbol that has to be linked.
+ *
+ * Error convention, matching the ORT shim: every function that can fail
+ * returns char* — NULL on success, or a malloc'd message the Go side turns
+ * into an error and frees.
+ */
+#ifndef EM_OPENSL_SHIM_H
+#define EM_OPENSL_SHIM_H
+
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <SLES/OpenSLES.h>
+#include <SLES/OpenSLES_Android.h>
+#include <SLES/OpenSLES_AndroidConfiguration.h>
+
+/* Forward declarations of the Go callbacks this file calls into (defined
+ * with //export in opensl.go; cgo emits matching prototypes into
+ * _cgo_export.h, but the buffer-queue callbacks below need them before that
+ * header is available, so they're declared here by hand — same signature,
+ * which is all C's redeclaration rules require). */
+extern void em_go_recorder_cb(long long ctx);
+extern void em_go_player_cb(long long ctx);
+
+static char *em_dup(const char *s) {
+	size_t n = strlen(s) + 1;
+	char *p = (char *)malloc(n);
+	if (p) memcpy(p, s, n);
+	return p;
+}
+
+static char *em_slerr(const char *what, SLresult r) {
+	char msg[160];
+	snprintf(msg, sizeof(msg), "%s failed: SLresult 0x%x", what, (unsigned)r);
+	return em_dup(msg);
+}
+
+/* em_resolve_iid dlsyms an SLInterfaceID constant by its exported symbol
+ * name. The symbol IS the SLInterfaceID value (a pointer into libOpenSLES's
+ * own static data), so dlsym gives the address of that pointer and this
+ * dereferences it once — the same shape as reading any other exported global
+ * via dlsym, just typed for this API. */
+static char *em_resolve_iid(void *dl, const char *name, SLInterfaceID *out) {
+	void *sym = dlsym(dl, name);
+	if (!sym) {
+		const char *e = dlerror();
+		char msg[128];
+		snprintf(msg, sizeof(msg), "dlsym %s: %s", name, e ? e : "symbol not found");
+		return em_dup(msg);
+	}
+	*out = *(const SLInterfaceID *)sym;
+	return NULL;
+}
+
+/* em_preset maps EchoMuse's small selector onto the real
+ * SL_ANDROID_RECORDING_PRESET_* macro, so the mapping is resolved by the
+ * compiler against the real header rather than a hex constant guessed on the
+ * Go side. See docs/native-afe-migration.md's input_source table: GENERIC is
+ * AUDIO_SOURCE_MIC (ASP pipeline 2, passthrough — the control), VOICE_
+ * RECOGNITION and VOICE_COMMUNICATION are pipelines 0 and 1. */
+static SLuint32 em_preset(int selector) {
+	switch (selector) {
+	case 1: return SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION;
+	case 2: return SL_ANDROID_RECORDING_PRESET_VOICE_COMMUNICATION;
+	default: return SL_ANDROID_RECORDING_PRESET_GENERIC;
+	}
+}
+
+/* ─── engine ──────────────────────────────────────────────────────────────── */
+
+typedef struct {
+	void *dl;
+	SLObjectItf obj;
+	SLEngineItf itf;
+	SLObjectItf outmix;
+
+	/* Resolved once at open and handed to every Recorder/Player this engine
+	 * creates, so opening N of them costs N-1 fewer dlsym round trips. */
+	SLInterfaceID iid_record;
+	SLInterfaceID iid_absq;
+	SLInterfaceID iid_androidconfig;
+	SLInterfaceID iid_play;
+} em_engine;
+
+typedef SLresult (*em_slCreateEngine_fn)(SLObjectItf *pEngine, SLuint32 numOptions,
+                                          const SLEngineOption *pEngineOptions,
+                                          SLuint32 numInterfaces,
+                                          const SLInterfaceID *pInterfaceIds,
+                                          const SLboolean *pInterfaceRequired);
+
+/* em_sl_open dlopens libOpenSLES.so, creates the engine, and realizes a
+ * single shared OutputMix — every Player this engine creates routes into it.
+ * One engine per process is not merely convenient: some Android versions
+ * enforce it. */
+static char *em_sl_open(const char *path, em_engine *out) {
+	memset(out, 0, sizeof(*out));
+
+	void *dl = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+	if (!dl) {
+		const char *e = dlerror();
+		return em_dup(e ? e : "dlopen failed");
+	}
+
+	em_slCreateEngine_fn create = (em_slCreateEngine_fn)dlsym(dl, "slCreateEngine");
+	if (!create) {
+		const char *e = dlerror();
+		char *msg = em_dup(e ? e : "slCreateEngine not found");
+		dlclose(dl);
+		return msg;
+	}
+
+	SLObjectItf engineObj = NULL;
+	SLresult r = create(&engineObj, 0, NULL, 0, NULL, NULL);
+	if (r != SL_RESULT_SUCCESS) {
+		dlclose(dl);
+		return em_slerr("slCreateEngine", r);
+	}
+	r = (*engineObj)->Realize(engineObj, SL_BOOLEAN_FALSE);
+	if (r != SL_RESULT_SUCCESS) {
+		(*engineObj)->Destroy(engineObj);
+		dlclose(dl);
+		return em_slerr("engine Realize", r);
+	}
+
+	SLInterfaceID iid_engine;
+	char *err;
+	if ((err = em_resolve_iid(dl, "SL_IID_ENGINE", &iid_engine)) ||
+	    (err = em_resolve_iid(dl, "SL_IID_RECORD", &out->iid_record)) ||
+	    (err = em_resolve_iid(dl, "SL_IID_ANDROIDSIMPLEBUFFERQUEUE", &out->iid_absq)) ||
+	    (err = em_resolve_iid(dl, "SL_IID_ANDROIDCONFIGURATION", &out->iid_androidconfig)) ||
+	    (err = em_resolve_iid(dl, "SL_IID_PLAY", &out->iid_play))) {
+		(*engineObj)->Destroy(engineObj);
+		dlclose(dl);
+		return err;
+	}
+
+	SLEngineItf engine = NULL;
+	r = (*engineObj)->GetInterface(engineObj, iid_engine, &engine);
+	if (r != SL_RESULT_SUCCESS) {
+		(*engineObj)->Destroy(engineObj);
+		dlclose(dl);
+		return em_slerr("GetInterface ENGINE", r);
+	}
+
+	SLObjectItf outmix = NULL;
+	r = (*engine)->CreateOutputMix(engine, &outmix, 0, NULL, NULL);
+	if (r != SL_RESULT_SUCCESS) {
+		(*engineObj)->Destroy(engineObj);
+		dlclose(dl);
+		return em_slerr("CreateOutputMix", r);
+	}
+	r = (*outmix)->Realize(outmix, SL_BOOLEAN_FALSE);
+	if (r != SL_RESULT_SUCCESS) {
+		(*outmix)->Destroy(outmix);
+		(*engineObj)->Destroy(engineObj);
+		dlclose(dl);
+		return em_slerr("OutputMix Realize", r);
+	}
+
+	out->dl = dl;
+	out->obj = engineObj;
+	out->itf = engine;
+	out->outmix = outmix;
+	return NULL;
+}
+
+static void em_engine_close(em_engine *e) {
+	if (e->outmix) (*e->outmix)->Destroy(e->outmix);
+	if (e->obj) (*e->obj)->Destroy(e->obj);
+	if (e->dl) dlclose(e->dl);
+	memset(e, 0, sizeof(*e));
+}
+
+/* ─── recorder ────────────────────────────────────────────────────────────── */
+
+typedef struct {
+	SLObjectItf obj;
+	SLRecordItf record;
+	SLAndroidSimpleBufferQueueItf queue;
+	void **bufs;
+	int nbuf;
+	int bufBytes;
+} em_recorder;
+
+static void em_recorder_cb(SLAndroidSimpleBufferQueueItf caller, void *pContext) {
+	(void)caller;
+	em_go_recorder_cb((long long)(intptr_t)pContext);
+}
+
+/* em_recorder_open creates a mono 16-bit AudioRecorder against the engine's
+ * default audio input, configured with the recording preset that selects the
+ * ASP pipeline (docs/native-afe-migration.md). ctx is an opaque handle the Go
+ * side uses to find the right Recorder when em_go_recorder_cb fires — it may
+ * run on an OpenSL ES-owned thread Go never created.
+ *
+ * The preset MUST be set via SLAndroidConfigurationItf before Realize: it is
+ * documented as a pre-realization-only configuration item, and setting it
+ * after would silently not apply. */
+static char *em_recorder_open(em_engine *e, int presetSel, int rateHz, int bufBytes,
+                               int nbuf, long long ctx, em_recorder *out) {
+	memset(out, 0, sizeof(*out));
+	if (!e->itf) return em_dup("engine not open");
+
+	SLDataLocator_IODevice locIn = {
+		SL_DATALOCATOR_IODEVICE, SL_IODEVICE_AUDIOINPUT, SL_DEFAULTDEVICEID_AUDIOINPUT, NULL
+	};
+	SLDataSource src = { &locIn, NULL };
+
+	SLDataLocator_AndroidSimpleBufferQueue locOut = {
+		SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, (SLuint32)nbuf
+	};
+	/* samplesPerSec is spec'd in milliHertz, not Hertz — hence *1000. Using
+	 * the arithmetic form rather than the SL_SAMPLINGRATE_* convenience
+	 * macros keeps this file's only rate dependency the well-documented
+	 * units, not a second set of vendor constants to get right. */
+	SLDataFormat_PCM fmt = {
+		SL_DATAFORMAT_PCM, 1, (SLuint32)rateHz * 1000,
+		SL_PCMSAMPLEFORMAT_FIXED_16, SL_PCMSAMPLEFORMAT_FIXED_16,
+		SL_SPEAKER_FRONT_CENTER, SL_BYTEORDER_LITTLEENDIAN
+	};
+	SLDataSink snk = { &locOut, &fmt };
+
+	const SLInterfaceID iids[2] = { e->iid_absq, e->iid_androidconfig };
+	const SLboolean req[2] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
+
+	SLObjectItf obj = NULL;
+	SLresult r = (*e->itf)->CreateAudioRecorder(e->itf, &obj, &src, &snk, 2, iids, req);
+	if (r != SL_RESULT_SUCCESS) return em_slerr("CreateAudioRecorder", r);
+
+	SLAndroidConfigurationItf config = NULL;
+	r = (*obj)->GetInterface(obj, e->iid_androidconfig, &config);
+	if (r != SL_RESULT_SUCCESS) {
+		(*obj)->Destroy(obj);
+		return em_slerr("GetInterface ANDROIDCONFIGURATION (recorder)", r);
+	}
+	SLuint32 preset = em_preset(presetSel);
+	r = (*config)->SetConfiguration(config, SL_ANDROID_KEY_RECORDING_PRESET, &preset, sizeof(preset));
+	if (r != SL_RESULT_SUCCESS) {
+		(*obj)->Destroy(obj);
+		return em_slerr("SetConfiguration RECORDING_PRESET", r);
+	}
+
+	r = (*obj)->Realize(obj, SL_BOOLEAN_FALSE);
+	if (r != SL_RESULT_SUCCESS) {
+		(*obj)->Destroy(obj);
+		return em_slerr("recorder Realize", r);
+	}
+
+	SLRecordItf record = NULL;
+	r = (*obj)->GetInterface(obj, e->iid_record, &record);
+	if (r != SL_RESULT_SUCCESS) {
+		(*obj)->Destroy(obj);
+		return em_slerr("GetInterface RECORD", r);
+	}
+	SLAndroidSimpleBufferQueueItf queue = NULL;
+	r = (*obj)->GetInterface(obj, e->iid_absq, &queue);
+	if (r != SL_RESULT_SUCCESS) {
+		(*obj)->Destroy(obj);
+		return em_slerr("GetInterface ANDROIDSIMPLEBUFFERQUEUE (recorder)", r);
+	}
+	r = (*queue)->RegisterCallback(queue, em_recorder_cb, (void *)(intptr_t)ctx);
+	if (r != SL_RESULT_SUCCESS) {
+		(*obj)->Destroy(obj);
+		return em_slerr("RegisterCallback (recorder)", r);
+	}
+
+	void **bufs = (void **)calloc((size_t)nbuf, sizeof(void *));
+	if (!bufs) {
+		(*obj)->Destroy(obj);
+		return em_dup("out of memory allocating recorder buffers");
+	}
+	for (int i = 0; i < nbuf; i++) {
+		bufs[i] = malloc((size_t)bufBytes);
+		if (!bufs[i]) {
+			for (int j = 0; j < i; j++) free(bufs[j]);
+			free(bufs);
+			(*obj)->Destroy(obj);
+			return em_dup("out of memory allocating a recorder buffer");
+		}
+	}
+
+	out->obj = obj;
+	out->record = record;
+	out->queue = queue;
+	out->bufs = bufs;
+	out->nbuf = nbuf;
+	out->bufBytes = bufBytes;
+	return NULL;
+}
+
+/* em_recorder_prime enqueues every buffer once, in slot order 0..nbuf-1 — the
+ * Go side mirrors this exact order into its own bookkeeping (see Recorder in
+ * opensl.go) so it can tell which slot a completion callback refers to
+ * without OpenSL ES saying so directly. Call once, after open and before
+ * em_recorder_start: an unprimed queue has nothing for the recorder to fill. */
+static char *em_recorder_prime(em_recorder *r) {
+	for (int i = 0; i < r->nbuf; i++) {
+		SLresult res = (*r->queue)->Enqueue(r->queue, r->bufs[i], (SLuint32)r->bufBytes);
+		if (res != SL_RESULT_SUCCESS) return em_slerr("Enqueue (recorder prime)", res);
+	}
+	return NULL;
+}
+
+static char *em_recorder_start(em_recorder *r) {
+	SLresult res = (*r->record)->SetRecordState(r->record, SL_RECORDSTATE_RECORDING);
+	if (res != SL_RESULT_SUCCESS) return em_slerr("SetRecordState RECORDING", res);
+	return NULL;
+}
+
+static char *em_recorder_stop(em_recorder *r) {
+	SLresult res = (*r->record)->SetRecordState(r->record, SL_RECORDSTATE_STOPPED);
+	if (res != SL_RESULT_SUCCESS) return em_slerr("SetRecordState STOPPED", res);
+	return NULL;
+}
+
+static void *em_recorder_bufptr(em_recorder *r, int idx) { return r->bufs[idx]; }
+
+static char *em_recorder_enqueue(em_recorder *r, int idx) {
+	SLresult res = (*r->queue)->Enqueue(r->queue, r->bufs[idx], (SLuint32)r->bufBytes);
+	if (res != SL_RESULT_SUCCESS) return em_slerr("Enqueue (recorder)", res);
+	return NULL;
+}
+
+static void em_recorder_close(em_recorder *r) {
+	if (!r->obj) return;
+	(*r->obj)->Destroy(r->obj);
+	for (int i = 0; i < r->nbuf; i++) free(r->bufs[i]);
+	free(r->bufs);
+	memset(r, 0, sizeof(*r));
+}
+
+/* ─── player ──────────────────────────────────────────────────────────────── */
+
+typedef struct {
+	SLObjectItf obj;
+	SLPlayItf play;
+	SLAndroidSimpleBufferQueueItf queue;
+	void **bufs;
+	int nbuf;
+	int bufBytes;
+} em_player;
+
+static void em_player_cb(SLAndroidSimpleBufferQueueItf caller, void *pContext) {
+	(void)caller;
+	em_go_player_cb((long long)(intptr_t)pContext);
+}
+
+/* em_player_open creates a mono 16-bit AudioPlayer feeding the engine's
+ * shared OutputMix. Playback is set running immediately with an empty queue:
+ * an OpenSL ES player that is merely PAUSED never fires buffer-queue
+ * completion callbacks, so — unlike PcmSpeaker's silence-filled ALSA
+ * session — there is no way to "start the stream on silence" here. The
+ * caller (slspeaker) supplies silence itself between periods if it wants the
+ * far-end AEC reference to stay continuous. */
+static char *em_player_open(em_engine *e, int rateHz, int bufBytes, int nbuf,
+                             long long ctx, em_player *out) {
+	memset(out, 0, sizeof(*out));
+	if (!e->itf || !e->outmix) return em_dup("engine not open");
+
+	SLDataLocator_AndroidSimpleBufferQueue locIn = {
+		SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, (SLuint32)nbuf
+	};
+	SLDataFormat_PCM fmt = {
+		SL_DATAFORMAT_PCM, 1, (SLuint32)rateHz * 1000,
+		SL_PCMSAMPLEFORMAT_FIXED_16, SL_PCMSAMPLEFORMAT_FIXED_16,
+		SL_SPEAKER_FRONT_CENTER, SL_BYTEORDER_LITTLEENDIAN
+	};
+	SLDataSource src = { &locIn, &fmt };
+
+	SLDataLocator_OutputMix locOut = { SL_DATALOCATOR_OUTPUTMIX, e->outmix };
+	SLDataSink snk = { &locOut, NULL };
+
+	const SLInterfaceID iids[1] = { e->iid_absq };
+	const SLboolean req[1] = { SL_BOOLEAN_TRUE };
+
+	SLObjectItf obj = NULL;
+	SLresult r = (*e->itf)->CreateAudioPlayer(e->itf, &obj, &src, &snk, 1, iids, req);
+	if (r != SL_RESULT_SUCCESS) return em_slerr("CreateAudioPlayer", r);
+
+	r = (*obj)->Realize(obj, SL_BOOLEAN_FALSE);
+	if (r != SL_RESULT_SUCCESS) {
+		(*obj)->Destroy(obj);
+		return em_slerr("player Realize", r);
+	}
+
+	SLPlayItf play = NULL;
+	r = (*obj)->GetInterface(obj, e->iid_play, &play);
+	if (r != SL_RESULT_SUCCESS) {
+		(*obj)->Destroy(obj);
+		return em_slerr("GetInterface PLAY", r);
+	}
+	SLAndroidSimpleBufferQueueItf queue = NULL;
+	r = (*obj)->GetInterface(obj, e->iid_absq, &queue);
+	if (r != SL_RESULT_SUCCESS) {
+		(*obj)->Destroy(obj);
+		return em_slerr("GetInterface ANDROIDSIMPLEBUFFERQUEUE (player)", r);
+	}
+	r = (*queue)->RegisterCallback(queue, em_player_cb, (void *)(intptr_t)ctx);
+	if (r != SL_RESULT_SUCCESS) {
+		(*obj)->Destroy(obj);
+		return em_slerr("RegisterCallback (player)", r);
+	}
+
+	void **bufs = (void **)calloc((size_t)nbuf, sizeof(void *));
+	if (!bufs) {
+		(*obj)->Destroy(obj);
+		return em_dup("out of memory allocating player buffers");
+	}
+	for (int i = 0; i < nbuf; i++) {
+		bufs[i] = malloc((size_t)bufBytes);
+		if (!bufs[i]) {
+			for (int j = 0; j < i; j++) free(bufs[j]);
+			free(bufs);
+			(*obj)->Destroy(obj);
+			return em_dup("out of memory allocating a player buffer");
+		}
+	}
+
+	r = (*play)->SetPlayState(play, SL_PLAYSTATE_PLAYING);
+	if (r != SL_RESULT_SUCCESS) {
+		for (int i = 0; i < nbuf; i++) free(bufs[i]);
+		free(bufs);
+		(*obj)->Destroy(obj);
+		return em_slerr("SetPlayState PLAYING", r);
+	}
+
+	out->obj = obj;
+	out->play = play;
+	out->queue = queue;
+	out->bufs = bufs;
+	out->nbuf = nbuf;
+	out->bufBytes = bufBytes;
+	return NULL;
+}
+
+static void *em_player_bufptr(em_player *p, int idx) { return p->bufs[idx]; }
+
+static char *em_player_enqueue(em_player *p, int idx, int n) {
+	SLresult res = (*p->queue)->Enqueue(p->queue, p->bufs[idx], (SLuint32)n);
+	if (res != SL_RESULT_SUCCESS) return em_slerr("Enqueue (player)", res);
+	return NULL;
+}
+
+/* em_player_clear drops every buffer queued but not yet played — the OpenSL
+ * ES equivalent of Flush()/FlushMusic() (barge-in / user stop). A buffer
+ * already handed to the HAL and mid-flight is unaffected, same as tinyalsa's
+ * "periods already in the ALSA ring still play". */
+static char *em_player_clear(em_player *p) {
+	SLresult res = (*p->queue)->Clear(p->queue);
+	if (res != SL_RESULT_SUCCESS) return em_slerr("Clear (player)", res);
+	return NULL;
+}
+
+static void em_player_close(em_player *p) {
+	if (!p->obj) return;
+	(*p->play)->SetPlayState(p->play, SL_PLAYSTATE_STOPPED);
+	(*p->obj)->Destroy(p->obj);
+	for (int i = 0; i < p->nbuf; i++) free(p->bufs[i]);
+	free(p->bufs);
+	memset(p, 0, sizeof(*p));
+}
+
+#endif /* EM_OPENSL_SHIM_H */

--- a/device/internal/server/server.go
+++ b/device/internal/server/server.go
@@ -162,7 +162,7 @@ func (s *Server) VolumeStepDown() {
 	s.volume.StepDown()
 }
 
-// SetVolume sets volume to an explicit level (0–175) — called by controller
+// SetVolume sets volume to an explicit level (0–volumeMax) — called by controller
 // command. Remote changes don't paint the volume arc: nobody is at the
 // device, and the ring lighting up unprompted reads as a glitch.
 func (s *Server) SetVolume(level int) {
@@ -191,13 +191,13 @@ func (s *Server) VolumeSeeded() bool {
 	return s.volumeSeeded.Load()
 }
 
-// VolumeLevel returns the current volume level (0–175).
+// VolumeLevel returns the current volume level (0–volumeMax).
 func (s *Server) VolumeLevel() int {
 	return s.volume.Get()
 }
 
 // SetVolumeChangeCallback wires a callback invoked when volume changes.
-// The callback receives the new level (0–175).
+// The callback receives the new level (0–volumeMax).
 func (s *Server) SetVolumeChangeCallback(cb func(level int)) {
 	s.volume.SetOnVolumeChange(cb)
 }

--- a/device/internal/server/volume.go
+++ b/device/internal/server/volume.go
@@ -10,10 +10,50 @@ import (
 )
 
 const (
-	volumeMin     = 0
-	volumeMax     = 175
-	volumeStep    = 17 // ~10% per press
-	volumeLEDSecs = 2  // how long to show volume ring
+	volumeMin = 0
+
+	// volumeMax is the codec's UNITY gain, not the top of the mixer control's
+	// range. tinymix ctl 61 is the tlv320aic32x4 DAC digital volume: 176
+	// steps of 0.5dB spanning -63.5dB..+24dB, with 0dB at index 127. The 48
+	// steps above 127 apply POSITIVE digital gain to already near-full-scale
+	// PCM, which saturates inside the DAC.
+	//
+	// Measured on hardware 2026-08-13 (1kHz at -6dBFS, recorded through the
+	// mic array): THD 1.5% at 127, 2.3% at 136, 65% at 153, 89% at 170 — with
+	// the output level FLAT from 153 upward, because it had already stopped
+	// being able to get louder. Third harmonic rose to -1.1dB relative to the
+	// fundamental, i.e. very nearly a square wave. The control run that
+	// isolates it: index 170 with the source scaled down to land at the same
+	// acoustic level reads 1.1%, clean — so the codec's gain stage is fine
+	// and it is purely source x gain exceeding full scale.
+	//
+	// Stock FireOS never writes this control at all: it appears in no
+	// /system binary and not once in /system/etc/audio_device.xml, which
+	// leaves the DAC at its 0dB reset default and takes user volume from
+	// AudioFlinger's software attenuation instead. That is why native Alexa
+	// has no such distortion, and why matching it means capping here.
+	//
+	// Do not raise this. The lost headroom cannot be bought back from
+	// Ext_Amp_Gain either — that control is inert on this board (measured
+	// 0.0dB of effect across its whole 6/12/18/24dB range, while still
+	// reading its new value back). "HP Driver Gain Volume" (ctl 62) is the
+	// stage that does work, if more output is ever wanted.
+	volumeMax = 127
+
+	// volumeButtonFloor is the bottom of the band the PHYSICAL buttons
+	// traverse. The scale is dB-linear, so index 0 is -63.5dB and roughly the
+	// bottom third of the control is indistinguishable from silence; stepping
+	// across it spends presses to go nowhere. Silencing the device is the
+	// mute button's job, not the volume button's.
+	//
+	// Explicit Set() calls are deliberately NOT floored — HA's volume 0.0
+	// has to still mean silent. A press from below the floor lands ON the
+	// floor rather than adding a step, so one press always reaches audible.
+	volumeButtonFloor = 47 // -40dB
+
+	// volumeStep is 4dB per press: 10 presses to cross the button band.
+	volumeStep    = 8
+	volumeLEDSecs = 2 // how long to show volume ring
 	numLEDs       = 12
 )
 
@@ -65,23 +105,32 @@ func newVolumeController(ledGetter func() led.Controller) *volumeController {
 	return vc
 }
 
-// readFromDevice reads current tinymix level. Returns volumeMax/2 on failure.
+// readFromDevice reads current tinymix level. Returns the midpoint of the
+// button band on failure — volumeMax/2 is -32dB on this dB-linear scale,
+// which is quiet enough to read as broken.
 func (vc *volumeController) readFromDevice() int {
+	fallback := (volumeButtonFloor + volumeMax) / 2
 	out, err := exec.Command("tinymix", "-D", "0", "61").Output()
 	if err != nil {
 		log.Printf("Volume read failed: %v", err)
-		return volumeMax / 2
+		return fallback
 	}
 	var l, r int
-	// Output: "PCM Playback Volume: 100 100 (range 0->175)"
+	// Output: "PCM Playback Volume: 100 100 (range 0->175)". The control's
+	// own range is 0->175; volumeMax caps us at 127 (unity) — see the
+	// constant. A device that was left above the cap reads back high here
+	// and the next Set() clamps it.
 	if _, err := fmt.Sscanf(string(out), "PCM Playback Volume: %d %d", &l, &r); err != nil {
 		log.Printf("Volume parse failed: %v (output: %s)", err, out)
-		return volumeMax / 2
+		return fallback
+	}
+	if l > volumeMax {
+		l = volumeMax
 	}
 	return l
 }
 
-// Set applies a new volume level (0–175) and updates tinymix. showRing
+// Set applies a new volume level (0–volumeMax) and updates tinymix. showRing
 // paints the cyan volume arc for the 2s display window — physical button
 // presses pass true; remote sets (controller command / HA) and the boot-time
 // SeedVolume pass false so the ring doesn't light when nobody is at the
@@ -147,20 +196,34 @@ func (vc *volumeController) Get() int {
 	return vc.level
 }
 
-// StepUp increases volume by one step.
+// StepUp increases volume by one step, within the button band.
 func (vc *volumeController) StepUp() {
 	vc.mu.Lock()
 	level := vc.level + volumeStep
 	vc.mu.Unlock()
-	vc.Set(level, true)
+	vc.Set(clampToButtonBand(level), true)
 }
 
-// StepDown decreases volume by one step.
+// StepDown decreases volume by one step, within the button band.
 func (vc *volumeController) StepDown() {
 	vc.mu.Lock()
 	level := vc.level - volumeStep
 	vc.mu.Unlock()
-	vc.Set(level, true)
+	vc.Set(clampToButtonBand(level), true)
+}
+
+// clampToButtonBand holds a stepped level inside [volumeButtonFloor,
+// volumeMax]. A device sitting below the floor — HA can put it there, and so
+// can a stored level from before the cap — lands ON the floor from one press
+// instead of creeping up 4dB at a time through inaudible territory.
+func clampToButtonBand(level int) int {
+	if level < volumeButtonFloor {
+		return volumeButtonFloor
+	}
+	if level > volumeMax {
+		return volumeMax
+	}
+	return level
 }
 
 // showLEDs lights N of 12 LEDs in cyan proportional to volume, then clears after 2s.
@@ -170,7 +233,18 @@ func (vc *volumeController) showLEDs(level int) {
 		return
 	}
 
-	lit := level * numLEDs / volumeMax
+	// The arc spans the BUTTON band, not the full control: over 0..volumeMax
+	// the audible range crowds into the top LEDs and a press often moves
+	// nothing. One LED stays lit anywhere above silence so the ring never
+	// reads as "off" when the device is merely quiet.
+	span := volumeMax - volumeButtonFloor
+	lit := (level - volumeButtonFloor) * numLEDs / span
+	if lit < 1 && level > volumeMin {
+		lit = 1
+	}
+	if lit > numLEDs {
+		lit = numLEDs
+	}
 	leds := make([]led.Led, numLEDs)
 	for i := 0; i < numLEDs; i++ {
 		if i < lit {

--- a/device/internal/server/volume_test.go
+++ b/device/internal/server/volume_test.go
@@ -31,3 +31,73 @@ func TestCancelDisplayReleasesTheRing(t *testing.T) {
 	// Idempotent: a second press must not panic on the already-stopped timer.
 	vc.CancelDisplay()
 }
+
+// tinymix ctl 61 spans 0..175, but 127 is the codec's 0dB. Above it the DAC
+// applies positive digital gain to near-full-scale PCM and saturates —
+// measured on hardware at 65% THD by index 153, 89% by 170, with the output
+// level flat from 153 up because it had stopped getting louder. Stock FireOS
+// never writes this control at all. If this constant creeps back toward 175,
+// the garbling above ~73% volume returns.
+func TestVolumeMaxIsCodecUnityNotTheControlMaximum(t *testing.T) {
+	if volumeMax != 127 {
+		t.Fatalf("volumeMax = %d, want 127 (0dB). Anything higher clips the DAC.",
+			volumeMax)
+	}
+	if volumeButtonFloor >= volumeMax {
+		t.Fatalf("button floor %d must sit below the ceiling %d",
+			volumeButtonFloor, volumeMax)
+	}
+}
+
+// The button band must be crossable in a sane number of presses: too few and
+// each press is a huge jump, too many and reaching the top is a chore.
+func TestButtonBandTakesAReasonableNumberOfPresses(t *testing.T) {
+	presses := (volumeMax - volumeButtonFloor) / volumeStep
+	if presses < 6 || presses > 16 {
+		t.Fatalf("%d presses to cross the band (step %d over %d..%d); "+
+			"want roughly 8-12", presses, volumeStep, volumeButtonFloor, volumeMax)
+	}
+}
+
+func TestStepsStayInsideTheButtonBand(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		// A level below the floor — HA can set one, and so could a stored
+		// level from before the cap — must reach audible in ONE press, not
+		// creep up 4dB at a time through inaudible territory.
+		{"far below the floor lands on it", volumeButtonFloor - 40, volumeButtonFloor},
+		{"just below the floor lands on it", volumeButtonFloor - 1, volumeButtonFloor},
+		{"inside the band is untouched", volumeButtonFloor + volumeStep, volumeButtonFloor + volumeStep},
+		{"above the ceiling clamps down", volumeMax + 30, volumeMax},
+	}
+	for _, tc := range cases {
+		if got := clampToButtonBand(tc.in); got != tc.want {
+			t.Errorf("%s: clampToButtonBand(%d) = %d, want %d",
+				tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// Stepping up from the top and down from the bottom must settle, not
+// oscillate or run away past the band.
+func TestSteppingSaturatesAtBothEnds(t *testing.T) {
+	level := volumeMax
+	for i := 0; i < 5; i++ {
+		level = clampToButtonBand(level + volumeStep)
+	}
+	if level != volumeMax {
+		t.Errorf("stepping up from the ceiling reached %d, want %d", level, volumeMax)
+	}
+
+	level = volumeButtonFloor
+	for i := 0; i < 5; i++ {
+		level = clampToButtonBand(level - volumeStep)
+	}
+	if level != volumeButtonFloor {
+		t.Errorf("stepping down from the floor reached %d, want %d",
+			level, volumeButtonFloor)
+	}
+}

--- a/device/pkg/mic/microphone.go
+++ b/device/pkg/mic/microphone.go
@@ -18,3 +18,21 @@ type Subscribable interface {
 	Subscribe() chan []byte
 	Unsubscribe(ch chan []byte)
 }
+
+// PassthroughReporter is implemented by backends whose fanned-out periods are
+// already one fully processed mono channel — the native-AFE backend
+// (internal/bindings/slmic), where Android's audio HAL has already run
+// per-mic AEC and beamforming before EchoMuse ever sees the stream (see
+// docs/native-afe-migration.md).
+//
+// A backend that does NOT implement this (PcmMicrophone) delivers raw
+// interleaved multi-channel capture instead, and callers must run it through
+// internal/beamformer before it means anything. Feeding an already-mono
+// stream to the beamformer would misinterpret its bytes as interleaved
+// channels — silently wrong, not just redundant — so this has to be an
+// explicit, backend-declared fact rather than inferred from buffer length.
+// A nil check (the backend doesn't implement the interface at all) is
+// equivalent to reporting false.
+type PassthroughReporter interface {
+	Passthrough() bool
+}

--- a/device/pkg/speaker/speaker.go
+++ b/device/pkg/speaker/speaker.go
@@ -27,3 +27,36 @@ type Speaker interface {
 
 	Close()
 }
+
+// StreamStats is the per-stream delivery report every backend emits once, at
+// EOS. Shared here (rather than living only in internal/bindings/speaker)
+// because the native-AFE backend (internal/bindings/slspeaker) has to report
+// the SAME shape — the schema v7 delivery instrumentation and the dashboard's
+// Activity tab are built on it regardless of which backend produced it (see
+// docs/native-afe-migration.md's "Instrumentation must survive"). Report
+// these properly or report nothing: a backend that fakes zeros for values it
+// never measured makes every device on this path look perfect.
+type StreamStats struct {
+	Periods     uint64 `json:"periods"`
+	Underruns   uint64 `json:"underruns"`
+	MinDepth    int    `json:"minDepth"`
+	PrimeWaitMs int64  `json:"primeWaitMs"`
+	RecvSpanMs  int64  `json:"recvSpanMs"`
+	MaxGapMs    int64  `json:"maxGapMs"`
+	BytesRecv   uint64 `json:"bytesRecv"`
+}
+
+// FullSpeaker is the superset cmd/server.go actually wires up, beyond the
+// core playback contract every backend must implement: per-stream delivery
+// stats, whether a voice stream is mid-flight (drives the on-device shadow
+// wake word's barge-in threshold), and re-enabling the speaker amp after a
+// headphone plug is removed (internal/bindings/jack). Both the tinyalsa and
+// native-AFE backends implement it, so cmd/server.go's backend-selection
+// switch can hold one interface-typed variable rather than duplicating every
+// call site per backend.
+type FullSpeaker interface {
+	Speaker
+	OnStreamStats(cb func(StreamStats))
+	IsStreaming() bool
+	EnableSpeakerAmp()
+}

--- a/device/tools/afe_probe/main.go
+++ b/device/tools/afe_probe/main.go
@@ -1,0 +1,370 @@
+//go:build server
+
+// afe_probe is the phase-0 spike for docs/native-afe-migration.md — a
+// standalone tool that answers, cheaply and on real hardware, everything the
+// rest of that plan assumes, before any interface or server code changes:
+//
+//  1. Does OpenSL ES work at all on this FireOS build?
+//  2. Does VOICE_RECOGNITION actually instantiate ASP pipeline 0? MIC is
+//     configured with an empty algorithm list, so it is the CONTROL: any
+//     difference between the two recordings IS the AFE, not the codec path.
+//  3. ERLE — the number the whole exercise is for. Plays a known tone and
+//     compares captured levels between MIC (no AEC) and VOICE_RECOGNITION
+//     (AEC'd) recordings of the SAME tone.
+//  4. Rough capture latency/jitter, against the mic pipeline's hard 160ms
+//     deadline (see CLAUDE.md's device audio pipeline section).
+//
+// It does not link into the server, does not change any interface, and
+// touches nothing but the microphone/speaker for the duration of a run.
+//
+// Kill criteria (docs/native-afe-migration.md): if ERLE at VOICE_RECOGNITION
+// is not clearly better than the ~7-9dB the current speexdsp path achieves,
+// stop there — the whole justification for this migration is that Amazon's
+// front end is better, and if it measures otherwise on this hardware, the
+// rest of the plan is not worth the disruption.
+//
+// Build with device/tools/build_tools.sh (needs the echomuse-compiler image;
+// like oww_probe this is a module tool, not standalone — it imports
+// internal/opensl, and Go's internal-package rule only permits that from
+// inside github.com/wilbowes/EchoMuse). Deploy the binary and run:
+//
+//	adb shell su -c 'stop echomuse'
+//	adb push build/afe_probe /data/local/tmp/afe_probe
+//	adb shell "su -c '/data/local/tmp/afe_probe -seconds 8 -out /sdcard'"
+//	adb pull /sdcard/afe_probe .
+//
+// Channel count (open question #4 in the plan — does the AFE ever want to
+// emit more than one channel?) is NOT explored here: this tool, like
+// slmic/slspeaker, always requests mono. If a preset needs to be tried at
+// stereo to answer that question, it needs a code change to
+// internal/opensl's fixed numChannels=1, not a flag here — cross-check with
+// `adb shell dumpsys audio` during a run instead.
+package main
+
+import (
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/wilbowes/EchoMuse/internal/opensl"
+)
+
+const (
+	micSampleRateHz = 16000
+	micPeriodFrames = 1280 // 80ms @ 16kHz — matches the real wire framing
+	micBuffers      = 4
+
+	toneSampleRateHz = 48000
+	tonePeriodFrames = 2048 // matches slspeaker's nominal period
+	toneBuffers      = 4
+)
+
+func main() {
+	var (
+		lib       = flag.String("lib", "libOpenSLES.so", "path to libOpenSLES.so (a bare soname resolves against /system/lib on the device)")
+		out       = flag.String("out", "/sdcard", "output directory for WAVs and the report")
+		seconds   = flag.Int("seconds", 8, "recording duration per preset")
+		presetsFl = flag.String("presets", "mic,voice_recognition,voice_communication", "comma-separated: mic, voice_recognition, voice_communication")
+		playTone  = flag.Bool("tone", true, "play a known tone through OpenSL ES during each recording (needed for the ERLE comparison)")
+		toneHz    = flag.Float64("tone-hz", 1000, "tone frequency")
+		toneAmp   = flag.Float64("tone-amp", 0.25, "tone amplitude, 0..1 of full scale")
+	)
+	flag.Parse()
+
+	if err := os.MkdirAll(*out, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "afe_probe: creating %s: %v\n", *out, err)
+		os.Exit(1)
+	}
+
+	presets, err := parsePresets(*presetsFl)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "afe_probe: %v\n", err)
+		os.Exit(2)
+	}
+
+	fmt.Printf("afe_probe: opening %s\n", *lib)
+	eng, err := opensl.Open(*lib)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "afe_probe: FAIL — OpenSL ES did not open: %v\n", err)
+		fmt.Fprintln(os.Stderr, "This answers question 1 on its own: OpenSL ES does not work on this build. Stop here.")
+		os.Exit(1)
+	}
+	fmt.Println("OpenSL ES engine opened OK — question 1 answered: yes.")
+
+	results := map[string]result{}
+	var order []string
+	for _, p := range presets {
+		fmt.Printf("\n=== recording %s for %ds (tone=%v) ===\n", p, *seconds, *playTone)
+		r, err := recordOne(eng, p, *seconds, *out, *playTone, *toneHz, *toneAmp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  FAIL: %v\n", err)
+			continue
+		}
+		fmt.Printf("  wrote %s\n", r.wavPath)
+		fmt.Printf("  frames=%d startupLatency=%s maxGap=%s rms=%.6f (%.1f dBFS)\n",
+			r.frames, r.startupLatency.Round(time.Millisecond), r.maxGap.Round(time.Millisecond),
+			r.rms, dbfs(r.rms))
+		results[p.String()] = r
+		order = append(order, p.String())
+	}
+
+	fmt.Println("\n=== summary ===")
+	for _, name := range order {
+		r := results[name]
+		fmt.Printf("  %-20s rms=%.1fdBFS startupLatency=%s maxGap=%s\n",
+			name, dbfs(r.rms), r.startupLatency.Round(time.Millisecond), r.maxGap.Round(time.Millisecond))
+	}
+
+	if *playTone {
+		reportERLE(results)
+	} else {
+		fmt.Println("\n(tone playback was off — no ERLE comparison; question 3 unanswered this run)")
+	}
+}
+
+// reportERLE compares captured level between the MIC control and each AEC
+// pipeline while the same known tone played, per docs/native-afe-
+// migration.md point 3. MIC has an empty algorithm list (passthrough), so it
+// stands in for "what the tone sounds like at this mic with no cancellation
+// at all" — the baseline any AEC is judged against.
+func reportERLE(results map[string]result) {
+	mic, ok := results[opensl.PresetMic.String()]
+	if !ok {
+		fmt.Println("\n(no MIC control recording — cannot compute ERLE)")
+		return
+	}
+	fmt.Println("\n=== ERLE (vs MIC control, no cancellation) ===")
+	any := false
+	for _, p := range []opensl.Preset{opensl.PresetVoiceRecognition, opensl.PresetVoiceCommunication} {
+		r, ok := results[p.String()]
+		if !ok {
+			continue
+		}
+		any = true
+		erle := dbfs(mic.rms) - dbfs(r.rms)
+		fmt.Printf("  %-20s ERLE ~= %.1f dB\n", p, erle)
+		if p == opensl.PresetVoiceRecognition {
+			switch {
+			case erle > 9:
+				fmt.Printf("    -> clearly better than the ~7-9dB speexdsp ceiling. Kill criteria NOT met — proceed.\n")
+			case erle >= 7:
+				fmt.Printf("    -> in the same range as the current speexdsp ceiling (~7-9dB), not clearly better.\n")
+				fmt.Printf("       Re-read the kill criteria in docs/native-afe-migration.md before proceeding.\n")
+			default:
+				fmt.Printf("    -> WORSE than or not clearly above the current ~7-9dB speexdsp ceiling.\n")
+				fmt.Printf("       Kill criteria MET — per the plan, stop here.\n")
+			}
+		}
+	}
+	if !any {
+		fmt.Println("  (neither VOICE_RECOGNITION nor VOICE_COMMUNICATION was recorded)")
+	}
+	fmt.Println("\nThis is a single-tone, single-room, single-take estimate — a real ERLE")
+	fmt.Println("number wants several takes, a real speaker/mic placement, and ideally")
+	fmt.Println("real speech rather than a pure tone. Treat this as a go/no-go signal,")
+	fmt.Println("not a number to publish.")
+}
+
+// ─── recording ────────────────────────────────────────────────────────────
+
+type result struct {
+	wavPath        string
+	frames         int
+	startupLatency time.Duration
+	maxGap         time.Duration
+	rms            float64 // 0..1 of int16 full scale, over the analysis window
+}
+
+// recordOne opens a recorder at preset, optionally plays a known tone for the
+// same duration, and writes a WAV. The RMS reported is measured over the
+// LAST 70% of the capture, skipping the opening ~30% — the recorder's own
+// startup transient and (when playing) the tone's ramp-in would otherwise
+// bias the level measurement.
+func recordOne(eng *opensl.Engine, preset opensl.Preset, seconds int, outDir string,
+	playTone bool, toneHz, toneAmp float64) (result, error) {
+	rec, err := eng.NewRecorder(preset, micSampleRateHz, micPeriodFrames, micBuffers)
+	if err != nil {
+		return result{}, fmt.Errorf("open recorder: %w", err)
+	}
+	defer rec.Close()
+
+	var tonePlayer *opensl.Player
+	toneDone := make(chan struct{})
+	if playTone {
+		tonePlayer, err = eng.NewPlayer(toneSampleRateHz, tonePeriodFrames*2, toneBuffers)
+		if err != nil {
+			return result{}, fmt.Errorf("open tone player: %w", err)
+		}
+		defer tonePlayer.Close()
+		go func() {
+			defer close(toneDone)
+			playSineFor(tonePlayer, toneHz, toneAmp, time.Duration(seconds+1)*time.Second)
+		}()
+		// Give the tone a moment's head start so the recording doesn't open
+		// on silence while the player is still spinning up.
+		time.Sleep(150 * time.Millisecond)
+	}
+
+	start := time.Now()
+	if err := rec.Start(); err != nil {
+		return result{}, fmt.Errorf("start recorder: %w", err)
+	}
+	defer rec.Stop()
+
+	var (
+		samples        []int16
+		startupLatency time.Duration
+		lastRead       time.Time
+		maxGap         time.Duration
+		gotFirst       bool
+	)
+	deadline := time.Now().Add(time.Duration(seconds) * time.Second)
+	for time.Now().Before(deadline) {
+		buf, err := rec.Read()
+		if err != nil {
+			return result{}, fmt.Errorf("read: %w", err)
+		}
+		now := time.Now()
+		if !gotFirst {
+			startupLatency = now.Sub(start)
+			gotFirst = true
+		} else if gap := now.Sub(lastRead); gap > maxGap {
+			maxGap = gap
+		}
+		lastRead = now
+		samples = append(samples, bytesToInt16(buf)...)
+	}
+
+	if playTone {
+		<-toneDone
+	}
+	if rec.Drops() > 0 {
+		fmt.Printf("  note: %d capture periods dropped (Read() fell behind)\n", rec.Drops())
+	}
+
+	wavPath := filepath.Join(outDir, "afe_probe_"+preset.String()+".wav")
+	if err := writeWAV(wavPath, samples, micSampleRateHz); err != nil {
+		return result{}, fmt.Errorf("write wav: %w", err)
+	}
+
+	// Analysis window: skip the first 30% (recorder startup + tone ramp-in).
+	skip := len(samples) * 3 / 10
+	window := samples[skip:]
+
+	return result{
+		wavPath:        wavPath,
+		frames:         len(samples),
+		startupLatency: startupLatency,
+		maxGap:         maxGap,
+		rms:            rmsInt16(window),
+	}, nil
+}
+
+// playSineFor writes a continuous sine tone to a Player for dur, in
+// tonePeriodFrames-sample chunks. Amplitude is applied directly in float
+// before quantising, so toneAmp=1.0 is exactly full scale.
+func playSineFor(p *opensl.Player, hz, amp float64, dur time.Duration) {
+	periodSamples := tonePeriodFrames
+	buf := make([]byte, periodSamples*2)
+	n := 0
+	deadline := time.Now().Add(dur)
+	for time.Now().Before(deadline) {
+		for i := 0; i < periodSamples; i++ {
+			t := float64(n) / float64(toneSampleRateHz)
+			v := amp * math.Sin(2*math.Pi*hz*t)
+			s := int16(v * math.MaxInt16)
+			binary.LittleEndian.PutUint16(buf[i*2:], uint16(s))
+			n++
+		}
+		if err := p.Write(buf); err != nil {
+			return // player closed underneath us — nothing left to do
+		}
+	}
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+func parsePresets(s string) ([]opensl.Preset, error) {
+	var out []opensl.Preset
+	for _, tok := range strings.Split(s, ",") {
+		switch strings.ToLower(strings.TrimSpace(tok)) {
+		case "mic":
+			out = append(out, opensl.PresetMic)
+		case "voice_recognition", "vr":
+			out = append(out, opensl.PresetVoiceRecognition)
+		case "voice_communication", "vc":
+			out = append(out, opensl.PresetVoiceCommunication)
+		case "":
+			// tolerate a trailing comma
+		default:
+			return nil, fmt.Errorf("unknown preset %q (want mic, voice_recognition, voice_communication)", tok)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no presets given")
+	}
+	return out, nil
+}
+
+func bytesToInt16(b []byte) []int16 {
+	out := make([]int16, len(b)/2)
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(b[i*2:]))
+	}
+	return out
+}
+
+func rmsInt16(s []int16) float64 {
+	if len(s) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, v := range s {
+		f := float64(v) / 32768.0
+		sum += f * f
+	}
+	return math.Sqrt(sum / float64(len(s)))
+}
+
+// dbfs converts a 0..1 RMS fraction to dBFS. A silent (zero) signal reports
+// a large negative floor rather than -Inf, so it still sorts/prints sanely.
+func dbfs(rms float64) float64 {
+	if rms <= 0 {
+		return -120
+	}
+	return 20 * math.Log10(rms)
+}
+
+func writeWAV(path string, samples []int16, rateHz int) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	dataSize := uint32(len(samples) * 2)
+	write := func(v any) { binary.Write(f, binary.LittleEndian, v) }
+
+	f.WriteString("RIFF")
+	write(uint32(36) + dataSize)
+	f.WriteString("WAVE")
+	f.WriteString("fmt ")
+	write(uint32(16))
+	write(uint16(1))          // PCM
+	write(uint16(1))          // mono
+	write(uint32(rateHz))     // sample rate
+	write(uint32(rateHz * 2)) // byte rate
+	write(uint16(2))          // block align
+	write(uint16(16))         // bits per sample
+	f.WriteString("data")
+	write(dataSize)
+	for _, s := range samples {
+		write(s)
+	}
+	return nil
+}

--- a/device/tools/build_tools.sh
+++ b/device/tools/build_tools.sh
@@ -43,9 +43,31 @@ build_module_tool() {
     echo "Output: $BUILD_DIR/$name"
 }
 
+# afe_probe is a module tool like oww_probe (imports internal/opensl — same
+# internal-package constraint) but unlike oww_probe it DOES need -tags
+# server: internal/opensl is itself //go:build server (it dlopens OpenSL ES,
+# which only exists on the device), so building without the tag fails with
+# "build constraints exclude all Go files", the same error cmd/server hits.
+build_module_tool_server() {
+    local name=$1
+
+    echo "Building $name..."
+    mkdir -p "$BUILD_DIR"
+    docker run --rm \
+        --entrypoint bash \
+        -e CGO_LDFLAGS="-Wl,--hash-style=both" \
+        -v "$(pwd)":/sdk \
+        -v "$REPO_ROOT/GoTinyAlsa":/GoTinyAlsa \
+        echomuse-compiler \
+        -c "cd /sdk && go build -tags server -o build/$name ./tools/$name"
+
+    echo "Output: $BUILD_DIR/$name"
+}
+
 build_tool capture_mics
 build_tool bf_capture
 build_module_tool oww_probe
+build_module_tool_server afe_probe
 
 echo ""
 echo "Deploy:"
@@ -70,3 +92,11 @@ echo "  adb shell \"su -c '/data/local/tmp/oww_probe -classifier /data/local/tmp
 echo ""
 echo "Without adb, push over the controller shell plane instead:"
 echo "  python controller/tools/push_file.py <local> <remote>   (resumable)"
+echo ""
+echo "afe_probe is the docs/native-afe-migration.md phase-0 spike — records"
+echo "through OpenSL ES at MIC/VOICE_RECOGNITION/VOICE_COMMUNICATION, plays a"
+echo "known tone for an ERLE estimate, writes WAVs, and prints a go/no-go line:"
+echo "  adb push $BUILD_DIR/afe_probe /sdcard/afe_probe"
+echo "  adb shell \"su -c 'cp /sdcard/afe_probe /data/local/tmp/afe_probe && chmod 755 /data/local/tmp/afe_probe'\""
+echo "  adb shell \"su -c '/data/local/tmp/afe_probe -seconds 8 -out /sdcard'\""
+echo "  adb pull /sdcard/afe_probe_mic.wav /sdcard/afe_probe_voice_recognition.wav /sdcard/afe_probe_voice_communication.wav ."

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,12 @@ Deeper technical references live elsewhere:
 
 - [support-bundle.md](support-bundle.md) — what a support bundle contains,
   what it deliberately excludes, and how to check before you share one.
+- [alexa-afe.md](alexa-afe.md) — how the stock Alexa stack does echo
+  cancellation and beamforming on the same hardware, where its tuning lives on
+  the device, and what of it EchoMuse can and cannot reuse. Nothing from Amazon
+  is vendored here; extract from your own Dot.
+- [native-afe-migration.md](native-afe-migration.md) — spec and phased plan for
+  moving device audio onto that native front end. Proposal, not started.
 - [rooting.md](rooting.md) — what a device needs before EchoMuse can use it.
   The exploit itself is R0rt1z2's work on XDA Forums and that thread is canon;
   this covers where EchoMuse picks up, and what the wizard does for you.

--- a/docs/alexa-afe.md
+++ b/docs/alexa-afe.md
@@ -1,0 +1,609 @@
+# Amazon's audio front end on the Echo Dot Gen 2
+
+Reverse-engineering notes on how the stock Alexa stack does acoustic echo
+cancellation and beamforming on the same hardware EchoMuse runs on, and an
+assessment of what — if anything — EchoMuse can reuse.
+
+Investigated 2026-08-12 against a fielded Dot (FireOS image dated 2022-11-18).
+
+**Nothing from Amazon is vendored into this repo.** The tuning files and
+libraries described here are Amazon proprietary and stay on the device. Every
+rooted Dot already has its own copy at the paths below; extract from your own
+hardware. This is the same line `echo-dot-2-playground` draws.
+
+## Summary
+
+The AEC is not in the audio HAL, not in `libpryon.so`, and not in any Java
+app. It is `/system/lib/libasp.so` — Amazon "ASP" (Audio Signal Processing) —
+which contains the whole AFE and runs **inside `/system/bin/mediaserver`**,
+the same process as AudioFlinger.
+
+The complete tuning is on disk in plain commented JSON at
+`/system/vendor/etc/audio-algorithms/`, including the beamformer coefficients
+designed for this exact array. That directory is the valuable find; the binary
+mostly just tells you how to read it.
+
+## Where everything is
+
+| Path | What |
+|---|---|
+| `/system/lib/libasp.so` | 1,083,168 B. The AFE. clang 3.5, ARMv7, built Feb 24 2022 |
+| `/system/lib/libaspclient.so` | 30,016 B. Binder proxy only |
+| `/system/vendor/etc/audio-algorithms/` | 28 files, 761 KB. All tuning |
+| `/system/lib/libpryon.so` | 21.6 MB. Wake word + ASR decoder. Consumes AFE output |
+| `/system/lib/libwakewordserver_jni.so` | JNI bridge. NEEDED = `libaspclient.so` + `libpryon.so` |
+| binder service | `audiosignalprocessor` → `com.amazon.asp.IAudioSignalProcessor` |
+| host process | `/system/bin/mediaserver` (confirmed via `/proc/<pid>/maps`) |
+
+Chain: **mediaserver/libasp (AEC + beamform) → binder → wakeword server JNI →
+libpryon (WW/ASR)**.
+
+`dumpsys audiosignalprocessor` works on a stock-ish device and prints live AFE
+debug JSON. With EchoMuse holding the mic there is no AFE pipeline
+instantiated, so it only reports the playback-side volume leveller.
+
+`libpryon` is the decoder only. It consumes AFE **metadata** alongside the
+audio — its strings include `ERLE ... from AFE metadata metrics calculator` and
+`AFE LSB metadata doesn't support fields of Sub-Base DTD flag or playback
+status. Skipping evaluation of DTD for the purposes of NTT self-wake
+suppression`. So the AFE hands the decoder ERLE, a double-talk flag and
+playback status, and the decoder uses them to suppress self-wake. Channel types
+include `BEAMFORMED`; strings `pre-aec` and `post-aec` exist.
+
+### Extracting it
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+adb connect 192.168.3.71:5555
+adb pull /system/vendor/etc/audio-algorithms .     # the tuning — start here
+adb pull /system/lib/libasp.so .
+adb shell su -c 'dumpsys audiosignalprocessor'
+```
+
+## The tuning directory
+
+```
+AFE.cfg                                 41,622   master config, commented JSON
+coefs_FBF.cfg                          460,701   fixed beamformer coefficients
+coefs_FilterBank_640.cfg                12,513   ASR analysis/synthesis prototype
+coefs_FilterBank_AnalysisSynthesis_1024.cfg 19,974   VoIP filterbank prototype
+coefs_FilterBank_160.cfg                 3,231
+EQ_{50..100}.cfg, VOIP_EQ_*, MBCL*, UserEQ.cfg, VOIP*ParametricEQ.cfg
+```
+
+`AFE.cfg` opens with `// Comments are accepted in JSON configuration files. Use
+cJSON_Minify to strip them prior to parsing.` It is written for a human, with
+units and rationale in the comments.
+
+```json
+"Hardware Definition": {
+    "Name"                  : "Biscuit",
+    "Num Mics"              : 7,
+    "Num Speakers"          : 2,
+    "Mics SamplingRate"     : 16000,
+    "ASR Path SamplingRate" : 16000,
+    "Speakers SamplingRate" : 48000
+}
+```
+
+Same rates EchoMuse uses. `coefs_FBF.cfg` self-describes as
+`coefs_FBF_6beams_64bands_Biscuit`, generated Mar 6 2019.
+
+## Pipeline
+
+The ASR path, in the order `AFE.cfg` states frames are processed:
+
+```
+Downsampler IIR → HPF 80Hz @ 16K (mic in AND ref in) → FilterBank
+  → AEC → ARA → ABF → VAD → RefBeamSelector → SNRBeamSelector
+  → False WW Prevention → Output Gain → EspFeatureExtraction
+```
+
+The VoIP path differs and is where the nonlinear stages live:
+
+```
+... FilterBank → AEC → Frequency Masking RES → Recursive Magnitude Estimation NR
+  → Random Filler CNG → FB AGC → parametric IIR → GainRampUp → limiter
+```
+
+Global policy:
+
+```json
+// If there is a reference signal, we will use AEC, otherwise we will use ANC
+// FBF is always enabled
+"Enable AEC/ABF according to ref level" : true,
+"Enable ABF" : true,
+"Enable AEC" : true
+```
+
+### Filterbank
+
+```json
+"ASR FilterBank": { "FFT Len": 128, "Decimation Rate": 64,
+                    "FilterLen": 640, "AnaSynFilterCoefs": "coefs_FilterBank_640.cfg" }
+```
+
+A uniform DFT (WOLA) filterbank: 128-point FFT, hop 64, 640-tap prototype
+window (supplied as 640 floats). Hop 64 at 16 kHz = **4 ms frames**, which
+matches the `Each number represents average ERLE number of %d frames(4ms)`
+string in the binary. 64 usable bands, 125 Hz apart.
+
+The NEON kernels that escaped stripping confirm the implementation:
+`neonAllpass2X2F32_DF2T` and `neonBiquad{1X4,2X2}F32_DF2T` for the filterbank,
+`neonV4cplxMAC32f` / `neonV4cplxMACCircular32f_optimized` for a **4-wide
+complex** MAC, and `neonAdaptAndComputeRefEstimate1` /
+`...Circular1` for the adaptive filter update. Float32 throughout. The
+coefficient file is laid out 4 bands at a time (`4REAL-4IMAG`), matching the
+4-wide SIMD.
+
+### AEC
+
+```json
+"ASR AcousticEchoCanceler": {
+    "Num Refs Per Input"    : 2,
+    "TailLen"               : 2560,
+    "MaxStepSize"           : 0.2,
+    "adaptBandLoHz"         : 0,
+    "adaptBandHiHz"         : 8000,
+    "leakyFactor"           : 1.0,
+    "DivFactorThd"          : 1.0,
+    "RegFactorScale"        : 1E-5,
+    "bandBasedTailLen"      : true,
+    "bandBasedStepSize"     : true,
+    "stepSizeRednScale"     : 5.0,
+    "stepSizeErrorScale"    : 5.0,
+    "RefSigEnThresh"        : 0,
+    "Enable VSS"            : true,
+    "Ord2 to Ord1 ratio Percent" : 50   // round robin
+}
+```
+
+Notes that matter:
+
+- **`TailLen` 2560 samples = 160 ms** at 16 kHz. EchoMuse's `AEC_TAIL_MS`
+  defaults to **300 ms** — nearly twice as long. Longer is not better: tail
+  length trades convergence speed and steady-state misadjustment against the
+  reverberation you can actually cancel.
+- One AEC **per microphone**, before beamforming — `SerialAEC: AEC_%d`,
+  `NumAECs`, `m_nInputsToAdapt`, and the commented-out
+  `"Adapted Inputs Indexes": [0,1,2,3,4,5,6]` (set at runtime to the mic count).
+- `bandBasedTailLen` / `bandBasedStepSize` — per-band tail and step size, not
+  one global value.
+- The VoIP AEC is tuned differently: 1 ref, `TailLen` 3840 (240 ms),
+  `MaxStepSize` 0.5, `adaptBandLoHz` 100, and a non-zero `RefSigEnThresh` of
+  `3.1623E-6` with the comment *"corresponds to wideband level of -55 dB (ref
+  signal)"* — i.e. it refuses to adapt on a reference quieter than −55 dB.
+
+### Beamformer
+
+```json
+"ASR FixedBeamFormer": { "Num Source Beams": 6, "Num Coefficients": 4,
+                         "BeamFormingCoefs": "coefs_FBF.cfg" }
+```
+
+`coefs_FBF.cfg` header:
+
+```
+/* It consists of 64 bands 6 beams 4 coefs 7 mics -> 64*6*4*7 = 10752 complex numbers */
+```
+
+Parsed and confirmed: exactly 2688 groups of 8 floats (4 real + 4 imag,
+covering 4 consecutive bands). So the FBF is a **subband filter-and-sum** — per
+band, per beam, a 4-tap complex filter on each of the 7 mics. Not delay-and-sum.
+
+What the coefficients show directly, without needing to pin the convention:
+
+- Each beam weights an **opposite pair** of perimeter mics highest and uses all
+  7. At 1000 Hz, normalised per beam, the on-axis pair sits at 1.00/0.99, the
+  other four at 0.59, and the centre mic at 0.41. The six beams fall into three
+  axis pairs, consistent with six look directions 60° apart aligned to the mic
+  axes.
+- Phase is symmetric about each beam's axis (mics either side of the axis carry
+  equal phase), which is what a beam steered along that axis looks like.
+- Of the 4 taps, **coefficient index 2 carries 94.7% of the energy** — a short
+  filter with a dominant centre tap, the rest shaping.
+- Weighting the whole array rather than the on-axis mic, with a centre-mic
+  term, is the signature of a superdirective/MVDR-style design rather than
+  delay-and-sum.
+
+On top of the fixed beams sits a **beamspace GSC**: each beam is cleaned using
+two *other beams* as noise references.
+
+```json
+"ASR AdaptiveBeamFormer": {
+    "FixedBeamFormer" : "ASR FixedBeamFormer",
+    "Num Beams"       : 6,
+    "Num Refs Per Input" : 2,            // 2 nulls per beam
+    "Input-References Info" : [ [2,4],[3,5],[4,0],[5,1],[0,2],[1,3] ],
+    "TailLen"         : 1536,
+    "MaxStepSize"     : 0.1,
+    "adaptBandLoHz"   : 200,
+    "adaptBandHiHz"   : 7000,
+    "leakyFactor"     : 1.0,
+    "RegFactorScale"  : 2.5E-4,
+    "Enable RoundRobin" : true,
+    "VSSLoHz" : 1000, "VSSHiHz" : 6000
+}
+```
+
+Beam *i* is adapted against beams *i*+2 and *i*+4 (mod 6) — the two beams
+120° and 240° away. Adaptation is band-limited to 200–7000 Hz, unlike the AEC
+which adapts 0–8000 Hz.
+
+Then a beam is **selected**, not merged:
+
+```json
+"ASR SNRBeamSelector": {
+    "energyAdaptationFactorFast" : 0.95,   "energyAdaptationFactorSlow" : 0.987,
+    "energyRatio" : 1.2,                   "noiseAdaptationFactor" : 1.001,
+    "bufferSize" : 10, "hangoverPeriod" : 15, "SNRThreshold" : 6.5
+}
+```
+
+That top layer is the same idea as EchoMuse's beamformer — a fast/slow energy
+ratio per direction with hysteresis. Amazon just selects among six
+superdirective beams instead of among six raw mics.
+
+### Residual echo suppression and double-talk
+
+This is the part EchoMuse has no equivalent of. `Frequency Masking RES` carries
+**ten columns of tuning, one per volume step**:
+
+```json
+"Frequency Masking RES": {
+  "numVolume" : 10,
+  "aecVssSumTh" : 60,
+  "internal": {
+    //                    Vol1     Vol2     Vol3     Vol4     Vol5    Vol6 ...
+    "erleAecFactor" : [    2.2,     2.1,     2.0,    1.95,    1.85,    1.8, ...],
+    "erleAecAttX"   : [   0.08,    0.07,    0.06,    0.05,   0.035,   0.03, ...],
+    "dtdSmoothUp"   : [   0.45,    0.45,    0.45,    0.45,    0.45,   0.45, ...],
+    "dtdSmoothDown" : [   0.49,    0.49,    0.49,    0.49,    0.49,   0.48, ...],
+    "dtdDecisionTh" : [   0.45,    0.45,    0.45,    0.45,    0.45,   0.33, ...],
+    ...
+  },
+  "lineout": { ... same shape, separate tuning ... },
+  "default speaker mode": "internal"
+}
+```
+
+Separate tables for the internal speaker and for lineout — which is exactly the
+jack case EchoMuse handles in `internal/bindings/jack`.
+
+`Karush-Kuhn-Tucker RES` attenuates only the lowest 3 of 16 bands by 0.001
+during double talk (`attenuationPerBand`), and nothing at all when it is echo
+only (`attenuationPerBandEchoOnly` all 1.0).
+
+### False wake word prevention
+
+A dedicated module, `"enable": true`, whose thresholds are indexed by playback
+volume — and note it distinguishes single talk from double talk at each volume:
+
+```json
+"Double talk threshold volume 10" : 1.0,   "Single talk threshold volume 10" : 4.0,
+"Double talk threshold volume 40" : 11.0,  "Single talk threshold volume 40" : 14.0,
+"Double talk threshold volume 100": 20.0,  "Single talk threshold volume 100": 24.0
+```
+
+This is the module whose job is precisely the risk CLAUDE.md flags for the
+timer ring: *"a chime whose residual scores as the wake word and silences its
+own alarm"*. Amazon's answer is a volume-indexed variance/hold test on the
+post-AEC signal, not a threshold change.
+
+### Filters, verbatim
+
+Both are given normalised (divided through by a0) and are directly usable.
+
+`HPF 80Hz @ 16K` — three biquads, applied to **both the mic input and the
+reference input**:
+
+```
+a1 = [-1.978964742877471, -1.920823752121581, -1.995031240858690]
+a2 = [ 0.980148787818626,  0.923195725460049,  0.995935784603137]
+b0 = [ 2.061764283274676, 12.481101519210988,  0.036465860122281]
+b1 = [-4.12286229274,    -24.9615622297,       -0.07291290428   ]
+b2 = [ 2.061764283274676, 12.481101519210988,  0.036465860122281]
+```
+
+`Downsampler IIR`, 48 kHz → 16 kHz — three biquads plus a first-order section
+(the 4th column). The comment says *"taken from Knight
+(lpfIIRFilterCoeffs16Kat48K.h)"*:
+
+```
+a1 = [-1.35381400585174560547, -1.16845381259918212891, -1.09131717681884765625, -0.74153685569763183594]
+a2 = [ 0.67048937082290649414,  0.85192829370498657227,  0.96150147914886474609,  0.0]
+b0 = [ 0.03503995016217231750,  0.48894411325454711914,  0.74522399902343750000,  0.50676357746124267578]
+b1 = [ 0.01067659538239240646, -0.29441374540328979492, -0.62026363611221313477,  0.50676357746124267578]
+b2 = [ 0.03503995016217231750,  0.48894411325454711914,  0.74522399902343750000,  0.0]
+```
+
+### Gain staging
+
+```json
+"Voice Activity Detector": {
+    "System Gain Available" : true,
+    "PGA Gain"   : 20.0,   "ADC Gain"   : 0.0,
+    "AFE In Gain": 0.0,    "AFE Out Gain": 7.2,
+    "referenceAudioLevelOutputInDb" : -53
+}
+```
+
+PGA 20 dB matches `audio_init.sh`, which sets `ADC_x MICPGA Volume Ctrl` to 40
+in 0.5 dB steps. Then +7.2 dB after the AFE. EchoMuse's `micGainDb` default of
++24 dB sits in a different place in the chain (pre-truncation, on the 24-bit
+sample) and is not directly comparable.
+
+## The reference, and why it has a whole subsystem
+
+Amazon never assumes the far-end reference is aligned. From the binary:
+
+```
+Loopback signal is zero. Cannot synchronize yet
+Synchronized. Slice %d. Removing %d samples from the buffer
+Out of sync, frames do not match
+Reference buffer is too big. Trimming to %d frames
+Failed to read echo reference. Sending silence.
+asp_set_ext_ref_sync_status          ← the host tells ASP whether the ref is synced
+sync_timeout / repeat_sync_timeout / sync_time_in_us / MIN_DELAY_DELTA_NS
+EchoReferenceBufferMatching / Reference Delay / AEC upload samples delay
+```
+
+The hardware is why. Measured live on a fielded device:
+
+- mic `pcm24c`: 9 ch, S24_3LE, **16 kHz**, period 512 — 4× TLV320AIC3101 over SPI
+- spk `pcm23p`: 2 ch, S16_LE, **48 kHz**, period 2048 — TLV320AIC3204 over I2S
+
+Two codecs, two rates, two buses. Relevant mixer controls and PCMs:
+
+| Control / PCM | State | Note |
+|---|---|---|
+| `Audio_I2S0dl1_get_timestamp` | BYTE[8], increments between reads | hardware playback timestamp |
+| `Audio_ExtCodec_EchoRef_Switch` | Off | external-codec echo reference route |
+| `Codec_Loopback_Setting` | OFF | |
+| `AP_Loopback_Select` | AP_LOOPBACK_NONE | |
+| `00-09 DL1_AWB_Record` | capture | MTK audio-write-back of the playback path |
+| `00-16 I2S0AWB_Capture` | capture | loopback of I2S0 out |
+| `LineIn ADC` | Off | `persist.adc.linein` unset |
+
+Adaptation is also gated on content state rather than run blind:
+`Enable AEC/ABF according to ref level`, `Automatic AEC/ABF Selection according
+to reference power`, `Alarm : set AEC adaptation %d`, `Enable For TTS`, plus
+per-band ERLE (`ERLEComputeLowBand`/`HighBand`) and a divergence counter
+(`AECD: AIC IS DIVERGING`).
+
+## Can EchoMuse use any of this?
+
+Four routes, in decreasing order of how well they work out.
+
+### 1. Reuse the tuning data — **yes, and this is where the value is**
+
+`AFE.cfg` and the coefficient files are data, they live on every rooted Dot,
+and they were designed against this exact array and enclosure. Reading them
+costs nothing and commits to nothing.
+
+Immediately usable with no new DSP:
+
+- **The `Downsampler IIR` coefficients.** EchoMuse currently 3:1 **box
+  decimates** the 48 kHz reference to 16 kHz (`device/internal/aec/aec.go`). A
+  box filter is a poor anti-alias filter; everything above 8 kHz folds back into
+  the reference band. Aliasing in the reference is uncorrelated with the mic
+  signal by construction, so it directly caps achievable ERLE. Swapping in
+  Amazon's 4-section IIR is ~20 constants and a biquad cascade.
+- **The `HPF 80Hz @ 16K` coefficients.** EchoMuse has no high-pass anywhere on
+  either path (grepped: no `highpass`/`hpf`/`dcblock` in `device/` or
+  `controller/`). Amazon high-passes **both** mic and reference before the AEC.
+  Low-frequency rumble inflates the reference power estimate and so shrinks the
+  effective step size at the frequencies that carry speech.
+- **`TailLen` 2560 = 160 ms** against EchoMuse's 300 ms default. Worth an A/B;
+  the shorter filter converges faster and misadjusts less.
+- The volume-indexed **DTD and RES tables** as a starting point if a residual
+  suppressor is ever built.
+
+The FBF coefficients are usable in principle but not for free — see the
+caveats below.
+
+### 2. Adopt the design decisions — **yes, and cheaper than porting**
+
+Two structural gaps stand out, both independent of the beamformer:
+
+- **A residual echo suppressor after the linear AEC.** Amazon ships four kinds
+  and none of the paths runs without one. This corroborates rather than
+  contradicts the existing "AEC ceiling is hardware" finding: Amazon hit the
+  same linear ceiling and answered it with a nonlinear spectral post-filter,
+  not with a better adaptive filter. A frequency-masking RES on the existing
+  speex output is additive and does not touch the AEC.
+- **A double-talk detector whose thresholds depend on playback volume.** Every
+  volume-sensitive parameter in Amazon's config is a 10-entry table, never a
+  constant.
+
+Both would also give the timer-ring barge-in path (`Ring listening (chime
+audible, AEC)`) something better than a fixed `bargeInThreshold`.
+
+### 3. dlopen `libasp.so` and drive it directly — **possible, but pointless given route 5**
+
+The precedent exists: `internal/wakeword/ort/` already dlopens ONNX Runtime
+rather than linking it. Every `NEEDED` library is present on the device
+(verified: `libaudioutils`, `libbinder`, `libc++`, `libcutils`, `liblog`,
+`libmedia`, `libspeexresampler`, `libutils`), and the config sits at a fixed
+read-only path.
+
+A disassembly pass says the ABI work is **moderate, not forbidding**. The
+exported functions are tiny — 6 to 180 bytes — because they are a thin C shim
+over a C++ object with a vtable:
+
+```
+asp_init                6 B    movs r0,#0 ; b asp_parameterized_init   -> init(0)
+asp_parameterized_init 84 B    takes a lock, calls internal 0x1d39c, sets a
+                               "already initialised" byte, returns int
+asp_create_pipeline   180 B    rejects type >= 0x13 (19 pipeline types),
+                               forwards (r0..r3) to internal 0x1da60,
+                               returns 0 on failure -> returns a handle
+asp_process            58 B    ldr r6,[r0] / ldr r6,[r6,#0x18] / blx r6
+                               = vtable slot 6.  8 incoming args (r0-r3 +
+                               4 stack), forwards them plus a trailing 0
+asp_process_ext        58 B    identical, but passes a real 9th arg
+asp_process_3p          6 B    mvn r0,#0x25 ; bx lr  -- STUBBED, always -38
+asp_set_device         44 B    vtable slot 3
+asp_set_ext_ref_sync_status 16 B  vtable slot 8
+```
+
+So the handle from `asp_create_pipeline` is a C++ object, `asp_process` takes
+roughly `(ctx, mic**, nMic, ref**, nRef, out**, nOut, nSamples)` — eight
+arguments whose types are unknowable from the shim, since all the real work is
+behind `vtable[6]`. Recovering them means reversing the internal
+implementation, and every wrong guess corrupts memory inside the process that
+owns the audio hardware. Note also `asp_process_3p` is a hard-coded `-38`
+stub, so at least one advertised entry point does nothing.
+
+Verdict: doable, days of work, ships nothing (Amazon proprietary — it could
+only ever be dlopen'd from the device's own copy), and route 5 gets the same
+DSP through a documented API for a fraction of the effort.
+
+### 4. Talk to the `audiosignalprocessor` binder service — **no, and it is the wrong door**
+
+The service is registered and `dumpsys audiosignalprocessor` responds. But the
+tap that would let a client read processed audio is fused off in retail builds
+(`ASP capture is disabled for ship build` / `ASP injection is disabled for ship
+build`), and the real audio transport is not this service at all.
+
+`libwakewordserver_jni.so` links `libaudiostream.so`, which implements
+`amazon.speech.audio.IAudioStreamService` — a binder service handing out
+**shared-memory ring buffers** (`amazon::ShmAudioStreamIOBase`,
+`allocateSharedMemory`, `openReader`/`openWriter`, `available`,
+`getPosition`/`setPosition`). That is how processed audio actually reaches the
+wake word engine. It is **not registered on an EchoMuse device**: its host is
+`amazon.speech.sim`, which EchoMuse's own debloat step puts in the `pm hide`
+list. Un-hiding it to get the stream back would restore the Alexa stack this
+project exists to remove.
+
+Releasing the microphone would not change either fact.
+
+### 5. Open the AFE through the standard Android capture API — **this is the real answer**
+
+The AFE is not behind an Amazon service. **It is inside the audio HAL**:
+
+```
+$ readelf -d audio.primary.mt8163.so | grep NEEDED
+   NEEDED  libasp.so
+$ nm -D --undefined-only audio.primary.mt8163.so | grep asp_
+   U asp_init   U asp_create_pipeline   U asp_process
+   U asp_set_device   U asp_command   U asp_destroy_pipeline
+```
+
+The HAL runs ASP on both directions — `AudioALSAPlaybackHandlerNormal::asp_open`
+/ `doProcessAsp` / `setASPDevice` on the way out, and
+`AudioALSACaptureDataClient::getAspPipelineType` on the way in. That last
+function is 44 bytes and decides everything. Disassembled, it is a switch on
+`audio_source_t`:
+
+| `input_source` | value | pipeline | `AFE.cfg` path |
+|---|---|---|---|
+| `AUDIO_SOURCE_VOICE_RECOGNITION` | 6 | **0** | **ASR** — per-mic AEC, FBF, ABF, beam selection, false-WW prevention |
+| `AUDIO_SOURCE_HOTWORD` | 1999 | **0** | same |
+| `AUDIO_SOURCE_VOICE_COMMUNICATION` | 7 | 1 | Voice/VoIP — AEC, RES, NR, CNG, AGC |
+| `AUDIO_SOURCE_MIC` | 1 | 2 | `"Mic": { "Algorithms": {} }` — empty, passthrough |
+| anything else | — | −1 | no ASP pipeline at all |
+
+So **an ordinary `AudioRecord` opened with `VOICE_RECOGNITION` gets Amazon's
+full ASR front end** — seven per-mic echo cancellers, the superdirective
+beamformer, the adaptive beamformer, SNR beam selection and +7.2 dB output
+gain — with no Amazon service running, no Alexa packages un-hidden, and no
+reversing of `libasp`.
+
+The device binary is Go and does not link the Android framework, but it does
+not have to. `/system/lib/libOpenSLES.so` is present, and OpenSL ES on API 22
+exposes recording with `SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION`, which
+maps to exactly this source. That is a documented, stable C API, dlopen'd the
+same way `internal/wakeword/ort` already dlopens ONNX Runtime.
+
+**The catch, and it is not small: the echo reference comes from the HAL's
+playback path.** ASP takes its far-end reference where the HAL writes output.
+EchoMuse currently runs `stop media` in `Init()` and then owns `pcm23p` and
+`pcm24c` directly with tinyalsa for the life of the process — audio written
+that way never passes through the HAL, so the AFE would have no reference for
+it and would cancel nothing. Getting the AEC means routing **both** capture and
+playback through AudioFlinger, which inverts a load-bearing part of the current
+device design (see the jack section of CLAUDE.md for why `stop media` is there).
+
+What it would cost, beyond that inversion:
+
+- Raw 7-channel access is gone. One processed channel comes back, so
+  `internal/beamformer`, `internal/aec`, `internal/processor` (AGC) and the
+  controller's `em_ns` denoiser are all bypassed — as is the direction estimate
+  the LED ring overlay uses.
+- 16-bit through the framework instead of S24_3LE, so the `micGainDb`
+  pre-truncation trick no longer applies; gain staging moves to the HAL's PGA
+  (20 dB) plus the AFE's +7.2 dB output boost.
+- AudioFlinger buffering is added on both paths, against a mic pipeline that
+  already has a hard 160 ms deadline.
+- The device stops being sovereign over its own audio hardware, which affects
+  the mute guarantee — currently the device rejects `mic_start` while muted and
+  mutes the ADC. That reasoning would need revisiting.
+
+**Status: static analysis only, not yet confirmed on hardware.** The whole
+chain above is read out of the HAL binary; nothing has been recorded through it
+yet. The experiment that would settle it is to open an `AudioRecord` at
+`VOICE_RECOGNITION` while playing a known signal through AudioFlinger, and
+measure ERLE against the same capture at `AUDIO_SOURCE_MIC` (pipeline 2, which
+the config says is empty and should therefore show none). That needs a small
+ARM binary built in the `echomuse-compiler` image; it does not need EchoMuse
+stopped for the analysis, only for the measurement.
+
+### Caveats on the beamformer coefficients
+
+Do not treat the FBF coefficients as drop-in. Using them requires the matching
+64-band WOLA analysis **and** synthesis filterbank (128-pt FFT, hop 64,
+640-tap prototype — the prototype is supplied), which does not exist in
+EchoMuse today. Cost is roughly 10,752 complex MACs per 4 ms hop for the
+beamformer plus the filterbank on 7 channels; plausible on this SoC with NEON
+but a real addition to a mic pipeline already at 18–20% of a core, on a device
+that may also be running on-device wake word at ~38%.
+
+And a correctness caveat: **I could not pin the coefficient convention.** The
+per-mic magnitude and phase structure is unambiguous (six beams, three axis
+pairs, all 7 mics used, dominant centre tap), but attempts to recover each
+beam's look direction against EchoMuse's empirically-confirmed geometry left a
+constant ~64° offset, and the resulting white-noise-gain and directivity
+figures came out mutually inconsistent (+8 dB WNG alongside 16 dB DI is not
+physically possible for 7 elements). That means the mic-index mapping, the
+delay sign, or the interpretation of the 4 taps is wrong — not that the design
+is. **No DI or WNG number should be quoted from this document.** Settling it
+needs either a measured impulse response per mic or a match against a known
+reference, and it must be settled before the coefficients are trusted, because
+the existing white-noise-gain objection to superdirective beamforming on
+unmatched capsules across four ADCs is exactly what those numbers would
+answer.
+
+## Open questions
+
+- The coefficient convention above.
+- Whether `Audio_ExtCodec_EchoRef_Switch` or `LineIn ADC` routes a real
+  electrical loopback into one of the two capture channels SETUP.md records as
+  unconnected (ch7, ch8). A reference on the same converter and clock as the
+  mics is a different problem from the one the current software tap has.
+- Whether `00-16 I2S0AWB_Capture` is openable alongside EchoMuse's own playback
+  and what its alignment to `pcm24c` actually is.
+- `ARA` is configured identically to the AEC and runs after it. Its expansion
+  is unknown; `SerialARA_BeamMerger`, `setAraReferenceBeam` and `ARA ON`/`OFF`
+  suggest a second canceller stage operating in beam space.
+
+## Also in the AFE, not AEC
+
+- **Tap detection is acoustic**, in the AFE, using inter-mic level difference
+  and coherence, and it reuses the AEC filters: `ILD Tap Detector`,
+  `DNN Tap Detector`, `Tap Mic Indices`, `Tap Coherence Threshold`,
+  `Tap HF Coherence Start/End Freq Hz`, `Tap AEC Filters`,
+  `Double Tap Window In Seconds`, `Button/Screen Press Lockout In Seconds`.
+  Relevant to #115: Amazon does not time taps on a wire at all.
+- Ultrasound presence detection (`Device Side Polling Ultrasound On/Off
+  Duration`, `Major`/`Minor Movement Threshold`).
+- Low-power sound detector (`LPMSDAPI`), acoustic event detection
+  (`libaed.so`), spatial audio / crosstalk canceller, multi-room (WHA cluster),
+  automatic volume levelling driven by `/vendor/smartvolume/*.csv`.
+
+## Prior art
+
+`github.com/albertoZurini/echo-dot-2-playground` covers `libpryon.so` and
+`libwakewordserver_jni.so` — wake word and speech interaction, with decompiled
+Java and JNI probes. It does not cover `libasp.so`, the AFE, the AEC or the
+tuning directory.

--- a/docs/native-afe-migration.md
+++ b/docs/native-afe-migration.md
@@ -16,7 +16,7 @@ exists specifically to make that cheap to do:
   The firmware build carrying this has been OTA'd to the one fielded device
   (`G090LF10728426PR`, now `20260812-2028-dev`), and its durable opt-in marker
   ("Opting a device in" below) is deployed and confirmed by md5, with a
-  dashboard toggle (Updates tab) to flip it and reboot — but the marker
+  dashboard toggle (Config tab, "Audio pipeline") to flip it and reboot — but the marker
   itself is **not set**, so that device is still running the tinyalsa path
   exactly as before. Nothing has run through the OpenSL ES path yet.
 - **Phase 2** — `native_afe` capability (advertised only while the backend is
@@ -275,15 +275,31 @@ erase a script edit:
 
 **Dashboard:** a device advertising `native_afe_backend` (unconditional —
 compiled-in backends + a `start_server.sh` new enough to check the marker,
-not whether it's active right now) shows an "Native AFE (experimental)" panel
-on its Updates tab, with Enable/Disable buttons. Both write the marker via
-`POST /api/devices/{id}/native_afe` (`{"enabled": bool, "reboot": bool}`,
-admin-only) and reboot immediately — a marker write with no reboot would be a
-control that visibly does nothing until some later, unrelated restart, which
-is worse than making the (brief, expected) interruption explicit up front.
-The dashboard confirms before sending it and reports afterward whether the
-capability actually came up matching what was asked (it may not: the backend
-falls back to tinyalsa on any OpenSL ES open failure, by design).
+not whether it's active right now) shows an **"Audio pipeline"** panel on its
+**Config** tab, offering EchoMuse's pipeline or Amazon's. Both write the
+marker via `POST /api/devices/{id}/native_afe`
+(`{"enabled": bool, "reboot": bool}`, admin-only) and reboot immediately — a
+marker write with no reboot would be a control that visibly does nothing until
+some later, unrelated restart, which is worse than making the (brief,
+expected) interruption explicit up front. The dashboard confirms before
+sending it and reports afterward whether the capability actually came up
+matching what was asked (it may not: the backend falls back to tinyalsa on any
+OpenSL ES open failure, by design).
+
+It sits on the Config tab because it decides what half the controls on that
+tab do — but **above the config form and outside it**, beside the WiFi block,
+for two reasons that both bite if ignored. It is not a config key: it is a
+marker file plus a reboot, applied immediately, never by "Push config". And it
+is always per-device, so it must not sit inside a `Stage` whose Fleet/Device
+switch would grey it out for any device following the fleet.
+
+The user-facing copy names the two choices **EchoMuse** and **Amazon** and
+says what each one does — "native AFE", "ASP", "audio HAL" and "tinyalsa" are
+names for the implementation, and a control whose label only makes sense
+having read this document is a control nobody will touch. The panel does say
+that recording and playback switch together, and why (the echo canceller can
+only remove sound it played itself), because that is the one part a user could
+otherwise reasonably expect to choose separately.
 
 Manually, over the shell proxy directly (what the endpoint above does under
 the hood) — write or remove the marker file
@@ -325,6 +341,13 @@ Controller side: `Device.native_afe_capable`, and the config controls listed
 in the bypass table above rendered **disabled with the reason** when it is set.
 `tests/test_capabilities.py` covers both directions of this pattern already —
 follow it.
+
+`Toggle` in `dashboard.jsx` **did not accept a `disabled` prop** when this
+first landed, only `Slider` did. So Beamforming, Echo cancel and Auto gain
+rendered greyed with their reason, read as off — and wrote the opposite value
+into config on a click, which is precisely the "silently does something else"
+that disabled-with-reason exists to prevent. Fixed 2026-08-13; the prop is now
+honoured in the handler, not only in the styling.
 
 ### Phase 3 — measurement on real devices
 

--- a/docs/native-afe-migration.md
+++ b/docs/native-afe-migration.md
@@ -14,10 +14,11 @@ exists specifically to make that cheap to do:
   tinyalsa on any failure to open). Compiles clean under `-tags server` and
   `go vet`; the existing tinyalsa path is unmodified and remains the default.
   The firmware build carrying this has been OTA'd to the one fielded device
-  (`G090LF10728426PR`, `20260812-1957-dev`), and its durable opt-in marker
-  ("Opting a device in" below) is deployed and confirmed by md5 — but the
-  marker itself is **not set**, so that device is still running the tinyalsa
-  path exactly as before. Nothing has run through the OpenSL ES path yet.
+  (`G090LF10728426PR`, now `20260812-2028-dev`), and its durable opt-in marker
+  ("Opting a device in" below) is deployed and confirmed by md5, with a
+  dashboard toggle (Updates tab) to flip it and reboot — but the marker
+  itself is **not set**, so that device is still running the tinyalsa path
+  exactly as before. Nothing has run through the OpenSL ES path yet.
 - **Phase 2** — `native_afe` capability (advertised only while the backend is
   actually active, not merely compiled in — see `control.go`'s
   `nativeAFEActive`), `Device.native_afe_capable`, `/api/devices`'s
@@ -272,7 +273,20 @@ erase a script edit:
 /data/local/etc/echomuse/native_afe.enabled   # present = EM_NATIVE_AFE=1
 ```
 
-To flip it, write or remove that file over the shell proxy
+**Dashboard:** a device advertising `native_afe_backend` (unconditional —
+compiled-in backends + a `start_server.sh` new enough to check the marker,
+not whether it's active right now) shows an "Native AFE (experimental)" panel
+on its Updates tab, with Enable/Disable buttons. Both write the marker via
+`POST /api/devices/{id}/native_afe` (`{"enabled": bool, "reboot": bool}`,
+admin-only) and reboot immediately — a marker write with no reboot would be a
+control that visibly does nothing until some later, unrelated restart, which
+is worse than making the (brief, expected) interruption explicit up front.
+The dashboard confirms before sending it and reports afterward whether the
+capability actually came up matching what was asked (it may not: the backend
+falls back to tinyalsa on any OpenSL ES open failure, by design).
+
+Manually, over the shell proxy directly (what the endpoint above does under
+the hood) — write or remove the marker file
 (`controller/tools/devshell.py`) — **never** `stop`/`start` the echomuse
 service from that same shell to make it take effect. That shell is a child of
 the very server process being stopped; per `devshell.py`'s own warning, doing

--- a/docs/native-afe-migration.md
+++ b/docs/native-afe-migration.md
@@ -1,0 +1,356 @@
+# Native AFE migration — spec and plan
+
+**Status:** Phases 0–2 implemented (branch `native-afe-migration`), Phase 3
+not started. Everything below still reflects static analysis only — nothing
+has been recorded through this path on real hardware yet, and the code
+exists specifically to make that cheap to do:
+
+- **Phase 0** — `device/tools/afe_probe`, `internal/opensl`. Builds and links
+  (verified via `echomuse-compiler`, real ARM binary produced); not yet run
+  on a device. This is the next step, and it gates everything after it — see
+  the kill criteria below.
+- **Phase 1** — `internal/bindings/slmic`, `internal/bindings/slspeaker`,
+  selected by `EM_NATIVE_AFE` in `cmd/server.go` (default off, falls back to
+  tinyalsa on any failure to open). Compiles clean under `-tags server` and
+  `go vet`; the existing tinyalsa path is unmodified and remains the default.
+  The firmware build carrying this has been OTA'd to the one fielded device
+  (`G090LF10728426PR`, `20260812-1957-dev`), and its durable opt-in marker
+  ("Opting a device in" below) is deployed and confirmed by md5 — but the
+  marker itself is **not set**, so that device is still running the tinyalsa
+  path exactly as before. Nothing has run through the OpenSL ES path yet.
+- **Phase 2** — `native_afe` capability (advertised only while the backend is
+  actually active, not merely compiled in — see `control.go`'s
+  `nativeAFEActive`), `Device.native_afe_capable`, `/api/devices`'s
+  `nativeAfeCapable`, and the bypassed config controls (beamforming, AEC,
+  AGC, mic/ADC gain) rendered disabled-with-reason in the dashboard when it
+  is set. Covered by `tests/test_capabilities.py`.
+- **Phase 3/4** — not started; both need Phase 0's numbers first.
+
+**Background:** [alexa-afe.md](alexa-afe.md) — read that first, especially
+"5. Open the AFE through the standard Android capture API".
+
+## What this is
+
+Amazon's audio front end lives inside the audio HAL
+(`audio.primary.mt8163.so` links `libasp.so` and calls `asp_init`,
+`asp_create_pipeline`, `asp_process`, `asp_set_device`). The HAL picks an ASP
+pipeline from the capture stream's `input_source`:
+
+| `input_source` | value | pipeline | `AFE.cfg` path |
+|---|---|---|---|
+| `AUDIO_SOURCE_VOICE_RECOGNITION` | 6 | **0** | **ASR** — per-mic AEC, fixed + adaptive beamformer, SNR beam selection, false-WW prevention, +7.2 dB |
+| `AUDIO_SOURCE_HOTWORD` | 1999 | **0** | same |
+| `AUDIO_SOURCE_VOICE_COMMUNICATION` | 7 | 1 | Voice/VoIP — AEC, RES, NR, CNG, AGC |
+| `AUDIO_SOURCE_MIC` | 1 | 2 | `"Mic": { "Algorithms": {} }` — empty, passthrough |
+| anything else | — | −1 | no ASP pipeline |
+
+So capturing at `VOICE_RECOGNITION` through the normal Android audio path
+gets Amazon's entire ASR front end, with no Amazon service running and no
+Alexa packages un-hidden.
+
+The goal of this work is to put EchoMuse's device audio on that path.
+
+## The one rule that matters
+
+**Capture and playback must BOTH go through the framework, or the AEC has
+nothing to cancel.**
+
+ASP takes its far-end reference on the HAL's playback side
+(`AudioALSAPlaybackHandlerNormal::asp_open` / `doProcessAsp`). EchoMuse today
+runs `stop media` and writes PCM straight to `pcm23p` with tinyalsa — audio
+written that way never passes through the HAL, so the AFE would never see it.
+
+A build that converts capture only will still *work*. It will produce audio
+that is beamformed but not echo-cancelled, with no error anywhere, and it will
+look like the AFE underperforming rather than like a wiring mistake. Any
+capture-side change must land together with the playback-side change or behind
+the same off-by-default flag.
+
+## Architecture
+
+New backends behind the **existing** interfaces. Nothing above them changes.
+
+```
+pkg/mic.Microphone       ← internal/bindings/mic       (tinyalsa, today)
+                         ← internal/bindings/slmic     (OpenSL ES, new)
+
+pkg/speaker.Speaker      ← internal/bindings/speaker   (tinyalsa, today)
+                         ← internal/bindings/slspeaker (OpenSL ES, new)
+
+internal/opensl/         ← shared dlopen shim
+```
+
+Both interfaces are already the right shape:
+
+- `mic.Microphone` is `Init()` + `Listen(cb, ctx)`, plus the optional
+  `mic.Subscribable` fan-out that `vadStreamHandler` uses. The new backend
+  implements both; it fans out one processed mono stream instead of one raw
+  9-channel stream.
+- `speaker.Speaker` already carries the two-plane music/voice API
+  (`PumpPeriod`, `PumpMusic`, `SetDuck`, `Flush`, `FlushMusic`, `EndStream`,
+  `EndMusicStream`). Keep all of it — see "Ducking" below.
+
+Selection happens in `cmd/server.go` where `mic.NewMicrophone()` and
+`speaker.NewPcmSpeaker()` are called today (lines ~71 and ~85). One config
+switch picks the pair. **They are chosen together, never independently.**
+
+### dlopen, don't link
+
+`/system/lib/libOpenSLES.so` is present on the device, but follow the
+`internal/wakeword/ort` precedent and dlopen it: a device where the load fails
+falls back to the tinyalsa path and keeps working, rather than producing a
+binary that will not start. `internal/opensl` holds the shim, the same shape as
+`ort/shim.h`.
+
+## Wire protocol: unchanged
+
+This is worth stating plainly, because it is the reason the change is
+containable.
+
+- **Mic.** The device sends mono S16 16 kHz in 80 ms frames today, after its
+  own beamformer reduces 9 channels to 1. The AFE hands us mono S16 16 kHz.
+  Same format, same framing. The controller needs no change.
+- **Speaker.** The controller sends mono 48 kHz on the voice plane (0x02/0x03)
+  and the music plane (0x04/0x05). Open the OpenSL player at 48 kHz so nothing
+  resamples. Unchanged.
+
+No new message types. No controller changes are required for the audio path
+itself — only for the dashboard's disabled-control handling (below).
+
+## Ducking stays exactly as it is
+
+The device-side music/voice mix is **not** removed. It moves from "mix at the
+ALSA write" to "mix before the AudioTrack write" — same code, same
+`SetDuck(db)`, same per-sample gain ramp, same saturation rather than wrap.
+
+The reason ducking has to be device-side is that the controller runs its music
+feed `LEAD_S` = 4.0 s ahead of realtime, so four seconds of un-ducked music
+have already left the controller when a wake word fires. Under this design the
+lead buffer moves into `slspeaker` rather than into the ALSA ring, so the
+argument is unchanged and the code that acts on it is unchanged. `audio_mix`
+stays advertised; `duckDb`, `music_flush` and `speaker_flush` keep their
+meaning.
+
+Do not "simplify" this into two AudioTracks with framework volume control
+until the mix path is proven — the per-sample ramp exists because a gain step
+at a period boundary is an audible click landing exactly when the user started
+speaking.
+
+## What is bypassed, and how
+
+Bypassed means **gated off and reported as unavailable**, never deleted. Every
+one of these has a dashboard control, and CLAUDE.md's rule is that a control
+whose feature the device lacks is shown **disabled with the reason**, never as
+a control that silently does nothing.
+
+| Component | Under the AFE path | Config key affected |
+|---|---|---|
+| `internal/beamformer` | replaced by FBF + ABF + SNR beam selection | `beamformingEnabled`, `beamAngle` |
+| `internal/aec` (speexdsp) | replaced by 7 per-mic subband AECs | `aecEnabled`, `aecDelayMs`, `aecTailMs` |
+| `internal/processor` (AGC) | replaced by the AFE's AGC | `agcEnabled` |
+| mic gain pre-truncation | 16-bit from the framework; gain is HAL PGA (20 dB) + AFE out (+7.2 dB) | `micGainDb`, `adcDigitalGain`, `adcMicpga` |
+| controller `em_ns` / DTLN | redundant; would be a second NS on an already-denoised stream | `nsAsr` — default OFF on this path |
+
+Kept and still ours:
+
+- **VAD gate.** EchoMuse's VAD runs on the processed mono stream and still
+  provides end-of-speech for bounded `lock_mic` turns. `vadThreshold` stays
+  meaningful, but its calibration changes — it is currently expressed in
+  pre-gain units and scaled internally, and the AFE's output level is not the
+  same. Re-tune, do not reuse the number.
+- **Mute.** Unchanged and still device-sovereign. The ADC mute is a `tinymix`
+  control on the TLV320ADC3101 and is independent of who owns the PCM; the
+  device still refuses `mic_start` while muted. **This must not regress** — it
+  is what makes the controller-side button logic safe (see CLAUDE.md).
+- **Jack handling.** `internal/bindings/jack` still re-enables
+  `Ext_Speaker_Amp_Switch` on plug removal. accdet mutes it on insert and
+  nothing else turns it back on.
+- **On-device wake word** (`internal/wakeword`, `oww_shadow`). It taps the
+  frames written to the wire, which are unchanged in format. Expect scores to
+  move — it is now scoring AFE output, not our own beamformed mic — so
+  shadow-mode comparisons across the change are not comparable and
+  `turns.dev_threshold` will need reading with that in mind.
+
+## `stop media` must not run
+
+`speaker.PcmSpeaker.Init()` runs `stop media` and then `waitForFreePcm` to take
+`pcm23p` from mediaserver; `mic.PcmMicrophone.Init()` runs `stop mixer`.
+Neither may happen on the AFE path — mediaserver has to own both PCMs for the
+HAL to be in the loop at all.
+
+Read the jack section of CLAUDE.md before touching this. `stop media` is there
+because a headset present at boot let mediaserver park a blocking `snd_pcm_open`
+ahead of us with no timeout, which stranded the whole device. Handing the PCM
+back to mediaserver makes that specific failure mode **moot rather than
+reintroduced** — we are no longer racing for the device — but the reasoning
+should be re-verified on hardware with a plug inserted at boot, because it is
+the exact scenario that produced the original report.
+
+## Instrumentation must survive
+
+`slspeaker` has to report the same `StreamStats` the tinyalsa backend does:
+`min_depth`, `prime_wait_ms`, `recv_span_ms`, `max_gap_ms`, `bytes_recv`,
+periods and underruns, measured against its own ring. The schema v7 delivery
+instrumentation and the dashboard's Activity tab are built on these.
+
+**Report them properly or report nothing.** Never emit zeros for values that
+were not measured — absence is stored as NULL precisely so that "never
+reported" and "zero underruns" stay distinguishable, and a backend that fakes
+zeros makes every device on this path look perfect.
+
+The level tap (`levelTap func(rms float64)`, which drives the `meter` LED
+pattern) moves to the new write point. It gets *more* accurate: the ALSA-write
+tap exists because audio sits ~5.5 s ahead of audible, and a shallower
+AudioTrack removes most of that skew.
+
+The echo tap (`canceller.WriteFar`) is no longer needed — the HAL takes the
+reference itself. Leave the plumbing, pass a no-op.
+
+## Phases
+
+### Phase 0 — spike, before touching anything
+
+A standalone probe in `device/tools/`, following `capture_mics`, `bf_capture`
+and `oww_probe`. Does not link into the server, does not change any interface.
+
+It should record N seconds via OpenSL ES and write WAVs, at each of
+`VOICE_RECOGNITION`, `VOICE_COMMUNICATION` and `MIC`, optionally while playing
+a known signal through an OpenSL player.
+
+This answers, cheaply and on hardware, everything the rest of the plan assumes:
+
+1. Does OpenSL ES work at all on this FireOS build?
+2. Does `VOICE_RECOGNITION` actually instantiate ASP pipeline 0? (`MIC` is
+   configured with an empty algorithm list, so it is a built-in control: any
+   difference between the two IS the AFE.)
+3. **ERLE.** Play a known signal, measure residual at the mic, both sources.
+   This is the number the whole exercise is for.
+4. What channel count comes back. `MicsPostAECOutputGain` sits in the ASR path
+   and pryon consumes `BEAMFORMED` / `pre-aec` / `post-aec` channel types, so
+   the AFE can plainly emit more than the beam — but `audio_policy.conf`
+   advertises only `MONO|STEREO` on the primary input, so mono is the
+   expectation. Worth confirming, because stereo carrying beam + something
+   would change the direction-arc story.
+5. End-to-end latency, against the mic pipeline's hard 160 ms deadline.
+
+**Kill criteria.** If ERLE at `VOICE_RECOGNITION` is not clearly better than
+the ~7–9 dB the current speexdsp path achieves, stop here. The whole
+justification is that Amazon's front end is better; if it measures otherwise on
+this hardware, none of the rest is worth the disruption.
+
+Needs the `echomuse-compiler` image (`cd device && docker build -t
+echomuse-compiler compiler/`), which is not built on every dev machine.
+
+### Phase 1 — capture + playback backends
+
+`internal/opensl` shim, `internal/bindings/slmic`, `internal/bindings/slspeaker`.
+Both selected together by one env/config switch, defaulting **off**. Old path
+untouched and still the default.
+
+`slspeaker` carries the lead ring, the prime-before-start hold, the two planes,
+the duck ramp, and `StreamStats`.
+
+#### Opting a device in
+
+`EM_NATIVE_AFE` is a boot-time env var, read once by `cmd/server.go` before any
+controller connection exists — deliberately not a config push (see the "Risks"
+section: recovery is a flag flip and a restart, not a dashboard toggle).
+
+Making that durable on a real device needs one more piece, because two of the
+obvious ways to set it don't survive: hand-exporting it in
+`/data/local/bin/start_server.sh` gets silently overwritten the next time an
+OTA re-syncs that script against the canonical payload
+(`em_api._sync_start_script`), and there is no config-message path that can
+reach a choice made before the device has even connected.
+
+The durable switch is a **marker file**, checked once near the top of
+`start_server.sh` (`controller/device_payloads/start_server.sh`, symlinked as
+`device/scripts/start_server.sh`) — data survives the same re-sync that would
+erase a script edit:
+
+```
+/data/local/etc/echomuse/native_afe.enabled   # present = EM_NATIVE_AFE=1
+```
+
+To flip it, write or remove that file over the shell proxy
+(`controller/tools/devshell.py`) — **never** `stop`/`start` the echomuse
+service from that same shell to make it take effect. That shell is a child of
+the very server process being stopped; per `devshell.py`'s own warning, doing
+so can strand the device until it is power-cycled, because stopping the
+service also kills the one channel that could send the follow-up `start`.
+**Reboot instead** — safe to issue from the same shell proctor (recovery is
+automatic; Android's own init re-execs every service, `echomuse` included, on
+its own once boot completes), and it is what actually gets `start_server.sh`
+to re-read its own file (per `_sync_start_script`'s comment, a running
+script's shell keeps the old inode open regardless):
+
+```bash
+# from inside the echomuse-controller container
+python devshell.py -d <device_id> \
+  'mkdir -p /data/local/etc/echomuse && touch /data/local/etc/echomuse/native_afe.enabled && echo MARKER_SET'
+python devshell.py -d <device_id> reboot
+
+# to revert:
+python devshell.py -d <device_id> \
+  'rm -f /data/local/etc/echomuse/native_afe.enabled && echo MARKER_CLEARED'
+python devshell.py -d <device_id> reboot
+```
+
+Run `device/tools/afe_probe` on the target device **before** flipping this —
+it answers the kill criteria without ever touching the live server, where
+enabling the marker puts brand-new, hardware-unverified code (OpenSL ES, HAL
+routing) directly in the path of the next real voice turn.
+
+### Phase 2 — capability and dashboard
+
+Advertise a capability (suggest `native_afe`) from `capabilities()` in
+`internal/client/control.go`. It is append-only and negotiated by capability,
+never by version.
+
+Controller side: `Device.native_afe_capable`, and the config controls listed
+in the bypass table above rendered **disabled with the reason** when it is set.
+`tests/test_capabilities.py` covers both directions of this pattern already —
+follow it.
+
+### Phase 3 — measurement on real devices
+
+Wake-word detection rate, barge-in behaviour, transcript quality (use
+`saveUtterances` — the tap is below NS, so the file is what STT actually
+heard), CPU, and the delivery stats. Compare against the same devices on the
+old path.
+
+### Phase 4 — decide the default
+
+Not before Phase 3 has numbers and the deferred item below is resolved.
+
+## Deferred / filed
+
+- **Speaker buffering depth.** Today: `audioChanDepth` 128 periods ≈ 5.46 s on
+  the device, `primePeriods` 24 ≈ 1 s hold before start, controller `LEAD_S`
+  4.0 s — sized against measured 1.8–2.6 s link stalls. `slspeaker` must
+  reproduce this in its own ring; an AudioTrack buffer is tens of milliseconds
+  and is not a substitute. **Filed, but this is a real regression if shipped
+  without it** — it is the thing that keeps music from gapping on a marginal
+  link, and it blocks Phase 4.
+- **Per-device tuning of the mic chain.** `AFE.cfg` is on read-only `/system`,
+  so the mic-path config keys become fleet-fixed rather than per-device. Filed;
+  no work planned. If it is ever wanted, it means remounting `/system` and
+  editing a system file, which is a device-image operation, not a config one.
+- **LED direction arc.** Dropped on this path. The AFE selects a beam
+  internally and `AFEDiagSelectedBeamNumber` exists only in ASP debug output,
+  not per-frame. Out of scope.
+
+## Risks
+
+- **Everything above the phase-0 line is inferred from a 44-byte function.**
+  `getAspPipelineType` is unambiguous about the mapping, but nothing has been
+  recorded through it. Phase 0 exists to make that inference cheap to falsify.
+- AudioFlinger adds buffering on both paths against a mic pipeline that already
+  has a hard 160 ms deadline and shares a core with wake-word inference.
+- The device stops owning its audio hardware outright, which is a real
+  reduction in how much of the failure surface we control. Mute is unaffected
+  (verified: separate mixer control), but boot ordering, jack behaviour and
+  mediaserver restarts all become things the HAL decides.
+- No fallback at runtime: if the AFE path misbehaves in the field, recovery is
+  a firmware flag flip and a restart, not a config push. Keep the old backends
+  compiled in for exactly this reason.


### PR DESCRIPTION
Puts EchoMuse's device audio through Amazon's own audio front end — the ASP pipeline inside the Echo's audio HAL — instead of tinyalsa's direct PCM writes, which bypass it entirely.   I reverse-engineered this after finding EchoMuse's default pipeline to 1) sound quite tin-can-y, even with EQ, and 2) not handle AEC as well as native-alexa while playing spoken word media like podcasts

Opt-in per device, default off, old path untouched and still the default.


Disclosure: Implemented completely with Claude under my supervision, (which seems to match the style for the existing project) - Its thoughts below:

-----

Full spec, phase plan, kill criteria and risks: [`docs/native-afe-migration.md`](docs/native-afe-migration.md). Background on the front end itself: [`docs/alexa-afe.md`](docs/alexa-afe.md).

## What's here

`internal/opensl` (dlopen'd OpenSL ES shim, following the `wakeword/ort` precedent so a device where the load fails falls back rather than failing to boot), `internal/bindings/slmic` + `slspeaker` behind the existing `mic.Microphone` / `speaker.Speaker` interfaces, `device/tools/afe_probe`, and the `native_afe` / `native_afe_backend` capabilities with the bypassed config controls rendered disabled-with-reason.

Capture and playback switch **together**, never independently — ASP takes its far-end reference on the HAL's playback side, so a capture-only conversion produces audio that is beamformed but not echo-cancelled, with no error anywhere. That failure looks like the AFE underperforming rather than like a wiring mistake, which is why it is one switch.

`slspeaker` keeps everything the tinyalsa backend carried: the lead ring, the prime-before-start hold, both music/voice planes, the per-sample duck ramp, and `StreamStats`. Ducking stays device-side for the reason it always was — the controller runs 4.0s ahead of realtime, so audio that has left the controller cannot be ducked by it.

**Opt-in is a marker file**, `/data/local/etc/echomuse/native_afe.enabled`, checked by `start_server.sh`. Not a config push: recovery from a bad AFE path is a flag flip and a restart, and a boot-time choice cannot come from a channel that needs the device to have connected first. Hand-exporting the env var in `start_server.sh` was the obvious alternative and does not survive — `_sync_start_script` re-syncs that file on every OTA.

**Dashboard**: an "Audio pipeline" panel on the device's Config tab, offering EchoMuse's pipeline or Amazon's, writing the marker and rebooting.

**Also included, not AFE-specific:** `Cap volume at the codec's unity gain`. tinymix ctl 61 is the DAC's *digital* volume — unity is index 127 of 175 — so the top 27% of the scale applied up to +24dB to already near-full-scale PCM. Measured on hardware: THD 1.5% at 127, **65% at 153, 89% at 170**, with output level flat above 153 because it had stopped being able to get louder. Stock FireOS never writes this control at all. Independent of the rest of this branch; happy to split it out if preferred.

## Bugs found along the way

Three were found by actually running this on hardware, and two of them are the kind that report success:

- **`slspeaker` never enabled `Ext_Speaker_Amp_Switch`.** `PcmSpeaker.Init()` sets it; `slspeaker.NewSpeaker` had no equivalent and its `Init()` was a no-op nothing called. The amp is a physical mixer control that defaults off and is turned off by accdet on headphone insert. So the path delivered every period with `underruns=0`, healthy `minDepth` and `outcome=ok` — into a dead amp. **Inaudible, with no failure visible in any log or in StreamStats.** Worth knowing generally: the delivery instrumentation all sits upstream of the amp, so when playback is silent, read the mixer state on the device before trusting any of it.
- **`internal/aec.Process()` still ran on the passthrough path**, where its own size guard silently no-ops it forever (`FrameSize` is tuned to the 160ms tinyalsa batch cadence, not slmic's 80ms). Harmless, but an `aecEnabled=true` leftover did nothing.
- **AGC had no such guard**, so it genuinely ran on top of the AFE's own AGC during a lockMic turn — real double-processing, not a no-op.

And one in the dashboard, unrelated to hardware: **`Toggle` did not accept a `disabled` prop at all** — only `Slider` did. Beamforming, Echo cancel and Auto gain therefore rendered greyed with their reason, read as off, and wrote the *opposite* value into config when clicked. That is worse than a control that does nothing, since the stored setting then silently disagreed with what the control showed. Fixed in the handler rather than the styling, with a test pinned against the component (the call sites already looked correct while the bug was live).

## Remaining items

Deferred and filed in the doc, not addressed here: `slspeaker`'s buffering depth against the controller's 4.0s lead (a real regression if the default is ever flipped without it), per-device mic tuning becoming fleet-fixed since `AFE.cfg` is on read-only `/system`, and the LED direction arc, which the AFE gives no per-frame beam number for.

## Verification

- ARM cross-build via `echomuse-compiler` (`-tags server`) — succeeds
- `go test ./internal/... ./pkg/...` — all pass
- `pytest controller/tests/` — 370 pass
- Dashboard node tests + pyflakes undefined-name check — pass
- Live on one Echo Dot Gen 2 (`20260813-0732-dev`), voice turns, music playback and barge-in