### PR TITLE
Expose debug logging as an add-on option

### DIFF
--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -76,6 +76,7 @@ options:
   oww_threshold: 0.5
   require_device_tls: false
   device_approval: "strict"
+  debug: false
 schema:
   server_host: "str"
   server_ip: "str"
@@ -85,3 +86,4 @@ schema:
   oww_threshold: "float(0,1)"
   require_device_tls: "bool"
   device_approval: "list(strict|auto)"
+  debug: "bool"

--- a/controller-ea/translations/en.yaml
+++ b/controller-ea/translations/en.yaml
@@ -45,3 +45,9 @@ configuration:
     description: >-
       strict holds new devices for administrator approval. auto immediately
       approves new devices with a generated name.
+  debug:
+    name: Debug logging
+    description: >-
+      Log protocol-level detail for devices and the Home Assistant
+      connection. Verbose — turn it on to diagnose something, then off
+      again.

--- a/controller/.env.example
+++ b/controller/.env.example
@@ -44,3 +44,9 @@ DB_PATH=/app/data/echomuse.db
 # strict — unknown devices held in pending queue until admin approves (default)
 # auto   — unknown devices approved immediately as "Unknown {serial[:8]}"
 DEVICE_APPROVAL=strict
+# ── Logging ───────────────────────────────────────────────────────────────────
+# 1 raises the controller to DEBUG: per-message ESPHome protocol detail, the
+# device control plane, and the wake/turn internals. Verbose enough to be a
+# diagnostic setting rather than a default. Read once at startup, so a change
+# needs a restart.
+DEBUG=0

--- a/controller/config.yaml
+++ b/controller/config.yaml
@@ -62,6 +62,7 @@ options:
   oww_threshold: 0.5
   require_device_tls: false
   device_approval: "strict"
+  debug: false
 schema:
   server_host: "str"
   server_ip: "str"
@@ -71,3 +72,4 @@ schema:
   oww_threshold: "float(0,1)"
   require_device_tls: "bool"
   device_approval: "list(strict|auto)"
+  debug: "bool"

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -83,8 +83,17 @@ import em_player
 
 _LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s — %(message)s"
 
+# Any non-empty string is truthy in Python, so `os.environ.get("DEBUG")`
+# alone turned debug logging ON for DEBUG=0 — and em_start.py renders a
+# false add-on option as exactly that string, so an untouched "Debug
+# logging" toggle would have shipped every add-on install at DEBUG level.
+# Same `== "1"` convention as REQUIRE_DEVICE_TLS, widened to the word
+# spellings because DEBUG went undocumented for long enough that a
+# container user's .env may already say `true`.
+DEBUG = os.environ.get("DEBUG", "0").strip().lower() in {"1", "true", "yes", "on"}
+
 logging.basicConfig(
-    level=logging.DEBUG if os.environ.get("DEBUG") else logging.INFO,
+    level=logging.DEBUG if DEBUG else logging.INFO,
     format=_LOG_FORMAT,
 )
 log = logging.getLogger("echomuse")

--- a/controller/em_start.py
+++ b/controller/em_start.py
@@ -35,6 +35,7 @@ OPTION_ENV_VARS = {
     "oww_threshold": "OWW_THRESHOLD",
     "require_device_tls": "REQUIRE_DEVICE_TLS",
     "device_approval": "DEVICE_APPROVAL",
+    "debug": "DEBUG",
 }
 
 if OPTIONS_PATH.is_file():

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1148,3 +1148,78 @@ def test_role_changes_refuse_to_strand_the_install():
     assert "admin_count" in body, "must count admins before demoting one"
     assert "last_admin" in body, "must refuse to remove the final admin"
 
+
+
+def test_addon_options_are_wired_end_to_end():
+    """
+    An add-on option needs four separate things to work: a default in
+    `options`, a type in `schema`, a translation, and a line in em_start.py's
+    OPTION_ENV_VARS. Miss one and it fails a different way each time, none of
+    them loud:
+
+      - no `schema` entry — Supervisor rejects the whole options block
+      - no translation      — the raw key renders as the field label
+      - no OPTION_ENV_VARS  — the setting is accepted, displayed, stored, and
+                              then ignored; em_start warns to the add-on log
+                              and starts anyway, which is the right call for
+                              boot resilience and means nobody sees it
+
+    The reverse direction matters too: an OPTION_ENV_VARS entry with no
+    option is a mapping for a setting Supervisor will never send.
+
+    Added with the `debug` option (2026-08-16). DEBUG had no add-on option at
+    all, so controller debug logging — the first thing support asks for — was
+    reachable on the container and not on the add-on.
+    """
+    import yaml
+
+    config = yaml.safe_load((CONTROLLER / "config.yaml").read_text())
+    translations = yaml.safe_load(
+        (CONTROLLER / "translations/en.yaml").read_text())
+
+    options = set(config["options"])
+    schema = set(config["schema"])
+    translated = set(translations["configuration"])
+
+    start = (CONTROLLER / "em_start.py").read_text()
+    block = re.search(r"OPTION_ENV_VARS\s*=\s*\{(.*?)\}", start, re.S)
+    assert block, "em_start.py no longer defines OPTION_ENV_VARS"
+    mapped = set(re.findall(r'"(\w+)"\s*:', block.group(1)))
+
+    assert not options - schema, \
+        f"options with no schema entry: {sorted(options - schema)}"
+    assert not schema - options, \
+        f"schema entries with no default: {sorted(schema - options)}"
+    assert not options - translated, \
+        f"options with no translation: {sorted(options - translated)}"
+    assert not options - mapped, (
+        f"options not in em_start.py's OPTION_ENV_VARS: "
+        f"{sorted(options - mapped)} — Supervisor would accept and store "
+        f"these and the controller would never see them")
+    assert not mapped - options, (
+        f"OPTION_ENV_VARS entries with no add-on option: "
+        f"{sorted(mapped - options)}")
+
+
+def test_debug_env_var_is_not_truthy_for_zero():
+    """
+    em_start.py renders a false bool option as the STRING "0", and every
+    non-empty string is truthy in Python. So a bare
+    `if os.environ.get("DEBUG")` puts every add-on install at DEBUG level
+    with the toggle showing off — the failure being verbose logs nobody
+    asked for, on the deployment least able to rotate them.
+
+    Pinned rather than assumed because the original line read exactly that
+    way, and the same shape is the obvious thing to write for the next
+    bool env var.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    assert not re.search(r'if\s+os\.environ\.get\(\s*"DEBUG"\s*\)\s*else', src), (
+        "DEBUG is being read as a bare truthiness test — the string \"0\" "
+        "that em_start.py writes for a false option is truthy")
+
+    match = re.search(r'^DEBUG\s*=\s*(.+)$', src, re.M)
+    assert match, "em_controller.py no longer defines a DEBUG flag"
+    assert '"0"' in match.group(1) and '"1"' in match.group(1), (
+        "DEBUG must default to \"0\" and test for \"1\", the convention "
+        "REQUIRE_DEVICE_TLS already uses")

--- a/controller/translations/en.yaml
+++ b/controller/translations/en.yaml
@@ -45,3 +45,9 @@ configuration:
     description: >-
       strict holds new devices for administrator approval. auto immediately
       approves new devices with a generated name.
+  debug:
+    name: Debug logging
+    description: >-
+      Log protocol-level detail for devices and the Home Assistant
+      connection. Verbose — turn it on to diagnose something, then off
+      again.


### PR DESCRIPTION
Controller debug logging is the first thing support asks for, and on the add-on there was no way to turn it on.

The only switch is the `DEBUG` env var, read once at import (`em_controller.py:87`). It was not an add-on option, not in `em_start.py`'s `OPTION_ENV_VARS`, not settable at runtime, and **not in `.env.example` either** — so container users could reach it undocumented and add-on users could not reach it at all. That is the #163 class of gap: a capability one deployment has and the other does not.

Found while trying to trace Home Assistant's voice satellite setup flow on a fresh EA install, which is exactly the situation where you want protocol-level logs and exactly the deployment that could not produce them.

## The truthiness bug comes first

`os.environ.get("DEBUG")` is a bare truthiness test, and every non-empty string is truthy in Python — including the `"0"` that `em_start.py` writes for a false bool option:

```python
if isinstance(value, bool):
    env_value = "1" if value else "0"
```

So adding the option on top of the existing line would have put **every add-on install at DEBUG level with the toggle showing off**. Fixed to the `== "1"` convention `REQUIRE_DEVICE_TLS` already uses, widened to the word spellings because `DEBUG` went undocumented long enough that a container user's `.env` may already say `true`.

## Guards

Both verified by reintroducing the bug.

**`test_addon_options_are_wired_end_to_end`** walks all four things an option needs — a default in `options`, a type in `schema`, a translation, and an `OPTION_ENV_VARS` line — in both directions. They fail differently and none of them loudly:

| missing | symptom |
|---|---|
| `schema` | Supervisor rejects the whole options block |
| translation | the raw key renders as the field label |
| `OPTION_ENV_VARS` | accepted, displayed, stored, then ignored |

The third is the quiet one. `em_start.py` warns to the add-on log and boots anyway, which is the right call — failing to start over one stray key would be worse — and it means nobody sees it.

**`test_debug_env_var_is_not_truthy_for_zero`** pins the parse, because the bare-truthiness shape is the obvious thing to write for the next bool env var.

## Not in scope

#163 suggests a test asserting every `.env.example` variable is either an add-on option or on an explicit exclusion list. That would **not** have caught this one — `DEBUG` was missing from `.env.example` too, so the audit would have compared two files that agreed with each other and disagreed with the code. If that test gets written it should walk the `os.environ.get` calls in the source, not `.env.example`. Left for #163.

`SERVER_TLS_PORT` and `SERVER_PORT` remain unexposed — also #163.

## Testing

422 tests pass. EA regenerated with `tools/sync_channels.py`, so `test_channels.py` stays green.
