### PR TITLE
Stop repeating the device label in every entity name

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -417,7 +417,14 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             yield api_pb2.ListEntitiesMediaPlayerResponse(
                 object_id="media_player",
                 key=MEDIA_PLAYER_KEY,
-                name=self.label,
+                # Empty, not the label. HA sets _attr_has_entity_name = True
+                # for every esphome entity and composes "<device> <entity>"
+                # itself, so a label here is rendered TWICE — "Lounge Voice
+                # Assistant Lounge". An empty name is HA's own convention for
+                # the device's primary entity (entity.py:
+                # `self._attr_name = static_info.name or None`), which renders
+                # as the device name alone.
+                name="",
                 supports_pause=True,
                 feature_flags=MEDIA_PLAYER_FEATURES,
                 supported_formats=[
@@ -440,7 +447,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 yield api_pb2.ListEntitiesEventResponse(
                     object_id="action_button",
                     key=EVENT_KEY,
-                    name=f"{self.label} Action Button",
+                    name="Action Button",
                     device_class="button",
                     event_types=BUTTON_EVENT_TYPES,
                 )
@@ -450,7 +457,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 yield api_pb2.ListEntitiesSensorResponse(
                     object_id="ambient_light",
                     key=AMBIENT_LUX_KEY,
-                    name=f"{self.label} Ambient Light",
+                    name="Ambient Light",
                     unit_of_measurement="lx",
                     accuracy_decimals=0,
                     device_class="illuminance",

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1322,3 +1322,36 @@ def test_a_run_ha_never_started_ends_the_turn():
     assert "self._intent_ended or self._turn_cancelled" in premature, (
         "a RUN_END that DID follow a RUN_START must stay non-terminal until "
         "INTENT_END — this is the guard against cutting genuine turns")
+
+
+def test_entity_names_do_not_repeat_the_device_label():
+    """
+    Home Assistant sets `_attr_has_entity_name = True` for every esphome
+    entity and composes "<device name> <entity name>" itself. Our device name
+    is already "<label> Voice Assistant", so putting the label in the entity
+    name too renders it twice:
+
+        'EA Test Device 01 Voice Assistant EA Test Device 01 Ambient Light'
+        'Lounge Voice Assistant Lounge'
+
+    Observed on every device and every entity (2026-08-16). em_ble_proxy had
+    it right all along with a bare "BLE advertisements", which is what makes
+    this a slip rather than a misunderstanding.
+
+    An empty name is HA's convention for the device's primary entity —
+    `self._attr_name = static_info.name or None` in esphome/entity.py — and
+    renders as the device name alone, so the media player is deliberately
+    "" rather than a label.
+    """
+    src = (CONTROLLER / "em_esphome.py").read_text()
+
+    block = re.search(r"ListEntitiesMediaPlayerResponse\((.*?)ListEntitiesDoneResponse",
+                      src, re.S)
+    assert block, "the ListEntities block was not found"
+    body = block.group(1)
+
+    assert "self.label" not in body, (
+        "an entity name must not include the device label — HA already "
+        "prefixes the device name, so it renders twice")
+    assert 'name=""' in body, \
+        "the media player should take the device's own name"


### PR DESCRIPTION
Home Assistant sets `_attr_has_entity_name = True` for every esphome entity and composes `<device name> <entity name>` itself. Our device name is already `<label> Voice Assistant`, so putting the label in the entity name too renders it **twice** — on every device, for every entity:

```
'EA Test Device 01 Voice Assistant EA Test Device 01 Ambient Light'
'EA Test Device 01 Voice Assistant EA Test Device 01 Action Button'
'Lounge Voice Assistant Lounge'
```

Not new — it has been true for every device since these entities existed. It surfaced while resolving which serial was which after a rename.

`em_ble_proxy` had it right all along with a bare `"BLE advertisements"`, which is what makes this a slip rather than a misunderstanding of the convention.

## The media player takes an empty name

Not a bare label. An empty name is HA's convention for a device's *primary* entity:

```python
# homeassistant/components/esphome/entity.py
self._attr_name = static_info.name or None
```

`None` renders as the device name alone, so the media player becomes `EA Test Device 01 Voice Assistant` rather than `… Voice Assistant Media Player`. HA's own comment two lines above anticipates exactly this case.

## What this does and does not change

**Entity keys are untouched**, which is the part that matters for anyone already running this. HA keys its registry on them, so registry rows survive and **entity_ids do not change** — existing automations keep working, and only the displayed name updates.

- A user who renamed an entity by hand has `name_by_user` set, which overrides this and is left alone.
- Existing installs keep the entity_ids they were created with (`sensor.office_ea_test_device_01_…`). Only new installs get clean ones. Renaming existing entity_ids would break automations for a cosmetic gain, so it is deliberately not done.

## Testing

431 tests pass. `test_entity_names_do_not_repeat_the_device_label` asserts no entity name in the `ListEntities` block references `self.label`, and that the media player takes `""`. Verified by reintroducing the prefix.