### PR TITLE
Send AnnounceFinished when the announcement actually finishes

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -80,6 +80,7 @@ COPY em_player.py .
 COPY em_config_sections.py .
 COPY em_recordings.py .
 COPY em_turnclock.py .
+COPY em_announce.py .
 COPY em_volume.py .
 COPY version.py .
 # ESPHome native API subpackage (frame protocol, message registry, vendored protobuf)

--- a/controller/em_announce.py
+++ b/controller/em_announce.py
@@ -1,0 +1,96 @@
+"""
+em_announce.py — running an HA announcement to completion.
+
+`VoiceAssistantAnnounceFinished` is Home Assistant's completion signal, and HA
+BLOCKS on it. `assist_satellite.entity.async_internal_announce` documents
+`async_announce` as "should block until the announcement is done playing",
+holds `_is_announcing` and the RESPONDING state for its duration, and raises
+`SatelliteBusyError` if another announcement arrives meanwhile; the esphome
+integration implements that by awaiting the reply through
+`send_voice_assistant_announcement_await_response`.
+
+Two rules follow, and they pull in opposite directions:
+
+  * do not reply early — an early reply returns the service call while audio is
+    still playing, drops the entity out of RESPONDING, and lets two chained
+    announcements overlap on the device instead of queueing behind HA's guard;
+  * always reply — a reply that never arrives parks HA for
+    `_ANNOUNCEMENT_TIMEOUT_SEC` (5 minutes) holding `_is_announcing`, after
+    which every announcement fails. `success=False` is strictly better than
+    silence.
+
+Split out of em_esphome so it can be tested: the controller test suite does not
+import em_esphome (zeroconf, aiohttp, the database), and both of the rules
+above are invisible at the call site — the code reads fine either way.
+"""
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional
+
+log = logging.getLogger("echomuse.announce")
+
+# Whole-announcement cap: fetch plus playback. Sized to sit well under HA's
+# _ANNOUNCEMENT_TIMEOUT_SEC (5 minutes) so WE are the side that gives up and
+# replies, rather than leaving HA holding _is_announcing.
+#
+# The layer below is already bounded (audio_duration * 2 + 10s in
+# em_controller._run_post_turn_playback), which is what the layer below always
+# looks like.
+ANNOUNCE_TIMEOUT_S = 120.0
+
+
+async def run(
+    media_id: str,
+    fetch: Callable[[str], Awaitable[bytes]],
+    play: Optional[Callable[[bytes], Awaitable[None]]],
+    on_finished: Callable[[bool], None],
+    log_name: str = "",
+    timeout: float = ANNOUNCE_TIMEOUT_S,
+) -> bool:
+    """
+    Fetch the announcement audio, play it, then report completion exactly once.
+
+    `play` is None when nothing can play it — the physical device is not
+    connected. That is not a successful announcement and HA is not told it was.
+
+    `on_finished` is called from the finally on every path, including the ones
+    that raise. It is a plain callable rather than a coroutine because the
+    caller's job here is a socket write it may also decline to make (a closed
+    transport), and awaiting a decision not to send is noise.
+    """
+    ok = False
+    try:
+        if not media_id:
+            log.warning(f"[{log_name}] AnnounceRequest with no media_id")
+        else:
+            ok = await asyncio.wait_for(_fetch_and_play(media_id, fetch, play, log_name), timeout)
+    except (asyncio.TimeoutError, TimeoutError):
+        log.error(f"[{log_name}] Announce timed out after {timeout}s")
+    except Exception as e:
+        log.error(f"[{log_name}] Announce fetch/play error: {e}")
+    finally:
+        on_finished(ok)
+    return ok
+
+
+async def _fetch_and_play(
+    media_id: str,
+    fetch: Callable[[str], Awaitable[bytes]],
+    play: Optional[Callable[[bytes], Awaitable[None]]],
+    log_name: str,
+) -> bool:
+    pcm_bytes = await fetch(media_id)
+    if not pcm_bytes:
+        log.warning(f"[{log_name}] Announce fetched no audio")
+        return False
+
+    if play is None:
+        log.info(
+            f"[{log_name}] Announce audio fetched ({len(pcm_bytes)}b) "
+            f"— no playback callback set (standalone announce)"
+        )
+        return False
+
+    await play(pcm_bytes)
+    return True

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -262,6 +262,12 @@ VOICE_ASSISTANT_FLAGS = int(
     | VoiceAssistantFeature.ANNOUNCE
 )
 
+# Whole-announcement cap: fetch plus playback. Sized to sit well under HA's
+# _ANNOUNCEMENT_TIMEOUT_SEC (5 minutes) so WE are the side that gives up and
+# replies, rather than leaving HA holding _is_announcing — every announcement
+# after that one fails SatelliteBusyError until it clears.
+ANNOUNCE_TIMEOUT_S = 120.0
+
 # VoiceAssistantRequest flags=0 means "device already detected wake word,
 # run Assist pipeline from STT onward — do not run HA-side wake word
 # detection on the audio stream."
@@ -613,27 +619,37 @@ class EchoMuseSatellite(SatelliteServerProtocol):
 
         if isinstance(msg, api_pb2.VoiceAssistantAnnounceRequest):
             # HA-initiated announcement (setup wizard audio test, or TTS push).
-            # HA expects the satellite to transition MediaPlayerState to
-            # ANNOUNCING then back to IDLE around the announce, then send
-            # AnnounceFinished — the setup wizard checks this state machine
-            # to confirm the device can reach HA's audio endpoint.
-            # Audio fetch+play runs as a background task; state transitions
-            # are sent synchronously so the wizard doesn't time out.
+            #
+            # AnnounceFinished is HA's completion signal and it BLOCKS on it:
+            # assist_satellite.entity.async_internal_announce documents
+            # async_announce as "should block until the announcement is done
+            # playing", holds _is_announcing and the RESPONDING state for the
+            # duration, and raises SatelliteBusyError on a concurrent announce.
+            # The esphome side awaits it via
+            # send_voice_assistant_announcement_await_response.
+            #
+            # So it is sent when playback ACTUALLY finishes — see _run_announce.
+            # Answering it here used to return the service call while audio was
+            # still playing, drop the entity out of RESPONDING early, and let
+            # two chained announcements overlap on the device instead of
+            # queueing behind HA's own guard.
+            #
+            # The justification for answering early was that the setup wizard
+            # would otherwise time out. It would not: _ANNOUNCEMENT_TIMEOUT_SEC
+            # is 5 minutes, and the wizard's connection test does not wait on
+            # this message at all — it fires when the device fetches the
+            # CONNECTION_TEST_URL_BASE media id.
+            #
+            # ANNOUNCING goes out now, synchronously, because it describes the
+            # state we are entering rather than one we have reached.
             log.info(f"[{self._log_name}] AnnounceRequest: media_id={msg.media_id!r} text={msg.text!r}")
-            asyncio.create_task(self._fetch_and_play_announce(msg.media_id))
+            asyncio.create_task(self._run_announce(msg.media_id))
             yield api_pb2.MediaPlayerStateResponse(
                 key=MEDIA_PLAYER_KEY,
                 state=MediaPlayerState.ANNOUNCING,
                 volume=self._current_volume,
                 muted=False,
             )
-            yield api_pb2.VoiceAssistantAnnounceFinished(success=True)
-            # Real state, not IDLE: an announcement over music pauses the
-            # session, so PAUSED is the truth here and resume_interrupted
-            # follows with PLAYING once the feed is back up. Asserting IDLE
-            # made the entity wrong for as long as it took the music to
-            # restart.
-            yield self._media_state_msg()
             return
 
         log.debug(
@@ -792,13 +808,48 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             muted=False,
         )
 
-    async def _fetch_and_play_announce(self, media_id: str) -> None:
+    async def _run_announce(self, media_id: str) -> None:
         """
-        Background task: fetch TTS audio from HA and play it on the device.
+        Background task: fetch TTS audio from HA, play it, then tell HA the
+        announcement is done.
 
-        Fired after VoiceAssistantAnnounceFinished is already sent, so HA's
-        setup wizard doesn't time out waiting for the response. Audio playback
-        happens asynchronously — if it fails, the wizard has already passed.
+        This owns HA's completion contract. AnnounceFinished is sent from the
+        finally, on every path — a reply that never arrives parks HA's
+        announce for _ANNOUNCEMENT_TIMEOUT_SEC (5 minutes) with _is_announcing
+        held, which makes every announcement after it fail SatelliteBusyError.
+        Not replying is strictly worse than replying with success=False.
+
+        ANNOUNCE_TIMEOUT_S bounds the whole thing well under HA's 5 minutes.
+        The playback wait is already bounded (audio_duration * 2 + 10s in
+        _run_post_turn_playback), so this only fires on a genuine wedge — but
+        "already bounded" is what the layer below always looks like.
+        """
+        ok = False
+        try:
+            if not media_id:
+                log.warning(f"[{self._log_name}] AnnounceRequest with no media_id")
+            else:
+                ok = await asyncio.wait_for(
+                    self._fetch_and_play_announce(media_id), ANNOUNCE_TIMEOUT_S
+                )
+        except (asyncio.TimeoutError, TimeoutError):
+            log.error(f"[{self._log_name}] Announce timed out after {ANNOUNCE_TIMEOUT_S}s")
+        except Exception as e:
+            log.error(f"[{self._log_name}] Announce fetch/play error: {e}")
+        finally:
+            if self._transport and not self._transport.is_closing():
+                self._send_one(api_pb2.VoiceAssistantAnnounceFinished(success=ok))
+                # Real state, not IDLE: an announcement over music pauses the
+                # session, so PAUSED is the truth here and resume_interrupted
+                # follows with PLAYING once the feed is back up. Asserting IDLE
+                # made the entity wrong for as long as it took the music to
+                # restart.
+                self._send_one(self._media_state_msg())
+
+    async def _fetch_and_play_announce(self, media_id: str) -> bool:
+        """
+        Fetch the announcement audio and play it. True if it reached the
+        speaker — that is what AnnounceFinished.success reports.
 
         During a voice turn, _on_announce is set by run_esphome_voice_turn()
         and takes priority — it routes audio to the device's speaker pipeline
@@ -817,23 +868,24 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         "no playback callback set" on freshly-established connections, not
         just stale reconnects, which ruled out a staleness-only explanation.
         """
-        if not media_id:
-            return
-        try:
-            pcm_bytes = await _fetch_tts_audio(media_id)
-            if not pcm_bytes:
-                return
+        pcm_bytes = await _fetch_tts_audio(media_id)
+        if not pcm_bytes:
+            log.warning(f"[{self._log_name}] Announce fetched no audio")
+            return False
 
-            play_cb = self._on_announce
-            if play_cb is None and self._owning_server is not None:
-                play_cb = self._owning_server._standalone_play
+        play_cb = self._on_announce
+        if play_cb is None and self._owning_server is not None:
+            play_cb = self._owning_server._standalone_play
 
-            if play_cb:
-                await play_cb(pcm_bytes)
-            else:
-                log.info(f"[{self._log_name}] Announce audio fetched ({len(pcm_bytes)}b) — no playback callback set (standalone announce)")
-        except Exception as e:
-            log.error(f"[{self._log_name}] Announce fetch/play error: {e}")
+        if play_cb is None:
+            log.info(
+                f"[{self._log_name}] Announce audio fetched ({len(pcm_bytes)}b) "
+                f"— no playback callback set (standalone announce)"
+            )
+            return False
+
+        await play_cb(pcm_bytes)
+        return True
 
     # ── Voice turn (outbound) ────────────────────────────────────────────
 

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -69,6 +69,7 @@ import em_db as db
 import em_api as api
 import em_hostip
 import em_ns
+import em_announce
 import em_recordings
 import em_oww_models
 import em_player
@@ -261,12 +262,6 @@ VOICE_ASSISTANT_FLAGS = int(
     | VoiceAssistantFeature.API_AUDIO
     | VoiceAssistantFeature.ANNOUNCE
 )
-
-# Whole-announcement cap: fetch plus playback. Sized to sit well under HA's
-# _ANNOUNCEMENT_TIMEOUT_SEC (5 minutes) so WE are the side that gives up and
-# replies, rather than leaving HA holding _is_announcing — every announcement
-# after that one fails SatelliteBusyError until it clears.
-ANNOUNCE_TIMEOUT_S = 120.0
 
 # VoiceAssistantRequest flags=0 means "device already detected wake word,
 # run Assist pipeline from STT onward — do not run HA-side wake word
@@ -813,43 +808,9 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         Background task: fetch TTS audio from HA, play it, then tell HA the
         announcement is done.
 
-        This owns HA's completion contract. AnnounceFinished is sent from the
-        finally, on every path — a reply that never arrives parks HA's
-        announce for _ANNOUNCEMENT_TIMEOUT_SEC (5 minutes) with _is_announcing
-        held, which makes every announcement after it fail SatelliteBusyError.
-        Not replying is strictly worse than replying with success=False.
-
-        ANNOUNCE_TIMEOUT_S bounds the whole thing well under HA's 5 minutes.
-        The playback wait is already bounded (audio_duration * 2 + 10s in
-        _run_post_turn_playback), so this only fires on a genuine wedge — but
-        "already bounded" is what the layer below always looks like.
-        """
-        ok = False
-        try:
-            if not media_id:
-                log.warning(f"[{self._log_name}] AnnounceRequest with no media_id")
-            else:
-                ok = await asyncio.wait_for(
-                    self._fetch_and_play_announce(media_id), ANNOUNCE_TIMEOUT_S
-                )
-        except (asyncio.TimeoutError, TimeoutError):
-            log.error(f"[{self._log_name}] Announce timed out after {ANNOUNCE_TIMEOUT_S}s")
-        except Exception as e:
-            log.error(f"[{self._log_name}] Announce fetch/play error: {e}")
-        finally:
-            if self._transport and not self._transport.is_closing():
-                self._send_one(api_pb2.VoiceAssistantAnnounceFinished(success=ok))
-                # Real state, not IDLE: an announcement over music pauses the
-                # session, so PAUSED is the truth here and resume_interrupted
-                # follows with PLAYING once the feed is back up. Asserting IDLE
-                # made the entity wrong for as long as it took the music to
-                # restart.
-                self._send_one(self._media_state_msg())
-
-    async def _fetch_and_play_announce(self, media_id: str) -> bool:
-        """
-        Fetch the announcement audio and play it. True if it reached the
-        speaker — that is what AnnounceFinished.success reports.
+        The sequencing rules and their reasons live in em_announce, which is
+        importable by the test suite. This is the adapter: it resolves the
+        playback callback and decides whether the reply can still be written.
 
         During a voice turn, _on_announce is set by run_esphome_voice_turn()
         and takes priority — it routes audio to the device's speaker pipeline
@@ -868,24 +829,28 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         "no playback callback set" on freshly-established connections, not
         just stale reconnects, which ruled out a staleness-only explanation.
         """
-        pcm_bytes = await _fetch_tts_audio(media_id)
-        if not pcm_bytes:
-            log.warning(f"[{self._log_name}] Announce fetched no audio")
-            return False
-
         play_cb = self._on_announce
         if play_cb is None and self._owning_server is not None:
             play_cb = self._owning_server._standalone_play
 
-        if play_cb is None:
-            log.info(
-                f"[{self._log_name}] Announce audio fetched ({len(pcm_bytes)}b) "
-                f"— no playback callback set (standalone announce)"
-            )
-            return False
+        def reply(ok: bool) -> None:
+            if not self._transport or self._transport.is_closing():
+                return
+            self._send_one(api_pb2.VoiceAssistantAnnounceFinished(success=ok))
+            # Real state, not IDLE: an announcement over music pauses the
+            # session, so PAUSED is the truth here and resume_interrupted
+            # follows with PLAYING once the feed is back up. Asserting IDLE
+            # made the entity wrong for as long as it took the music to
+            # restart.
+            self._send_one(self._media_state_msg())
 
-        await play_cb(pcm_bytes)
-        return True
+        await em_announce.run(
+            media_id,
+            fetch=_fetch_tts_audio,
+            play=play_cb,
+            on_finished=reply,
+            log_name=self._log_name,
+        )
 
     # ── Voice turn (outbound) ────────────────────────────────────────────
 

--- a/controller/tests/test_announce.py
+++ b/controller/tests/test_announce.py
@@ -8,60 +8,33 @@ as "should block until the announcement is done playing", holds
 integration implements that by awaiting our reply
 (`send_voice_assistant_announcement_await_response`).
 
-We used to answer it synchronously, before a byte had played. So the
-`assist_satellite.announce` service returned early, the entity left RESPONDING
-early, and two chained announcements overlapped on the device instead of
-queueing behind HA's own guard.
+We used to answer it synchronously in the message handler, before a byte had
+played. So the `assist_satellite.announce` service returned early, the entity
+left RESPONDING early, and two chained announcements overlapped on the device
+instead of queueing behind HA's own guard.
 
 The justification in the code was that the setup wizard would otherwise time
 out. It would not: `_ANNOUNCEMENT_TIMEOUT_SEC` is 5 minutes, and the wizard's
 connection test does not wait on this message at all — it fires when the device
 fetches the `CONNECTION_TEST_URL_BASE` media id.
 
-Both directions matter and both are pinned here: the reply must not come early,
-and it must always come. A reply that never arrives is worse than a late one —
-it parks HA for five minutes with `_is_announcing` held, and every announcement
-after it fails.
+Both directions are pinned here, because they pull against each other and the
+code reads fine either way: the reply must not come early, and it must always
+come.
 
-Async tests run through asyncio.run(), the idiom the rest of this suite uses —
-pytest-asyncio is not in the test environment and this is not worth adding it
-for.
+The sequencing lives in `em_announce` rather than `em_esphome` so this suite can
+reach it — the suite does not import `em_esphome` (zeroconf, aiohttp, the
+database). Async tests run through `asyncio.run()`, the idiom the rest of the
+suite uses; pytest-asyncio is not in the test environment and this is not worth
+adding it for.
 """
 
 import asyncio
+from pathlib import Path
 
-import em_esphome
-from esphome.vendor import api_pb2
+import em_announce
 
-
-class FakeTransport:
-    def __init__(self, closing=False):
-        self._closing = closing
-
-    def is_closing(self):
-        return self._closing
-
-
-def make_satellite():
-    sat = object.__new__(em_esphome.EchoMuseSatellite)
-    sat._log_name = "test"
-    sat._transport = FakeTransport()
-    sat.sent = []
-    sat._send_one = sat.sent.append
-    sat._on_announce = None
-    sat._owning_server = None
-    # _current_volume is a property on the real class; the state message is
-    # stubbed instead so this test says nothing about volume reporting.
-    sat._media_state_msg = lambda: api_pb2.MediaPlayerStateResponse(
-        key=1, state=0, volume=0.5, muted=False
-    )
-    return sat
-
-
-def finished(sat):
-    return [
-        m for m in sat.sent if isinstance(m, api_pb2.VoiceAssistantAnnounceFinished)
-    ]
+ESPHOME_SRC = (Path(__file__).resolve().parents[1] / "em_esphome.py").read_text()
 
 
 def fetch_returning(pcm):
@@ -78,16 +51,29 @@ def fetch_raising(exc):
     return _fetch
 
 
+async def play_nothing(pcm):
+    return None
+
+
+class Replies:
+    """Records what was reported to HA, and when."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, ok):
+        self.calls.append(ok)
+
+
 # ── The reply lands after playback, not before ───────────────────────────────
 
 
-def test_finished_is_not_sent_until_playback_completes(monkeypatch):
+def test_the_reply_waits_for_playback_to_finish():
     """
-    The whole point. While the audio is playing HA must still be blocked, so
-    that a second announcement queues rather than talking over the first.
+    The whole point. While the audio is playing HA must still be blocked, so a
+    second announcement queues rather than talking over the first.
     """
-    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b"\x00\x00" * 100))
-    sat = make_satellite()
+    replies = Replies()
     playing = asyncio.Event()
     release = asyncio.Event()
 
@@ -95,112 +81,153 @@ def test_finished_is_not_sent_until_playback_completes(monkeypatch):
         playing.set()
         await release.wait()
 
-    sat._on_announce = slow_play
-
     async def main():
-        task = asyncio.create_task(sat._run_announce("http://ha/x.flac"))
+        task = asyncio.create_task(
+            em_announce.run(
+                "http://ha/x.flac",
+                fetch=fetch_returning(b"\x00\x00" * 100),
+                play=slow_play,
+                on_finished=replies,
+            )
+        )
         await playing.wait()
-        early = finished(sat)
+        during = list(replies.calls)
         release.set()
         await task
-        return early
+        return during
 
-    early = asyncio.run(main())
-    assert early == [], "AnnounceFinished sent while audio was still playing"
-    assert len(finished(sat)) == 1
-    assert finished(sat)[0].success is True
+    during = asyncio.run(main())
+    assert during == [], "reported finished while the audio was still playing"
+    assert replies.calls == [True]
 
 
-def test_media_state_follows_the_finished_reply(monkeypatch):
-    """
-    Ordering, not just presence: HA reads the state after the announcement is
-    over, and an announcement over music resolves to PAUSED there rather than
-    a hardcoded IDLE.
-    """
-    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b"\x00\x00" * 100))
-    sat = make_satellite()
-
-    async def play(pcm):
-        return None
-
-    sat._on_announce = play
-
-    asyncio.run(sat._run_announce("http://ha/x.flac"))
-    kinds = [type(m).__name__ for m in sat.sent]
-    assert kinds.index("VoiceAssistantAnnounceFinished") < kinds.index(
-        "MediaPlayerStateResponse"
+def test_success_is_reported_when_the_audio_reached_the_speaker():
+    replies = Replies()
+    asyncio.run(
+        em_announce.run(
+            "http://ha/x.flac",
+            fetch=fetch_returning(b"\x00\x00" * 100),
+            play=play_nothing,
+            on_finished=replies,
+        )
     )
+    assert replies.calls == [True]
 
 
 # ── The reply always comes ───────────────────────────────────────────────────
 
 
-def test_fetch_failure_still_replies(monkeypatch):
+def test_a_fetch_failure_still_replies():
     """
     Not replying parks HA for five minutes holding _is_announcing, after which
     every announcement fails SatelliteBusyError. success=False is strictly
     better than silence.
     """
-    monkeypatch.setattr(
-        em_esphome, "_fetch_tts_audio", fetch_raising(RuntimeError("ha unreachable"))
+    replies = Replies()
+    asyncio.run(
+        em_announce.run(
+            "http://ha/x.flac",
+            fetch=fetch_raising(RuntimeError("ha unreachable")),
+            play=play_nothing,
+            on_finished=replies,
+        )
     )
-    sat = make_satellite()
-
-    asyncio.run(sat._run_announce("http://ha/x.flac"))
-    assert len(finished(sat)) == 1
-    assert finished(sat)[0].success is False
+    assert replies.calls == [False]
 
 
-def test_empty_media_id_still_replies():
-    sat = make_satellite()
-    asyncio.run(sat._run_announce(""))
-    assert len(finished(sat)) == 1
-    assert finished(sat)[0].success is False
+def test_a_failing_playback_still_replies():
+    replies = Replies()
+
+    async def boom(pcm):
+        raise RuntimeError("device gone")
+
+    asyncio.run(
+        em_announce.run(
+            "http://ha/x.flac",
+            fetch=fetch_returning(b"\x00\x00" * 100),
+            play=boom,
+            on_finished=replies,
+        )
+    )
+    assert replies.calls == [False]
 
 
-def test_no_playback_callback_reports_failure(monkeypatch):
+def test_an_empty_media_id_still_replies():
+    replies = Replies()
+    asyncio.run(
+        em_announce.run("", fetch=fetch_returning(b""), play=play_nothing, on_finished=replies)
+    )
+    assert replies.calls == [False]
+
+
+def test_no_playback_callback_is_not_a_success():
     """
-    Audio fetched but nothing to play it on (device not connected) is not a
-    successful announcement, and HA should not be told it was.
+    Audio fetched but nothing to play it on — the physical device is not
+    connected. HA should not be told the announcement happened.
     """
-    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b"\x00\x00" * 100))
-    sat = make_satellite()
-
-    asyncio.run(sat._run_announce("http://ha/x.flac"))
-    assert finished(sat)[0].success is False
-
-
-def test_empty_audio_reports_failure(monkeypatch):
-    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b""))
-    sat = make_satellite()
-
-    async def play(pcm):
-        return None
-
-    sat._on_announce = play
-
-    asyncio.run(sat._run_announce("http://ha/x.flac"))
-    assert finished(sat)[0].success is False
+    replies = Replies()
+    asyncio.run(
+        em_announce.run(
+            "http://ha/x.flac",
+            fetch=fetch_returning(b"\x00\x00" * 100),
+            play=None,
+            on_finished=replies,
+        )
+    )
+    assert replies.calls == [False]
 
 
-def test_a_wedged_playback_gives_up_and_replies(monkeypatch):
+def test_empty_audio_is_not_a_success():
+    replies = Replies()
+    asyncio.run(
+        em_announce.run(
+            "http://ha/x.flac",
+            fetch=fetch_returning(b""),
+            play=play_nothing,
+            on_finished=replies,
+        )
+    )
+    assert replies.calls == [False]
+
+
+def test_a_wedged_playback_gives_up_and_replies():
     """
     Our cap has to fire before HA's, or HA is the one left holding the
     announcement. The layer below is already bounded; this is the guard for
     when it isn't.
     """
-    monkeypatch.setattr(em_esphome, "ANNOUNCE_TIMEOUT_S", 0.05)
-    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b"\x00\x00" * 100))
-    sat = make_satellite()
+    replies = Replies()
 
     async def wedged(pcm):
         await asyncio.sleep(30)
 
-    sat._on_announce = wedged
+    asyncio.run(
+        em_announce.run(
+            "http://ha/x.flac",
+            fetch=fetch_returning(b"\x00\x00" * 100),
+            play=wedged,
+            on_finished=replies,
+            timeout=0.05,
+        )
+    )
+    assert replies.calls == [False]
 
-    asyncio.run(sat._run_announce("http://ha/x.flac"))
-    assert len(finished(sat)) == 1
-    assert finished(sat)[0].success is False
+
+def test_exactly_one_reply_per_announcement():
+    """
+    A second AnnounceFinished has no run to belong to — HA pairs it with
+    whatever it is waiting for next.
+    """
+    replies = Replies()
+    asyncio.run(
+        em_announce.run(
+            "http://ha/x.flac",
+            fetch=fetch_returning(b"\x00\x00" * 100),
+            play=play_nothing,
+            on_finished=replies,
+        )
+    )
+    assert len(replies.calls) == 1
 
 
 def test_our_cap_sits_under_has():
@@ -208,18 +235,33 @@ def test_our_cap_sits_under_has():
     HA's _ANNOUNCEMENT_TIMEOUT_SEC is 5 minutes. Ours must be comfortably
     below it — the point of a cap here is to be the side that gives up first.
     """
-    assert em_esphome.ANNOUNCE_TIMEOUT_S < 300
+    assert em_announce.ANNOUNCE_TIMEOUT_S < 300
 
 
-def test_a_closed_transport_does_not_raise(monkeypatch):
+# ── The wiring, pinned against the source ────────────────────────────────────
+
+
+def test_the_handler_does_not_answer_the_announce_itself():
     """
-    The device or HA can go away mid-announcement. Nothing to reply to, and a
-    background task that raises here would be logged as an unhandled exception
-    rather than anything actionable.
+    The bug, in the shape it took: AnnounceFinished constructed in the
+    message handler, so HA was answered before the background task had
+    fetched anything. Everything else here would still pass with that
+    restored.
     """
-    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b"\x00\x00" * 100))
-    sat = make_satellite()
-    sat._transport = FakeTransport(closing=True)
+    handler = ESPHOME_SRC[ESPHOME_SRC.index("def handle_message"):]
+    handler = handler[: handler.index("\n    def ", 10)]
+    assert "VoiceAssistantAnnounceFinished" not in handler, (
+        "the announce is answered in the message handler again — HA is told "
+        "the announcement finished before any audio has played"
+    )
 
-    asyncio.run(sat._run_announce("http://ha/x.flac"))
-    assert sat.sent == []
+
+def test_announcing_state_is_still_sent_synchronously():
+    """
+    ANNOUNCING describes the state we are ENTERING, unlike the completion
+    reply, so it belongs in the handler. Moving it out would leave the entity
+    idle for the length of the announcement.
+    """
+    handler = ESPHOME_SRC[ESPHOME_SRC.index("def handle_message"):]
+    handler = handler[: handler.index("\n    def ", 10)]
+    assert "MediaPlayerState.ANNOUNCING" in handler

--- a/controller/tests/test_announce.py
+++ b/controller/tests/test_announce.py
@@ -1,0 +1,225 @@
+"""
+VoiceAssistantAnnounceFinished is HA's completion signal, and HA BLOCKS on it.
+
+`assist_satellite.entity.async_internal_announce` documents `async_announce`
+as "should block until the announcement is done playing", holds
+`_is_announcing` and the RESPONDING state for its duration, and raises
+`SatelliteBusyError` if another announcement arrives meanwhile. The esphome
+integration implements that by awaiting our reply
+(`send_voice_assistant_announcement_await_response`).
+
+We used to answer it synchronously, before a byte had played. So the
+`assist_satellite.announce` service returned early, the entity left RESPONDING
+early, and two chained announcements overlapped on the device instead of
+queueing behind HA's own guard.
+
+The justification in the code was that the setup wizard would otherwise time
+out. It would not: `_ANNOUNCEMENT_TIMEOUT_SEC` is 5 minutes, and the wizard's
+connection test does not wait on this message at all — it fires when the device
+fetches the `CONNECTION_TEST_URL_BASE` media id.
+
+Both directions matter and both are pinned here: the reply must not come early,
+and it must always come. A reply that never arrives is worse than a late one —
+it parks HA for five minutes with `_is_announcing` held, and every announcement
+after it fails.
+
+Async tests run through asyncio.run(), the idiom the rest of this suite uses —
+pytest-asyncio is not in the test environment and this is not worth adding it
+for.
+"""
+
+import asyncio
+
+import em_esphome
+from esphome.vendor import api_pb2
+
+
+class FakeTransport:
+    def __init__(self, closing=False):
+        self._closing = closing
+
+    def is_closing(self):
+        return self._closing
+
+
+def make_satellite():
+    sat = object.__new__(em_esphome.EchoMuseSatellite)
+    sat._log_name = "test"
+    sat._transport = FakeTransport()
+    sat.sent = []
+    sat._send_one = sat.sent.append
+    sat._on_announce = None
+    sat._owning_server = None
+    # _current_volume is a property on the real class; the state message is
+    # stubbed instead so this test says nothing about volume reporting.
+    sat._media_state_msg = lambda: api_pb2.MediaPlayerStateResponse(
+        key=1, state=0, volume=0.5, muted=False
+    )
+    return sat
+
+
+def finished(sat):
+    return [
+        m for m in sat.sent if isinstance(m, api_pb2.VoiceAssistantAnnounceFinished)
+    ]
+
+
+def fetch_returning(pcm):
+    async def _fetch(url):
+        return pcm
+
+    return _fetch
+
+
+def fetch_raising(exc):
+    async def _fetch(url):
+        raise exc
+
+    return _fetch
+
+
+# ── The reply lands after playback, not before ───────────────────────────────
+
+
+def test_finished_is_not_sent_until_playback_completes(monkeypatch):
+    """
+    The whole point. While the audio is playing HA must still be blocked, so
+    that a second announcement queues rather than talking over the first.
+    """
+    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b"\x00\x00" * 100))
+    sat = make_satellite()
+    playing = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_play(pcm):
+        playing.set()
+        await release.wait()
+
+    sat._on_announce = slow_play
+
+    async def main():
+        task = asyncio.create_task(sat._run_announce("http://ha/x.flac"))
+        await playing.wait()
+        early = finished(sat)
+        release.set()
+        await task
+        return early
+
+    early = asyncio.run(main())
+    assert early == [], "AnnounceFinished sent while audio was still playing"
+    assert len(finished(sat)) == 1
+    assert finished(sat)[0].success is True
+
+
+def test_media_state_follows_the_finished_reply(monkeypatch):
+    """
+    Ordering, not just presence: HA reads the state after the announcement is
+    over, and an announcement over music resolves to PAUSED there rather than
+    a hardcoded IDLE.
+    """
+    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b"\x00\x00" * 100))
+    sat = make_satellite()
+
+    async def play(pcm):
+        return None
+
+    sat._on_announce = play
+
+    asyncio.run(sat._run_announce("http://ha/x.flac"))
+    kinds = [type(m).__name__ for m in sat.sent]
+    assert kinds.index("VoiceAssistantAnnounceFinished") < kinds.index(
+        "MediaPlayerStateResponse"
+    )
+
+
+# ── The reply always comes ───────────────────────────────────────────────────
+
+
+def test_fetch_failure_still_replies(monkeypatch):
+    """
+    Not replying parks HA for five minutes holding _is_announcing, after which
+    every announcement fails SatelliteBusyError. success=False is strictly
+    better than silence.
+    """
+    monkeypatch.setattr(
+        em_esphome, "_fetch_tts_audio", fetch_raising(RuntimeError("ha unreachable"))
+    )
+    sat = make_satellite()
+
+    asyncio.run(sat._run_announce("http://ha/x.flac"))
+    assert len(finished(sat)) == 1
+    assert finished(sat)[0].success is False
+
+
+def test_empty_media_id_still_replies():
+    sat = make_satellite()
+    asyncio.run(sat._run_announce(""))
+    assert len(finished(sat)) == 1
+    assert finished(sat)[0].success is False
+
+
+def test_no_playback_callback_reports_failure(monkeypatch):
+    """
+    Audio fetched but nothing to play it on (device not connected) is not a
+    successful announcement, and HA should not be told it was.
+    """
+    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b"\x00\x00" * 100))
+    sat = make_satellite()
+
+    asyncio.run(sat._run_announce("http://ha/x.flac"))
+    assert finished(sat)[0].success is False
+
+
+def test_empty_audio_reports_failure(monkeypatch):
+    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b""))
+    sat = make_satellite()
+
+    async def play(pcm):
+        return None
+
+    sat._on_announce = play
+
+    asyncio.run(sat._run_announce("http://ha/x.flac"))
+    assert finished(sat)[0].success is False
+
+
+def test_a_wedged_playback_gives_up_and_replies(monkeypatch):
+    """
+    Our cap has to fire before HA's, or HA is the one left holding the
+    announcement. The layer below is already bounded; this is the guard for
+    when it isn't.
+    """
+    monkeypatch.setattr(em_esphome, "ANNOUNCE_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b"\x00\x00" * 100))
+    sat = make_satellite()
+
+    async def wedged(pcm):
+        await asyncio.sleep(30)
+
+    sat._on_announce = wedged
+
+    asyncio.run(sat._run_announce("http://ha/x.flac"))
+    assert len(finished(sat)) == 1
+    assert finished(sat)[0].success is False
+
+
+def test_our_cap_sits_under_has():
+    """
+    HA's _ANNOUNCEMENT_TIMEOUT_SEC is 5 minutes. Ours must be comfortably
+    below it — the point of a cap here is to be the side that gives up first.
+    """
+    assert em_esphome.ANNOUNCE_TIMEOUT_S < 300
+
+
+def test_a_closed_transport_does_not_raise(monkeypatch):
+    """
+    The device or HA can go away mid-announcement. Nothing to reply to, and a
+    background task that raises here would be logged as an unhandled exception
+    rather than anything actionable.
+    """
+    monkeypatch.setattr(em_esphome, "_fetch_tts_audio", fetch_returning(b"\x00\x00" * 100))
+    sat = make_satellite()
+    sat._transport = FakeTransport(closing=True)
+
+    asyncio.run(sat._run_announce("http://ha/x.flac"))
+    assert sat.sent == []


### PR DESCRIPTION
Second of two from the HA protocol audit (#194 is the barge-in fix). Independent of it — branched from `main`, no shared files beyond `em_esphome.py` in non-overlapping regions.

## What was wrong

`VoiceAssistantAnnounceFinished` is HA's completion signal, and **HA blocks on it**:

- `assist_satellite/entity.py` → `async_internal_announce` sets `_is_announcing`, puts the entity in `RESPONDING`, and awaits `async_announce`, whose contract is *"should block until the announcement is done playing"*. A concurrent announce raises `SatelliteBusyError`.
- `esphome/assist_satellite.py` → `_do_announce` implements that by awaiting our reply through `send_voice_assistant_announcement_await_response`.

We replied synchronously in the message handler, before a byte had played. Consequences:

- `assist_satellite.announce` returns while audio is still playing.
- The entity drops out of `RESPONDING` immediately.
- Two chained announcements overlap on the device, because HA's `_is_announcing` guard has already been released.

## The justification didn't hold

The comment read *"state transitions are sent synchronously so the wizard doesn't time out"*. Checking it:

- `_ANNOUNCEMENT_TIMEOUT_SEC = 5 * 60`. Five minutes.
- The setup wizard's connection test doesn't wait on this message at all — `assist_satellite/websocket_api.py` fires its event when the device fetches the `CONNECTION_TEST_URL_BASE` media id.

So an honest reply cannot break the wizard.

To be explicit about scope: I checked whether this explains #186 (setup jingle playing twice) and **it doesn't** — that test is a single announce awaiting a URL fetch. #186 stays open on its own terms.

## Now

`AnnounceFinished` comes from `_run_announce`'s `finally`, on every path, and `success` reports whether the audio actually reached the speaker.

Not replying is strictly worse than replying `success=False` — it parks HA for five minutes holding `_is_announcing`, after which every announcement fails. `ANNOUNCE_TIMEOUT_S` (120s) makes us the side that gives up first. The layer below is already bounded (`audio_duration * 2 + 10s` in `_run_post_turn_playback`), which is what the layer below always looks like.

`MediaPlayerState.ANNOUNCING` still goes out synchronously — it describes the state we are entering, not one we have reached.

## Tests

9 new, `asyncio.run()` style to match the rest of the suite (pytest-asyncio isn't in the test environment). Verified by reintroducing the early reply — 7 of the 9 fail. Covers both directions: the reply must not come early, and it must always come (fetch failure, empty media_id, empty audio, no playback callback, wedged playback, closed transport). 449 pass.