### PR TITLE
Show Speaking on the dashboard

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -663,10 +663,37 @@ class Device:
     async def push_config(self, **kwargs):
         await self.send_control({"type": "config", **kwargs})
 
+    async def _set_speaking(self, value: bool) -> None:
+        """
+        Set the speaking flag AND tell the dashboard.
+
+        The single writer, because the flag and the push had drifted apart:
+        stream_speaker/stream_speaker_chunks set it, and nothing pushed the
+        transition. _push_device_state has always carried `speaking` and the
+        dashboard has always rendered it above `thinking` — but the only
+        pushes were at listening, thinking and turn end, so a turn read
+        listening -> thinking -> idle and **never showed Speaking at all**. It
+        appeared only when the dashboard's 5s poll of /api/devices happened to
+        land mid-playback, which for a typical ~2s response it usually did not.
+
+        Guarded rather than plain, because one caller is stream_speaker's
+        finally, which is also reached when barge-in cancels the task
+        mid-send: the flag assignment is synchronous and always happens, and a
+        push that cannot complete is not worth failing a speaker stream over —
+        turn end pushes the same state moments later.
+        """
+        if self.speaking == value:
+            return
+        self.speaking = value
+        try:
+            await _push_device_state(self)
+        except BaseException:
+            pass
+
     async def stream_speaker(self, pcm: bytes):
         """Stream resampled mono 48kHz PCM as 0x02 frames, then 0x03 EOS."""
         self.begin_data_stream()
-        self.speaking = True
+        await self._set_speaking(True)
         try:
             offset = 0
             while offset < len(pcm):
@@ -681,7 +708,7 @@ class Device:
                 await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
                 offset += SPEAKER_BYTES
         finally:
-            self.speaking = False
+            await self._set_speaking(False)
             # EOS must go out on EVERY exit, including task cancellation
             # (barge-in cancels this task mid-send): the device's barge-in
             # flush discards 0x02 frames until it sees this stream's 0x03 —
@@ -704,7 +731,7 @@ class Device:
         end of the response.
         """
         self.begin_data_stream()
-        self.speaking = True
+        await self._set_speaking(True)
         pending = bytearray()
         total_pcm = 0
         eq_seconds = 0.0
@@ -755,7 +782,7 @@ class Device:
                 await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
                 send_seconds += asyncio.get_event_loop().time() - _t_send
         finally:
-            self.speaking = False
+            await self._set_speaking(False)
             # One EOS terminates the complete response. Sending EOS per HTTP
             # chunk would make the device repeatedly prime and flush.
             try:

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1433,3 +1433,53 @@ def test_an_announcement_reports_whether_it_actually_played():
     assert re.search(r"return not .*cancel_event\.is_set\(\)", body), (
         "the return value must reflect whether playback was cancelled"
     )
+
+
+def test_the_speaking_flag_and_its_dashboard_push_cannot_drift():
+    """
+    The dashboard renders `speaking` above `thinking` and _push_device_state
+    has always carried it — but nothing pushed the transition. The only pushes
+    were at listening, thinking and turn end, so a turn read
+    listening -> thinking -> idle and never showed Speaking at all. It appeared
+    only when the dashboard's 5s poll of /api/devices happened to land
+    mid-playback, which for a ~2s response it usually did not.
+
+    Setting the flag and telling anyone about it are now one operation, so a
+    third streaming path cannot reintroduce the gap by doing only the first.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+
+    setter = re.search(r"async def _set_speaking\(.*?\n(?=    async def |    def )",
+                       src, re.S)
+    assert setter, "_set_speaking not found"
+    assert "_push_device_state(self)" in setter.group(0), (
+        "the setter must push — that is the whole reason it exists"
+    )
+
+    # Every other write is a bug. __init__'s default and the setter's own
+    # assignment are the two legitimate ones.
+    writes = re.findall(r"self\.speaking\s*=\s*(?!=)", src)
+    assert len(writes) == 2, (
+        f"expected 2 assignments to self.speaking (the __init__ default and "
+        f"the setter), found {len(writes)} — a streaming path is setting the "
+        f"flag without pushing it"
+    )
+
+
+def test_the_speaking_push_cannot_fail_a_speaker_stream():
+    """
+    One caller is stream_speaker's finally, which is also reached when
+    barge-in cancels the task mid-send. A push that cannot complete there must
+    not take the stream down with it — turn end pushes the same state moments
+    later. The flag assignment is synchronous and happens either way.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    setter = re.search(r"async def _set_speaking\(.*?\n(?=    async def |    def )",
+                       src, re.S).group(0)
+    assign = setter.find("self.speaking = value")
+    push = setter.find("_push_device_state(self)")
+    assert assign < push, "the flag must be set before the push is attempted"
+    assert "except BaseException" in setter, (
+        "a bare `except Exception` does not catch the CancelledError this sees "
+        "during barge-in"
+    )


### PR DESCRIPTION
The device tile stays on **Thinking** for the whole spoken response.

## Not a precedence bug

`deviceState()` already renders `speaking` above `thinking`, and `_push_device_state` has always carried the flag. **Nothing ever pushed the transition.**

The pushes are at listening (`1366`), thinking (`1406`) and turn end (`1390`). `stream_speaker` and `stream_speaker_chunks` set `self.speaking` and told nobody — so a turn reads:

```
listening → thinking → (speaking happens, silently) → idle
```

Speaking appeared only when the dashboard's 5s poll of `/api/devices` happened to land mid-playback. For a typical ~2s response it usually did not, which is why this presents as "stuck on thinking" rather than "Speaking never works".

## Fix

Setting the flag and telling anyone about it are now one operation, `_set_speaking`. All four writers go through it, and a test pins that no other assignment to `self.speaking` exists — so a third streaming path can't reintroduce the gap by doing only half.

The push is guarded, because one caller is `stream_speaker`'s `finally`, which is also reached when barge-in cancels the task mid-send. The flag assignment is synchronous and always happens; a push that can't complete there isn't worth failing a speaker stream over, and turn end pushes the same state moments later. `except BaseException`, not `Exception` — a bare `Exception` doesn't catch the `CancelledError` this actually sees, which a test also pins.

## Unaffected

Music. `em_player` must not set `device.speaking` — it would make the wake loop drop frames for the length of a song — and still doesn't.

Both guards verified by mutation: making a streaming path set the flag directly, and downgrading the except clause.