### PR TITLE
Say what an Early Access entry is built on

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.20.0-ea.6 — Early Access
 
+An Early Access build on top of 2.20.0. The 2.20.0 notes below are the
+release this builds on — you already have them if you were running an
+earlier Early Access build.
+
 - **Installing wake word models on a device works again.** Sending a wake
   word model to an Echo failed with an internal error, every time. If you
   changed a device's wake word to one it had not been given during setup, it

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.20.0-ea.6 — Early Access
 
+An Early Access build on top of 2.20.0. The 2.20.0 notes below are the
+release this builds on — you already have them if you were running an
+earlier Early Access build.
+
 - **Installing wake word models on a device works again.** Sending a wake
   word model to an Echo failed with an internal error, every time. If you
   changed a device's wake word to one it had not been given during setup, it


### PR DESCRIPTION
Supervisor renders the whole `CHANGELOG.md` in the add-on update dialog. So updating Early Access from `ea.5` to `ea.6` showed this:

```
## 2.20.0-ea.6 — Early Access     <- what you are actually getting
## 2.20.0                          <- ~98 lines you already have
   ### Early Access prereleases    <- the note explaining that, at the bottom
```

Not wrong — one program, one changelog, newest first, and `ea.6` does come after `2.20.0`. But it reads as though the entire GA release is part of the update, and the sentence that says otherwise is a hundred lines down.

One line at the top of the EA entry fixes the reading. **Deliberately not a second changelog file**: two files describing one program is #160's failure, and `sync_channels.py` copies this one verbatim so it cannot drift.

Worth deciding separately (not here): whether folding EA entries into a GA section at release time is the right model at all, given the channel guard requires each channel's changelog to name the version it pins. That tension is what produced this.