### PR TITLE
dashboard: make Toggle honour `disabled`, not just style it

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -331,19 +331,29 @@ function Slider({ label, sub, value, min, max, step = 1, unit = '', formatValue,
   );
 }
 
-function Toggle({ label, sub, value, onChange }) {
+function Toggle({ label, sub, value, onChange, disabled = false }) {
   // minWidth: 0 on the flex container and label lets long label/sub text
   // shrink and wrap instead of forcing the row (and the switch with it)
   // wider than the grid column — which pushed the switch past the edge of
   // the config dialog. flexShrink: 0 keeps the switch at full size.
+  //
+  // `disabled` is honoured in the HANDLER, not only in the styling — the
+  // capability rule ("shown disabled with the reason, never a control that
+  // silently does nothing") is a claim about what a click does, and a switch
+  // that greys itself while still writing is worse than one that does
+  // nothing: the stored setting then disagrees with what the control shows.
+  // Slider has always taken the same prop; Toggle did not take it at all, so
+  // every caller that wanted it had to fake it by neutering `value` and
+  // `onChange` at the call site.
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20, minWidth: 0, gap: 10 }}>
       <div style={{ minWidth: 0, flex: 1 }}>
-        <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: 'var(--text2)' }}>{label}</span>
+        <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: disabled ? 'var(--muted)' : 'var(--text2)' }}>{label}</span>
         {sub && <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)', marginLeft: 8 }}>{sub}</span>}
       </div>
-      <div onClick={() => onChange(!value)} style={{
-        width: 36, height: 20, borderRadius: 10, cursor: 'pointer', position: 'relative', flexShrink: 0,
+      <div onClick={() => { if (!disabled) onChange(!value); }} style={{
+        width: 36, height: 20, borderRadius: 10, cursor: disabled ? 'default' : 'pointer',
+        position: 'relative', flexShrink: 0, opacity: disabled ? 0.45 : 1,
         background: value ? 'var(--accent)' : 'var(--muted)',
         border: value ? '1px solid var(--accent-deep)' : '1px solid var(--muted)',
         transition: 'background 0.15s',
@@ -5346,13 +5356,16 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
         scope={scopeEl('advanced')} dim={secStyle('advanced')}>
         {subHeader('Action button', true)}
         <div className="em-grid2" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 24px', ...inputStyle }}>
-          {/* Offered only when the device says it can measure a hold. */}
-          <Toggle label="Tap sends an event"
+          {/* Offered only when the device says it can measure a hold. The
+              value still reads through holdCapable so an incapable device
+              shows the switch off rather than showing a stored true it
+              cannot honour. */}
+          <Toggle label="Tap sends an event" disabled={!holdCapable}
             sub={holdCapable
               ? "tap fires the HA action-button event instead of starting a turn — hold still fires 'long'; the button can no longer cancel a response. A tap is easy to trigger by accident and the button is unauthenticated — bind destructive automations to 'long' instead"
               : 'needs newer firmware on this Echo — it has no action-button event for a tap to fire'}
             value={holdCapable && (config.buttonSingleTapEvent ?? false)}
-            onChange={holdCapable ? (v => set('buttonSingleTapEvent', v)) : (() => {})}/>
+            onChange={v => set('buttonSingleTapEvent', v)}/>
           <Slider label="Multi-tap window" sub="0 = off. Coalesces quick taps into double/triple, at the cost of delaying every tap by this much. Needs 'Tap sends an event'" value={config.buttonMultiTapMs ?? 0} min={0} max={600} step={50} unit="ms" disabled={!(holdCapable && (config.buttonSingleTapEvent ?? false))} onChange={v => set('buttonMultiTapMs', v)}/>
         </div>
         {subHeader('Turn processing')}

--- a/controller/tests/test_capabilities.py
+++ b/controller/tests/test_capabilities.py
@@ -107,6 +107,35 @@ def test_triggering_is_a_separate_capability_from_scoring():
         "the dashboard must gate the 'On device' option on the capability"
 
 
+def test_the_toggle_control_actually_honours_disabled():
+    """
+    "Disabled WITH the reason, never a control that silently does nothing" is
+    the rule every capability gate above is enforced by — and Toggle did not
+    accept a `disabled` prop at all; only Slider did. So the rule could not be
+    expressed on a switch, and the one call site that needed it ("Tap sends an
+    event", gated on button_hold) had to fake it by neutering `value` and
+    `onChange` by hand — which leaves the control looking live: full-contrast
+    label, pointer cursor, a switch that animates when clicked and stores
+    nothing. Any caller passing `disabled` in good faith got worse: a switch
+    greyed with its reason that WROTE THE OPPOSITE VALUE on click, so the
+    stored setting silently disagreed with what the control showed.
+
+    Asserted against the component rather than the call sites, because the
+    call sites already looked correct while the bug was live.
+    """
+    jsx = (ROOT / "controller" / "static" / "dashboard.jsx").read_text()
+    m = re.search(r'function Toggle\(\{(.*?)\}\)', jsx, re.S)
+    assert m, "dashboard.jsx must still define a Toggle component"
+    assert "disabled" in m.group(1), \
+        "Toggle must accept a `disabled` prop — every caller that passes one " \
+        "is relying on it to refuse the write, not merely to grey the switch"
+
+    body = jsx[m.end():jsx.index("\n}", m.end())]
+    assert re.search(r'if\s*\(!disabled\)|disabled\s*\?\s*undefined|disabled\s*\|\|', body), \
+        "Toggle's click handler must check `disabled` before calling onChange — " \
+        "styling it grey while still writing the value is the bug this pins"
+
+
 def test_capabilities_reported_before_the_server_exists_are_not_lost():
     """
     A device registers BEFORE its ESPHome server is created — the listener


### PR DESCRIPTION
`Toggle` did not accept a `disabled` prop at all — only `Slider` did. So the capability rule the rest of the dashboard is built on ("a UI control whose feature the device lacks is shown disabled WITH the reason, never as a control that silently does nothing") could not be expressed on a switch, and the two ways of coping with that are both wrong:

- Passing `disabled` in good faith greys the switch and its reason, and the click still writes — the *opposite* value, since the handler flips whatever `value` was forced to. That is worse than a control that does nothing: the stored setting then silently disagrees with what the control shows, and the user has no way to see it.
- Faking it at the call site, as "Tap sends an event" does today, leaves the control looking live: full-contrast label, pointer cursor, and a switch that animates on click and stores nothing.

The prop is now honoured in the handler, and the label/switch pick up the same greying `Slider` has always had. The one existing caller moves onto it, so the fix is exercised rather than dead: `value` still reads through `holdCapable`, so a device that cannot measure a hold shows the switch off rather than showing a stored `true` it has no way to honour.


Split out of #168 at the maintainer's request: the component takes no `disabled` prop on main today, independently of the native-AFE work.


Claude-Session: https://claude.ai/code/session_01QzfqxetgNSBPMnPEgXPR5d