### PR TITLE
Fix two announcement faults found on hardware

### DIFF
--- a/controller/em_announce.py
+++ b/controller/em_announce.py
@@ -64,7 +64,8 @@ async def run(
         if not media_id:
             log.warning(f"[{log_name}] AnnounceRequest with no media_id")
         else:
-            ok = await asyncio.wait_for(_fetch_and_play(media_id, fetch, play, log_name), timeout)
+            ok = await asyncio.wait_for(
+                play_media(media_id, fetch, play, log_name), timeout)
     except (asyncio.TimeoutError, TimeoutError):
         log.error(f"[{log_name}] Announce timed out after {timeout}s")
     except Exception as e:
@@ -74,12 +75,26 @@ async def run(
     return ok
 
 
-async def _fetch_and_play(
+async def play_media(
     media_id: str,
     fetch: Callable[[str], Awaitable[bytes]],
-    play: Optional[Callable[[bytes], Awaitable[None]]],
-    log_name: str,
+    play: Optional[Callable[[bytes], Awaitable[object]]],
+    log_name: str = "",
 ) -> bool:
+    """
+    Fetch and play, with no reply to anyone. True if the audio reached the
+    speaker.
+
+    Public because HA has TWO ways to announce and only one of them waits for
+    a completion message: `VoiceAssistantAnnounceRequest` (run(), above) and
+    `play_media` with announce=true, which is an ordinary media_player command.
+    Sending AnnounceFinished for the latter would answer a question nobody
+    asked.
+
+    A `play` callback returning False means the audio did not reach the
+    speaker — cancelled by a mute or a button mid-playback. None (the common
+    case) means it has no opinion and is taken as played.
+    """
     pcm_bytes = await fetch(media_id)
     if not pcm_bytes:
         log.warning(f"[{log_name}] Announce fetched no audio")
@@ -92,5 +107,4 @@ async def _fetch_and_play(
         )
         return False
 
-    await play(pcm_bytes)
-    return True
+    return await play(pcm_bytes) is not False

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -2420,11 +2420,23 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
         await leds_off(device)
         await api.notify_device_connected(device_id)
         _device_ref = device
-        async def _standalone_play(pcm_bytes: bytes, _d=_device_ref) -> None:
+        async def _standalone_play(pcm_bytes: bytes, _d=_device_ref) -> bool:
             # Same acoustic-feedback guard as voice turns: announcements
             # play outside a turn, so the always-on OWW stream is live —
             # stop it for the duration and put it back after. An active
             # media session pauses for the announcement and resumes.
+            #
+            # cancel_event is cleared first, exactly as a voice turn does.
+            # It is set by a cancel (a button press during a turn, a mute)
+            # and was ONLY ever cleared when the next voice turn started —
+            # so a cancelled turn left it set and _run_post_turn_playback
+            # then abandoned every subsequent announcement at "Cancelled
+            # during playback", silently, until a turn happened to run.
+            # Measured on Test Device 01 on 2026-08-17: a turn cancelled at
+            # 12:02:32 killed the next seven announcements over three
+            # minutes. An announcement is a new action and nothing that set
+            # that flag earlier has any claim on it.
+            _d.cancel_event.clear()
             await em_player.interrupt(_d.device_id)
             await _d.mic_stop()
             try:
@@ -2432,6 +2444,11 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
             finally:
                 await _d.mic_start()
                 await em_player.resume_interrupted(_d.device_id)
+            # Whether the audio actually reached the speaker. Something that
+            # cancelled mid-playback (a mute, a button) means the user did
+            # not hear it, and telling HA it finished successfully would be
+            # untrue — it is the one thing the announcement reply reports.
+            return not _d.cancel_event.is_set()
         async def _send_volume_set(level: int, _d=_device_ref) -> None:
             await _d.send_control({"type": "volume_set", "level": level})
         # Capabilities before the servers come up: they decide which HA

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -304,7 +304,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                               # standalone-announce path can read the live
                               # _standalone_play callback rather than a
                               # point-in-time copy taken at connect (see
-                              # _fetch_and_play_announce). Optional/typed
+                              # _announce_play_cb). Optional/typed
                               # loosely to avoid a circular import; may be
                               # None in tests or the reject-connection path.
     ) -> None:
@@ -375,7 +375,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._on_tts_received   = None   # async callable(pcm_url_or_bytes)
         self._on_thinking       = None   # async callable()
         self._on_stt_end        = None   # async callable(text: str)
-        self._on_announce       = None   # async callable(pcm_bytes) — set only during an active voice turn (run_esphome_voice_turn); None otherwise. The standalone-announce path (setup wizard, push TTS) does NOT use this — it reads self._owning_server._standalone_play live at call time instead, since that value can legitimately change after this satellite was constructed (see _fetch_and_play_announce).
+        self._on_announce       = None   # async callable(pcm_bytes) — set only during an active voice turn (run_esphome_voice_turn); None otherwise. The standalone-announce path (setup wizard, push TTS) does NOT use this — it reads self._owning_server._standalone_play live at call time instead, since that value can legitimately change after this satellite was constructed (see _announce_play_cb).
 
     # ── Message handling ─────────────────────────────────────────────────
 
@@ -576,7 +576,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     # VoiceAssistantAnnounceRequest (interrupts music via
                     # the standalone-play wrapper, resumes after).
                     log.info(f"[{self._log_name}] play_media announce: {msg.media_url!r}")
-                    asyncio.create_task(self._fetch_and_play_announce(msg.media_url))
+                    asyncio.create_task(self._play_media_announce(msg.media_url))
                 else:
                     log.info(f"[{self._log_name}] play_media: {msg.media_url!r}")
                     asyncio.create_task(em_player.play(device_id, msg.media_url))
@@ -844,6 +844,34 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             muted=False,
         )
 
+    def _announce_play_cb(self):
+        """
+        Where announcement audio goes, resolved at call time.
+
+        """
+        cb = self._on_announce
+        if cb is None and self._owning_server is not None:
+            cb = self._owning_server._standalone_play
+        return cb
+
+    async def _play_media_announce(self, media_id: str) -> None:
+        """
+        play_media with announce=true — an ordinary media_player command.
+
+        Deliberately does NOT send VoiceAssistantAnnounceFinished: HA is not
+        waiting for one here, unlike VoiceAssistantAnnounceRequest. Two ways
+        to announce, one of which has a completion contract.
+        """
+        try:
+            await em_announce.play_media(
+                media_id,
+                fetch=_fetch_tts_audio,
+                play=self._announce_play_cb(),
+                log_name=self._log_name,
+            )
+        except Exception as e:
+            log.error(f"[{self._log_name}] play_media announce failed: {e}")
+
     async def _run_announce(self, media_id: str) -> None:
         """
         Background task: fetch TTS audio from HA, play it, then tell HA the
@@ -870,10 +898,6 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         "no playback callback set" on freshly-established connections, not
         just stale reconnects, which ruled out a staleness-only explanation.
         """
-        play_cb = self._on_announce
-        if play_cb is None and self._owning_server is not None:
-            play_cb = self._owning_server._standalone_play
-
         def reply(ok: bool) -> None:
             if not self._transport or self._transport.is_closing():
                 return
@@ -888,7 +912,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         await em_announce.run(
             media_id,
             fetch=_fetch_tts_audio,
-            play=play_cb,
+            play=self._announce_play_cb(),
             on_finished=reply,
             log_name=self._log_name,
         )

--- a/controller/tests/test_announce.py
+++ b/controller/tests/test_announce.py
@@ -30,11 +30,13 @@ adding it for.
 """
 
 import asyncio
+import re
 from pathlib import Path
 
 import em_announce
 
-ESPHOME_SRC = (Path(__file__).resolve().parents[1] / "em_esphome.py").read_text()
+CONTROLLER = Path(__file__).resolve().parents[1]
+ESPHOME_SRC = (CONTROLLER / "em_esphome.py").read_text()
 
 
 def fetch_returning(pcm):
@@ -230,6 +232,70 @@ def test_exactly_one_reply_per_announcement():
     assert len(replies.calls) == 1
 
 
+def test_a_play_callback_reporting_failure_is_not_a_success():
+    """
+    The device can cancel mid-playback — a mute, a button press — and then the
+    user did not hear the announcement. Reporting success for it is untrue, and
+    success is the one fact this reply carries.
+    """
+    replies = Replies()
+
+    async def cancelled(pcm):
+        return False
+
+    asyncio.run(
+        em_announce.run(
+            "http://ha/x.flac",
+            fetch=fetch_returning(b"\x00\x00" * 100),
+            play=cancelled,
+            on_finished=replies,
+        )
+    )
+    assert replies.calls == [False]
+
+
+def test_a_play_callback_with_no_opinion_counts_as_played():
+    """
+    Most callbacks return None. Treating that as failure would report every
+    ordinary announcement as failed.
+    """
+    replies = Replies()
+    asyncio.run(
+        em_announce.run(
+            "http://ha/x.flac",
+            fetch=fetch_returning(b"\x00\x00" * 100),
+            play=play_nothing,
+            on_finished=replies,
+        )
+    )
+    assert replies.calls == [True]
+
+
+# ── the other way HA announces ───────────────────────────────────────────────
+
+
+def test_play_media_announce_plays_without_replying():
+    """
+    HA has TWO announce paths and only one waits for a completion message.
+    `play_media` with announce=true is an ordinary media_player command;
+    sending AnnounceFinished for it answers a question nobody asked.
+    """
+    played = []
+
+    async def play(pcm):
+        played.append(len(pcm))
+
+    ok = asyncio.run(
+        em_announce.play_media(
+            "http://ha/x.flac",
+            fetch=fetch_returning(b"\x00\x00" * 100),
+            play=play,
+        )
+    )
+    assert ok is True
+    assert played == [200]
+
+
 def test_our_cap_sits_under_has():
     """
     HA's _ANNOUNCEMENT_TIMEOUT_SEC is 5 minutes. Ours must be comfortably
@@ -265,3 +331,36 @@ def test_announcing_state_is_still_sent_synchronously():
     handler = ESPHOME_SRC[ESPHOME_SRC.index("def handle_message"):]
     handler = handler[: handler.index("\n    def ", 10)]
     assert "MediaPlayerState.ANNOUNCING" in handler
+
+
+def test_both_announce_paths_resolve_the_callback_the_same_way():
+    """
+    Renaming the shared helper broke the play_media path and not the other,
+    because only one call site was checked — every play_media announce raised
+    AttributeError on a released build (2026-08-17). One resolver, used by
+    both, so there is nothing to miss next time.
+    """
+    src = ESPHOME_SRC
+    assert src.count("_announce_play_cb()") >= 2, (
+        "the two announce paths must share one callback resolver"
+    )
+    assert "_fetch_and_play_announce" not in src, (
+        "a caller still references the removed helper"
+    )
+
+
+def test_no_handler_dispatches_to_a_method_that_does_not_exist():
+    """
+    handle_message catches nothing: a missing attribute surfaces only as
+    'handle_message raised for MediaPlayerCommandRequest' in the log, at
+    runtime, on a device someone is using. Cheap to check statically.
+    """
+    src = ESPHOME_SRC
+    base = (CONTROLLER / "esphome" / "satellite_server.py").read_text()
+    defined = set(re.findall(r"^    (?:async )?def (_[a-z_]+)", src + base, re.M))
+    # Callables held as attributes rather than defined as methods — the
+    # turn-scoped callbacks. Assigned with aligned "=" so the spacing varies.
+    held = set(re.findall(r"self\.(_[a-z_]+)\s*[:=]", src))
+    called = set(re.findall(r"self\.(_[a-z_]+)\(", src))
+    missing = called - defined - held
+    assert not missing, f"dispatched to methods that do not exist: {sorted(missing)}"

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1384,3 +1384,52 @@ def test_asset_sync_does_not_shadow_its_accumulator():
     assert not re.search(r"pushed\s*=\s*await\s+_stream_file_to_device", body), (
         "the transfer result must not be assigned to `pushed` — that shadows "
         "the accumulator and the append raises AttributeError")
+
+
+def test_an_announcement_clears_the_cancel_flag_before_playing():
+    """
+    cancel_event is set by a cancel — a button press during a turn, a mute —
+    and was ONLY ever cleared when the next VOICE TURN started. Nothing in the
+    announcement path cleared it, and _run_post_turn_playback checks it, so a
+    cancelled turn silently killed every subsequent announcement until a turn
+    happened to run.
+
+    Measured on Test Device 01, 2026-08-17: a turn cancelled at 12:02:32 left
+    seven announcements over the next three minutes logging "Cancelled during
+    playback" and playing nothing. Adding a second device made it look like a
+    routing bug — that device played fine, because its own flag was clear.
+
+    An announcement is a new action; nothing that set the flag earlier has any
+    claim on it.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    fn = re.search(r"async def _standalone_play\(.*?\n(?=        async def )",
+                   src, re.S)
+    assert fn, "_standalone_play not found"
+    body = fn.group(0)
+
+    # The literal calls, not the prose: this function's comments name
+    # _run_post_turn_playback before either call happens.
+    clear = body.find("_d.cancel_event.clear()")
+    play = body.find("await _run_post_turn_playback(")
+    assert clear != -1, (
+        "an announcement no longer clears cancel_event — a cancelled turn "
+        "will silently kill every announcement that follows it"
+    )
+    assert clear < play, "the flag must be cleared BEFORE the audio is played"
+
+
+def test_an_announcement_reports_whether_it_actually_played():
+    """
+    The reply to HA carries one fact — did the user hear it. Something that
+    cancels mid-playback means they did not, and `return True` regardless
+    would make the reply decorative.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    fn = re.search(r"async def _standalone_play\(.*?\n(?=        async def )",
+                   src, re.S)
+    body = fn.group(0)
+    assert "-> bool" in body, "_standalone_play must report whether it played"
+    assert re.search(r"return not .*cancel_event\.is_set\(\)", body), (
+        "the return value must reflect whether playback was cancelled"
+    )


### PR DESCRIPTION
Found by @wilbowes testing #196 on 2.20.1-ea.1. Reported as: long-press announcements worked, then stopped on device 01; adding device 02 as a second target made 02 announce while 01 stayed silent; a voice turn on 01 restored it.

Two independent causes, and the second device is what made it look like one bug.

## 1. A cancelled turn silently killed every announcement after it

`cancel_event` is set by a cancel — a button press during a turn, a mute — and was **only ever cleared when the next voice turn started**. Nothing in the announcement path cleared it, and `_run_post_turn_playback` checks it.

From the log, device 01:

```
12:02:32  Dot button — cancelling voice turn
12:02:37  Cancelled during playback
12:02:38  Cancelled during playback
12:02:47  Cancelled during playback
12:03:02  Cancelled during playback
12:03:18  Cancelled during playback
```

Seven announcements over three minutes, all silent, until a turn happened to run. Device 02 played fine throughout because its own flag was clear — which is exactly why adding a second target read as a routing fault.

**Pre-existing**, not introduced by #196; hammering announcements to test that change is what surfaced it.

`_standalone_play` now clears the flag first, as a voice turn does — an announcement is a new action and nothing that set that flag earlier has a claim on it. It also returns whether the audio reached the speaker, so the reply to HA carries the truth instead of an unconditional success.

## 2. A renamed helper broke the other announce path — mine

HA has **two** announce paths: `VoiceAssistantAnnounceRequest`, which waits for a completion message, and `play_media` with `announce=true`, which is an ordinary media_player command and does not.

When I renamed `_fetch_and_play_announce` in #196 I updated the first call site and checked for others *by memory rather than by grep*. Every `play_media` announce then raised:

```
handle_message raised for MediaPlayerCommandRequest:
'EchoMuseSatellite' object has no attribute '_fetch_and_play_announce'
```

Both paths now share one resolver (`_announce_play_cb`), so there is nothing to miss. `play_media` deliberately still sends no `AnnounceFinished` — HA is not waiting for one there, and sending it would answer a question nobody asked.

A test also walks every `self._method()` dispatch in `em_esphome` against what actually exists. `handle_message` catches nothing, so a missing attribute surfaces only at runtime, in a log, on a device someone is using — cheap to check statically.

## Tests

Four new guards, each verified by reintroducing the fault: dropping the `cancel_event` clear, returning unconditional success, restoring the stale method name, and the dispatch walk. 473 pass.