### PR TITLE
Hold the ring briefly when a turn ends instantly

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -836,6 +836,12 @@ _OUTCOME_ANIM = {
     "tts_error":     "error_anim",
     "timeout":       "error_anim",
     "stream_timeout": "error_anim",
+    # Not an error — HA took the wake word and ended the run deliberately,
+    # which the satellite setup flow does on every prompt. Needs a cue
+    # because the turn is over in milliseconds: without one the ring lights
+    # and clears too fast to register, and a device that worked perfectly
+    # looks like it glitched.
+    "pipeline_refused": "ack_anim",
 }
 
 

--- a/controller/em_scenes.py
+++ b/controller/em_scenes.py
@@ -234,6 +234,28 @@ def resolve(config: dict) -> dict:
             "pattern": "pulse", "colors": outcome_colors,
             "periodMs": 220, "ttlSec": 1,
         },
+        # A steady hold — "heard you, nothing more to do."
+        #
+        # Solid rather than a pulse on purpose: the two cues above are
+        # OUTCOMES and their rhythm says something went wrong or unheard.
+        # This one is an acknowledgement, and holding the listening colour
+        # steady reads as a continuation of the listening ring rather than a
+        # new signal to decode.
+        #
+        # It exists because a turn can now end in milliseconds. Home
+        # Assistant's satellite setup intercepts the wake word and ends the
+        # run immediately, so the ring lit and cleared inside ~100ms and read
+        # as a glitch — the device looked broken at exactly the moment it was
+        # working. Before the turn was released promptly it stayed lit only
+        # because the turn was hung, which is feedback by accident.
+        #
+        # 1s is the TTL floor the device supports and comfortably shorter
+        # than the gap between setup's two wake word prompts (measured at
+        # 3.0s and 5.6s on hardware), so it cannot bleed into the next one.
+        "ack_anim":       {
+            "pattern": "solid", "colors": outcome_colors,
+            "ttlSec": 1,
+        },
     }
 
 

--- a/controller/tests/test_scenes.py
+++ b/controller/tests/test_scenes.py
@@ -133,3 +133,29 @@ def test_outcome_cues_are_self_clearing_and_distinct():
         assert 0 < a["ttlSec"] <= 2
     assert ns["periodMs"] != err["periodMs"]
     assert err["periodMs"] < ns["periodMs"]   # error reads as more agitated
+
+
+def test_ack_cue_is_a_steady_hold_not_a_rhythm():
+    """
+    The acknowledgement cue says "heard you, nothing more to do" — it is not
+    an outcome, so it must not borrow the rhythm the outcome cues use to mean
+    something is wrong or was unheard.
+
+    It exists because a turn can end in milliseconds: Home Assistant's
+    satellite setup intercepts the wake word and ends the run immediately, so
+    the ring lit and cleared inside ~100ms and read as a glitch on a device
+    that was working. It stayed lit before only because the turn was hung.
+
+    Self-clearing like the others, and short enough not to bleed into the
+    next prompt — setup's two wake word tests were 3.0s and 5.6s apart on
+    hardware.
+    """
+    scene = em_scenes.resolve({})
+    ack = scene["ack_anim"]
+
+    assert ack["pattern"] == "solid", \
+        "a pulse would read as an outcome signal, which this is not"
+    assert "periodMs" not in ack, "a steady hold has no rhythm to carry"
+    assert 0 < ack["ttlSec"] <= 2, \
+        "must retire on the device's own ticker, and well inside the gap " \
+        "between the setup flow's two wake word prompts"


### PR DESCRIPTION
Follow-up to #182, found in the same hardware session.

#182 releases the turn as soon as Home Assistant ends a run it never started — which the satellite setup flow does on **every** wake word prompt. So the ring now lights and clears inside ~100ms and reads as a glitch, on a device that just worked perfectly.

Reported as: *"the led ring lights so briefly it feels like its glitching, we need it to stay lit long enough that it feels like it's worked, but not so long it interrupts the flow of waiting for the second wakeword test."*

Worth being explicit about what happened: before #182 the ring stayed lit **only because the turn was hung**, waiting for speech nothing was listening to. That was feedback by accident, and fixing the hang removed it. The cue is the deliberate replacement.

## The cue

`pipeline_refused` gets `ack_anim` — **solid, not a pulse.**

The two existing cues are *outcomes*, and their rhythm carries the meaning: fast blinks for something went wrong, one slow throb for nothing heard. This is an acknowledgement, not an outcome. Holding the listening colour steady reads as a continuation of the listening ring rather than a new signal to decode — and it keeps rhythm meaning what it already means.

**1s TTL.** Self-clearing on the device's own ticker like the others, so there is no follow-up message to lose if the controller dies. Sized against the real gap between setup's two wake word prompts, measured on hardware at **3.0s and 5.6s** — long enough to register, comfortably short of the next prompt.

## Testing

431 tests pass. `test_ack_cue_is_a_steady_hold_not_a_rhythm` pins that it is solid, carries no `periodMs`, and self-clears — the three properties that distinguish it from the outcome cues it sits beside.

Needs an EA build to see on hardware.