### PR TITLE
Add follow-up conversation window after voice turns

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -52,6 +52,7 @@ import collections
 import contextlib
 import json
 import logging
+import math
 import os
 import socket
 import struct
@@ -169,6 +170,43 @@ SPEAKER_BYTES  = SPEAKER_PERIOD * 2       # 4096 bytes/period (mono S16)
 # arrives) — primePeriods in pcm_speaker.go. The post-playback drain sleep
 # must allow for the delayed start.
 SPEAKER_PRIME_SECONDS = 1.1
+
+# How long a follow-up listening window (opened after every answer that
+# actually said something — see the turn loop in _run_voice_locked) waits
+# for the user to start a next sentence before giving up quietly and
+# returning to wake-word idle. User-tuned: long enough for a real
+# back-and-forth reply, short enough that the mic doesn't sit hot picking up
+# unrelated room chatter for too long.
+FOLLOWUP_NO_SPEECH_TIMEOUT = 9.0
+
+
+def _synth_tone(freq_hz: float, duration_s: float, amplitude: float = 0.22,
+                 fade_s: float = 0.015) -> bytes:
+    """Raw S16LE mono PCM at SPEAKER_RATE — same format stream_speaker() sends
+    to the device directly, no ffmpeg/EQ chain involved. fade_s ramps the
+    edges in/out to avoid a click at the tone's start/end."""
+    n = int(SPEAKER_RATE * duration_s)
+    fade_n = max(1, int(SPEAKER_RATE * fade_s))
+    out = bytearray()
+    for i in range(n):
+        env = 1.0
+        if i < fade_n:
+            env = i / fade_n
+        elif i > n - fade_n:
+            env = (n - i) / fade_n
+        val = amplitude * env * math.sin(2 * math.pi * freq_hz * i / SPEAKER_RATE)
+        out += struct.pack("<h", int(val * 32767))
+    return bytes(out)
+
+
+# "Still listening" earcon played before a follow-up window opens — two
+# short ascending tones, synthesized once at import time since it never
+# changes. Deliberately quiet/short: it's a cue, not an announcement.
+FOLLOWUP_CHIME_PCM = (
+    _synth_tone(660.0, 0.09)
+    + bytes(int(SPEAKER_RATE * 0.03) * 2)   # 30ms of silence between tones
+    + _synth_tone(880.0, 0.12)
+)
 
 # Control-plane RTT probing. 5s rather than the old 30s keepalive cadence:
 # characterising jitter needs samples, and one tiny JSON message per device
@@ -1217,6 +1255,23 @@ async def _meter_at_playback_start(pcm_chunks, on_start):
         await on_start()
 
 
+async def _play_followup_chime(device: Device) -> None:
+    """
+    Earcon signalling a follow-up listening window is open — played on the
+    already-stopped mic (turn's own mic_stop already ran) before the
+    follow-up branch in _run_voice_locked reopens it. Best-effort: a chime
+    failure shouldn't block the follow-up window itself.
+    """
+    try:
+        await device.stream_speaker(FOLLOWUP_CHIME_PCM)
+        # Same margin the streamed-TTS path relies on (SPEAKER_PRIME_SECONDS
+        # docstring above) — stream_speaker() returns once bytes are sent,
+        # not once the device has actually finished playing them.
+        await asyncio.sleep(SPEAKER_PRIME_SECONDS)
+    except Exception as e:
+        log.warning(f"[{device.device_id}] Follow-up chime failed: {e}")
+
+
 async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
     """
     Play decoded HA TTS while the HTTP response is still arriving.
@@ -1543,15 +1598,27 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
             # initial wakeword-triggered turn.
             turn_label      = trigger_label
             preroll_discard = esphome.VOICE_PREROLL_DISCARD if is_wakeword else 0
+            # None on the first (wake/button) turn — mints a fresh id there.
+            # Carried forward across continuation/follow-up turns below so
+            # HA's conversation agent keeps short-term context.
+            conversation_id = None
             while True:
-                should_continue = False
+                should_continue       = False
+                no_speech_timeout_hit = False
                 try:
-                    should_continue = await esphome.trigger_voice_turn(
+                    should_continue, no_speech_timeout_hit, conversation_id = await esphome.trigger_voice_turn(
                         device=device,
                         on_thinking=on_thinking_esphome,
                         post_turn_play=post_turn_play_esphome,
                         trigger_label=turn_label,
                         preroll_discard=preroll_discard,
+                        conversation_id=conversation_id,
+                        # Only follow-up turns get the longer, user-tuned
+                        # grace period — the original wake/button/barge/
+                        # HA-continuation turns keep em_turnclock's default.
+                        no_speech_timeout=(
+                            FOLLOWUP_NO_SPEECH_TIMEOUT if turn_label == "followup" else None
+                        ),
                     )
                 finally:
                     # Watcher spans thinking→playback and is owned here:
@@ -1576,6 +1643,9 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
                     device.barge_detected = False
                     device.cancel_event.clear()
                     log.info(f"[{device.device_id}] Barge-in: starting interrupting turn")
+                    # Fresh conversation — an interrupting command is a new
+                    # utterance, not a reply to what was just cut off.
+                    conversation_id = None
                     await device.mic_start()  # defensive no-op if running
                     # Re-arm listening state — cleanup_esphome() in the
                     # finally just turned the ring off, which left the
@@ -1630,6 +1700,40 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
                     stop_spin.clear()
                     spin_task = None
                     # Fresh phase flag for the next turn's watcher.
+                    playback_started = asyncio.Event()
+                elif not no_speech_timeout_hit and not device.cancel_event.is_set():
+                    # Turn produced a real spoken answer (wake/button/barge/
+                    # continuation all land here — no_speech_timeout_hit is
+                    # False for all of them) and HA didn't itself ask a
+                    # follow-up question. Open a short follow-up listening
+                    # window instead of dropping straight back to wake-word
+                    # idle, so the next sentence doesn't need "Hey Jarvis"
+                    # again. Chains: if the user speaks and gets another real
+                    # answer, this branch fires again on the next iteration
+                    # and opens another window. Ends quietly, one iteration
+                    # later, when a "followup" turn comes back with
+                    # no_speech_timeout_hit=True (see the final `else`) —
+                    # same closing behaviour as an accidental wake, just via
+                    # the longer FOLLOWUP_NO_SPEECH_TIMEOUT grace period.
+                    log.info(f"[{device.device_id}] Opening follow-up listening window ({FOLLOWUP_NO_SPEECH_TIMEOUT}s)")
+                    await _play_followup_chime(device)
+                    await device.mic_start()
+                    drained = 0
+                    while not device.voice_queue.empty():
+                        try:
+                            device.voice_queue.get_nowait()
+                            drained += 1
+                        except asyncio.QueueEmpty:
+                            break
+                    if drained:
+                        log.debug(f"[{device.device_id}] Follow-up window: drained {drained} stale frames")
+                    device.listening = True
+                    await leds_listening(device)
+                    await _push_device_state(device)
+                    turn_label      = "followup"
+                    preroll_discard = 0
+                    stop_spin.clear()
+                    spin_task = None
                     playback_started = asyncio.Event()
                 else:
                     break

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -841,6 +841,8 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         trace: "TurnTrace | None" = None,
         preroll_discard: int = VOICE_PREROLL_DISCARD,
         wake_word_phrase: str = "",
+        conversation_id: str | None = None,
+        no_speech_timeout: float | None = None,
     ) -> None:
         """
         Execute one voice turn over the live HA connection.
@@ -862,6 +864,17 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         (see review C3). Returns nothing; the caller reads
         self._continue_conversation after this returns to decide whether to
         re-trigger — see trigger_voice_turn().
+
+        conversation_id: reuse an existing conversation rather than starting
+        one — pass the previous turn's id for a continuation/follow-up turn
+        so HA's conversation agent keeps short-term context ("turn off the
+        lights" → "make it warmer" without re-stating the room). None (the
+        wake/button/barge case) mints a fresh id, same as before this param
+        existed.
+
+        no_speech_timeout: forwarded to _stream_mic_audio's no-speech grace
+        period; None uses em_turnclock's normal default. Follow-up windows
+        pass a longer value here — see em_controller.py.
         """
         if not self._transport or self._transport.is_closing():
             log.warning(f"[{self._log_name}] No active HA connection — cannot start voice turn")
@@ -883,7 +896,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._on_announce    = None   # set below after announcement path is confirmed
         self._trace          = trace  # may be None — all trace.x calls guard against this
 
-        self._conversation_id = str(uuid.uuid4())
+        self._conversation_id = conversation_id or str(uuid.uuid4())
 
         log.info(
             f"[{self._log_name}] Starting ESPHome voice turn "
@@ -1087,7 +1100,12 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     pass  # dashboard notification is best-effort
             log.info(f"[{self._log_name}] ESPHome voice turn complete")
 
-    async def _stream_mic_audio(self, device, preroll_discard: int = VOICE_PREROLL_DISCARD) -> None:
+    async def _stream_mic_audio(
+        self,
+        device,
+        preroll_discard: int = VOICE_PREROLL_DISCARD,
+        no_speech_timeout: float | None = None,
+    ) -> None:
         """
         Pull PCM frames from device.voice_queue and send them to HA as
         VoiceAssistantAudio messages.
@@ -1193,6 +1211,14 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         speech_seen = False
         listening_since = None      # monotonic; set when the first real frame lands
         turn_start = time.monotonic()
+        # Follow-up listening windows (em_controller.py's post-answer re-open,
+        # no wake word required) pass a longer grace period here — the caller
+        # decides how patient to be; this method just applies it. None means
+        # "not a follow-up turn", so em_turnclock's own default applies.
+        effective_no_speech_timeout = (
+            no_speech_timeout if no_speech_timeout is not None
+            else em_turnclock.NO_SPEECH_TIMEOUT
+        )
 
         def _is_speech(chunk: bytes) -> bool:
             samples = np.frombuffer(chunk, dtype=np.int16)
@@ -1238,6 +1264,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 give_up, why = em_turnclock.no_speech_verdict(
                     now=time.monotonic(), turn_start=turn_start,
                     listening_since=listening_since, speech_seen=speech_seen,
+                    no_speech_timeout=effective_no_speech_timeout,
                 )
                 if give_up:
                     log.info(
@@ -2047,7 +2074,9 @@ async def trigger_voice_turn(
     post_turn_play,   # async callable(pcm_chunks) -> decoded byte count
     trigger_label: str = "unknown",  # "wakeword(0.522)" or "button" for trace
     preroll_discard: int = VOICE_PREROLL_DISCARD,
-) -> bool:
+    conversation_id: str | None = None,
+    no_speech_timeout: float | None = None,
+) -> tuple[bool, bool, str]:
     """
     Entry point for OWW/button-triggered voice turns in esphome mode.
 
@@ -2062,12 +2091,26 @@ async def trigger_voice_turn(
     doesn't specify it, but em_controller.py's call sites should always pass
     it explicitly so the choice is visible at the call site.
 
-    Returns True if HA requested conversation continuation (continue_conversation
-    flag set in INTENT_END) — the controller uses this to re-trigger immediately
-    rather than returning to OWW idle. Returns False in all other cases including
-    no active HA connection.
+    conversation_id, no_speech_timeout: forwarded to
+    run_esphome_voice_turn() — see there. Both None for a fresh wake/button/
+    barge turn.
 
-    If no active HA connection exists, logs and returns False.
+    Returns (should_continue, no_speech_timeout_hit, conversation_id):
+      - should_continue: True if HA requested conversation continuation
+        (continue_conversation flag set in INTENT_END) — the controller
+        re-triggers immediately with the SAME conversation_id rather than
+        returning to OWW idle.
+      - no_speech_timeout_hit: True if this turn ended with nothing said
+        (accidental wake, or a follow-up window that timed out). The
+        controller uses this to tell "produced a real answer" apart from
+        "gave up quietly" when deciding whether to open a follow-up window.
+      - conversation_id: the id actually used for this turn (freshly minted
+        if the caller passed None) — pass it back in on the next call to
+        keep HA's short-term context across a continuation/follow-up chain.
+
+    All three are (False, True, conversation_id or "") if no active HA
+    connection exists — treated the same as "nothing said" so the caller
+    doesn't try to open a follow-up window against a dead connection.
     """
     # Pop the wake detection detail set by wake_word_listener/_barge_watcher
     # — pop, not read, so continuation turns (which loop back here with no
@@ -2082,7 +2125,7 @@ async def trigger_voice_turn(
             f"— was start_esphome_servers() called?"
         )
         await _record_dropped_turn(device, trigger_label, wake_info)
-        return False
+        return False, True, conversation_id or ""
 
     satellite = server.get_satellite()
     if satellite is None:
@@ -2091,7 +2134,7 @@ async def trigger_voice_turn(
             f"cannot start voice turn (HA not connected to this device's port)"
         )
         await _record_dropped_turn(device, trigger_label, wake_info)
-        return False
+        return False, True, conversation_id or ""
 
     trace = TurnTrace(
         trigger=trigger_label, t0=time.monotonic(), wake_info=wake_info
@@ -2114,9 +2157,15 @@ async def trigger_voice_turn(
         post_turn_play=post_turn_play,
         trace=trace,
         wake_word_phrase=wake_word_phrase,
+        conversation_id=conversation_id,
+        no_speech_timeout=no_speech_timeout,
     )
 
-    return satellite._continue_conversation
+    return (
+        satellite._continue_conversation,
+        satellite._no_speech_timeout,
+        satellite._conversation_id,
+    )
 
 
 def cancel_voice_turn(device_id: str) -> None:


### PR DESCRIPTION
After any turn that produced a real spoken answer, play a short chime and reopen the mic for ~9s without requiring the wake word — treats a timely follow-up as a continuation (same conversation_id, so HA's agent keeps short-term context) and falls back to wake-word idle quietly if nothing is said.

- em_esphome.py: thread conversation_id and no_speech_timeout through run_esphome_voice_turn/trigger_voice_turn; trigger_voice_turn now returns (should_continue, no_speech_timeout_hit, conversation_id) instead of a bare bool.
- em_controller.py: synthesize a two-tone earcon, and extend the post-turn loop with a follow-up branch that reuses the existing continuation-turn mechanics.