### PR TITLE
Serialise pipeline runs across a barge-in

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -80,6 +80,7 @@ COPY em_player.py .
 COPY em_config_sections.py .
 COPY em_recordings.py .
 COPY em_turnclock.py .
+COPY em_runbarrier.py .
 COPY em_volume.py .
 COPY version.py .
 # ESPHome native API subpackage (frame protocol, message registry, vendored protobuf)

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -1066,11 +1066,20 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
                     device.cancel_event.set()
                     if in_playback:
                         await device.send_control({"type": "speaker_flush"})
+                        # HA's run is normally over by now (RUN_END follows
+                        # TTS_END, and we only reach playback at TTS_END), but
+                        # a barge in the first milliseconds of audio can beat
+                        # it. Serialise anyway — the interrupting turn is the
+                        # thing that pays if we lose that race.
+                        esphome.abort_ha_run(device.device_id)
                     else:
-                        # Nothing is playing — abort the in-flight HA
-                        # pipeline instead (local-only; a late HA result is
-                        # discarded on arrival).
-                        esphome.cancel_voice_turn(device.device_id)
+                        # Nothing is playing — HA is mid-pipeline, and an
+                        # interrupting turn is about to start on the same
+                        # connection. The protocol carries no run id, so the
+                        # old run MUST be aborted upstream first or its tail
+                        # events land on the new turn and kill it
+                        # (pipeline_refused, 5 of 5 attempts, 2026-08-17).
+                        esphome.cancel_voice_turn(device.device_id, abort_ha=True)
                     return
     finally:
         rms_mean = rms_sum / frames if frames else 0.0

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -325,6 +325,19 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._intent_ended      = False
         self._run_started       = False
         self._ha_never_started  = False
+        # Barge-in run serialisation. The ESPHome voice protocol carries NO
+        # run identifier — VoiceAssistantEventResponse is event_type + data
+        # and nothing else — so it is designed for strictly one pipeline run
+        # at a time per connection, and the satellite is what enforces that.
+        # HA does not: handle_pipeline_start clears the audio queue and
+        # cancels _tts_streaming_task, then overwrites _pipeline_task WITHOUT
+        # cancelling the old one, so a second start orphans the first run and
+        # leaves it emitting events onto the same socket.
+        #
+        # _abort_pending is armed by cancel_turn(abort_ha=True) and handed to
+        # the next turn as _discard_until_run_start — see _handle_voice_event.
+        self._abort_pending          = False
+        self._discard_until_run_start = False
         # Set on VOICE_ASSISTANT_INTENT_END when HA requests conversation
         # continuation (continue_conversation == "1"). Read by trigger_voice_turn
         # after run_esphome_voice_turn returns to decide whether to re-trigger
@@ -655,6 +668,30 @@ class EchoMuseSatellite(SatelliteServerProtocol):
 
         log.debug(f"[{self._log_name}] VoiceAssistantEvent type={event_type} data={data}")
 
+        if self._discard_until_run_start:
+            # We aborted a run and started another. HA acknowledges an abort
+            # with NO wire message at all (_abort_pipeline just cancels the
+            # task), so the barrier has to be ordering rather than timing:
+            # discard everything until the next RUN_START, which is
+            # necessarily ours — HA emits RUN_START only when it creates a
+            # pipeline, we created exactly one more, and the connection is
+            # processed in order.
+            #
+            # Without it the aborted run's tail lands on the new turn: its
+            # RUN_END arrives ~4ms after we start, _run_started is False for
+            # the new turn, and the "HA ended a run it never started" branch
+            # below reads it as terminal. Every barge-in then ended
+            # pipeline_refused with zero audio captured (measured 2026-08-17,
+            # 5 of 5 attempts).
+            if event_type != ET.VOICE_ASSISTANT_RUN_START:
+                log.debug(
+                    f"[{self._log_name}] Discarding event {event_type} from the "
+                    f"aborted run — waiting for our RUN_START"
+                )
+                return
+            self._discard_until_run_start = False
+            log.debug(f"[{self._log_name}] Aborted run drained — our RUN_START seen")
+
         if event_type == ET.VOICE_ASSISTANT_STT_VAD_START:
             # HA's model-driven VAD heard speech begin — authoritative
             # counterpart to the controller's SNR-relative check in
@@ -879,6 +916,13 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._intent_ended          = False
         self._run_started           = False
         self._ha_never_started      = False
+        # Hand a pending abort to this turn: every event is discarded until
+        # our own RUN_START arrives. Deliberately NOT reset to False here —
+        # the arm is set during the PREVIOUS turn (at the barge) and has to
+        # survive this reset to reach the turn it protects. Bounded to
+        # exactly one turn: cleared unconditionally in the finally below.
+        self._discard_until_run_start = self._abort_pending
+        self._abort_pending           = False
         self._continue_conversation = False
         self._no_speech_timeout     = False
         self._ha_vad_end.clear()
@@ -1049,6 +1093,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 # the feed is actually up.
                 self._send_one(self._media_state_msg())
             self._turn_active    = False
+            self._discard_until_run_start = False
             self._on_thinking    = None
             self._on_announce    = None
             self._trace          = None
@@ -1398,20 +1443,56 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         if self._transport and not self._transport.is_closing():
             self._transport.close()
 
-    def cancel_turn(self) -> None:
+    def cancel_turn(self, abort_ha: bool = False) -> None:
         """
-        Cancel an in-flight voice turn — local only, no upstream signal.
+        Cancel an in-flight voice turn.
 
-        Per ESPHOME_SPEC.md §7.4: the ESPHome protocol has no server-side
-        abort mechanism. cancel_turn() stops local state only; any in-flight
-        HA pipeline generation is left to complete and its result discarded
-        on arrival — the cancel is local-only; nothing reaches into HA's
-        in-flight pipeline.
+        abort_ha=False is local-only: HA's pipeline is left to complete and
+        its result discarded on arrival. Correct when nothing follows this
+        turn, or when HA has already finished (a barge during PLAYBACK — the
+        run ended at RUN_END and only our speaker is still busy).
+
+        abort_ha=True additionally sends VoiceAssistantRequest(start=False).
+        aioesphomeapi maps that to handle_stop(True) → HA's _abort_pipeline(),
+        which queues the audio-stream sentinel AND cancels _pipeline_task. It
+        is required before starting another turn on this connection, because
+        the protocol has no run id and HA does not serialise runs itself.
+
+        (An earlier docstring here claimed the protocol has no server-side
+        abort, citing an ESPHOME_SPEC.md §7.4 that no longer exists in the
+        tree. It does have one; we simply never sent it.)
         """
-        if self._turn_active:
+        if not self._turn_active:
+            return
+        if abort_ha:
+            self.abort_ha_run()
+            log.info(f"[{self._log_name}] Turn cancelled (HA pipeline aborted)")
+        else:
             log.info(f"[{self._log_name}] Turn cancelled (local only)")
-            self._turn_cancelled = True
-            self._tts_event.set()  # unblock any waiting coroutine
+        self._turn_cancelled = True
+        self._tts_event.set()  # unblock any waiting coroutine
+
+    def abort_ha_run(self) -> None:
+        """
+        Abort HA's pipeline and arm the run barrier, without touching local
+        turn state.
+
+        Split out of cancel_turn because a barge during PLAYBACK must not mark
+        the turn cancelled — the response was delivered and the trace outcome
+        should say so — but still has to serialise against the interrupting
+        turn. HA's RUN_END lands after TTS_END, so it is usually consumed by
+        the still-active turn before the barge; "usually" is not a guarantee,
+        and the cost of losing that race is the whole interrupting turn.
+
+        Aborting an already-finished pipeline is harmless: _abort_pipeline
+        cancels a completed task (a no-op) and queues a sentinel into a queue
+        that handle_pipeline_start drains before the next run.
+        """
+        if self._transport and not self._transport.is_closing():
+            self._send_one(api_pb2.VoiceAssistantRequest(start=False))
+        # Armed even if the transport is gone: the barrier is cheap, and a
+        # reconnect that replays events is exactly when it earns its keep.
+        self._abort_pending = True
 
 
 # ─── TTS audio fetch ─────────────────────────────────────────────────────────
@@ -2123,12 +2204,16 @@ async def trigger_voice_turn(
     return satellite._continue_conversation
 
 
-def cancel_voice_turn(device_id: str) -> None:
+def cancel_voice_turn(device_id: str, abort_ha: bool = False) -> None:
     """
     Cancel an in-flight ESPHome voice turn for a device.
 
-    Local-only per ESPHOME_SPEC.md §7.4 — does not signal HA.
-    Called from em_controller.handle_button_event() when voice_lock is held.
+    abort_ha=True also aborts HA's pipeline — pass it whenever another turn
+    is going to start on this connection (barge-in during thinking). See
+    EchoMuseSatellite.cancel_turn.
+
+    Called from em_controller.handle_button_event() when voice_lock is held,
+    and from _barge_watcher.
     """
     server = get_server(device_id)
     if server is None:
@@ -2136,7 +2221,25 @@ def cancel_voice_turn(device_id: str) -> None:
     satellite = server.get_satellite()
     if satellite is None:
         return
-    satellite.cancel_turn()
+    satellite.cancel_turn(abort_ha=abort_ha)
+
+
+def abort_ha_run(device_id: str) -> None:
+    """
+    Abort HA's in-flight pipeline without cancelling the local turn.
+
+    For a barge during playback: the response was delivered, so the turn is
+    not "cancelled", but an interrupting turn is about to start on the same
+    connection and the protocol serialises runs at the satellite or not at
+    all. See EchoMuseSatellite.abort_ha_run.
+    """
+    server = get_server(device_id)
+    if server is None:
+        return
+    satellite = server.get_satellite()
+    if satellite is None:
+        return
+    satellite.abort_ha_run()
 
 
 async def push_media_state(device_id: str, state: str) -> None:

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -70,6 +70,7 @@ import em_api as api
 import em_hostip
 import em_ns
 import em_recordings
+import em_runbarrier
 import em_oww_models
 import em_player
 import em_turnclock
@@ -325,19 +326,11 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._intent_ended      = False
         self._run_started       = False
         self._ha_never_started  = False
-        # Barge-in run serialisation. The ESPHome voice protocol carries NO
-        # run identifier — VoiceAssistantEventResponse is event_type + data
-        # and nothing else — so it is designed for strictly one pipeline run
-        # at a time per connection, and the satellite is what enforces that.
-        # HA does not: handle_pipeline_start clears the audio queue and
-        # cancels _tts_streaming_task, then overwrites _pipeline_task WITHOUT
-        # cancelling the old one, so a second start orphans the first run and
-        # leaves it emitting events onto the same socket.
-        #
-        # _abort_pending is armed by cancel_turn(abort_ha=True) and handed to
-        # the next turn as _discard_until_run_start — see _handle_voice_event.
-        self._abort_pending          = False
-        self._discard_until_run_start = False
+        # Barge-in run serialisation — the protocol has no run id, so the
+        # satellite is what keeps two runs from overlapping on one connection.
+        # See em_runbarrier for the whole reasoning; it is a separate module
+        # because the test suite cannot import this one.
+        self._barrier = em_runbarrier.RunBarrier()
         # Set on VOICE_ASSISTANT_INTENT_END when HA requests conversation
         # continuation (continue_conversation == "1"). Read by trigger_voice_turn
         # after run_esphome_voice_turn returns to decide whether to re-trigger
@@ -668,7 +661,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
 
         log.debug(f"[{self._log_name}] VoiceAssistantEvent type={event_type} data={data}")
 
-        if self._discard_until_run_start:
+        if self._barrier.active:
             # We aborted a run and started another. HA acknowledges an abort
             # with NO wire message at all (_abort_pipeline just cancels the
             # task), so the barrier has to be ordering rather than timing:
@@ -683,13 +676,12 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             # below reads it as terminal. Every barge-in then ended
             # pipeline_refused with zero audio captured (measured 2026-08-17,
             # 5 of 5 attempts).
-            if event_type != ET.VOICE_ASSISTANT_RUN_START:
+            if self._barrier.discards(event_type == ET.VOICE_ASSISTANT_RUN_START):
                 log.debug(
                     f"[{self._log_name}] Discarding event {event_type} from the "
                     f"aborted run — waiting for our RUN_START"
                 )
                 return
-            self._discard_until_run_start = False
             log.debug(f"[{self._log_name}] Aborted run drained — our RUN_START seen")
 
         if event_type == ET.VOICE_ASSISTANT_STT_VAD_START:
@@ -916,13 +908,10 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._intent_ended          = False
         self._run_started           = False
         self._ha_never_started      = False
-        # Hand a pending abort to this turn: every event is discarded until
-        # our own RUN_START arrives. Deliberately NOT reset to False here —
-        # the arm is set during the PREVIOUS turn (at the barge) and has to
-        # survive this reset to reach the turn it protects. Bounded to
-        # exactly one turn: cleared unconditionally in the finally below.
-        self._discard_until_run_start = self._abort_pending
-        self._abort_pending           = False
+        # Takes ownership of an abort armed during the PREVIOUS turn (at the
+        # barge). Deliberately not a plain reset: the arm has to survive this
+        # block to reach the turn it protects.
+        self._barrier.begin_turn()
         self._continue_conversation = False
         self._no_speech_timeout     = False
         self._ha_vad_end.clear()
@@ -1093,7 +1082,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 # the feed is actually up.
                 self._send_one(self._media_state_msg())
             self._turn_active    = False
-            self._discard_until_run_start = False
+            self._barrier.end_turn()
             self._on_thinking    = None
             self._on_announce    = None
             self._trace          = None
@@ -1492,7 +1481,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             self._send_one(api_pb2.VoiceAssistantRequest(start=False))
         # Armed even if the transport is gone: the barrier is cheap, and a
         # reconnect that replays events is exactly when it earns its keep.
-        self._abort_pending = True
+        self._barrier.abort()
 
 
 # ─── TTS audio fetch ─────────────────────────────────────────────────────────

--- a/controller/em_runbarrier.py
+++ b/controller/em_runbarrier.py
@@ -1,0 +1,90 @@
+"""
+em_runbarrier.py — serialising ESPHome pipeline runs across a barge-in.
+
+The ESPHome voice protocol carries NO run identifier. `VoiceAssistantEventResponse`
+is an event type plus a list of name/value pairs and nothing else, so a client
+structurally cannot tell which run an event belongs to. The protocol is built
+for strictly one pipeline run at a time per connection, and the SATELLITE is
+what enforces that.
+
+Home Assistant does not enforce it for us. `handle_pipeline_start` clears the
+audio queue and cancels the TTS streaming task, then overwrites `_pipeline_task`
+*without cancelling the previous one* — so starting a second run orphans the
+first, which keeps emitting events onto the same socket.
+
+Barge-in is the only place we overlap two runs. Measured on 2026-08-17: five
+barge-ins, five interrupting turns dead in 4-17ms with zero audio captured. The
+aborted run's RUN_END arrived ~4ms after the new turn started, the new turn had
+not yet seen a RUN_START of its own, and the "HA ended a run it never started"
+branch read it as terminal.
+
+HA acknowledges an abort with **no wire message at all** (`_abort_pipeline` just
+cancels the task), so the barrier cannot be a timeout. It is ordering: after an
+abort, discard every event until the next RUN_START, which is necessarily ours —
+HA emits RUN_START only when it creates a pipeline, we created exactly one more,
+and the connection is processed in order.
+
+Split out of em_esphome for the reason em_linkauth and em_button.decide are: the
+test suite does not import em_esphome (zeroconf, aiohttp, the database), so
+logic living there has no coverage, and this is a state machine whose two
+failure modes are both silent — swallow too little and the interrupting turn
+dies; swallow too much and the satellite goes deaf.
+"""
+
+
+class RunBarrier:
+    """
+    Two flags and four transitions.
+
+    `armed` is set when a run is aborted, during the turn being abandoned.
+    `active` is the barrier in force, during the turn that follows. They are
+    separate because the arm has to survive the next turn's state reset to
+    reach the turn it protects.
+    """
+
+    __slots__ = ("armed", "active")
+
+    def __init__(self) -> None:
+        self.armed = False
+        self.active = False
+
+    def abort(self) -> None:
+        """A run was aborted upstream; the next turn inherits the barrier."""
+        self.armed = True
+
+    def begin_turn(self) -> None:
+        """
+        Start of a turn. Takes ownership of a pending arm.
+
+        The arm is consumed here rather than merely read, so exactly one turn
+        is ever protected. A barrier that outlived its turn would discard the
+        events of turns that have nothing to do with the abort.
+        """
+        self.active = self.armed
+        self.armed = False
+
+    def end_turn(self) -> None:
+        """
+        End of a turn. Drops the barrier whether or not a RUN_START arrived.
+
+        This is the bound. If HA never sends the RUN_START we are waiting for
+        — the connection dropped, the pipeline failed to start — the barrier
+        must not persist into the next turn, or the satellite discards every
+        event forever and no turn can ever complete again.
+        """
+        self.active = False
+
+    def discards(self, is_run_start: bool) -> bool:
+        """
+        Should this event be dropped?
+
+        RUN_START releases the barrier and is itself DELIVERED, not swallowed:
+        the caller needs it to set `_run_started`, and eating it would re-arm
+        the very bug this exists to fix for the turn's own terminal RUN_END.
+        """
+        if not self.active:
+            return False
+        if is_run_start:
+            self.active = False
+            return False
+        return True

--- a/controller/tests/test_barge_serialisation.py
+++ b/controller/tests/test_barge_serialisation.py
@@ -32,8 +32,6 @@ abort, and only for one turn.
 import re
 from pathlib import Path
 
-import pytest
-
 import em_esphome
 from esphome.vendor import api_pb2
 from esphome.vendor.api_pb2 import VoiceAssistantEvent as ET

--- a/controller/tests/test_barge_serialisation.py
+++ b/controller/tests/test_barge_serialisation.py
@@ -17,254 +17,196 @@ audio captured, because the aborted run's RUN_END arrived ~4ms after the new
 turn started and the "HA ended a run it never started" branch read it as
 terminal.
 
-Two halves are pinned here, and both are needed:
+The state machine lives in `em_runbarrier` rather than in `em_esphome` for the
+reason `em_linkauth.decide` does: this suite cannot import `em_esphome` (it
+pulls in zeroconf, aiohttp and the database), so logic that lives there has no
+coverage. Both of this machine's failure modes are silent — swallow too little
+and the interrupting turn dies, swallow too much and the satellite goes deaf —
+which is exactly the shape that should not be sitting untested inside a big
+async method.
 
-  * the abort actually reaches HA — `VoiceAssistantRequest(start=False)`,
-    which aioesphomeapi maps to `handle_stop(True)` → `_abort_pipeline()`;
-  * the new turn discards the old run's tail until its own RUN_START.
-
-The second half must NOT swallow the setup-flow's genuine
-RUN_END-without-RUN_START, which is a real thing HA does and which
-`_ha_never_started` exists to catch — so the barrier is armed only by an
-abort, and only for one turn.
+The wiring in `em_esphome` is pinned separately, against the source.
 """
 
 import re
 from pathlib import Path
 
-import em_esphome
-from esphome.vendor import api_pb2
-from esphome.vendor.api_pb2 import VoiceAssistantEvent as ET
+from em_runbarrier import RunBarrier
 
-ESPHOME_SRC = Path(em_esphome.__file__).read_text()
-
-
-class FakeTransport:
-    def __init__(self, closing=False):
-        self._closing = closing
-
-    def is_closing(self):
-        return self._closing
+ESPHOME_SRC = (Path(__file__).resolve().parents[1] / "em_esphome.py").read_text()
+CONTROLLER_SRC = (Path(__file__).resolve().parents[1] / "em_controller.py").read_text()
 
 
-def make_satellite():
+# ── The barrier ──────────────────────────────────────────────────────────────
+
+
+def test_an_untouched_barrier_discards_nothing():
     """
-    A satellite with just enough state to drive _handle_voice_event and
-    cancel_turn. Built without __init__ deliberately: the real constructor
-    wants a server, a transport and a device registry, none of which this
-    behaviour touches.
+    The overwhelmingly common case: no barge, no abort, every event delivered.
     """
-    sat = object.__new__(em_esphome.EchoMuseSatellite)
-    sat._log_name = "test"
-    sat._transport = FakeTransport()
-    sat.sent = []
-    sat._send_one = sat.sent.append
-    # Per-turn state, as run_esphome_voice_turn's reset block leaves it.
-    sat._turn_active = True
-    sat._turn_cancelled = False
-    sat._intent_ended = False
-    sat._run_started = False
-    sat._ha_never_started = False
-    sat._continue_conversation = False
-    sat._abort_pending = False
-    sat._discard_until_run_start = False
-    sat._trace = None
-    sat._on_thinking = None
-    sat._on_stt_end = None
-    sat._tts_audio_url = None
-    import asyncio
-
-    sat._tts_event = asyncio.Event()
-    sat._ha_vad_end = asyncio.Event()
-    sat._ha_vad_start = asyncio.Event()
-    return sat
+    b = RunBarrier()
+    b.begin_turn()
+    assert b.discards(is_run_start=False) is False
+    assert b.discards(is_run_start=True) is False
 
 
-def event(event_type, **data):
-    return api_pb2.VoiceAssistantEventResponse(
-        event_type=event_type,
-        data=[api_pb2.VoiceAssistantEventData(name=k, value=v) for k, v in data.items()],
+def test_an_abort_arms_the_NEXT_turn_not_the_current_one():
+    """
+    The abort happens during the turn being abandoned, and that turn still has
+    tearing-down of its own to do. It is the turn AFTER it that must not see
+    the old run's tail.
+    """
+    b = RunBarrier()
+    b.begin_turn()
+    b.abort()
+    assert b.discards(is_run_start=False) is False, "armed the turn doing the aborting"
+    b.end_turn()
+
+    b.begin_turn()
+    assert b.discards(is_run_start=False) is True
+
+
+def test_the_stale_tail_is_discarded_until_run_start():
+    """
+    The measured failure. RUN_END, STT_VAD_END and the orphan's eventual ERROR
+    all arrived on the new turn; each one alone is enough to kill it.
+    """
+    b = RunBarrier()
+    b.abort()
+    b.begin_turn()
+    assert b.discards(is_run_start=False) is True   # stale RUN_END
+    assert b.discards(is_run_start=False) is True   # stale STT_VAD_END
+    assert b.discards(is_run_start=False) is True   # stale ERROR
+
+
+def test_run_start_releases_the_barrier_and_is_itself_delivered():
+    """
+    RUN_START is the release AND a real event. Swallowing it would leave
+    `_run_started` False and re-arm the very bug this fixes, for the turn's
+    own terminal RUN_END.
+    """
+    b = RunBarrier()
+    b.abort()
+    b.begin_turn()
+    assert b.discards(is_run_start=True) is False
+    assert b.active is False
+
+
+def test_everything_after_run_start_is_delivered():
+    b = RunBarrier()
+    b.abort()
+    b.begin_turn()
+    b.discards(is_run_start=False)                  # stale, dropped
+    b.discards(is_run_start=True)                   # ours, releases
+    assert b.discards(is_run_start=False) is False
+    assert b.discards(is_run_start=False) is False
+
+
+def test_the_barrier_does_not_outlive_its_turn():
+    """
+    If HA never sends the RUN_START we are waiting for — connection dropped,
+    pipeline failed to start — the barrier must come down when the turn ends.
+    Events are dispatched whether or not a turn is in progress, so a barrier
+    left standing discards them indefinitely.
+
+    `begin_turn` would also clear it, but only once another turn starts; that
+    is not a bound, because the turn that would clear it is one whose events
+    are being discarded.
+    """
+    b = RunBarrier()
+    b.abort()
+    b.begin_turn()
+    assert b.discards(is_run_start=False) is True
+    b.end_turn()                                    # RUN_START never came
+    assert b.active is False
+    assert b.discards(is_run_start=False) is False
+
+
+def test_the_barrier_is_bounded_to_one_turn():
+    b = RunBarrier()
+    b.abort()
+    b.begin_turn()
+    assert b.discards(is_run_start=False) is True
+    b.end_turn()
+
+    b.begin_turn()
+    assert b.discards(is_run_start=False) is False
+
+
+def test_an_arm_is_consumed_not_merely_read():
+    """
+    One abort protects exactly one turn. Leaving `armed` set would re-arm
+    every subsequent turn off a single barge.
+    """
+    b = RunBarrier()
+    b.abort()
+    b.begin_turn()
+    assert b.armed is False
+    b.discards(is_run_start=True)
+    b.end_turn()
+
+    b.begin_turn()
+    assert b.discards(is_run_start=False) is False
+
+
+def test_two_aborts_before_a_turn_still_protect_one_turn():
+    b = RunBarrier()
+    b.abort()
+    b.abort()
+    b.begin_turn()
+    assert b.discards(is_run_start=False) is True
+    b.end_turn()
+    b.begin_turn()
+    assert b.discards(is_run_start=False) is False
+
+
+# ── The wiring, pinned against the source ────────────────────────────────────
+
+
+def test_the_abort_actually_reaches_ha():
+    """
+    `VoiceAssistantRequest(start=False)` is the one message that reaches into
+    HA's in-flight pipeline: aioesphomeapi maps it to `handle_stop(True)` ->
+    `_abort_pipeline()`, which queues the audio sentinel AND cancels
+    `_pipeline_task`. cancel_turn's old docstring claimed no such mechanism
+    existed, citing an ESPHOME_SPEC.md §7.4 that is not in the tree.
+    """
+    assert "VoiceAssistantRequest(start=False)" in ESPHOME_SRC, (
+        "nothing aborts HA's pipeline — the old run keeps emitting onto the "
+        "connection the interrupting turn is using"
     )
 
 
-# ── The abort reaches HA ─────────────────────────────────────────────────────
-
-
-def test_abort_sends_start_false():
+def test_the_satellite_hands_the_arm_over_at_turn_start_and_drops_it_at_end():
     """
-    The one message that reaches into HA's in-flight pipeline. Without it the
-    old run is merely ignored locally and carries on emitting.
+    Both calls are load-bearing and neither is obviously necessary at the call
+    site, which is how one of them would get tidied away.
     """
-    sat = make_satellite()
-    sat.abort_ha_run()
-    assert len(sat.sent) == 1
-    msg = sat.sent[0]
-    assert isinstance(msg, api_pb2.VoiceAssistantRequest)
-    assert msg.start is False
+    assert "self._barrier.begin_turn()" in ESPHOME_SRC
+    assert "self._barrier.end_turn()" in ESPHOME_SRC
 
 
-def test_local_only_cancel_sends_nothing():
+def test_the_event_handler_consults_the_barrier_before_anything_else():
     """
-    The default stays local-only — a button cancel with no turn behind it must
-    not abort a pipeline HA is about to answer from.
+    The gate has to sit above the dispatch, not inside a branch — a stale
+    STT_VAD_END is as fatal to the interrupting turn as a stale RUN_END, and
+    listing event types to guard would go stale the next time one is added.
     """
-    sat = make_satellite()
-    sat.cancel_turn()
-    assert sat.sent == []
-    assert sat._turn_cancelled is True
-    assert sat._abort_pending is False
-
-
-def test_cancel_with_abort_sends_start_false_and_arms():
-    sat = make_satellite()
-    sat.cancel_turn(abort_ha=True)
-    assert any(
-        isinstance(m, api_pb2.VoiceAssistantRequest) and m.start is False
-        for m in sat.sent
-    )
-    assert sat._turn_cancelled is True
-    assert sat._abort_pending is True
-
-
-def test_abort_arms_even_when_the_transport_is_gone():
-    """
-    A closed transport means the abort could not be sent, which is exactly
-    when a reconnect might replay events at us. Arming is free; not arming
-    trades a cheap barrier for the failure it exists to prevent.
-    """
-    sat = make_satellite()
-    sat._transport = FakeTransport(closing=True)
-    sat.abort_ha_run()
-    assert sat.sent == []
-    assert sat._abort_pending is True
-
-
-def test_abort_is_a_no_op_on_an_inactive_turn():
-    sat = make_satellite()
-    sat._turn_active = False
-    sat.cancel_turn(abort_ha=True)
-    assert sat.sent == []
-    assert sat._abort_pending is False
-
-
-# ── The barrier: discard the aborted run's tail ──────────────────────────────
-
-
-def test_stale_run_end_does_not_end_the_new_turn():
-    """
-    The measured failure, reproduced: the aborted run's RUN_END lands a few ms
-    after the interrupting turn starts. Before the barrier this set
-    _ha_never_started and the turn reported pipeline_refused with no audio.
-    """
-    sat = make_satellite()
-    sat._discard_until_run_start = True
-    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_END))
-    assert sat._ha_never_started is False
-    assert sat._tts_event.is_set() is False
-
-
-def test_stale_vad_end_does_not_stop_the_new_turns_mic():
-    """
-    The same second of the same log also showed a stale STT_VAD_END landing on
-    the new turn, which stops mic streaming — so the interrupting turn would
-    have captured nothing even if it had survived the RUN_END.
-    """
-    sat = make_satellite()
-    sat._discard_until_run_start = True
-    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_STT_VAD_END))
-    assert sat._ha_vad_end.is_set() is False
-
-
-def test_stale_error_does_not_reach_the_new_turn():
-    """
-    The orphaned run's real ending arrived ~470ms later as
-    stt-no-text-recognized. On the new turn that unblocks both waiters.
-    """
-    sat = make_satellite()
-    sat._discard_until_run_start = True
-    sat._handle_voice_event(
-        event(ET.VOICE_ASSISTANT_ERROR, code="stt-no-text-recognized")
-    )
-    assert sat._tts_event.is_set() is False
-    assert sat._ha_vad_end.is_set() is False
-
-
-def test_run_start_drops_the_barrier_and_is_itself_processed():
-    """
-    RUN_START is the barrier's release AND a real event — swallowing it would
-    leave _run_started False and re-arm the very bug this fixes for the
-    turn's own terminal RUN_END.
-    """
-    sat = make_satellite()
-    sat._discard_until_run_start = True
-    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_START))
-    assert sat._discard_until_run_start is False
-    assert sat._run_started is True
-
-
-def test_events_after_run_start_are_processed_normally():
-    sat = make_satellite()
-    sat._discard_until_run_start = True
-    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_END))       # stale
-    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_START))     # ours
-    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_INTENT_END))
-    assert sat._intent_ended is True
-    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_END))       # ours, terminal
-    assert sat._tts_event.is_set() is True
-
-
-# ── What the barrier must not break ──────────────────────────────────────────
-
-
-def test_unarmed_run_end_without_run_start_is_still_terminal():
-    """
-    HA's wake-word interception (the voice satellite setup dialog) emits
-    RUN_END having never started a pipeline. That is genuinely terminal and
-    holding the mic through it is what stalled the setup flow for the life of
-    the feature. The barrier is armed only by an abort, so this path is
-    untouched.
-    """
-    sat = make_satellite()
-    assert sat._discard_until_run_start is False
-    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_END))
-    assert sat._ha_never_started is True
-    assert sat._tts_event.is_set() is True
-
-
-# ── Handoff and lifetime, pinned against the source ──────────────────────────
-
-
-def test_turn_reset_hands_the_arm_over_rather_than_clearing_it():
-    """
-    The arm is set during the PREVIOUS turn (at the barge) and has to survive
-    the next turn's reset block to reach the turn it protects. Resetting it to
-    False alongside its neighbours is the obvious tidy-up and would silently
-    restore the bug, with every test above still passing.
-    """
-    m = re.search(
-        r"self\._discard_until_run_start = self\._abort_pending\s*\n"
-        r"\s*self\._abort_pending\s*= False",
-        ESPHOME_SRC,
-    )
-    assert m, (
-        "run_esphome_voice_turn must hand _abort_pending to "
-        "_discard_until_run_start, not clear it"
-    )
-    assert "self._discard_until_run_start = False\n" in ESPHOME_SRC, (
-        "the barrier must be cleared when the turn ends — it is bounded to "
-        "exactly one turn, or a lost RUN_START deafens the satellite forever"
+    handler = ESPHOME_SRC[ESPHOME_SRC.index("def _handle_voice_event"):]
+    gate = handler.index("self._barrier")
+    first_dispatch = handler.index("if event_type ==")
+    assert gate < first_dispatch, (
+        "the barrier must gate every event, not selected ones"
     )
 
 
-def test_barge_during_thinking_aborts_upstream():
+def test_barge_serialises_in_both_phases():
     """
-    em_controller's barge watcher: the thinking branch starts another turn on
-    this connection, so it must abort HA's run first. The playback branch must
-    serialise too — RUN_END follows TTS_END and a barge in the first
-    milliseconds of audio can beat it.
+    Thinking starts another turn on this connection, so HA's run must be
+    aborted first. Playback must serialise too: RUN_END follows TTS_END, so a
+    barge in the first milliseconds of audio can beat it.
     """
-    src = (Path(em_esphome.__file__).parent / "em_controller.py").read_text()
-    watcher = src[src.index("async def _barge_watcher") :]
+    watcher = CONTROLLER_SRC[CONTROLLER_SRC.index("async def _barge_watcher"):]
     watcher = watcher[: watcher.index("\nasync def ", 10)]
     assert "abort_ha=True" in watcher, (
         "barge during thinking must abort HA's pipeline before the "
@@ -273,3 +215,16 @@ def test_barge_during_thinking_aborts_upstream():
     assert "abort_ha_run" in watcher, (
         "barge during playback must serialise against the interrupting turn"
     )
+
+
+def test_the_unarmed_run_end_path_is_still_there():
+    """
+    HA's wake-word interception emits RUN_END having never started a pipeline.
+    That is genuinely terminal, and missing it stalled the voice satellite
+    setup dialog for the life of the feature. The barrier is armed only by an
+    abort, so this path must survive untouched.
+    """
+    assert re.search(r"if not self\._run_started:", ESPHOME_SRC), (
+        "the RUN_END-without-RUN_START discriminator is gone"
+    )
+    assert "self._ha_never_started = True" in ESPHOME_SRC

--- a/controller/tests/test_barge_serialisation.py
+++ b/controller/tests/test_barge_serialisation.py
@@ -1,0 +1,277 @@
+"""
+The ESPHome voice protocol serialises pipeline runs at the SATELLITE or not
+at all.
+
+`VoiceAssistantEventResponse` carries `event_type` and a `data` list of
+name/value pairs — there is no run identifier anywhere in the protocol, so a
+client structurally cannot attribute an event to a particular run. Home
+Assistant does not enforce one-run-at-a-time either: `handle_pipeline_start`
+clears the audio queue and cancels the TTS streaming task, then overwrites
+`_pipeline_task` WITHOUT cancelling the previous one. Starting a second run
+therefore orphans the first, which keeps emitting events onto the same
+connection.
+
+Barge-in is the only place two runs can overlap, and it did. Measured on
+2026-08-17: five barge-ins, five interrupting turns dead in 4-17ms with zero
+audio captured, because the aborted run's RUN_END arrived ~4ms after the new
+turn started and the "HA ended a run it never started" branch read it as
+terminal.
+
+Two halves are pinned here, and both are needed:
+
+  * the abort actually reaches HA — `VoiceAssistantRequest(start=False)`,
+    which aioesphomeapi maps to `handle_stop(True)` → `_abort_pipeline()`;
+  * the new turn discards the old run's tail until its own RUN_START.
+
+The second half must NOT swallow the setup-flow's genuine
+RUN_END-without-RUN_START, which is a real thing HA does and which
+`_ha_never_started` exists to catch — so the barrier is armed only by an
+abort, and only for one turn.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+import em_esphome
+from esphome.vendor import api_pb2
+from esphome.vendor.api_pb2 import VoiceAssistantEvent as ET
+
+ESPHOME_SRC = Path(em_esphome.__file__).read_text()
+
+
+class FakeTransport:
+    def __init__(self, closing=False):
+        self._closing = closing
+
+    def is_closing(self):
+        return self._closing
+
+
+def make_satellite():
+    """
+    A satellite with just enough state to drive _handle_voice_event and
+    cancel_turn. Built without __init__ deliberately: the real constructor
+    wants a server, a transport and a device registry, none of which this
+    behaviour touches.
+    """
+    sat = object.__new__(em_esphome.EchoMuseSatellite)
+    sat._log_name = "test"
+    sat._transport = FakeTransport()
+    sat.sent = []
+    sat._send_one = sat.sent.append
+    # Per-turn state, as run_esphome_voice_turn's reset block leaves it.
+    sat._turn_active = True
+    sat._turn_cancelled = False
+    sat._intent_ended = False
+    sat._run_started = False
+    sat._ha_never_started = False
+    sat._continue_conversation = False
+    sat._abort_pending = False
+    sat._discard_until_run_start = False
+    sat._trace = None
+    sat._on_thinking = None
+    sat._on_stt_end = None
+    sat._tts_audio_url = None
+    import asyncio
+
+    sat._tts_event = asyncio.Event()
+    sat._ha_vad_end = asyncio.Event()
+    sat._ha_vad_start = asyncio.Event()
+    return sat
+
+
+def event(event_type, **data):
+    return api_pb2.VoiceAssistantEventResponse(
+        event_type=event_type,
+        data=[api_pb2.VoiceAssistantEventData(name=k, value=v) for k, v in data.items()],
+    )
+
+
+# ── The abort reaches HA ─────────────────────────────────────────────────────
+
+
+def test_abort_sends_start_false():
+    """
+    The one message that reaches into HA's in-flight pipeline. Without it the
+    old run is merely ignored locally and carries on emitting.
+    """
+    sat = make_satellite()
+    sat.abort_ha_run()
+    assert len(sat.sent) == 1
+    msg = sat.sent[0]
+    assert isinstance(msg, api_pb2.VoiceAssistantRequest)
+    assert msg.start is False
+
+
+def test_local_only_cancel_sends_nothing():
+    """
+    The default stays local-only — a button cancel with no turn behind it must
+    not abort a pipeline HA is about to answer from.
+    """
+    sat = make_satellite()
+    sat.cancel_turn()
+    assert sat.sent == []
+    assert sat._turn_cancelled is True
+    assert sat._abort_pending is False
+
+
+def test_cancel_with_abort_sends_start_false_and_arms():
+    sat = make_satellite()
+    sat.cancel_turn(abort_ha=True)
+    assert any(
+        isinstance(m, api_pb2.VoiceAssistantRequest) and m.start is False
+        for m in sat.sent
+    )
+    assert sat._turn_cancelled is True
+    assert sat._abort_pending is True
+
+
+def test_abort_arms_even_when_the_transport_is_gone():
+    """
+    A closed transport means the abort could not be sent, which is exactly
+    when a reconnect might replay events at us. Arming is free; not arming
+    trades a cheap barrier for the failure it exists to prevent.
+    """
+    sat = make_satellite()
+    sat._transport = FakeTransport(closing=True)
+    sat.abort_ha_run()
+    assert sat.sent == []
+    assert sat._abort_pending is True
+
+
+def test_abort_is_a_no_op_on_an_inactive_turn():
+    sat = make_satellite()
+    sat._turn_active = False
+    sat.cancel_turn(abort_ha=True)
+    assert sat.sent == []
+    assert sat._abort_pending is False
+
+
+# ── The barrier: discard the aborted run's tail ──────────────────────────────
+
+
+def test_stale_run_end_does_not_end_the_new_turn():
+    """
+    The measured failure, reproduced: the aborted run's RUN_END lands a few ms
+    after the interrupting turn starts. Before the barrier this set
+    _ha_never_started and the turn reported pipeline_refused with no audio.
+    """
+    sat = make_satellite()
+    sat._discard_until_run_start = True
+    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_END))
+    assert sat._ha_never_started is False
+    assert sat._tts_event.is_set() is False
+
+
+def test_stale_vad_end_does_not_stop_the_new_turns_mic():
+    """
+    The same second of the same log also showed a stale STT_VAD_END landing on
+    the new turn, which stops mic streaming — so the interrupting turn would
+    have captured nothing even if it had survived the RUN_END.
+    """
+    sat = make_satellite()
+    sat._discard_until_run_start = True
+    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_STT_VAD_END))
+    assert sat._ha_vad_end.is_set() is False
+
+
+def test_stale_error_does_not_reach_the_new_turn():
+    """
+    The orphaned run's real ending arrived ~470ms later as
+    stt-no-text-recognized. On the new turn that unblocks both waiters.
+    """
+    sat = make_satellite()
+    sat._discard_until_run_start = True
+    sat._handle_voice_event(
+        event(ET.VOICE_ASSISTANT_ERROR, code="stt-no-text-recognized")
+    )
+    assert sat._tts_event.is_set() is False
+    assert sat._ha_vad_end.is_set() is False
+
+
+def test_run_start_drops_the_barrier_and_is_itself_processed():
+    """
+    RUN_START is the barrier's release AND a real event — swallowing it would
+    leave _run_started False and re-arm the very bug this fixes for the
+    turn's own terminal RUN_END.
+    """
+    sat = make_satellite()
+    sat._discard_until_run_start = True
+    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_START))
+    assert sat._discard_until_run_start is False
+    assert sat._run_started is True
+
+
+def test_events_after_run_start_are_processed_normally():
+    sat = make_satellite()
+    sat._discard_until_run_start = True
+    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_END))       # stale
+    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_START))     # ours
+    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_INTENT_END))
+    assert sat._intent_ended is True
+    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_END))       # ours, terminal
+    assert sat._tts_event.is_set() is True
+
+
+# ── What the barrier must not break ──────────────────────────────────────────
+
+
+def test_unarmed_run_end_without_run_start_is_still_terminal():
+    """
+    HA's wake-word interception (the voice satellite setup dialog) emits
+    RUN_END having never started a pipeline. That is genuinely terminal and
+    holding the mic through it is what stalled the setup flow for the life of
+    the feature. The barrier is armed only by an abort, so this path is
+    untouched.
+    """
+    sat = make_satellite()
+    assert sat._discard_until_run_start is False
+    sat._handle_voice_event(event(ET.VOICE_ASSISTANT_RUN_END))
+    assert sat._ha_never_started is True
+    assert sat._tts_event.is_set() is True
+
+
+# ── Handoff and lifetime, pinned against the source ──────────────────────────
+
+
+def test_turn_reset_hands_the_arm_over_rather_than_clearing_it():
+    """
+    The arm is set during the PREVIOUS turn (at the barge) and has to survive
+    the next turn's reset block to reach the turn it protects. Resetting it to
+    False alongside its neighbours is the obvious tidy-up and would silently
+    restore the bug, with every test above still passing.
+    """
+    m = re.search(
+        r"self\._discard_until_run_start = self\._abort_pending\s*\n"
+        r"\s*self\._abort_pending\s*= False",
+        ESPHOME_SRC,
+    )
+    assert m, (
+        "run_esphome_voice_turn must hand _abort_pending to "
+        "_discard_until_run_start, not clear it"
+    )
+    assert "self._discard_until_run_start = False\n" in ESPHOME_SRC, (
+        "the barrier must be cleared when the turn ends — it is bounded to "
+        "exactly one turn, or a lost RUN_START deafens the satellite forever"
+    )
+
+
+def test_barge_during_thinking_aborts_upstream():
+    """
+    em_controller's barge watcher: the thinking branch starts another turn on
+    this connection, so it must abort HA's run first. The playback branch must
+    serialise too — RUN_END follows TTS_END and a barge in the first
+    milliseconds of audio can beat it.
+    """
+    src = (Path(em_esphome.__file__).parent / "em_controller.py").read_text()
+    watcher = src[src.index("async def _barge_watcher") :]
+    watcher = watcher[: watcher.index("\nasync def ", 10)]
+    assert "abort_ha=True" in watcher, (
+        "barge during thinking must abort HA's pipeline before the "
+        "interrupting turn starts"
+    )
+    assert "abort_ha_run" in watcher, (
+        "barge during playback must serialise against the interrupting turn"
+    )


### PR DESCRIPTION
## The report

Barge-in "really isn't working" on Test Device 01. It isn't the detector — that fired correctly every time (0.932, 0.992, 0.997, 0.619 against a 0.50 threshold). The turn that follows the barge is what dies.

Five barge-ins in the EA log window, five `pipeline_refused`, zero audio captured:

```
09:07:59,836  Barge-in: starting interrupting turn
09:07:59,836  Starting ESPHome voice turn conversation_id=55f840aa…
09:07:59,840  Pipeline run ended
09:07:59,841  HA ended the run without starting a pipeline — releasing the turn
09:07:59,841  [TURN] trigger=barge-in outcome=pipeline_refused total=+4ms audio=0frames/0ms
```

## The cause

`VoiceAssistantEventResponse` carries `event_type` and a name/value `data` list — **no run identifier anywhere in the protocol**. It is designed for strictly one pipeline run at a time per connection, and the satellite is what enforces that.

HA doesn't enforce it for us. `handle_pipeline_start` clears the audio queue and cancels `_tts_streaming_task`, then assigns a new `_pipeline_task` *without cancelling the old one*. So a second start orphans the first run, which keeps emitting onto the same socket.

Barge-during-thinking cancelled locally and immediately started another turn, so the aborted run's tail landed on it: `RUN_END` 4ms in (read as terminal by the `_run_started` discriminator), a stale `STT_VAD_END` in the same millisecond, and the orphan's real ending 470ms later after we'd already closed the turn.

## The fix

**The abort exists and we weren't sending it.** `VoiceAssistantRequest(start=False)` → aioesphomeapi `handle_stop(True)` → HA `_abort_pipeline()`, which queues the audio sentinel *and* cancels `_pipeline_task`. `cancel_turn`'s docstring claimed otherwise, citing an `ESPHOME_SPEC.md §7.4` that no longer exists in the tree.

**HA acknowledges an abort with no wire message at all**, so the barrier has to be ordering, not timing: after an abort, discard every event until the next `RUN_START` — necessarily ours, since HA emits it only on pipeline creation, we created exactly one more, and the connection is processed in order.

Armed only by an abort and bounded to one turn, so HA's wake-word interception — a genuine `RUN_END` with no `RUN_START`, which `_ha_never_started` exists to catch and whose absence stalled the satellite setup dialog — is untouched.

The playback branch serialises through `abort_ha_run()`, which arms the barrier without marking the turn cancelled (the response *was* delivered). `RUN_END` follows `TTS_END` so it's usually consumed before the barge lands; "usually" costs the whole interrupting turn when it loses.

## Not covered

Barging in and then thinking better of it. Once aborted the original turn cannot be resumed — the protocol has no resume — so preserving it needs the abort deferred until speech is confirmed. Filed separately.

## Tests

13 new, each verified by reintroducing the bug it covers, including the two that would pass silently otherwise: tidying `_discard_until_run_start = False` into the reset block alongside its neighbours, and dropping `abort_ha=True` at the call site. 453 pass.