### PR TITLE
Align the controller-image job with the bumped action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
     name: Controller image builds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # the diff below needs the base commit
       # Plain git rather than a paths-filter action: this decides whether a
@@ -207,7 +207,7 @@ jobs:
           fi
       - name: Set up Docker Buildx
         if: steps.changed.outputs.build == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       # Why this job exists: NOTHING else builds this image on a PR.
       # controller-build.yml runs on push to main only, and the test jobs
       # above pin themselves to python-version 3.12 regardless of what the
@@ -237,7 +237,7 @@ jobs:
       # state a branch protection rule cannot tell apart from "not finished".
       - name: Build the controller image
         if: steps.changed.outputs.build == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: controller
           push: false


### PR DESCRIPTION
Dependabot #205 was raised before the `controller-image` job existed, so it left the new steps on `actions/checkout@v4`, `docker/setup-buildx-action@v3` and `docker/build-push-action@v6` while every other job in the file moved to v7/v4/v7.

Nothing is broken by the mismatch. It is worth closing anyway: a workflow running two generations of the same action is how one of them gets missed on the next review, and Dependabot will not raise it again until next week's run.

The job itself is unchanged. Since this PR does not touch `Dockerfile` or `requirements.txt`, the image job should report **skipped-but-successful** — which incidentally re-exercises the skip path against the new action versions.