### PR TITLE
Stop the asset push shadowing its own accumulator

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -3511,10 +3511,16 @@ async def _sync_oww_assets(live, device_id: str, progress=None) -> dict:
 
         dest = em_oww_assets.device_path(asset.name)
         part = f"{dest}.part"
-        pushed = await _stream_file_to_device(live, data, part, mode="644")
-        if not pushed:
-            await say("error", f"{asset.name} transfer failed: {pushed}")
-            return {"ok": False, "error": f"{asset.name}: {pushed}"}
+        # NOT `pushed` — that is the accumulator above, and assigning the
+        # transfer result to it shadowed the list on the first file, so the
+        # append below raised AttributeError and asset installation failed
+        # outright. TransferResult is truthy-compatible, which is what let
+        # this reach a release: every `if not …` call site kept working and
+        # only the one that treated it as a list broke.
+        sent = await _stream_file_to_device(live, data, part, mode="644")
+        if not sent:
+            await say("error", f"{asset.name} transfer failed: {sent}")
+            return {"ok": False, "error": f"{asset.name}: {sent}"}
 
         res = await _shell_run(live, (
             f'GOT=$(busybox md5sum {part} | busybox cut -d" " -f1); '

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1355,3 +1355,32 @@ def test_entity_names_do_not_repeat_the_device_label():
         "prefixes the device name, so it renders twice")
     assert 'name=""' in body, \
         "the media player should take the device's own name"
+
+
+def test_asset_sync_does_not_shadow_its_accumulator():
+    """
+    _sync_oww_assets keeps a `pushed` list of installed asset names. Assigning
+    the per-file transfer result to that same name shadowed the list on the
+    FIRST file, so the append at the end of the loop raised
+    AttributeError: 'TransferResult' object has no attribute 'append'
+    and on-device wake word assets could not be installed at all.
+
+    It reached a release because TransferResult is deliberately truthy-
+    compatible so existing `if not …` call sites keep working — which is
+    exactly why the one call site that treated the result as a list was the
+    only thing that broke, and nothing else complained.
+
+    Found on hardware 2026-08-16: a device reporting "classifier model not
+    installed" while the dashboard offered to send it and returned 500.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+    fn = re.search(r"async def _sync_oww_assets\(.*?\n(?=\nasync def |\ndef )",
+                   src, re.S)
+    assert fn, "_sync_oww_assets not found"
+    body = fn.group(0)
+
+    assert "pushed = []" in body, "the accumulator is gone"
+    assert "pushed.append(" in body, "nothing accumulates installed names"
+    assert not re.search(r"pushed\s*=\s*await\s+_stream_file_to_device", body), (
+        "the transfer result must not be assigned to `pushed` — that shadows "
+        "the accumulator and the append raises AttributeError")


### PR DESCRIPTION
Installing on-device wake word assets fails outright:

```
File "/app/em_api.py", line 3527, in _sync_oww_assets
AttributeError: 'TransferResult' object has no attribute 'append'
```

`_sync_oww_assets` keeps a `pushed` list of installed asset names, and the per-file transfer result was assigned to **that same name**:

```python
pushed = []                                     # accumulator
...
pushed = await _stream_file_to_device(...)      # shadows it, first file
...
pushed.append(asset.name)                       # AttributeError
```

**Every push of a wake word classifier 500s.** Live in GA 2.20.0.

## Why it survived

`TransferResult` is deliberately truthy-compatible so existing `if not …` call sites keep working — that is the right design, and it is exactly why nothing else complained. The only call site that broke is the one treating the result as a list.

## What it costs in practice

Found on hardware: a device logging `classifier model not installed at …/hey_mycroft_v0.1.onnx` while the dashboard offered to send that very file and returned 500.

Provisioning installs the runtime, the shared models and the classifier for the wake word configured **at that moment**. Change the wake word afterwards and the device needs a classifier it has never had — and this is the only path that installs it.

With `owwOnDevice=on` the result is a device with **no wake word at all**: it cannot score without the classifier, and the controller no longer triggers on its behalf. Silent, with the dashboard reporting nothing wrong.

## Testing

440 tests pass. `test_asset_sync_does_not_shadow_its_accumulator` pins the accumulator, the append, and that the transfer result is not assigned over it. Verified by reintroducing the assignment.