### PR TITLE
Take the routine half of #129, and fix the guard the other half slipped past

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,16 +30,26 @@ updates:
     groups:
       python-dependencies:
         patterns: ["*"]
-    # Major bumps of these two are not routine maintenance and should not
-    # arrive as a weekly PR: numpy majors have broken openwakeword's array
-    # handling before, and an onnxruntime major changes inference behaviour
-    # on every device at once. Both want a deliberate upgrade with a wake
-    # word test behind it.
+    # Bumps of these two are not routine maintenance and should not arrive as
+    # a weekly PR: numpy majors have broken openwakeword's array handling
+    # before, and an onnxruntime bump changes inference behaviour on every
+    # device at once. Both want a deliberate upgrade with a wake word test
+    # behind it.
+    #
+    # onnxruntime is ignored on MINOR too, and that is the whole point rather
+    # than caution: it has never bumped major and shows no sign of doing so,
+    # so a major-only rule can never fire and protects nothing. #129 proposed
+    # 1.20.1 -> 1.28.0 — eight minor versions, exactly the change described
+    # above — as an ordinary weekly PR, alongside bumps that genuinely were
+    # routine. Nothing in CI can catch an inference regression, so the guard
+    # has to be here or it does not exist.
     ignore:
       - dependency-name: numpy
         update-types: ["version-update:semver-major"]
       - dependency-name: onnxruntime
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
 
   # ── Controller base image ───────────────────────────────────────────────
   # python:3.12-slim is where ffmpeg, curl and the whole Debian layer come

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -5,15 +5,15 @@
 #
 # Tested with Python 3.12.
 # WebSocket server (device connections)
-websockets==16.0
+websockets==17.0.1
 # HTTP API + dashboard server
-aiohttp==3.13.5
+aiohttp==3.14.3
 # Password hashing
 bcrypt==5.0.0
 # Device-link TLS: CA + server cert generation (em_pki.py). The controller
 # runs fine without it (plain ws only, wss listener disabled) but the
 # published image always ships it.
-cryptography==44.0.1
+cryptography==50.0.0
 # mDNS advertisement (_emcontroller._tcp.local)
 #
 # Held at >=0.149.12 for three advisories against 0.148.0, all unauthenticated
@@ -26,9 +26,10 @@ cryptography==44.0.1
 #   PYSEC-2026-3435  unbounded deferred truncated-query queues, O(N) per arrival
 # None has an in-process workaround; the fix is the upgrade.
 #
-# 0.149.17 rather than 0.150.0: the smallest jump that clears all three, on a
-# dependency the whole fleet's discovery depends on.
-zeroconf==0.149.17
+# It sat at 0.149.17 rather than 0.150.0 for a while — the smallest jump that
+# cleared all three, on a dependency the whole fleet's discovery depends on.
+# 0.150.0 now that it has had time in the wild.
+zeroconf==0.150.0
 # Wake word inference — openwakeword deps installed manually to avoid
 # tflite-runtime which has no Python 3.12 x86_64 build.
 # openwakeword itself is installed via --no-deps in the Dockerfile.
@@ -50,4 +51,14 @@ onnxruntime==1.20.1
 # Protobuf runtime — required by esphome/vendor/api_pb2.py (vendored from
 # aioesphomeapi==45.3.1). Not pulled in transitively since we vendor only
 # the two generated files rather than depending on the full aioesphomeapi package.
-protobuf>=4.21.0
+#
+# Moving this floor across a MAJOR needs checking rather than assuming, and
+# nothing in CI can do it for you: api_pb2.py calls
+# ValidateProtobufRuntimeVersion at import with the gencode version baked in
+# (6.30.0), and the test suite never imports em_esphome, so a rejection would
+# first appear at controller startup — i.e. every user's voice satellite, on
+# release day. Verified by hand for 7.x on 2026-08-18: gencode 6.30.0 imports
+# and round-trips under runtime 7.35.1. The rule only rejects a runtime OLDER
+# than its gencode, so this direction is the safe one — but protobuf's
+# cross-version guarantee is a window, not a promise, so check again at 8.x.
+protobuf>=7.35.1


### PR DESCRIPTION
Splits Dependabot #129. This is the half that is ordinary maintenance.

| package | from | to |
|---|---|---|
| websockets | 16.0 | 17.0.1 |
| aiohttp | 3.13.5 | **3.14.3** |
| cryptography | 44.0.1 | 50.0.0 |
| zeroconf | 0.149.17 | 0.150.0 |
| protobuf | >=4.21.0 | >=7.35.1 |

**aiohttp is the one with a deadline** — CVE-2026-69244, denial of service via malformed HTTP, which `security-scan.yml` has been failing on. That library serves the dashboard and, under the add-on, ingress.

## What is deliberately not here

`onnxruntime 1.20.1 -> 1.28.0` and `numpy 2.4.4 -> 2.5.2`. Those change inference behaviour on every device at once and want a wake word comparison behind them rather than a merge button. Tracked separately.

## The guard that should have stopped it

`dependabot.yml` already ignored major bumps of both, with the reason written out. It could not fire: **onnxruntime has never bumped major** and shows no sign of doing so, so a major-only rule protects nothing, and eight minor versions arrived as routine weekly maintenance next to bumps that genuinely were. Now ignored on minor too.

## protobuf, and why it was checked by hand

Crossing a protobuf major is not obviously safe and **nothing in CI can tell you**: `esphome/vendor/api_pb2.py` calls `ValidateProtobufRuntimeVersion` at import with its gencode version baked in (6.30.0), and the test suite never imports `em_esphome`, so a rejection would first surface at controller startup — every user's voice satellite, on release day.

Verified directly: gencode 6.30.0 imports and round-trips a message under runtime 7.35.1. The validator only rejects a runtime *older* than its gencode, so this direction is the safe one, but protobuf's cross-version guarantee is a window rather than a promise. That is now recorded next to the pin so whoever crosses 8.x knows to repeat it.

## Verification

`516 passed`. Note the controller-image job merged earlier today should build on this PR, since `requirements.txt` changed — which is the first real use of it and the only thing here that checks these five actually install together.

One limitation worth stating: I could not import-check websockets 17.0.1 locally, because this machine's pip index is stale and does not carry it (PyPI's own API does). The image build is what covers that.