### PR TITLE
Focus the console when the tab opens

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -688,6 +688,12 @@ function Shell({ deviceId, token, height = 320 }) {
     term.loadAddon(fit);
     term.open(containerRef.current);
     fit.fit();
+    // Take the caret straight away. Shell is mounted only while the Console
+    // tab is selected (see `tab === 'console'`), so this component existing
+    // IS the user asking for a terminal — there is nothing else on the tab
+    // that could reasonably want focus, and without it every visit starts
+    // with a click that does nothing except tell xterm you meant it.
+    term.focus();
 
     const sock = new WebSocket(ingressWebSocketUrl(`/api/devices/${deviceId}/shell?token=${token}`));
     sock.binaryType = 'arraybuffer';


### PR DESCRIPTION
Clicking the **Console** tab put a terminal on screen that did not have the caret, so every visit began with a click that did nothing except tell xterm you meant it.

`Shell` is mounted only while `tab === 'console'`, so the component existing *is* the request for a terminal — there is nothing else on that tab that could reasonably want focus. One `term.focus()` after `fit.fit()`.

Verified the JSX still compiles with the same esbuild invocation the Dockerfile uses. 439 controller tests pass.