### PR TITLE
Fix ingress login crash: get_user_by_ha_id calls _conn as a function

### DIFF
--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -2090,10 +2090,7 @@ def create_user(username: str, password_hash: str, role: str = "readonly") -> in
 
 def get_user_by_ha_id(ha_user_id: str) -> Optional[sqlite3.Row]:
     """Return the user linked to a Home Assistant user id, or None."""
-    with _conn() as conn:
-        return conn.execute(
-            "SELECT * FROM users WHERE ha_user_id = ?", (ha_user_id,)
-        ).fetchone()
+    return _q1("SELECT * FROM users WHERE ha_user_id = ?", (ha_user_id,))
 
 
 def create_ha_user(ha_user_id: str, username: str, role: str) -> int:

--- a/controller/tests/test_db_users.py
+++ b/controller/tests/test_db_users.py
@@ -1,0 +1,44 @@
+"""
+Tests for the Home Assistant user lookup path (em_db.get_user_by_ha_id /
+create_ha_user).
+
+get_user_by_ha_id shipped broken (`with _conn() as conn:` called the raw
+connection object as a function instead of using the module's own _q1
+helper) and stayed that way through several releases because nothing
+exercised it — it is only reached via ingress login, which the test suite
+had no coverage for either. These tests run it against a real database, the
+same discipline test_db_instrumentation.py uses.
+"""
+
+import pytest
+
+import em_db as db
+
+
+@pytest.fixture()
+def fresh_db(tmp_path):
+    """A real database migrated from scratch to the current schema."""
+    path = tmp_path / "test.db"
+    db.init(str(path))
+    yield db
+    if db._conn is not None:
+        db._conn.close()
+        db._conn = None
+
+
+def test_ha_user_found_by_ha_id(fresh_db):
+    user_id = db.create_ha_user("ha-abc123", "wil", "admin")
+
+    row = db.get_user_by_ha_id("ha-abc123")
+
+    assert row is not None
+    assert row["id"] == user_id
+    assert row["username"] == "wil"
+    assert row["role"] == "admin"
+    # No password can ever match this account via the standalone login form
+    # — see create_ha_user's docstring.
+    assert row["password_hash"] == db.HA_USER_PASSWORD_SENTINEL
+
+
+def test_unknown_ha_id_returns_none(fresh_db):
+    assert db.get_user_by_ha_id("no-such-id") is None


### PR DESCRIPTION
POST /api/auth/ingress 500s on every request — the one path that exercised this function — with:

    TypeError: function takes exactly 1 argument (0 given)
      with _conn() as conn:
      em_db.py:2093, in get_user_by_ha_id
      em_auth.py:165, in login_via_ingress

_conn is the module-level sqlite3.Connection itself (set once in init()), not a callable — every other single-row lookup in this file goes through _q1(sql, params), which also holds _db_lock around the shared connection, and this bypassed it entirely on top of the crash.

Introduced in 07cd8c9 ("Fix four things a review of this branch turned up") and never exercised by the test suite, so it shipped and stayed broken through several releases — the add-on's Home Assistant auto-login (the whole point of running it as an add-on rather than standalone) has been unusable since. Added tests/test_db_users.py so it can't regress silently again.