### PR TITLE
Fix TypeError in get_user_by_ha_id causing Ingress login to fail

### DIFF
--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -2090,10 +2090,8 @@ def create_user(username: str, password_hash: str, role: str = "readonly") -> in
 
 def get_user_by_ha_id(ha_user_id: str) -> Optional[sqlite3.Row]:
     """Return the user linked to a Home Assistant user id, or None."""
-    with _conn() as conn:
-        return conn.execute(
-            "SELECT * FROM users WHERE ha_user_id = ?", (ha_user_id,)
-        ).fetchone()
+    # Use the existing _q1 helper which safely handles _db_lock and returns a single row
+    return _q1("SELECT * FROM users WHERE ha_user_id = ?", (ha_user_id,))
 
 
 def create_ha_user(ha_user_id: str, username: str, role: str) -> int:


### PR DESCRIPTION
### Description
This PR fixes a bug that caused the Home Assistant Ingress authentication to fail and fall back to the setup token page. 

When accessing the app via the Home Assistant sidebar, the `POST /api/auth/ingress` endpoint threw a `HTTP 500` error:
`TypeError: function takes exactly 1 argument (0 given)`

This should fix #211 

### Root Cause & Fix
In `controller/em_db.py`, inside `get_user_by_ha_id`, the global `sqlite3.Connection` object `_conn` was mistakenly called as a context manager (`with _conn() as conn:`). 

I fixed this by replacing the faulty block with the existing thread-safe `_q1` helper function, which  handles the `_db_lock` and the `fetchone()` logic.