### PR TITLE
Align the Speaking tile to the device, not to the socket

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -687,6 +687,18 @@ class Device:
         appeared only when the dashboard's 5s poll of /api/devices happened to
         land mid-playback, which for a typical ~2s response it usually did not.
 
+        WHEN each edge fires, and how true each is:
+
+        - **False is device truth.** The playback functions wait on the
+          device's own `playback_stats`, sent once its audio channel drains
+          after EOS, and clear the flag there.
+        - **True is still a controller-side ESTIMATE** — the first period put
+          on the wire. The device holds audio until roughly
+          SPEAKER_PRIME_SECONDS is queued (primePeriods, pcm_speaker.go), so
+          the tile leads the speaker by up to that much. Closing that gap needs
+          the DEVICE to report the moment it starts, which no released firmware
+          does; `playback_stats` is the only playback message it sends.
+
         Guarded rather than plain, because one caller is stream_speaker's
         finally, which is also reached when barge-in cancels the task
         mid-send: the flag assignment is synchronous and always happens, and a
@@ -696,6 +708,12 @@ class Device:
         if self.speaking == value:
             return
         self.speaking = value
+        if value:
+            # Mutually exclusive phases. Leaving `thinking` set meant the tile
+            # FELL BACK to Thinking the moment speaking cleared, instead of
+            # going quiet — which is what made an early clear look like the
+            # device had started thinking again mid-response.
+            self.thinking = False
         try:
             await _push_device_state(self)
         except BaseException:
@@ -719,7 +737,10 @@ class Device:
                 await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
                 offset += SPEAKER_BYTES
         finally:
-            await self._set_speaking(False)
+            # NOT where speaking clears — see _run_post_turn_playback. This
+            # returns when the last byte is written to the socket, which
+            # completes near-instantly however slow the link is; the device
+            # still has its whole buffer to play.
             # EOS must go out on EVERY exit, including task cancellation
             # (barge-in cancels this task mid-send): the device's barge-in
             # flush discards 0x02 frames until it sees this stream's 0x03 —
@@ -742,7 +763,6 @@ class Device:
         end of the response.
         """
         self.begin_data_stream()
-        await self._set_speaking(True)
         pending = bytearray()
         total_pcm = 0
         eq_seconds = 0.0
@@ -771,6 +791,7 @@ class Device:
                     if first_send_time is None:
                         first_send_time = asyncio.get_event_loop().time()
                         self.playback_send_t0 = first_send_time
+                        await self._set_speaking(True)
                         log.info(
                             f"[{self.device_id}] First streamed PCM period "
                             "sent to device"
@@ -785,6 +806,7 @@ class Device:
                 if first_send_time is None:
                     first_send_time = asyncio.get_event_loop().time()
                     self.playback_send_t0 = first_send_time
+                    await self._set_speaking(True)
                     log.info(
                         f"[{self.device_id}] First streamed PCM period "
                         "sent to device"
@@ -793,7 +815,7 @@ class Device:
                 await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
                 send_seconds += asyncio.get_event_loop().time() - _t_send
         finally:
-            await self._set_speaking(False)
+            # NOT where speaking clears — see the note in stream_speaker.
             # One EOS terminates the complete response. Sending EOS per HTTP
             # chunk would make the device repeatedly prime and flush.
             try:
@@ -1227,6 +1249,14 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
                     f"{timeout:.1f}s with no playback_stats — clearing ring anyway"
                 )
 
+    # The real end of audio, not the end of the socket write. The device
+    # reports playback_stats once its audio channel drains after EOS, and
+    # everything above waits for exactly that — so this is the one place that
+    # knows the speaker has actually stopped. Clearing it in the stream task's
+    # finally instead dropped the tile out of Speaking seconds early (the write
+    # completes near-instantly), which is the same mistake the ring made until
+    # 2026-07-24.
+    await device._set_speaking(False)
     cancel_task.cancel()
     done_task.cancel()
 
@@ -1350,6 +1380,10 @@ async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
             )
         return total_pcm
     finally:
+        # See _run_post_turn_playback: the end of audio is what the DEVICE
+        # reports, not when the last byte reached the socket. In the finally so
+        # a cancel or an error leaves the tile idle rather than stuck Speaking.
+        await device._set_speaking(False)
         for t in (cancel_task, done_task):
             t.cancel()
         if not stream_task.done():

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1522,6 +1522,54 @@ def test_the_speaking_flag_and_its_dashboard_push_cannot_drift():
     )
 
 
+def test_speaking_clears_on_device_confirmation_not_on_the_socket_write():
+    """
+    The stream task returns when the last byte reaches the socket, which
+    completes near-instantly however slow the link is — the device still has
+    its whole buffer to play. Clearing the flag there dropped the tile out of
+    Speaking seconds early, and because `thinking` was still set it fell BACK
+    to Thinking mid-response before finally going idle.
+
+    Exactly the mistake the LED ring made until 2026-07-24, in the same file.
+    The playback functions wait on the device's playback_stats; they are the
+    only things that know the speaker has stopped.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+
+    for fn_name in ("stream_speaker", "stream_speaker_chunks"):
+        fn = re.search(rf"async def {fn_name}\(.*?\n(?=    async def |    def )",
+                       src, re.S)
+        assert fn, f"{fn_name} not found"
+        assert "_set_speaking(False)" not in fn.group(0), (
+            f"{fn_name} clears speaking when the socket write finishes, not "
+            f"when the audio does"
+        )
+
+    for fn_name in ("_run_post_turn_playback", "_run_streaming_post_turn_playback"):
+        fn = re.search(rf"async def {fn_name}\(.*?\n(?=\nasync def |\ndef )",
+                       src, re.S)
+        assert fn, f"{fn_name} not found"
+        assert "_set_speaking(False)" in fn.group(0), (
+            f"{fn_name} waits for the device's playback_stats and must be what "
+            f"clears speaking"
+        )
+
+
+def test_speaking_and_thinking_are_mutually_exclusive():
+    """
+    Both flags reach the dashboard and `speaking` outranks `thinking`, so a
+    stale `thinking` is invisible until speaking clears — and then the tile
+    reads as if the device started thinking again mid-response.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    setter = re.search(r"async def _set_speaking\(.*?\n(?=    async def |    def )",
+                       src, re.S).group(0)
+    assert "self.thinking = False" in setter, (
+        "starting to speak must clear thinking, or the tile falls back to "
+        "Thinking when speaking ends"
+    )
+
+
 def test_the_speaking_push_cannot_fail_a_speaker_stream():
     """
     One caller is stream_speaker's finally, which is also reached when


### PR DESCRIPTION
Follow-up to #201. Reported after it landed: the tile went to Speaking **too early**, back to **Thinking** before the device had finished playing, then idle.

Three causes, one theme — the state was following controller-side bookkeeping rather than what the speaker was doing.

## Speaking cleared when the socket write finished

`stream_speaker` returns when the last byte reaches the socket, which completes near-instantly however slow the link is. The device still has its whole buffer to play — measured at 1.4–1.8s on these turns.

This is precisely the mistake the LED ring made until 2026-07-24, in the same file, with the comment warning about it a few lines away:

> the ring cleared 6.1s before the audio actually stopped

It now clears where the ring does: after the device's own `playback_stats` arrives, in the playback functions that already wait for it. **That edge is now device truth.**

## Falling back to Thinking

`thinking` stayed set for the whole response. Invisible while `speaking` outranked it in `deviceState()` — and revealed the instant speaking cleared, so an early clear read as the device having started thinking again mid-answer. Starting to speak now clears it; they are mutually exclusive phases.

## Speaking started when the function was entered

`stream_speaker_chunks` set the flag at the top, before any PCM existed — on the streaming path HA may still be synthesising. It now fires on the first period actually put on the wire.

## What is still an estimate, and why

That last edge is **not** device truth and is documented as an estimate. The device holds audio until roughly `SPEAKER_PRIME_SECONDS` is queued (`primePeriods`, `pcm_speaker.go`), so the tile leads the speaker by up to that much.

Closing it needs the device to say when it starts playing. I checked: `SendPlaybackStats` is the only playback message the firmware sends, and it fires at the end. So this needs a firmware change and no released firmware has it — filed separately rather than faked with another controller-side guess.

## Tests

Two new guards, both verified by mutation: clearing speaking on the socket write again, and leaving `thinking` set when speaking starts. 500 pass.