### PR TITLE
Stop openwakeword scoring its own reset noise

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -73,6 +73,7 @@ COPY em_esphome.py .
 COPY em_ble_proxy.py .
 COPY em_oww_assets.py  ./
 COPY em_oww_models.py .
+COPY em_oww_warmup.py .
 COPY em_arbiter.py .
 COPY em_button.py .
 COPY em_tap_burst.py .

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -73,6 +73,7 @@ import em_linkauth
 import em_eq
 import em_scenes
 import em_shadow
+import em_oww_warmup
 import em_arbiter
 import em_button
 import em_tap_burst
@@ -1028,6 +1029,12 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
     # above); scoring needs the openwakeword prediction key (path → stem).
     barge_pred_key = em_oww_models.prediction_key(device._barge_model_key)
     model.reset()
+    # reset() seeds the classifier's window with embeddings of random noise,
+    # so the first FEATURE_WINDOW chunks score that noise as much as the room.
+    # This watcher is where that hurt most: it reset and scored immediately,
+    # and twice cancelled a turn the user was waiting on, at 0.867 and 0.700
+    # within 10 chunks of starting. See em_oww_warmup.
+    warmup = em_oww_warmup.WarmupGate()
 
     # Drop anything queued before the watcher started (command tail,
     # silence) — only fresh audio should be scored.
@@ -1081,6 +1088,7 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
                 prediction = await loop.run_in_executor(None, model.predict, samples)
                 score = prediction.get(barge_pred_key, 0.0)
                 frames += 1
+                trusted = warmup.feed()
                 in_playback = playback_started.is_set()
                 if in_playback:
                     threshold = device.barge_threshold
@@ -1103,6 +1111,13 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
                         )
                     else:
                         fired = False
+                if fired and not trusted:
+                    log.info(
+                        f"[{device.device_id}] Barge watcher: {fire_note} "
+                        f"ignored — openwakeword warm-up, "
+                        f"{warmup.progress()} chunks since reset"
+                    )
+                    fired = False
                 prev_score = score
                 if score > peak:
                     peak = score
@@ -1778,6 +1793,11 @@ async def wake_word_listener(device: Device):
     await device.mic_start()
 
     buf = bytearray()
+    # openwakeword seeds its classifier window with embeddings of random noise
+    # on construction AND on every reset(), so scores are partly scores of that
+    # noise until the window has refilled. Un-warmed at construction to match
+    # the model above; re-armed at every reset() below. See em_oww_warmup.
+    warmup = em_oww_warmup.WarmupGate()
     last_near_miss_log_ts = 0.0  # Q4: rate-limit near-miss INFO logging to 1/2s
     nm_pending = 0    # near-misses buffered since the last hourly-rollup flush
     nm_max     = 0.0  # highest buffered near-miss score
@@ -1807,6 +1827,8 @@ async def wake_word_listener(device: Device):
                     current_model_name = new_name
                     current_speex_ns  = new_speex
                     buf.clear()
+                    # A new model is noise-seeded exactly like a reset one.
+                    warmup.reset()
                     log.info(f"[{device.device_id}] OWW: model reloaded → {new_name} (speex_ns={new_speex})")
                 except Exception as e:
                     log.error(
@@ -1909,6 +1931,10 @@ async def wake_word_listener(device: Device):
                     None, model.predict, samples
                 )
                 score = prediction.get(model_key, 0.0)
+                # Exactly once per chunk the MODEL saw, whatever the score —
+                # the `device.speaking` skip above returns before predict(),
+                # so the gate and the model stay in step.
+                trusted = warmup.feed()
 
                 # Log any score above noise floor so we can see near-misses
                 # and understand whether failed wakes are "close but below
@@ -1938,7 +1964,7 @@ async def wake_word_listener(device: Device):
                 if device.barge_in_enabled and em_player.is_playing(device.device_id):
                     eff_threshold = min(eff_threshold, device.barge_threshold)
 
-                if 0.05 < score < eff_threshold:
+                if trusted and 0.05 < score < eff_threshold:
                     device.oww_near_misses += 1
                     nm_pending += 1
                     nm_max = max(nm_max, float(score))
@@ -1978,7 +2004,13 @@ async def wake_word_listener(device: Device):
                 # this controller's own crossing is demoted to a measurement —
                 # see em_shadow.decide_wake_source for why it keeps scoring at
                 # all. In every other mode this is exactly the old condition.
-                ctrl_hit = score >= eff_threshold
+                if not trusted and score >= eff_threshold:
+                    log.info(
+                        f"[{device.device_id}] Wake score {score:.3f} >= "
+                        f"{eff_threshold:.3f} ignored — openwakeword warm-up, "
+                        f"{warmup.progress()} chunks since reset"
+                    )
+                ctrl_hit = trusted and score >= eff_threshold
                 dev_wake, dev_age = device.pending_wake.take()
                 if dev_wake is None and dev_age is not None:
                     # Expired before anything could act on it. Worth a warning
@@ -2041,6 +2073,7 @@ async def wake_word_listener(device: Device):
                         # TTS mic_stop/mic_start remains untouched — that
                         # acoustic-feedback guard is load-bearing.
                         model.reset()
+                        warmup.reset()
                         buf.clear()
                         device.cancel_event.clear()
                         # Wake detail for the turn's persistent record —
@@ -2160,6 +2193,7 @@ async def wake_word_listener(device: Device):
                                 f"drained {drained} stale frames post-turn"
                             )
                         model.reset()
+                        warmup.reset()
                         buf.clear()
                         # mic_start without lock_mic — device stays on ch6 omni
                         # (beamforming=off), same stream as OWW listening.
@@ -2174,6 +2208,7 @@ async def wake_word_listener(device: Device):
                             f"ignoring wake"
                         )
                         model.reset()
+                        warmup.reset()
 
     except asyncio.CancelledError:
         await device.mic_stop()

--- a/controller/em_oww_warmup.py
+++ b/controller/em_oww_warmup.py
@@ -1,0 +1,130 @@
+"""
+The post-reset warm-up gate for openwakeword, as pure logic.
+
+`openwakeword.Model.reset()` does not clear the classifier's input; it REFILLS
+it with embeddings computed from four seconds of RANDOM NOISE — and so does
+`AudioFeatures.__init__`, so a newly constructed model starts the same way:
+
+    def reset(self):
+        self.raw_data_buffer.clear()
+        self.melspectrogram_buffer = np.ones((76, 32))
+        self.accumulated_samples = 0
+        self.raw_data_remainder = np.empty(0)
+        self.feature_buffer = self._get_embeddings(
+            np.random.randint(-1000, 1000, 16000*4).astype(np.int16))
+
+Measured against the installed package: that leaves 41 noise embeddings in
+`feature_buffer`, and the classifier's input is [1, 16, 96] — the most recent
+FEATURE_WINDOW of them. So every prediction is partly a score OF THAT NOISE
+until FEATURE_WINDOW real chunks have been fed, and the noise is unseeded, so
+it lands somewhere the classifier likes occasionally rather than never.
+
+That is not a theoretical concern. On a single fleet device over one day: 19
+wake events that captured no speech at all, scoring up to 0.994, every one of
+them starting 0.79–1.25s after a turn ended — which is where the reset is.
+The upper end of that band is the tell: FEATURE_WINDOW chunks is 1.28s, and
+nothing was ever observed past it, because by then the noise is shifted out.
+
+It also fired the barge-in watcher, which resets on the same model and scores
+immediately: twice within 9-10 chunks of starting, at 0.867 and 0.700, each
+time CANCELLING a turn the user was waiting on. That is the worse of the two
+symptoms — a false wake wastes a moment, a false barge loses the request.
+
+Raising the threshold does not help and is the trap worth naming: these score
+higher than real speech does, and two of the recorded events cleared a
+threshold of 0.80. The scores are not marginal, they are confident scores of
+noise.
+
+Reproduced away from the room, so the mechanism is not inferred from field
+data alone: score the SAME audio twice, once immediately after `reset()` and
+once on a model already warmed on audio of the same kind. 60 trials per level,
+uniform noise, hey_jarvis, over the max of the 16 chunks:
+
+    input level    cold max   cold p95   warm max
+    ±30            0.225      0.135      0.001
+    ±300           0.346      0.244      0.008
+    ±1000          0.333      0.292      0.004
+    ±3000          0.464      0.417      0.004
+
+Identical input, two orders of magnitude apart, and the level barely matters —
+it is the window that decides. Note where the cold p95 lands against the
+defaults: `bargeInThreshold` is 0.05, cleared at every level, which is why the
+barge-in watcher — the one site that resets and scores immediately — was where
+this hurt rather than merely showed. Pure digital silence never fires (0/150
+resets), which is why the fault needed a room to appear in.
+
+The firmware's own Go port of this pipeline does NOT have the bug: it starts
+its feature buffer empty and `Score` returns `ErrNotReady` until FEATURE_WINDOW
+real embeddings exist (`device/internal/wakeword/stream.go`). So on shadow
+mode the two detectors were not comparing like with like for the first 1.28s
+after every reset — the device declined to answer while this one scored noise.
+
+Gating on this gate rather than skipping the chunk outright is deliberate. A
+device that scores wake words itself reports them on the control plane, and
+the wake listener acts on those in the same loop iteration (see
+`em_shadow.decide_wake_source`); a `continue` here would swallow a detection
+this model had no part in.
+
+Note the real wake word is not lost, only delayed at worst. Its audio stays in
+the window while the window fills, so an utterance spoken during warm-up is
+still scored — at the moment the window goes clean instead of before it.
+"""
+
+# Embeddings the classifier consumes per prediction: the wake models' input
+# shape is [1, FEATURE_WINDOW, 96]. One embedding is produced per 1280-sample
+# (80ms) chunk, so this is also how many chunks must be fed after a reset
+# before the window holds no reset noise — 1.28s.
+FEATURE_WINDOW = 16
+
+
+class WarmupGate:
+    """
+    Tracks whether a model's classifier window still contains reset noise.
+
+    Call `reset()` wherever `Model.reset()` is called, and `feed()` exactly
+    once per chunk scored. `feed()` returns whether that chunk's score can be
+    trusted; it must be called for every chunk regardless of the score, or the
+    window never fills.
+
+    A NEW gate starts un-warmed, because a new model does too: `AudioFeatures`
+    seeds `feature_buffer` with those same noise embeddings in its constructor,
+    not only in `reset()`. So constructing a model and constructing a gate need
+    no coordination — every gate begins where its model does. Starting ready
+    would leave the first second after startup and after every wake-model swap
+    unguarded, which is the one window nothing else covers.
+    """
+
+    def __init__(self, window: int = FEATURE_WINDOW) -> None:
+        if window < 0:
+            raise ValueError("window must not be negative")
+        self._window = window
+        self._fed = 0
+
+    def reset(self) -> None:
+        """Record that the model's buffers were just seeded with noise."""
+        self._fed = 0
+
+    def feed(self) -> bool:
+        """
+        Record one scored chunk. True if that chunk's score is trustworthy.
+
+        Saturates rather than counting forever, so a long-running listener
+        cannot overflow anything.
+        """
+        if self._fed < self._window:
+            self._fed += 1
+        return self._fed >= self._window
+
+    @property
+    def ready(self) -> bool:
+        """Whether scores are currently trustworthy, without feeding."""
+        return self._fed >= self._window
+
+    @property
+    def fed(self) -> int:
+        """Chunks fed since the last reset, saturating at the window size."""
+        return self._fed
+
+    def progress(self) -> str:
+        """`N/16`, for a log line explaining a suppressed detection."""
+        return f"{self._fed}/{self._window}"

--- a/controller/tests/test_oww_warmup.py
+++ b/controller/tests/test_oww_warmup.py
@@ -1,0 +1,134 @@
+"""
+The post-reset warm-up gate for openwakeword.
+
+The bug it exists for: `Model.reset()` and `AudioFeatures.__init__` both fill
+the classifier's input with embeddings of four seconds of RANDOM NOISE, so
+until FEATURE_WINDOW real chunks have been fed, every score is partly a score
+of that noise. Unseeded, so it lands somewhere the classifier likes
+occasionally rather than never.
+
+Measured on one device over a day before the fix: 19 wake events that captured
+no speech at all, scoring up to 0.994, every one of them 0.79-1.25s after a
+turn ended — the reset site — and none past 1.28s, which is what
+FEATURE_WINDOW chunks of 80ms comes to. The same artefact fired the barge-in
+watcher twice within 10 chunks of its own reset, at 0.867 and 0.700, each time
+cancelling a turn the user was waiting on.
+"""
+
+import em_oww_warmup as W
+
+
+def feed_n(gate, n):
+    """Feed n chunks, returning the trust verdict for each."""
+    return [gate.feed() for _ in range(n)]
+
+
+# ─── The window ───────────────────────────────────────────────────────────────
+
+def test_window_matches_the_classifier_input():
+    """
+    The wake models take [1, 16, 96] — sixteen embeddings, one per 80ms chunk.
+    That is where the constant comes from; it is not a tuned timeout, and
+    16 x 80ms = 1.28s is exactly the band the false wakes were observed in.
+    """
+    assert W.FEATURE_WINDOW == 16
+
+
+def test_a_new_gate_is_not_ready():
+    """
+    A new model is noise-seeded by its own constructor, not only by reset(),
+    so a new gate must not start trusted. Getting this backwards would leave
+    controller startup and every wake-model swap unguarded.
+    """
+    assert not W.WarmupGate().ready
+
+
+def test_trust_arrives_exactly_on_the_window_th_chunk():
+    gate = W.WarmupGate()
+    verdicts = feed_n(gate, W.FEATURE_WINDOW)
+    assert verdicts[:-1] == [False] * (W.FEATURE_WINDOW - 1)
+    assert verdicts[-1] is True
+    assert gate.ready
+
+
+def test_trust_persists_once_earned():
+    gate = W.WarmupGate()
+    feed_n(gate, W.FEATURE_WINDOW)
+    assert all(feed_n(gate, 500))
+
+
+def test_reset_disarms_a_warmed_gate():
+    """The whole point: the gate has to re-arm at every reset, not just once."""
+    gate = W.WarmupGate()
+    feed_n(gate, W.FEATURE_WINDOW)
+    assert gate.ready
+    gate.reset()
+    assert not gate.ready
+    assert feed_n(gate, W.FEATURE_WINDOW)[-1] is True
+
+
+def test_repeated_resets_each_require_a_full_window():
+    gate = W.WarmupGate()
+    for _ in range(5):
+        gate.reset()
+        assert feed_n(gate, W.FEATURE_WINDOW - 1) == [False] * (W.FEATURE_WINDOW - 1)
+        assert gate.feed() is True
+
+
+# ─── The failure it reproduces ────────────────────────────────────────────────
+
+def test_a_confident_score_inside_the_window_is_not_trusted():
+    """
+    The recorded events scored 0.770-0.994 and two of them cleared a threshold
+    of 0.80, which is why raising the threshold was never the fix. Trust is
+    decided by position in the window, never by the score.
+    """
+    gate = W.WarmupGate()
+    gate.reset()
+    for chunk, score in enumerate([0.994, 0.900, 0.871, 0.789, 0.770], start=1):
+        trusted = gate.feed()
+        assert not trusted, f"chunk {chunk} scoring {score} must not fire"
+
+
+def test_the_real_wake_word_is_delayed_not_lost():
+    """
+    A wake word spoken during warm-up still fires — its audio is in the window
+    while the window fills, so it is scored the moment the window goes clean.
+    A gate that latched the suppression instead would drop it.
+    """
+    gate = W.WarmupGate()
+    gate.reset()
+    feed_n(gate, W.FEATURE_WINDOW - 1)
+    assert gate.feed() is True
+
+
+# ─── Counter hygiene ──────────────────────────────────────────────────────────
+
+def test_the_counter_saturates():
+    """A listener runs for weeks; the counter must not grow without bound."""
+    gate = W.WarmupGate()
+    feed_n(gate, 10_000)
+    assert gate.fed == W.FEATURE_WINDOW
+
+
+def test_progress_reports_position_for_the_log_line():
+    gate = W.WarmupGate()
+    gate.reset()
+    feed_n(gate, 3)
+    assert gate.progress() == f"3/{W.FEATURE_WINDOW}"
+
+
+def test_a_zero_window_is_always_ready():
+    """Degenerate but well-defined — a gate configured off must not block."""
+    gate = W.WarmupGate(window=0)
+    assert gate.ready
+    gate.reset()
+    assert gate.feed() is True
+
+
+def test_a_negative_window_is_refused():
+    try:
+        W.WarmupGate(window=-1)
+    except ValueError:
+        return
+    raise AssertionError("a negative window must be refused")


### PR DESCRIPTION
Fixes #214

`openwakeword.Model.reset()` does not clear the classifier's input — it refills it with embeddings of four seconds of random noise, and `AudioFeatures.__init__` does the same, so a freshly built model starts that way too. That leaves 41 noise embeddings against a classifier input of `[1, 16, 96]`, so every prediction is partly a score of that noise until 16 real chunks (1.28s) have been fed.

Full evidence in the issue. The short version:

- **19 wake events on one device in one day that captured no speech**, up to 0.994, all of them 0.79–1.25s after a turn ended and none past 1.28s.
- **Two barge-ins that cancelled a turn the user was waiting on**, at 0.867 and 0.700, within 10 chunks of the watcher's own reset.
- Scoring the *same* audio cold vs warm: **0.417 p95 against 0.004**. `bargeInThreshold` defaults to 0.05.
- Raising the threshold does not help — these score higher than real speech does, and two recorded events cleared 0.80.

## What this does

`em_oww_warmup.WarmupGate` counts chunks since the last reset and reports whether the window is clean. It is wired into both scoring loops (`wake_word_listener`, `_barge_watcher`) and at every reset site, including the wake-model swap, which builds a model and is therefore noise-seeded the same way.

Two decisions worth reviewing on purpose:

- **The gate is consulted, not used to skip the chunk.** A device that scores wake words itself reports crossings on the control plane, and the listener acts on those in the same loop iteration (`em_shadow.decide_wake_source`); a `continue` here would swallow a detection this model had no part in.
- **The real wake word is delayed, never lost.** Its audio stays in the window while the window fills, so an utterance spoken during warm-up is scored the moment the window goes clean, rather than dropped. Worst case is one chunk of latency on a wake in the 1.28s after a turn.

A new gate starts *un-warmed*, matching a new model — otherwise controller startup and every wake-model swap stay unguarded, which is the one window nothing else covers.

Suppressed detections log at INFO with `N/16 chunks since reset`, so this is visible rather than silent if it ever fires on something real.

## Not changed, deliberately

- No threshold, no default, no config key. The gate is positional, not a sensitivity knob.
- Near-miss counting is gated too (`trusted and 0.05 < score < eff_threshold`), so the near-miss statistics stop being fed noise as well — they were the other reader of these scores.
- Nothing device-side. `device/internal/wakeword/stream.go` starts its feature buffer empty and returns `ErrNotReady` until 16 real embeddings exist, so the firmware never had this bug. One consequence worth noting for shadow-mode readers: before this change the two detectors were not comparing like with like for 1.28s after every reset.

## Testing

- `controller/tests/test_oww_warmup.py` — 12 tests over the gate: the window matches the classifier input, a new gate is not ready, trust arrives exactly on the 16th chunk and persists, every reset re-arms, a confident score inside the window is still refused (the recorded 0.994/0.867 values), the real wake word is delayed not lost, the counter saturates, and the degenerate windows are defined.
- `cd controller && python -m pytest tests/` — 451 passed, 1 skipped.
