### PR TITLE
Send the wake word phrase Home Assistant asks for

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -322,6 +322,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         # send before the turn has actually progressed (observed in practice —
         # see _handle_voice_event's RUN_END branch).
         self._intent_ended      = False
+        self._run_end_before_stt = False
         # Set on VOICE_ASSISTANT_INTENT_END when HA requests conversation
         # continuation (continue_conversation == "1"). Read by trigger_voice_turn
         # after run_esphome_voice_turn returns to decide whether to re-trigger
@@ -479,13 +480,47 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 available_wake_words=[
                     api_pb2.VoiceAssistantWakeWord(
                         id=self.oww_model_id,
-                        wake_word=self.oww_model_id.replace("_", " "),
+                        wake_word=em_oww_models.display_name(self.oww_model_id),
                         trained_languages=["en"],
                     )
                 ],
                 active_wake_words=[self.oww_model_id],
                 max_active_wake_words=1,
             )
+            return
+
+        if isinstance(msg, api_pb2.VoiceAssistantSetConfiguration):
+            # HA writing a wake-word choice back to us (its select entity's
+            # async_select_option). Handled explicitly rather than falling into
+            # the generic "unhandled" debug, which made a user-visible control
+            # silently do nothing.
+            #
+            # We advertise ONE model with max_active_wake_words=1, so HA's
+            # dropdown offers exactly our model plus "no wake word" — there is
+            # nothing to switch between, and a request naming our own model is
+            # genuinely a no-op rather than an unimplemented one. Selecting our
+            # model back is therefore correct and silent.
+            #
+            # An EMPTY list means "no wake word", i.e. deafen this satellite.
+            # That is a real request we do not implement — wake detection is
+            # controller-side config, not an HA-owned setting — so it is logged
+            # at warning rather than accepted quietly. Honouring it, and
+            # offering a choice worth making, both wait on multi-model support
+            # (#112).
+            requested = list(msg.active_wake_words)
+            if requested == [self.oww_model_id]:
+                log.debug(
+                    f"[{self._log_name}] VoiceAssistantSetConfiguration: "
+                    f"{self.oww_model_id} already active — nothing to do"
+                )
+            else:
+                log.warning(
+                    f"[{self._log_name}] VoiceAssistantSetConfiguration asked "
+                    f"for active_wake_words={requested or '[] (no wake word)'} "
+                    f"— not applied; this device's wake word is set in the "
+                    f"EchoMuse dashboard and stays {self.oww_model_id}"
+                )
+            yield _HANDLED
             return
 
         if isinstance(msg, api_pb2.MediaPlayerCommandRequest):
@@ -674,6 +709,14 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             if self._intent_ended or self._turn_cancelled:
                 self._tts_event.set()
             else:
+                # Record that HA closed the run before it engaged at all — no
+                # VAD start, no STT. Recorded, NOT acted on: the premature
+                # RUN_END above is real and ending the turn here would cut
+                # genuine turns, so this only re-labels an outcome that was
+                # already going to be a give-up. See the _no_speech_timeout
+                # branch in run_esphome_voice_turn.
+                if not self._ha_vad_start.is_set():
+                    self._run_end_before_stt = True
                 log.debug(
                     f"[{self._log_name}] Ignoring RUN_END — INTENT_END not yet "
                     f"seen, treating as premature/duplicate rather than turn end"
@@ -767,6 +810,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         post_turn_play,    # async callable(pcm_chunks) -> decoded byte count
         trace: "TurnTrace | None" = None,
         preroll_discard: int = VOICE_PREROLL_DISCARD,
+        wake_word_phrase: str = "",
     ) -> None:
         """
         Execute one voice turn over the live HA connection.
@@ -799,6 +843,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._tts_audio_url         = None
         self._tts_audio_data        = None
         self._intent_ended          = False
+        self._run_end_before_stt    = False
         self._continue_conversation = False
         self._no_speech_timeout     = False
         self._ha_vad_end.clear()
@@ -817,10 +862,25 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         try:
             # ── Tell HA to start the Assist pipeline ──────────────────────
             # flags=0 → device detected wake word, skip HA-side wake word step.
+            #
+            # wake_word_phrase names WHICH wake word fired, and is empty for
+            # a button turn — where no wake word fired and claiming one would
+            # tell HA something untrue. aioesphomeapi maps "" back to None
+            # (client.py: `if wake_word_phrase == "": wake_word_phrase = None`),
+            # so an empty string is the correct way to say "no wake word",
+            # not a phrase that happens to be blank.
+            #
+            # Sending nothing at all is what stalled Home Assistant's voice
+            # satellite setup dialog: it arms an interceptor for the next wake
+            # word, reads this field, and on None raises
+            # AssistSatelliteError("No wake word phrase provided") and ends the
+            # run within milliseconds. Every turn worked, and the one flow that
+            # asks the device to prove it heard a wake word could never finish.
             self._send_one(api_pb2.VoiceAssistantRequest(
                 start=True,
                 conversation_id=self._conversation_id,
                 flags=VOICE_REQUEST_FLAGS_WAKE_WORD_DONE,
+                wake_word_phrase=wake_word_phrase,
             ))
 
             # ── Stream mic audio from device.voice_queue ──────────────────
@@ -857,7 +917,23 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 # so there's no in-flight HA pipeline to wait on. Close the
                 # turn immediately rather than sitting on the 30s TTS wait
                 # for a response that was never requested.
-                if trace: trace.outcome = "no_speech"
+                #
+                # Unless HA had already closed the run without ever engaging,
+                # in which case "no_speech" blames the user for something they
+                # did not do: the audio was captured and streamed into a
+                # pipeline that was no longer listening. Same class of
+                # mis-attribution em_turnclock exists to avoid, and it is
+                # persisted, so every HA-side refusal would otherwise show up
+                # in the activity stats as a silent user.
+                if self._run_end_before_stt:
+                    log.info(
+                        f"[{self._log_name}] HA ended the pipeline before it "
+                        f"engaged — recording 'pipeline_refused', not "
+                        f"'no_speech' (audio was captured and streamed)"
+                    )
+                    if trace: trace.outcome = "pipeline_refused"
+                else:
+                    if trace: trace.outcome = "no_speech"
                 return
 
             # ── Wait for TTS response (or RUN_END / error / timeout) ──────
@@ -1990,12 +2066,23 @@ async def trigger_voice_turn(
         trigger=trigger_label, t0=time.monotonic(), wake_info=wake_info
     )
 
+    # Only a wake-word turn names a wake word. A button turn genuinely has
+    # none, and "" is how the protocol says so — aioesphomeapi turns it back
+    # into None. Keyed on the trigger label rather than on whether a model is
+    # configured, because a model is always configured; what varies is whether
+    # it fired. Covers "wakeword(0.522)" and the on-device "wakeword-dev(…)".
+    wake_word_phrase = (
+        em_oww_models.display_name(server.oww_model_id)
+        if trigger_label.startswith("wakeword") else ""
+    )
+
     await satellite.run_esphome_voice_turn(
         device=device,
         preroll_discard=preroll_discard,
         on_thinking=on_thinking,
         post_turn_play=post_turn_play,
         trace=trace,
+        wake_word_phrase=wake_word_phrase,
     )
 
     return satellite._continue_conversation

--- a/controller/em_oww_models.py
+++ b/controller/em_oww_models.py
@@ -41,6 +41,29 @@ def prediction_key(model_name: str) -> str:
     return model_name
 
 
+# openWakeWord ships its stock models with a version suffix in the FILENAME
+# ("hey_jarvis_v0.1.onnx"). That is a packaging convention, not part of the
+# wake word, and it has no business in a string a user reads.
+_VERSION_SUFFIX = re.compile(r"_v\d+(?:\.\d+)*$")
+
+
+def display_name(model_name: str) -> str:
+    """
+    The wake word as a person says it — "hey_jarvis_v0.1" -> "hey jarvis".
+
+    This is NOT cosmetic. Home Assistant compares the `wake_word_phrase` on
+    a pipeline start against the STATE of its wake-word select entity, whose
+    options are the display names we advertise
+    (esphome/assist_satellite.py: `ww_state.state == wake_word_phrase`, and
+    select.py's `_wake_words` dict is commented "name -> id"). So the phrase
+    we announce and the name we advertise must be the same string, or HA
+    matches neither and silently falls back to pipeline 1.
+
+    One function so the two call sites cannot drift.
+    """
+    return _VERSION_SUFFIX.sub("", prediction_key(model_name)).replace("_", " ")
+
+
 def models_dir(db_path: str | None = None) -> Path:
     """
     Resolve the custom-models directory: `oww_models/` beside the SQLite

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1223,3 +1223,79 @@ def test_debug_env_var_is_not_truthy_for_zero():
     assert '"0"' in match.group(1) and '"1"' in match.group(1), (
         "DEBUG must default to \"0\" and test for \"1\", the convention "
         "REQUIRE_DEVICE_TLS already uses")
+def test_wake_word_phrase_is_sent_and_matches_what_we_advertise():
+    """
+    Home Assistant's voice satellite setup arms an interceptor for the next
+    wake word and reads `wake_word_phrase` off the pipeline start. On None it
+    raises AssistSatelliteError("No wake word phrase provided") and ends the
+    run in milliseconds — so every voice turn worked while the one flow that
+    asks a device to prove it heard a wake word could never complete, and the
+    only way past was Skip (confirmed on hardware 2026-08-16).
+
+    HA then matches that phrase against the STATE of its wake-word select
+    entity, whose options are the display names we advertise
+    (esphome/assist_satellite.py `ww_state.state == wake_word_phrase`). So the
+    phrase and the advertised name must come from ONE function or they drift
+    apart and HA silently matches neither.
+
+    Source-shape assertions: this suite does not import em_esphome, which
+    needs aiohttp and the protobufs.
+    """
+    src = (CONTROLLER / "em_esphome.py").read_text()
+
+    start = re.search(r"api_pb2\.VoiceAssistantRequest\((.*?)\)\)", src, re.S)
+    assert start, "the pipeline-start VoiceAssistantRequest was not found"
+    assert "wake_word_phrase" in start.group(1), (
+        "VoiceAssistantRequest must carry wake_word_phrase — without it HA "
+        "refuses the run and the satellite setup dialog never advances")
+
+    advertised = re.search(r"api_pb2\.VoiceAssistantWakeWord\((.*?)\)", src, re.S)
+    assert advertised, "VoiceAssistantWakeWord advertisement not found"
+    assert "em_oww_models.display_name" in advertised.group(1), (
+        "the advertised wake_word must come from em_oww_models.display_name, "
+        "the same source as the phrase we send")
+
+    assert 'display_name(server.oww_model_id)' in src, (
+        "the phrase must be derived with display_name too — a second spelling "
+        "is how it drifts from what we advertised")
+
+
+def test_button_turns_claim_no_wake_word():
+    """
+    A button turn has no wake word, and saying otherwise tells HA something
+    untrue about how the turn started — it would also satisfy a setup-flow
+    interceptor with a wake word nobody spoke. aioesphomeapi maps "" back to
+    None, so an empty string is the protocol's way to say "none".
+    """
+    src = (CONTROLLER / "em_esphome.py").read_text()
+    gate = re.search(r'wake_word_phrase\s*=\s*\((.*?)else ""', src, re.S)
+    assert gate, "the wake_word_phrase gate was not found"
+    assert 'trigger_label.startswith("wakeword")' in gate.group(1), (
+        "the phrase must be gated on the trigger being a wake word, so button "
+        "turns send \"\"")
+
+
+def test_ha_refusal_is_not_recorded_as_no_speech():
+    """
+    HA closing the pipeline before it engages is not the user being silent —
+    the audio was captured and streamed into a run that had already ended.
+    Recording it as `no_speech` blames the user and pollutes the persisted
+    activity stats, the same mis-attribution em_turnclock exists to prevent.
+
+    The flag is recorded on RUN_END and read at give-up time rather than
+    acted on immediately, because a premature RUN_END before STT_START is a
+    real thing HA does mid-turn and ending the turn there would cut genuine
+    turns short.
+    """
+    src = (CONTROLLER / "em_esphome.py").read_text()
+    assert "_run_end_before_stt" in src, \
+        "no flag records an HA pipeline that ended before it engaged"
+    assert '"pipeline_refused"' in src, \
+        "an HA-side refusal must get its own outcome, not no_speech"
+
+    handler = re.search(
+        r"VOICE_ASSISTANT_RUN_END:(.*?)elif event_type", src, re.S)
+    assert handler, "RUN_END handler not found"
+    assert "_tts_event.set()" not in handler.group(1).split("_run_end_before_stt")[1], (
+        "RUN_END before INTENT_END must stay non-terminal — recording the "
+        "refusal must not start ending turns early")

--- a/controller/tests/test_oww_models.py
+++ b/controller/tests/test_oww_models.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 import em_oww_models as owm
 
 
@@ -74,3 +76,48 @@ def test_in_use_by_matches_path_refs_only(tmp_path):
         "device-d": None,
     }
     assert owm.in_use_by(str(model), configs) == ["device-a"]
+
+
+# ── display_name ──────────────────────────────────────────────────────────
+
+def test_display_name_strips_the_version_suffix():
+    assert owm.display_name("hey_jarvis_v0.1") == "hey jarvis"
+    assert owm.display_name("alexa_v0.1") == "alexa"
+
+
+def test_display_name_handles_custom_model_paths():
+    """
+    Custom models arrive as a path (owwModel stores one), and carry no
+    version suffix — oww_forge names the file after the phrase, which is
+    the only source of the name that exists for them: the ONNX files have
+    no metadata at all (metadata_props={}, empty doc strings, raw torch_jit
+    exports) and custom models are not in openwakeword.MODELS either.
+    """
+    assert owm.display_name(
+        "/data/oww_models/hey_clarra.onnx") == "hey clarra"
+    assert owm.display_name("hey_clarra") == "hey clarra"
+
+
+def test_display_name_leaves_a_version_inside_the_name_alone():
+    """Only a TRAILING _v<n> is a packaging suffix."""
+    assert owm.display_name("hey_v2_robot") == "hey v2 robot"
+
+
+def test_display_name_matches_openwakeword_own_names():
+    """
+    The version suffix is a filename convention, so trimming it is a guess
+    unless it is checked against the package that invented the convention.
+    openwakeword.MODELS is keyed by the clean name and values point at the
+    versioned file, which makes it the authority for every stock model.
+
+    Skipped where openwakeword is absent — CI installs pytest/numpy/scipy/
+    pyyaml only, and em_oww_models stays dependency-free so it can be unit
+    tested at all. Where the package IS present this is exact.
+    """
+    openwakeword = pytest.importorskip("openwakeword")
+
+    for name, spec in openwakeword.MODELS.items():
+        stem = Path(spec["model_path"]).stem
+        assert owm.display_name(stem) == name.replace("_", " "), (
+            f"display_name({stem!r}) disagrees with openwakeword's own name "
+            f"for the model, {name!r}")


### PR DESCRIPTION
Home Assistant's voice satellite setup dialog never advanced past "say *&lt;wake word&gt;* to wake the device up". Saying it lit the ring and ran a complete voice turn; the dialog sat there. Clicking **Skip** and configuring the pipeline by hand was the only way through — the workaround an author develops on their second device and a new user never discovers.

Hit on a fresh add-on install (2026-08-16).

## The cause, from HA's own debug log

```
16:00:20.363  [assist_satellite.entity]   Next wake word will be intercepted: assist_satellite.…
16:00:30.162  [esphome.assist_satellite]  Running pipeline 1 from stt to tts
16:00:30.163  [assist_satellite.entity]   Intercepted wake word: None  (entity_id=…)
16:00:30.166  [esphome.assist_satellite]  Pipeline finished
```

HA arms an interceptor for the next wake word and reads `wake_word_phrase` off the pipeline start. From `assist_satellite/entity.py`:

```python
if wake_word_phrase is None:
    self._wake_word_intercept_future.set_exception(
        AssistSatelliteError("No wake word phrase provided")
    )
```

We never set it. Field 5 of `VoiceAssistantRequest` appeared nowhere in the tree. Matching controller-side trace, showing HA's `RUN_END` arriving 6ms after we start the turn, and us streaming 5.28s of captured audio into a pipeline that had already closed:

```
15:45:16,404  Starting ESPHome voice turn conversation_id=9ee56d8f…
15:45:16,410  Pipeline run ended
15:45:21,561  [TURN] trigger=wakeword(0.954) outcome=no_speech … audio=66frames/5280ms
```

Every ordinary turn worked, which is why this survived: the setup flow is the only one that reads the field.

## Why the name changes too

HA matches that phrase against the **state of its wake-word select entity** (`esphome/assist_satellite.py`):

```python
if (ww_state := self.hass.states.get(ww_entity_id)) and ww_state.state == wake_word_phrase:
```

and `select.py`'s `_wake_words` dict is commented `# name -> id`, so the state is the *display name we advertise*. The phrase and the advertised name therefore have to be one string. Both now come from `em_oww_models.display_name`, and a test pins that neither call site spells it its own way.

### ⚠️ Breaking change

The advertised name loses its version suffix: **`hey jarvis v0.1` → `hey jarvis`**. `_v0.1` is an openWakeWord *filename* convention that was reaching Home Assistant's own device registry.

HA restores a select's previous option by string, so **an existing device's wake word may come back unselected and need choosing once** in Settings → Devices & Services. One dropdown, once per device.

Chosen over keeping the ugly name or carrying an alias: the install base is small, and an alias for a string that was never meant to be user-facing is the kind of shim that outlives everyone who understood it.

The trim is verified, not guessed. `openwakeword.MODELS` is keyed by exactly the trimmed name, and a test asserts `display_name()` agrees with it for every stock model (skipped where the package is absent, since `em_oww_models` stays dependency-free so it can be unit-tested at all). The ONNX files themselves carry nothing to read — `metadata_props={}`, empty doc strings, raw `torch_jit` exports — and custom models are in neither place, so the filename is genuinely the only source for those.

## Two more things the same investigation turned up

**`VoiceAssistantSetConfiguration` was falling into the generic "unhandled" debug.** That is HA writing a wake-word choice back to us, so a user-visible control silently did nothing — the exact shape the project's capability rule exists to prevent. Now handled and logged. Actually *applying* it waits on #112: we advertise one model with `max_active_wake_words=1`, so HA's dropdown offers our model plus "no wake word" and there is nothing to switch between. A request naming our own model is genuinely a no-op; an empty list means "deafen this satellite", which is a real request we do not implement and now says so at warning level instead of vanishing.

**An HA refusal was recorded as `no_speech`.** The audio was captured and streamed into a run that had already closed, so blaming the user is wrong — and it is persisted, which puts every HA-side refusal into the activity stats as a silent user. Same class of mis-attribution `em_turnclock` exists to prevent. Now `pipeline_refused`.

It is **recorded on `RUN_END` and read at give-up time, not acted on**. A premature `RUN_END` before `STT_START` is a real thing HA does mid-turn — the existing handler documents it — so ending the turn there would cut genuine turns short. This only re-labels an outcome that was already going to be a give-up. A test pins that it stays non-terminal.

Ending the turn immediately on a genuine refusal, rather than after the 5s no-speech window, is a follow-up: it needs a discriminator we do not have yet.

## Testing

427 tests pass. New coverage:

- `display_name` against `openwakeword.MODELS`, custom model paths, and a trailing-suffix-only rule (`hey_v2_robot` keeps its `v2`)
- `wake_word_phrase` is sent, and comes from the same function as the advertised name
- button turns send `""` — aioesphomeapi maps that back to `None`, so a turn with no wake word says so rather than claiming one
- an HA refusal is not recorded as `no_speech`, and `RUN_END` stays non-terminal

Source-shape assertions for the `em_esphome` half, since the suite deliberately does not import it.

## Still to verify on hardware

The dialog itself. The mechanism is confirmed from both sides of the wire, but this has not yet been run against a real setup flow end to end.
