### PR TITLE
Deliver frames to the scorer that is actually installed

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -688,6 +688,12 @@ function Shell({ deviceId, token, height = 320 }) {
     term.loadAddon(fit);
     term.open(containerRef.current);
     fit.fit();
+    // Take the caret straight away. Shell is mounted only while the Console
+    // tab is selected (see `tab === 'console'`), so this component existing
+    // IS the user asking for a terminal — there is nothing else on the tab
+    // that could reasonably want focus, and without it every visit starts
+    // with a click that does nothing except tell xterm you meant it.
+    term.focus();
 
     const sock = new WebSocket(ingressWebSocketUrl(`/api/devices/${deviceId}/shell?token=${token}`));
     sock.binaryType = 'arraybuffer';

--- a/device/internal/client/data.go
+++ b/device/internal/client/data.go
@@ -568,15 +568,19 @@ func (d *DataClient) streamMic(conn *websocket.Conn, stopCh <-chan struct{}, loc
 	gainDb := -1
 	gainLin := 1.0
 
-	// On-device shadow scoring, read once per stream rather than per period:
-	// the pointer only changes on a config push, which also restarts nothing,
-	// so a stream that began before the change keeps using the scorer it
-	// started with until the next StartMic. Reset because a StopMic/StartMic
-	// pair happens after every voice turn and the detector must not splice
-	// across the gap.
-	shadowScorer := d.ShadowScorer()
-	if shadowScorer != nil {
-		shadowScorer.Reset()
+	// On-device shadow scoring. Reset at stream start because a
+	// StopMic/StartMic pair happens after every voice turn and the detector
+	// must not splice across the gap.
+	//
+	// The pointer is re-read PER FRAME below, not captured here. It used to be
+	// captured, on the reasoning that a stream which began before a config
+	// change could keep using the scorer it started with — but a config change
+	// CLOSES that scorer, so the stream went on feeding a dead one and the
+	// newly installed scorer never saw a single frame. Wake word detection
+	// then stayed dead until the next StartMic, which only follows a voice
+	// turn, which could not happen because the wake word was dead.
+	if sc := d.ShadowScorer(); sc != nil {
+		sc.Reset()
 	}
 
 	sendFrame := func(payload []byte) {
@@ -798,8 +802,10 @@ func (d *DataClient) streamMic(conn *websocket.Conn, stopCh <-chan struct{}, loc
 					// PushBytes never blocks: it drops when the scorer is
 					// behind rather than delaying this loop, which reads
 					// 160ms ALSA batches out of a 160ms-deep ring.
-					if shadowScorer != nil {
-						shadowScorer.PushBytes(buf[:vadOwwChunkBytes])
+					// Re-read per frame: a config push can swap the scorer
+					// mid-stream, and the replaced one is closed.
+					if sc := d.ShadowScorer(); sc != nil {
+						sc.PushBytes(buf[:vadOwwChunkBytes])
 					}
 					sendFrame(buf[:vadOwwChunkBytes])
 					buf = buf[vadOwwChunkBytes:]


### PR DESCRIPTION
Follow-up to #187, found on hardware within hours of it shipping. **These two belong in the same firmware release** — #187 alone leaves the device worse off in one specific way.

## #187 removed a crash that was accidentally load-bearing

The mic stream captures the scorer pointer **once per stream** (`DataClient.startMicStream`), and the comment says why:

```go
// the pointer only changes on a config push, which also restarts nothing,
// so a stream that began before the change keeps using the scorer it
// started with until the next StartMic.
```

But a config change **closes** that scorer. So:

| | what happened on a wake word change |
|---|---|
| **before #187** | next frame panicked on a closed channel → process restarted in ~6s → fresh mic stream picked up the new scorer → **worked** |
| **after #187** | `enqueue` drops silently → the new scorer receives **nothing** → detection dead until the next `StartMic` |

And `StartMic` only follows a voice turn, which cannot happen, because the wake word is dead. So it never recovers — a reboot is the only way out.

The crash was self-healing. Removing it exposed the real bug underneath, which had been masked for as long as the panic existed.

## The fix

Re-read the pointer per frame instead of caching it. A mutex read every 80ms is nothing next to the inference it feeds, and the reasoning for caching — that a stream should keep the scorer it started with — was the mistaken part.

## Verified on hardware

Three wake word changes in a row, each triggering from the device, no reboot between them:

```
20:30:03  on-device wake: score=0.699  (device triggered)
20:30:11  on-device wake: score=0.566  (device triggered)
20:30:50  on-device wake: score=0.799  (device triggered)
```

The previous build went deaf after the first change and stayed that way. Full device suite and `go vet` clean.