### PR TITLE
Stop a wake word change from killing the device

### DIFF
--- a/device/internal/wakeword/shadow/shadow.go
+++ b/device/internal/wakeword/shadow/shadow.go
@@ -106,6 +106,15 @@ type Scorer struct {
 	ch   chan []int16
 	done chan struct{}
 	stop sync.Once
+	// quit ends the scorer goroutine. Close must NOT close `ch`: the mic
+	// goroutine captures the scorer pointer once per stream (see
+	// DataClient.startMicStream) and keeps pushing to it, so closing the
+	// channel it sends on panics the process on the next 80ms frame.
+	quit chan struct{}
+	// closed makes enqueue a no-op after Close. Not required for safety once
+	// `ch` is never closed — a send into a buffered channel nobody reads is
+	// harmless — but it stops a dead scorer silently accruing drop counts.
+	closed atomic.Bool
 
 	// closer releases the inference engine, when one owns resources (the ORT
 	// sessions). Nil for an injected Inferer, e.g. in tests.
@@ -153,6 +162,7 @@ func NewScorer(inf wakeword.Inferer, threshold float32, onCross func(score, thre
 		onCross:   onCross,
 		ch:        make(chan []int16, queueFrames),
 		done:      make(chan struct{}),
+		quit:      make(chan struct{}),
 	}
 	go s.run()
 	return s
@@ -223,6 +233,12 @@ func (s *Scorer) PushBytes(b []byte) {
 // happen — deliberately one place, so "never block the audio path" is a
 // property of one function rather than a convention.
 func (s *Scorer) enqueue(cp []int16) {
+	// A closed scorer still receives frames: the mic goroutine holds the
+	// pointer it captured when the stream started, and a config push can
+	// replace and close it mid-stream.
+	if s.closed.Load() {
+		return
+	}
 	// Producer cadence, measured here rather than in Push/PushBytes so both
 	// entry points are covered by one site — the same reason drops are counted
 	// in exactly one place.
@@ -286,7 +302,8 @@ func (s *Scorer) Info() string { return s.info }
 // those can overlap.
 func (s *Scorer) Close() {
 	s.stop.Do(func() {
-		close(s.ch)
+		s.closed.Store(true)
+		close(s.quit)
 		<-s.done
 		// After the goroutine has exited, so no inference is in flight.
 		if s.closer != nil {
@@ -297,7 +314,13 @@ func (s *Scorer) Close() {
 
 func (s *Scorer) run() {
 	defer close(s.done)
-	for pcm := range s.ch {
+	for {
+		var pcm []int16
+		select {
+		case <-s.quit:
+			return
+		case pcm = <-s.ch:
+		}
 		s.mu.Lock()
 		reset := s.resetReq
 		s.resetReq = false

--- a/device/internal/wakeword/shadow/shadow_test.go
+++ b/device/internal/wakeword/shadow/shadow_test.go
@@ -522,3 +522,36 @@ func TestCrossingReportsTheThresholdItCleared(t *testing.T) {
 			"actually cleared, not the nominal one", got[1])
 	}
 }
+
+// TestCloseDuringPushDoesNotPanic reproduces the crash a wake word change
+// caused on hardware (2026-08-16).
+//
+// The mic goroutine captures the scorer pointer ONCE per stream and keeps
+// pushing to it for the life of that stream. A config push replaces the
+// scorer and closes the old one underneath it. While Close() closed the
+// channel enqueue sends on, the next 80ms frame panicked the process with
+// "send on closed channel" — the device died and start_server.sh restarted
+// it seconds later, which read as "changing the wake word crashes the Dot".
+//
+// Present since shadow mode shipped and latent because it needs BOTH
+// on-device scoring active AND the model changed.
+func TestCloseDuringPushDoesNotPanic(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		s := NewScorer(&fakeInferer{score: 0.1}, 0.5, func(float32, float32, time.Time) {})
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() { // the mic goroutine, holding the pointer it started with
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				s.Push(make([]int16, 1280))
+			}
+		}()
+
+		time.Sleep(time.Duration(i%5) * time.Millisecond)
+		s.Close() // the config push
+		wg.Wait()
+
+		s.Close() // documented as safe to call twice
+	}
+}


### PR DESCRIPTION
Changing a device's wake word while on-device scoring was running panicked the firmware with `send on closed channel`. The process died and `start_server.sh` restarted it ~6s later — which presents as the Dot vanishing and coming back, or as a device that crashed and did not return.

Found on hardware today while testing a local build (2026-08-16).

## Two reasonable pieces that are fatal together

**`DataClient.startMicStream` captures the scorer pointer once per stream** and keeps pushing to it — deliberately, and the comment says so:

```go
// the pointer only changes on a config push, which also restarts nothing,
// so a stream that began before the change keeps using the scorer it
// started with until the next StartMic.
shadowScorer := d.ShadowScorer()
```

**`SetShadowScorer` swaps the pointer and calls `old.Close()`**, which closed the channel `enqueue` sends on.

So the mic goroutine goes on pushing into a channel that has just been closed underneath it, and the next 80ms frame takes the process down. *"Keeps using the scorer it started with"* is precisely what makes it fatal.

Controller log, both devices, every time:

```
19:32:53,212  OWW model → hey_mycroft_v0.1 — bouncing HA connection
19:32:53,362  Device disconnected: 80440EFF      ← 150ms after the push
19:32:59,696  Device connected: v2.11.0-97…      ← restarted 6.3s later
```

## The fix

`Close` no longer closes `ch`. The goroutine ends via a dedicated `quit` channel, and `enqueue` drops frames once `closed` is set — so a scorer can be retired while a producer still holds it, which is the situation the call site creates **by design**. Sends into a buffered channel nobody reads are harmless, and the whole thing is collected.

Fixing it in the Scorer rather than at the call site is deliberate: it makes the lifetime safe however callers hold the pointer, instead of depending on every future call site getting the ordering right.

## Pre-existing, and newly urgent

Identical in v2.11.0, and present since shadow mode shipped in **v2.9.10 on 2026-07-30**. It stayed latent because it needs *both* on-device scoring active *and* the wake word changed.

It matters now because **the next firmware release un-greys "On device" for everyone** — turning a bug almost nobody could reach into one that is easy to hit. This should land before v2.12.0 is tagged.

## Testing

`TestCloseDuringPushDoesNotPanic` pushes from a goroutine holding the pointer while `Close` runs, across a spread of timings, 50 iterations. Verified by reverting the fix:

```
panic: send on closed channel
FAIL	github.com/wilbowes/EchoMuse/internal/wakeword/shadow
```

Full device suite and `go vet` clean. Needs hardware confirmation — a build is going onto the same two test devices that reproduced it.