### PR TITLE
Build the controller image on PRs that change what goes into it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,12 +44,41 @@ updates:
   # ── Controller base image ───────────────────────────────────────────────
   # python:3.12-slim is where ffmpeg, curl and the whole Debian layer come
   # from — the majority of what any image scan reports.
+  #
+  # The Python version is NOT ours to choose: it is the highest one every
+  # pinned wheel publishes for, and today that is 3.12. Measured on PyPI
+  # 2026-08-18, for the versions requirements.txt actually pins:
+  #
+  #   speexdsp-ns 0.1.2  cp37 … cp312     <- the binding constraint
+  #   onnxruntime 1.20.1 cp310 … cp313
+  #   numpy       2.4.4  cp311 … cp314
+  #
+  # Neither builds from source in this image, so a bump past the lowest of
+  # those does not degrade — it fails to build. #127 proposed 3.14 and
+  # carried seven green checks, because until ci.yml gained the
+  # controller-image job nothing built the image on a PR at all.
+  #
+  # So majors and minors are ignored and moving Python is a deliberate
+  # upgrade: check the wheels first, then bump this and requirements.txt
+  # together.
+  #
+  # That leaves this ecosystem quiet, which is correct and worth stating so
+  # nobody reads the silence as coverage: `python:3.12-slim` is a FLOATING
+  # tag, so Debian security fixes arrive by rebuilding, not by a PR here.
+  # security-scan.yml is what watches for them — it scans the published
+  # image on a schedule precisely because the digest can go stale while the
+  # tag stands still.
   - package-ecosystem: docker
     directory: /controller
     schedule:
       interval: weekly
       day: monday
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: python
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
 
   # ── Device Go modules ───────────────────────────────────────────────────
   # The GoTinyAlsa replace directive points at a submodule path, which

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,75 @@ jobs:
         working-directory: device
         run: govulncheck ./internal/... ./pkg/... || true
 
+  controller-image:
+    name: Controller image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # the diff below needs the base commit
+      # Plain git rather than a paths-filter action: this decides whether a
+      # build runs, so it is not worth a third-party action holding repo
+      # credentials. On push to main there is nothing to diff against and
+      # controller-build.yml builds anyway, so this only ever runs on a PR.
+      - name: Did the image inputs change?
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            echo "not a pull request — controller-build.yml covers main"
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          files=$(git diff --name-only "$base"...HEAD -- \
+                    controller/Dockerfile controller/requirements.txt)
+          if [ -n "$files" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            echo "$files"
+          else
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            echo "Dockerfile and requirements.txt unchanged"
+          fi
+      - name: Set up Docker Buildx
+        if: steps.changed.outputs.build == 'true'
+        uses: docker/setup-buildx-action@v3
+      # Why this job exists: NOTHING else builds this image on a PR.
+      # controller-build.yml runs on push to main only, and the test jobs
+      # above pin themselves to python-version 3.12 regardless of what the
+      # Dockerfile says — so a base-image or dependency bump arrives with
+      # seven green checks and no evidence behind any of them.
+      #
+      # That is not hypothetical. Dependabot #127 (python:3.12-slim ->
+      # 3.14-slim) was green on every check while speexdsp-ns==0.1.2 has no
+      # wheel past cp312 and onnxruntime==1.20.1 none past cp313, so the
+      # image could not have built at all. The first failure would have been
+      # on main, in the job that publishes.
+      #
+      # Deliberately narrow, because a full image build is minutes:
+      #   - Only when the Dockerfile or requirements.txt actually changed.
+      #     Application code cannot break the build in a way the other jobs
+      #     miss; a missing wheel is exactly what they cannot see.
+      #   - amd64 only. The break this catches is a missing wheel or an apt
+      #     package that moved, both of which show up on either architecture,
+      #     and arm64 under QEMU costs far more than it adds. The release
+      #     path still builds both.
+      #   - No push, no registry login, no GHCR credentials. This answers
+      #     "does it build", nothing more.
+      #
+      # It is a JOB rather than a separate workflow so that it always reports
+      # a result, including when it skips. A workflow-level `paths:` filter
+      # would leave the check simply absent on most PRs, which is the one
+      # state a branch protection rule cannot tell apart from "not finished".
+      - name: Build the controller image
+        if: steps.changed.outputs.build == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: controller
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   device-vet:
     name: Device go vet
     runs-on: ubuntu-latest

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -51,5 +51,3 @@ onnxruntime==1.20.1
 # aioesphomeapi==45.3.1). Not pulled in transitively since we vendor only
 # the two generated files rather than depending on the full aioesphomeapi package.
 protobuf>=4.21.0
-
-# (temporary line to exercise the new controller-image job — reverted next commit)

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -51,3 +51,5 @@ onnxruntime==1.20.1
 # aioesphomeapi==45.3.1). Not pulled in transitively since we vendor only
 # the two generated files rather than depending on the full aioesphomeapi package.
 protobuf>=4.21.0
+
+# (temporary line to exercise the new controller-image job — reverted next commit)


### PR DESCRIPTION
## The gap

Nothing built the controller image on a pull request. `controller-build.yml` runs on `push: branches: [main]`, and every test job in `ci.yml` pins itself to `python-version: "3.12"` regardless of what the Dockerfile says. So a base-image or dependency bump arrived with **seven green checks and no evidence behind any of them**, and the first failure would have been on main, in the job that publishes.

Dependabot #127 is the worked example — `python:3.12-slim` → `3.14-slim`, green on all seven checks, and unbuildable. Measured on PyPI for the versions `requirements.txt` pins:

```
speexdsp-ns 0.1.2   cp37 … cp312     <- the binding constraint
onnxruntime 1.20.1  cp310 … cp313
numpy       2.4.4   cp311 … cp314
```

Neither builds from source in this image, so the bump does not degrade — it fails.

## The job

Narrow on purpose, since a full build is minutes:

- **Only when `Dockerfile` or `requirements.txt` changed.** Application code cannot break the build in a way the other jobs miss; a missing wheel is exactly what they cannot see.
- **amd64 only.** The break this catches is a missing wheel or an apt package that moved, both of which show on either architecture, and arm64 under QEMU costs far more than it adds. The release path still builds both.
- **No push, no registry login, no GHCR credentials.** It answers "does it build", nothing more.

Two shape decisions worth reviewing rather than assuming:

- **A job, not a separate workflow.** A workflow-level `paths:` filter would leave the check simply *absent* on most PRs, which is the one state a branch protection rule cannot distinguish from "not finished". As a job it always reports, including when it skips.
- **Plain `git diff`, not a paths-filter action.** This step decides whether a build runs, so it is not worth a third-party action holding repo credentials.

## dependabot.yml

Python major and minor bumps on the docker ecosystem are now ignored, with the wheel table written into the comment. Moving Python is a deliberate upgrade that starts by checking wheels, not a weekly PR — the same reasoning as the existing numpy and onnxruntime entries.

It also records why this ecosystem going quiet is **not** coverage: `python:3.12-slim` is a floating tag, so Debian security fixes arrive by rebuilding rather than by a PR here, and `security-scan.yml` is what watches for them.

## Verification

This PR touches `.github/` only, so the new job should report **skipped** on itself — which is the behaviour worth confirming in the checks below. #127 is the negative case and I have closed it against this evidence rather than merging it into a red build.