### PR TITLE
Fix ESPHome MAC collision for multiple devices by hashing DSN

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -2558,13 +2558,15 @@ def _serialno_to_mac(device_id: str) -> str:
     """
     Derive a stable MAC-format string from a device's ro.serialno.
 
-    ro.serialno on the biscuit is a 12-char uppercase hex string
-    (e.g. G0K0XXXXXXXX). We take the last 12 hex chars (or pad/truncate)
-    to build a MAC-style address for ESPHome's mac_address field.
-    This is cosmetic only — ESPHome's protocol uses it as a stable
-    device identifier in HA's device registry.
+    Amazon Device Serial Numbers (DSNs) are alphanumeric. Devices from the 
+    same batch often differ only in non-hexadecimal characters at the end 
+    (e.g., ...FRK vs ...FRR). Stripping non-hex characters destroys entropy 
+    and causes ESPHome MAC collisions in Home Assistant.
+    
+    Instead, we hash the entire device_id to generate a stable, pseudo-random 
+    MAC address to guarantee uniqueness per device.
     """
-    # Extract hex chars only, take last 12, pad with zeros if short
-    hex_chars = "".join(c for c in device_id if c in "0123456789ABCDEFabcdef")
-    hex_chars = hex_chars[-12:].upper().zfill(12)
+    import hashlib
+    hashed = hashlib.md5(device_id.encode('utf-8')).hexdigest()
+    hex_chars = hashed[:12].upper()
     return ":".join(hex_chars[i:i+2] for i in range(0, 12, 2))


### PR DESCRIPTION
### Description
This PR fixes a bug (fix #212) where adding multiple Echo devices to Home Assistant via ESPHome overwrites the existing device instead of creating a new one. 

### Root Cause
The `_serialno_to_mac(device_id)` function stripped all non-hexadecimal characters from the alphanumeric Amazon Device Serial Number (DSN). Because devices from the same batch often only differ in non-hex characters at the end (e.g., ending in `...FRK` vs `...FRR`), the function generated the exact same MAC address for multiple satellites. 
Since Home Assistant strictly uses the `mac_address` as the `unique_id` in its device registry, it overwrote the existing entity instead of discovering a second one.

### The Fix
Instead of stripping characters (which destroys entropy), the function now hashes the entire `device_id` using MD5 to generate a stable, truly unique pseudo-MAC address for each device.

⚠️ **BREAKING CHANGE / NOTICE:** 
Because the algorithm for generating MAC addresses changes with this PR, already registered Echo devices in Home Assistant will change their MAC address. Users will need to re-add their devices to Home Assistant, as the old entities will become orphaned.