### PR TITLE
CI: let govulncheck build itself on a newer toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,22 @@ jobs:
           go-version-file: device/go.mod
           cache-dependency-path: device/go.sum
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # GOTOOLCHAIN=auto for the INSTALL only, so Go fetches whatever
+        # toolchain the tool needs to compile itself. golang.org/x/vuln raised
+        # its minimum to Go 1.25 at v1.2.0, and this runner is pinned to the
+        # firmware's 1.24.0 via device/go.mod — so `@latest` started failing
+        # on every run, on a check whose scan step already carries `|| true`
+        # and cannot fail the job. Pure noise: red emails for a check that
+        # was not reporting anything.
+        #
+        # Not a version pin: v1.1.4 is the last release that builds under
+        # 1.24, which would freeze the scanner on 2024 and re-break the day
+        # its minimum moves again. This survives the next bump.
+        #
+        # Scoped to this step deliberately. The scan below must keep running
+        # under the module's own Go, or it analyses a standard library the
+        # firmware does not ship.
+        run: GOTOOLCHAIN=auto go install golang.org/x/vuln/cmd/govulncheck@latest
       # govulncheck reports only vulnerabilities on REACHABLE call paths, so
       # it is low-noise enough to read every time — unlike a plain dependency
       # diff, most of which never executes.


### PR DESCRIPTION
Fixes the recurring CI failure behind the notification emails.

```
go: golang.org/x/vuln@v1.7.0 requires go >= 1.25.0
   (running go 1.24.0; GOTOOLCHAIN=local)
```

golang.org/x/vuln raised its minimum to Go 1.25 at **v1.2.0** (v1.1.4 is the last release that builds under 1.24). The runner takes its Go from `device/go.mod` — 1.24.0, pinned because that is the firmware toolchain — so `go install ...@latest` has failed on every run since.

**It was pure noise.** The scan step already carries `|| true` and cannot fail the job, so these were red builds for a check that was not reporting anything. It hit four Dependabot PRs among others.

`GOTOOLCHAIN=auto` on the **install** only, so Go fetches whatever toolchain the tool needs to compile itself.

- **Not a version pin.** Pinning to v1.1.4 would freeze the scanner on 2024 and re-break the day its minimum moves again. This survives the next bump.
- **Scoped to that one step.** The scan must keep running under the module own Go, or it analyses a standard library the firmware does not ship — the blind spot already noted in the surrounding comment.

This PR own CI run is the test: if the vulnerability job goes green, the fix works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)