### PR TITLE
Release the turn when Home Assistant ends a run it never started

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -322,7 +322,8 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         # send before the turn has actually progressed (observed in practice —
         # see _handle_voice_event's RUN_END branch).
         self._intent_ended      = False
-        self._run_end_before_stt = False
+        self._run_started       = False
+        self._ha_never_started  = False
         # Set on VOICE_ASSISTANT_INTENT_END when HA requests conversation
         # continuation (continue_conversation == "1"). Read by trigger_voice_turn
         # after run_esphome_voice_turn returns to decide whether to re-trigger
@@ -693,8 +694,38 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             self._tts_audio_url = url
             self._tts_event.set()
 
+        elif event_type == ET.VOICE_ASSISTANT_RUN_START:
+            # First event of any genuine pipeline run — measured on hardware
+            # at 2ms before STT_START, with RUN_END last after TTS_END. Its
+            # ABSENCE is what identifies a RUN_END that HA emitted without
+            # running a pipeline at all: the wake-word interception the
+            # satellite setup flow uses returns straight after
+            # `_internal_on_pipeline_event(PipelineEvent(RUN_END))`, so no
+            # RUN_START is ever sent. Structural, not a race on timing.
+            self._run_started = True
+
         elif event_type == ET.VOICE_ASSISTANT_RUN_END:
             log.info(f"[{self._log_name}] Pipeline run ended")
+
+            if not self._run_started:
+                # HA ended a run it never started. Terminal, and safe to act
+                # on: the premature RUN_END below is a real thing HA does
+                # MID-turn, and a mid-turn RUN_END by definition follows the
+                # RUN_START that opened it.
+                #
+                # Without this the turn held the microphone until our own
+                # timers expired — measured at 20.0s (the streaming hard cap)
+                # and 5.2s (the no-speech window) — while HA had re-armed for
+                # the next wake word 18ms after ending this one. That is what
+                # made the setup flow's second "say it again" step land on a
+                # device still listening for the first.
+                #
+                # Unblocking both waiters mirrors the ERROR path below, which
+                # is the established shape for "HA is done, stop feeding it".
+                self._ha_never_started = True
+                self._ha_vad_end.set()
+                self._tts_event.set()
+                return
             # HA can emit a RUN_END that isn't the turn's real terminal event —
             # confirmed in practice: a RUN_END arriving before STT_START, with
             # the genuine terminal RUN_END following ~5s later after TTS_END.
@@ -709,14 +740,6 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             if self._intent_ended or self._turn_cancelled:
                 self._tts_event.set()
             else:
-                # Record that HA closed the run before it engaged at all — no
-                # VAD start, no STT. Recorded, NOT acted on: the premature
-                # RUN_END above is real and ending the turn here would cut
-                # genuine turns, so this only re-labels an outcome that was
-                # already going to be a give-up. See the _no_speech_timeout
-                # branch in run_esphome_voice_turn.
-                if not self._ha_vad_start.is_set():
-                    self._run_end_before_stt = True
                 log.debug(
                     f"[{self._log_name}] Ignoring RUN_END — INTENT_END not yet "
                     f"seen, treating as premature/duplicate rather than turn end"
@@ -843,7 +866,8 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._tts_audio_url         = None
         self._tts_audio_data        = None
         self._intent_ended          = False
-        self._run_end_before_stt    = False
+        self._run_started           = False
+        self._ha_never_started      = False
         self._continue_conversation = False
         self._no_speech_timeout     = False
         self._ha_vad_end.clear()
@@ -911,6 +935,18 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 if trace: trace.outcome = "cancelled"
                 return
 
+            if self._ha_never_started:
+                # HA ended the run without starting a pipeline — currently
+                # only the satellite setup flow's wake-word interception.
+                # Release the microphone now rather than waiting out a timer
+                # for speech nobody is listening to.
+                log.info(
+                    f"[{self._log_name}] HA ended the run without starting a "
+                    f"pipeline — releasing the turn"
+                )
+                if trace: trace.outcome = "pipeline_refused"
+                return
+
             if self._no_speech_timeout:
                 # Device gave up locally before any speech was detected —
                 # _stream_mic_audio already skipped sending end=True to HA,
@@ -918,22 +954,10 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 # turn immediately rather than sitting on the 30s TTS wait
                 # for a response that was never requested.
                 #
-                # Unless HA had already closed the run without ever engaging,
-                # in which case "no_speech" blames the user for something they
-                # did not do: the audio was captured and streamed into a
-                # pipeline that was no longer listening. Same class of
-                # mis-attribution em_turnclock exists to avoid, and it is
-                # persisted, so every HA-side refusal would otherwise show up
-                # in the activity stats as a silent user.
-                if self._run_end_before_stt:
-                    log.info(
-                        f"[{self._log_name}] HA ended the pipeline before it "
-                        f"engaged — recording 'pipeline_refused', not "
-                        f"'no_speech' (audio was captured and streamed)"
-                    )
-                    if trace: trace.outcome = "pipeline_refused"
-                else:
-                    if trace: trace.outcome = "no_speech"
+                # A genuine no-speech turn. An HA run that never started is
+                # caught above by _ha_never_started, so reaching here means
+                # HA was listening and nobody spoke.
+                if trace: trace.outcome = "no_speech"
                 return
 
             # ── Wait for TTS response (or RUN_END / error / timeout) ──────

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1275,27 +1275,50 @@ def test_button_turns_claim_no_wake_word():
         "turns send \"\"")
 
 
-def test_ha_refusal_is_not_recorded_as_no_speech():
+def test_a_run_ha_never_started_ends_the_turn():
     """
-    HA closing the pipeline before it engages is not the user being silent —
-    the audio was captured and streamed into a run that had already ended.
-    Recording it as `no_speech` blames the user and pollutes the persisted
-    activity stats, the same mis-attribution em_turnclock exists to prevent.
+    Home Assistant's satellite setup intercepts a wake word by emitting
+    RUN_END and returning, without ever starting a pipeline. The controller
+    held the microphone anyway until its own timers expired — measured at
+    20.0s (streaming hard cap) and 5.2s (no-speech window) — while HA had
+    re-armed for the next wake word 18ms after ending the first. That is why
+    the setup flow's second "say it again" step landed on a device still
+    listening for the first.
 
-    The flag is recorded on RUN_END and read at give-up time rather than
-    acted on immediately, because a premature RUN_END before STT_START is a
-    real thing HA does mid-turn and ending the turn there would cut genuine
-    turns short.
+    The discriminator is RUN_START, not timing. Measured on hardware, a
+    genuine run is RUN_START (2ms before STT_START) … RUN_END (last, after
+    TTS_END); an interception is RUN_END alone. So a RUN_END with no
+    RUN_START cannot be the premature/duplicate RUN_END the other branch
+    exists for, because that one arrives MID-turn and a mid-turn RUN_END
+    follows the RUN_START that opened it.
+
+    Also: the outcome is `pipeline_refused`, not `no_speech`. The audio was
+    captured and streamed into a run that had already closed, and the outcome
+    is persisted — so `no_speech` would put every HA-side refusal into the
+    activity stats as a silent user.
     """
     src = (CONTROLLER / "em_esphome.py").read_text()
-    assert "_run_end_before_stt" in src, \
-        "no flag records an HA pipeline that ended before it engaged"
+
+    assert "VOICE_ASSISTANT_RUN_START" in src, (
+        "RUN_START must be handled — its absence is what identifies a "
+        "RUN_END that HA emitted without running a pipeline")
+    assert "_run_started" in src and "_ha_never_started" in src, \
+        "no state tracks whether HA ever started the run it just ended"
     assert '"pipeline_refused"' in src, \
-        "an HA-side refusal must get its own outcome, not no_speech"
+        "an HA run that never started must not be recorded as no_speech"
 
     handler = re.search(
         r"VOICE_ASSISTANT_RUN_END:(.*?)elif event_type", src, re.S)
     assert handler, "RUN_END handler not found"
-    assert "_tts_event.set()" not in handler.group(1).split("_run_end_before_stt")[1], (
-        "RUN_END before INTENT_END must stay non-terminal — recording the "
-        "refusal must not start ending turns early")
+    body = handler.group(1)
+
+    assert "if not self._run_started:" in body, (
+        "RUN_END must check whether a RUN_START was ever seen before "
+        "treating itself as terminal")
+
+    # The premature/duplicate branch must stay gated on INTENT_END — acting
+    # on a mid-turn RUN_END would cut genuine turns short.
+    premature = body.split("if not self._run_started:")[1]
+    assert "self._intent_ended or self._turn_cancelled" in premature, (
+        "a RUN_END that DID follow a RUN_START must stay non-terminal until "
+        "INTENT_END — this is the guard against cutting genuine turns")


### PR DESCRIPTION
Follow-up to #180, found testing it on hardware.

The satellite setup flow asks for the wake word twice. #180 made the first step pass; **the second landed on a device still listening for the first**, and only recovered when our own timers gave up.

## What was happening

HA intercepts a wake word by emitting `RUN_END` and returning, without ever starting a pipeline. We received that `RUN_END` and deliberately held it — a premature `RUN_END` before `STT_START` is a real thing HA does mid-turn, and acting on it would cut genuine turns short. So the turn ran to our own limits instead:

```
16:47:08.190  Running pipeline 1 from stt to tts
16:47:08.190  Intercepted wake word: hey jarvis
16:47:08.191  Pipeline finished                    <- RUN_END to us, 1ms in
16:47:08.209  Next wake word will be intercepted   <- HA ready again, 18ms later
16:47:28.192  Requested pipeline stop              <- 20.0s: OUR streaming hard cap
```

HA was armed and waiting 18ms after the first test. The device was not.

## The discriminator is RUN_START, not timing

Measured on hardware, using the add-on debug option that shipped in the same release:

```
16:55:06,697   RUN_START      <- first, 2ms before STT_START
16:55:06,699   STT_START
   ... VAD, STT, INTENT, TTS ...
16:55:19,581   RUN_END        <- last, after TTS_END
```

An interception is `RUN_END` alone. So a `RUN_END` with no `RUN_START` **cannot** be the premature/duplicate case the existing guard exists for: that one arrives mid-turn, and a mid-turn `RUN_END` follows the `RUN_START` that opened it. Structural rather than a race on timing, which is what makes it safe to act on.

`RUN_START` was in the protobuf and in a docstring, and handled nowhere.

Unblocking both waiters mirrors the `ERROR` path — the established shape for "HA is done, stop feeding it".

## It also corrects #180

This replaces `_run_end_before_stt`, which inferred the same thing from the absence of a VAD start. That was deliberately label-only — it could not safely end a turn — and it was **wrong in one case** the new check gets right: a genuine no-speech turn that happened to receive a premature `RUN_END` was recorded as `pipeline_refused` rather than `no_speech`. Reaching the no-speech branch now means HA was listening and nobody spoke.

## Testing

430 tests pass. The guard was verified by reintroducing both failure modes: making `RUN_END` terminal unconditionally, and leaving `RUN_START` unhandled.

Not yet run against a live setup flow — that needs another EA build.