### PR TITLE
Cap volume at the codec's unity gain to stop the DAC clipping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1263,6 +1263,44 @@ Reverting a section **discards** its stored values (`set_device_config_sections`
 
 ### Volume / mute persistence
 
+**The scale stops at the codec's unity gain, and that ceiling is load-bearing.**
+tinymix ctl 61 is the tlv320aic32x4 DAC *digital* volume: 176 steps of 0.5dB
+spanning −63.5…+24dB, with 0dB at index **127**. The firmware shipped
+`volumeMax = 175` — the control's own maximum — so the top 27% of the range
+applied up to +24dB of digital gain to already near-full-scale PCM and
+saturated inside the DAC. Measured on hardware 2026-08-13 (1kHz at −6dBFS,
+recorded through the mic array): THD 1.5% at index 127, 2.3% at 136, **65% at
+153, 89% at 170**, with the output level *flat* from 153 upward because it had
+stopped being able to get louder, and h3 at −1.1dB relative to the fundamental
+(very nearly a square wave). The control that isolates it: index 170 with the
+source scaled down to land at the same acoustic level reads 1.1% — clean — so
+the gain stage is fine and it is purely source × gain exceeding full scale.
+Stock FireOS never writes this control **at all** (absent from
+`/system/etc/audio_device.xml` and from every `/system` binary), leaving the
+DAC at its 0dB reset default and taking user volume from AudioFlinger's
+software attenuation, which only ever attenuates — that is why native Alexa
+has no such distortion.
+
+Two things not to undo: `DEVICE_VOLUME_MAX`/`volumeMax` stay at 127 (both
+pinned by test), and the conversion lives in **one** place — `em_volume.py`,
+because `level / 175` was copy-pasted into `em_controller`, `em_esphome` and
+`em_api` with no test on any of them, which is how the wrong ceiling survived.
+The lost headroom **cannot** be bought back from `Ext_Amp_Gain` (ctl 13): that
+control is inert on this board — sweeping its full 6/12/18/24dB range moves
+the output 0.0dB while still reading its new value back, the same shape as the
+mute LED being on a different GPIO than Amazon's own HAL believed.
+`HP Driver Gain Volume` (ctl 62) *is* live (+18dB commanded → +18.1dB actual,
+THD 2.25%) if more output is ever wanted, but that is a taste call to make by
+ear, and the speaker's behaviour above stock level is unmeasured.
+
+The **physical buttons** traverse `volumeButtonFloor`(47, −40dB)…127 in 4dB
+steps rather than the whole control: the scale is dB-linear, so the bottom
+third is indistinguishable from silence and stepping across it spends presses
+to go nowhere. Silencing the device is the mute button's job. Explicit `Set()`
+calls are deliberately **not** floored — HA's volume 0.0 must still mean
+silent — and a press from below the floor lands *on* it, so one press always
+reaches audible.
+
 Volume is **state, not a setting** — it rides the config channel but has no dashboard control (the slider was removed 2026-07-25: `SeedVolume` ignores later pushes, so moving it did nothing until the device restarted and any real volume change overwrote it). It is listed in `em_config_sections.STATE_KEYS`, exempt from section scoping, and shown read-only on the Status tab.
 
 Volume persists through reboots **controller-side**: every device `volume_state` report is stored into the device's `startupVolume` config, and the device restores it via `Server.SeedVolume` on the **first config push per run only** (later pushes must not stomp live changes). Until seeded (or a local volume change makes the device authoritative), the device suppresses its connect-time `volume_state` report — reporting the boot-default level is what used to clobber the stored value on reboot. Mute is the opposite: **device-sovereign**, persisted locally in `/data/local/etc/echomuse/state.json` (survives OTA slot flips; written on toggle, restored at boot pre-connect — ADC mute immediately, red ring/button LED after LED init).

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -80,6 +80,7 @@ COPY em_player.py .
 COPY em_config_sections.py .
 COPY em_recordings.py .
 COPY em_turnclock.py .
+COPY em_volume.py .
 COPY version.py .
 # ESPHome native API subpackage (frame protocol, message registry, vendored protobuf)
 COPY esphome/ ./esphome/

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -60,6 +60,7 @@ import em_oww_models
 import em_pki
 import em_player
 import em_recordings
+import em_volume
 import em_scenes
 import em_shadow
 import em_support
@@ -4112,7 +4113,11 @@ def _stored_volume(row):
     if level is None:
         return None
     try:
-        return max(0.0, min(1.0, float(level) / 175.0))
+        # float() first, deliberately: em_volume swallows bad input and
+        # returns 0.0, which is the right answer on the audio path and the
+        # wrong one here — this function's None means "not known", and a
+        # corrupt stored value must not report as "silent".
+        return em_volume.device_level_to_ha(float(level))
     except (TypeError, ValueError):
         return None
 

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -80,6 +80,7 @@ import em_esphome as esphome
 import em_ble_proxy
 import em_oww_models
 import em_player
+import em_volume
 
 _LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s — %(message)s"
 
@@ -204,16 +205,11 @@ SPEAKER_FRAME_TYPE = 0x02
 SPEAKER_EOS_TYPE   = 0x03
 MIC_HEADER_LEN     = 3   # [type][seq_hi][seq_lo]
 
-# Volume conversion — device uses integer 0–175, HA expects float 0.0–1.0.
-VOLUME_MAX_DEVICE = 175
-
-def _device_level_to_ha(level: int) -> float:
-    """Convert device volume (0–175) to HA float (0.0–1.0)."""
-    return max(0.0, min(1.0, level / VOLUME_MAX_DEVICE))
-
-def _ha_volume_to_device(volume: float) -> int:
-    """Convert HA volume float (0.0–1.0) to device integer (0–175)."""
-    return max(0, min(VOLUME_MAX_DEVICE, round(volume * VOLUME_MAX_DEVICE)))
+# Volume conversion lives in em_volume so the scale has ONE definition and a
+# test — it used to be spelled `/ 175` in three separate modules.
+VOLUME_MAX_DEVICE = em_volume.DEVICE_VOLUME_MAX
+_device_level_to_ha = em_volume.device_level_to_ha
+_ha_volume_to_device = em_volume.ha_volume_to_device
 
 # ─── Device registry ──────────────────────────────────────────────────────────
 
@@ -2508,7 +2504,7 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                     })
 
                 elif msg_type == "volume_state":
-                    # Device reports current volume level (0–175 int).
+                    # Device reports its current volume level (raw tinymix index).
                     # Convert to HA float, update in-memory state, persist to
                     # config so the value survives controller and device restarts.
                     raw_level = int(msg.get("level", 85))

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -73,6 +73,7 @@ import em_recordings
 import em_oww_models
 import em_player
 import em_turnclock
+import em_volume
 
 # ── VAD sentinels ──────────────────────────────────────────────────────────────
 # Queue items marking end-of-speech in mic_queue/voice_queue, in place of
@@ -492,9 +493,12 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             device_id = (self._owning_server.device_id
                          if self._owning_server is not None else None)
             if msg.has_volume and self._owning_server is not None:
-                # HA set an explicit volume — convert float (0.0–1.0) to device
-                # integer (0–175) and forward to the physical device.
-                level = max(0, min(175, round(msg.volume * 175)))
+                # HA set an explicit volume — convert float (0.0–1.0) to the
+                # device's native level and forward to the physical device.
+                # The conversion is em_volume's, not a local `* 175`: the
+                # ceiling is the codec's unity gain, above which the DAC
+                # clips (see em_volume's docstring).
+                level = em_volume.ha_volume_to_device(msg.volume)
                 log.debug(
                     f"[{self._log_name}] MediaPlayerCommandRequest: "
                     f"volume={msg.volume:.3f} → level={level}"

--- a/controller/em_volume.py
+++ b/controller/em_volume.py
@@ -1,0 +1,47 @@
+"""Volume scale conversion between the device's native level and HA's float.
+
+Split out as pure logic for the reason em_linkauth.py was: the three call
+sites (em_controller, em_esphome, em_api) each had their OWN copy of
+`level / 175`, so the scale lived in three places and none of them were
+covered by a test. Changing the ceiling meant finding all three.
+
+The device level is the raw tinymix ctl 61 index — the tlv320aic32x4 DAC
+digital volume, 0.5dB per step with 0dB (unity) at index 127. The scale is
+therefore dB-linear, which is roughly perceptually linear, so the mapping to
+HA's 0.0–1.0 is a plain proportion and needs no extra taper.
+
+DEVICE_VOLUME_MAX is 127 and NOT the control's own maximum of 175. Indexes
+above 127 apply positive digital gain to near-full-scale PCM and saturate
+inside the DAC — measured at 65% THD by index 153 (see
+device/internal/server/volume.go for the full measurement and why stock
+FireOS never touches this control).
+"""
+
+# Codec unity gain. The mixer control accepts up to 175; everything above
+# this clips. See the module docstring.
+DEVICE_VOLUME_MAX = 127
+
+# 0.5dB per index step, 0dB at DEVICE_VOLUME_MAX.
+DB_PER_STEP = 0.5
+
+
+def level_to_db(level: int) -> float:
+    """Device level as dB relative to unity. Index 127 -> 0.0, index 0 -> -63.5."""
+    return (level - DEVICE_VOLUME_MAX) * DB_PER_STEP
+
+
+def device_level_to_ha(level: int) -> float:
+    """Convert a device volume level to an HA float (0.0–1.0)."""
+    try:
+        return max(0.0, min(1.0, float(level) / DEVICE_VOLUME_MAX))
+    except (TypeError, ValueError, ZeroDivisionError):
+        return 0.0
+
+
+def ha_volume_to_device(volume: float) -> int:
+    """Convert an HA volume float (0.0–1.0) to a device volume level.
+
+    Clamped to the codec's unity gain, so HA asking for full volume can never
+    put the DAC into positive digital gain.
+    """
+    return max(0, min(DEVICE_VOLUME_MAX, round(float(volume) * DEVICE_VOLUME_MAX)))

--- a/controller/tests/test_volume.py
+++ b/controller/tests/test_volume.py
@@ -1,0 +1,48 @@
+"""Volume scale conversion.
+
+The scale existed as `/ 175` copy-pasted into three modules with no test at
+all, which is how it went four releases with a ceiling that put the codec's
+DAC into positive digital gain. These pin the ceiling and the round trip.
+"""
+import pytest
+
+import em_volume
+
+
+def test_ceiling_is_codec_unity_not_the_controls_maximum():
+    # tinymix ctl 61 accepts 0..175. 127 is 0dB; everything above it is
+    # POSITIVE digital gain on near-full-scale PCM and clips inside the DAC
+    # (measured 65% THD at index 153). If this ever reads 175 again, the
+    # distortion above ~73% volume is back.
+    assert em_volume.DEVICE_VOLUME_MAX == 127
+
+
+def test_full_ha_volume_cannot_exceed_unity():
+    assert em_volume.ha_volume_to_device(1.0) == 127
+    # Out-of-range input must clamp, not scale past the ceiling.
+    assert em_volume.ha_volume_to_device(1.5) == 127
+    assert em_volume.ha_volume_to_device(-0.5) == 0
+
+
+def test_level_to_db_anchors():
+    assert em_volume.level_to_db(127) == pytest.approx(0.0)
+    assert em_volume.level_to_db(0) == pytest.approx(-63.5)
+    # The old ceiling was +24dB of digital gain.
+    assert em_volume.level_to_db(175) == pytest.approx(24.0)
+
+
+def test_ha_round_trip_is_stable():
+    for level in range(0, 128):
+        ha = em_volume.device_level_to_ha(level)
+        assert em_volume.ha_volume_to_device(ha) == level
+
+
+def test_device_level_above_the_cap_reports_as_full():
+    # A device still sitting at a pre-cap level must not report >1.0 to HA.
+    assert em_volume.device_level_to_ha(175) == 1.0
+    assert em_volume.device_level_to_ha(140) == 1.0
+
+
+def test_bad_input_does_not_raise():
+    assert em_volume.device_level_to_ha(None) == 0.0
+    assert em_volume.device_level_to_ha("nonsense") == 0.0

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -427,7 +427,8 @@ func (c *ControlClient) connect(ctx context.Context, server *discovery.ServerInf
 
 		case "volume_set":
 			// Controller forwarding a volume command from HA (MediaPlayerCommandRequest).
-			// level is an integer 0–175 matching the device's native tinymix range.
+			// level is an integer in the device's native tinymix range, capped
+			// at the codec's unity gain — see internal/server/volume.go.
 			var msg struct {
 				Level int `json:"level"`
 			}
@@ -805,7 +806,8 @@ func (c *ControlClient) SendAmbientLight(lux int) {
 	})
 }
 
-// SendVolumeState notifies the controller of the current volume level (0–175).
+// SendVolumeState notifies the controller of the current volume level
+// (0–volumeMax, the raw tinymix ctl 61 index).
 // Called on connect (to sync controller state) and after every local change.
 // Safe for concurrent use — silently drops if not connected.
 func (c *ControlClient) SendVolumeState(level int) {

--- a/device/internal/server/server.go
+++ b/device/internal/server/server.go
@@ -162,7 +162,7 @@ func (s *Server) VolumeStepDown() {
 	s.volume.StepDown()
 }
 
-// SetVolume sets volume to an explicit level (0–175) — called by controller
+// SetVolume sets volume to an explicit level (0–volumeMax) — called by controller
 // command. Remote changes don't paint the volume arc: nobody is at the
 // device, and the ring lighting up unprompted reads as a glitch.
 func (s *Server) SetVolume(level int) {
@@ -191,13 +191,13 @@ func (s *Server) VolumeSeeded() bool {
 	return s.volumeSeeded.Load()
 }
 
-// VolumeLevel returns the current volume level (0–175).
+// VolumeLevel returns the current volume level (0–volumeMax).
 func (s *Server) VolumeLevel() int {
 	return s.volume.Get()
 }
 
 // SetVolumeChangeCallback wires a callback invoked when volume changes.
-// The callback receives the new level (0–175).
+// The callback receives the new level (0–volumeMax).
 func (s *Server) SetVolumeChangeCallback(cb func(level int)) {
 	s.volume.SetOnVolumeChange(cb)
 }

--- a/device/internal/server/volume.go
+++ b/device/internal/server/volume.go
@@ -10,10 +10,50 @@ import (
 )
 
 const (
-	volumeMin     = 0
-	volumeMax     = 175
-	volumeStep    = 17 // ~10% per press
-	volumeLEDSecs = 2  // how long to show volume ring
+	volumeMin = 0
+
+	// volumeMax is the codec's UNITY gain, not the top of the mixer control's
+	// range. tinymix ctl 61 is the tlv320aic32x4 DAC digital volume: 176
+	// steps of 0.5dB spanning -63.5dB..+24dB, with 0dB at index 127. The 48
+	// steps above 127 apply POSITIVE digital gain to already near-full-scale
+	// PCM, which saturates inside the DAC.
+	//
+	// Measured on hardware 2026-08-13 (1kHz at -6dBFS, recorded through the
+	// mic array): THD 1.5% at 127, 2.3% at 136, 65% at 153, 89% at 170 — with
+	// the output level FLAT from 153 upward, because it had already stopped
+	// being able to get louder. Third harmonic rose to -1.1dB relative to the
+	// fundamental, i.e. very nearly a square wave. The control run that
+	// isolates it: index 170 with the source scaled down to land at the same
+	// acoustic level reads 1.1%, clean — so the codec's gain stage is fine
+	// and it is purely source x gain exceeding full scale.
+	//
+	// Stock FireOS never writes this control at all: it appears in no
+	// /system binary and not once in /system/etc/audio_device.xml, which
+	// leaves the DAC at its 0dB reset default and takes user volume from
+	// AudioFlinger's software attenuation instead. That is why native Alexa
+	// has no such distortion, and why matching it means capping here.
+	//
+	// Do not raise this. The lost headroom cannot be bought back from
+	// Ext_Amp_Gain either — that control is inert on this board (measured
+	// 0.0dB of effect across its whole 6/12/18/24dB range, while still
+	// reading its new value back). "HP Driver Gain Volume" (ctl 62) is the
+	// stage that does work, if more output is ever wanted.
+	volumeMax = 127
+
+	// volumeButtonFloor is the bottom of the band the PHYSICAL buttons
+	// traverse. The scale is dB-linear, so index 0 is -63.5dB and roughly the
+	// bottom third of the control is indistinguishable from silence; stepping
+	// across it spends presses to go nowhere. Silencing the device is the
+	// mute button's job, not the volume button's.
+	//
+	// Explicit Set() calls are deliberately NOT floored — HA's volume 0.0
+	// has to still mean silent. A press from below the floor lands ON the
+	// floor rather than adding a step, so one press always reaches audible.
+	volumeButtonFloor = 47 // -40dB
+
+	// volumeStep is 4dB per press: 10 presses to cross the button band.
+	volumeStep    = 8
+	volumeLEDSecs = 2 // how long to show volume ring
 	numLEDs       = 12
 )
 
@@ -65,23 +105,32 @@ func newVolumeController(ledGetter func() led.Controller) *volumeController {
 	return vc
 }
 
-// readFromDevice reads current tinymix level. Returns volumeMax/2 on failure.
+// readFromDevice reads current tinymix level. Returns the midpoint of the
+// button band on failure — volumeMax/2 is -32dB on this dB-linear scale,
+// which is quiet enough to read as broken.
 func (vc *volumeController) readFromDevice() int {
+	fallback := (volumeButtonFloor + volumeMax) / 2
 	out, err := exec.Command("tinymix", "-D", "0", "61").Output()
 	if err != nil {
 		log.Printf("Volume read failed: %v", err)
-		return volumeMax / 2
+		return fallback
 	}
 	var l, r int
-	// Output: "PCM Playback Volume: 100 100 (range 0->175)"
+	// Output: "PCM Playback Volume: 100 100 (range 0->175)". The control's
+	// own range is 0->175; volumeMax caps us at 127 (unity) — see the
+	// constant. A device that was left above the cap reads back high here
+	// and the next Set() clamps it.
 	if _, err := fmt.Sscanf(string(out), "PCM Playback Volume: %d %d", &l, &r); err != nil {
 		log.Printf("Volume parse failed: %v (output: %s)", err, out)
-		return volumeMax / 2
+		return fallback
+	}
+	if l > volumeMax {
+		l = volumeMax
 	}
 	return l
 }
 
-// Set applies a new volume level (0–175) and updates tinymix. showRing
+// Set applies a new volume level (0–volumeMax) and updates tinymix. showRing
 // paints the cyan volume arc for the 2s display window — physical button
 // presses pass true; remote sets (controller command / HA) and the boot-time
 // SeedVolume pass false so the ring doesn't light when nobody is at the
@@ -147,20 +196,34 @@ func (vc *volumeController) Get() int {
 	return vc.level
 }
 
-// StepUp increases volume by one step.
+// StepUp increases volume by one step, within the button band.
 func (vc *volumeController) StepUp() {
 	vc.mu.Lock()
 	level := vc.level + volumeStep
 	vc.mu.Unlock()
-	vc.Set(level, true)
+	vc.Set(clampToButtonBand(level), true)
 }
 
-// StepDown decreases volume by one step.
+// StepDown decreases volume by one step, within the button band.
 func (vc *volumeController) StepDown() {
 	vc.mu.Lock()
 	level := vc.level - volumeStep
 	vc.mu.Unlock()
-	vc.Set(level, true)
+	vc.Set(clampToButtonBand(level), true)
+}
+
+// clampToButtonBand holds a stepped level inside [volumeButtonFloor,
+// volumeMax]. A device sitting below the floor — HA can put it there, and so
+// can a stored level from before the cap — lands ON the floor from one press
+// instead of creeping up 4dB at a time through inaudible territory.
+func clampToButtonBand(level int) int {
+	if level < volumeButtonFloor {
+		return volumeButtonFloor
+	}
+	if level > volumeMax {
+		return volumeMax
+	}
+	return level
 }
 
 // showLEDs lights N of 12 LEDs in cyan proportional to volume, then clears after 2s.
@@ -170,7 +233,18 @@ func (vc *volumeController) showLEDs(level int) {
 		return
 	}
 
-	lit := level * numLEDs / volumeMax
+	// The arc spans the BUTTON band, not the full control: over 0..volumeMax
+	// the audible range crowds into the top LEDs and a press often moves
+	// nothing. One LED stays lit anywhere above silence so the ring never
+	// reads as "off" when the device is merely quiet.
+	span := volumeMax - volumeButtonFloor
+	lit := (level - volumeButtonFloor) * numLEDs / span
+	if lit < 1 && level > volumeMin {
+		lit = 1
+	}
+	if lit > numLEDs {
+		lit = numLEDs
+	}
 	leds := make([]led.Led, numLEDs)
 	for i := 0; i < numLEDs; i++ {
 		if i < lit {

--- a/device/internal/server/volume_test.go
+++ b/device/internal/server/volume_test.go
@@ -31,3 +31,73 @@ func TestCancelDisplayReleasesTheRing(t *testing.T) {
 	// Idempotent: a second press must not panic on the already-stopped timer.
 	vc.CancelDisplay()
 }
+
+// tinymix ctl 61 spans 0..175, but 127 is the codec's 0dB. Above it the DAC
+// applies positive digital gain to near-full-scale PCM and saturates —
+// measured on hardware at 65% THD by index 153, 89% by 170, with the output
+// level flat from 153 up because it had stopped getting louder. Stock FireOS
+// never writes this control at all. If this constant creeps back toward 175,
+// the garbling above ~73% volume returns.
+func TestVolumeMaxIsCodecUnityNotTheControlMaximum(t *testing.T) {
+	if volumeMax != 127 {
+		t.Fatalf("volumeMax = %d, want 127 (0dB). Anything higher clips the DAC.",
+			volumeMax)
+	}
+	if volumeButtonFloor >= volumeMax {
+		t.Fatalf("button floor %d must sit below the ceiling %d",
+			volumeButtonFloor, volumeMax)
+	}
+}
+
+// The button band must be crossable in a sane number of presses: too few and
+// each press is a huge jump, too many and reaching the top is a chore.
+func TestButtonBandTakesAReasonableNumberOfPresses(t *testing.T) {
+	presses := (volumeMax - volumeButtonFloor) / volumeStep
+	if presses < 6 || presses > 16 {
+		t.Fatalf("%d presses to cross the band (step %d over %d..%d); "+
+			"want roughly 8-12", presses, volumeStep, volumeButtonFloor, volumeMax)
+	}
+}
+
+func TestStepsStayInsideTheButtonBand(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		// A level below the floor — HA can set one, and so could a stored
+		// level from before the cap — must reach audible in ONE press, not
+		// creep up 4dB at a time through inaudible territory.
+		{"far below the floor lands on it", volumeButtonFloor - 40, volumeButtonFloor},
+		{"just below the floor lands on it", volumeButtonFloor - 1, volumeButtonFloor},
+		{"inside the band is untouched", volumeButtonFloor + volumeStep, volumeButtonFloor + volumeStep},
+		{"above the ceiling clamps down", volumeMax + 30, volumeMax},
+	}
+	for _, tc := range cases {
+		if got := clampToButtonBand(tc.in); got != tc.want {
+			t.Errorf("%s: clampToButtonBand(%d) = %d, want %d",
+				tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// Stepping up from the top and down from the bottom must settle, not
+// oscillate or run away past the band.
+func TestSteppingSaturatesAtBothEnds(t *testing.T) {
+	level := volumeMax
+	for i := 0; i < 5; i++ {
+		level = clampToButtonBand(level + volumeStep)
+	}
+	if level != volumeMax {
+		t.Errorf("stepping up from the ceiling reached %d, want %d", level, volumeMax)
+	}
+
+	level = volumeButtonFloor
+	for i := 0; i < 5; i++ {
+		level = clampToButtonBand(level - volumeStep)
+	}
+	if level != volumeButtonFloor {
+		t.Errorf("stepping down from the floor reached %d, want %d",
+			level, volumeButtonFloor)
+	}
+}


### PR DESCRIPTION
tinymix ctl 61 is the tlv320aic32x4 DAC *digital* volume: 176 steps of 0.5dB spanning -63.5..+24dB, with 0dB at index 127. volumeMax was 175 — the control's own maximum — so the top 27% of the range applied up to +24dB of digital gain to already near-full-scale PCM and saturated inside the DAC. That is the "audio is garbled above ~75% volume" report; 127/175 is 72.6%.

It is not a corner of the range you have to go looking for. volumeStep was 17, so from the boot midpoint the physical button lands on 119, 136, 153, 170 — the top THREE presses are all above unity, and 65% THD is three presses away on a device with no other way to turn it up. Every one of them was reported as "EchoMuse sounds worse than stock at high volume", which it is, for this reason.

Measured on hardware (1kHz at -6dBFS, recorded through the mic array):

  ctl 61   DAC out   fundamental   THD    h3 rel
     119     -10.0        -20.0    1.0%    -45dB
     127      -6.0        -16.1    1.5%    -42dB
     136      -1.5        -11.9    2.3%    -40dB
     153      +7.0         -8.0     65%   -3.7dB
     170     +15.5         -8.4     89%   -1.1dB
     170*    -10.0        -20.4    1.1%    -43dB   (*source scaled down)

Two independent signatures: the output level goes FLAT from 153 upward (136->153 gained 3.9dB where the mixer promised 8.5, 153->170 gained nothing) because it had stopped being able to get louder, and the odd harmonics explode while h2 barely moves — symmetric clipping, not speaker breakup. The last row is the control that rules out the amp and the speaker: same ctl 61 as the worst run, source scaled down to land at the reference acoustic level, and it is clean. So the gain stage is fine and it is purely source x gain exceeding full scale.

Stock FireOS never writes this control at all — it appears in no /system binary and not once in /system/etc/audio_device.xml — leaving the DAC at its 0dB reset default and taking user volume from AudioFlinger's software attenuation, which only ever attenuates. That is why native Alexa has no such distortion.

The lost headroom cannot be bought back from Ext_Amp_Gain (ctl 13): sweeping its full 6/12/18/24dB range moves the output 0.0dB while still reading its new value back, i.e. it is inert on this board. HP Driver Gain Volume (ctl 62) is live (+18dB commanded -> +18.1dB actual, THD 2.25%) but that is a taste call to make by ear, and the speaker above stock level is unmeasured.

Also:

- The physical buttons now traverse volumeButtonFloor(47, -40dB)..127 in 4dB steps instead of the whole control. The scale is dB-linear, so the bottom third is indistinguishable from silence and stepping across it spends presses to go nowhere; silencing the device is the mute button's job. Explicit Set() calls are NOT floored, so HA's volume 0.0 still means silent, and a press from below the floor lands on it.
- The LED arc spans the button band rather than 0..175, where the audible range crowded into the top LEDs.
- The conversion moves to em_volume.py. It was spelled `level / 175` in em_controller, em_esphome and em_api with no test on any of them, which is how the wrong ceiling survived; the ceiling now has one definition and is pinned by test on both sides of the wire.
- em_api._stored_volume validates with float() before calling, because em_volume returns 0.0 for bad input — right on the audio path, wrong where None means "not known".

Split out of #168 at the maintainer's request: this is a live bug on the current pipeline and is independent of the native-AFE work.


Claude-Session: https://claude.ai/code/session_01HqXJuZe2jCMpj4bRm8sV9z