### PR TITLE
Write down the project's direction: portable, and not dependent on Amazon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,46 @@ EchoMuse repurposes Amazon Echo Dot Gen 2 (FireOS 5 / Android 5.1, codename "bis
 - **`controller/`** — Python asyncio WebSocket server that manages devices, runs wake word detection, and proxies to a voice pipeline
 - **`oww_forge/`** — standalone Docker batch trainer for custom openWakeWord models (synthetic TTS positives → augmentation → classifier head → `.onnx`). Not part of the controller; see `oww_forge/README.md`. Upstream pins in its Dockerfile are load-bearing (piper-sample-generator v2.0.0 flat layout; openWakeWord SHA with a `--convert_to_tflite` argparse patch). Models install via the dashboard (Config → Wake word → "+ Custom model" → `/api/oww_models/upload`) into `oww_models/` beside the SQLite DB; `owwModel` stores the file path for custom models. openwakeword keys predictions by filename *stem*, never the path — always score via `em_oww_models.prediction_key`
 
+## Direction: portable, and not dependent on Amazon
+
+**EchoMuse should run on more than one piece of hardware, with minimal change
+per platform, and should not depend on Amazon's software to work.** That is
+the direction, stated 2026-08-18. It is written here because contributors have
+sent multi-thousand-line PRs without knowing which project they were
+contributing to, and the answer changes how a change should be judged.
+
+**The dependency is already thin, and keeping it thin is the job.** The entire
+Android-specific surface in `device/` is about twenty call sites: `tinymix`
+(×10), `stop <service>` (×6), `svc wifi` (×2), `getprop` (×2). Everything else
+— mic, speaker, LEDs, buttons, ambient light, jack detect, WiFi state — is
+ALSA, i2c, evdev, sysfs and wpa_supplicant. This is a Linux daemon that
+happens to be running on Android because that is what shipped on the box.
+
+Three consequences for reviewing a change:
+
+- **Prefer the Linux interface to the Android one**, and where an Android call
+  is unavoidable, isolate it rather than spread it.
+- **Resolve hardware by NAME, not by number.** `event2` is the volume button
+  on biscuit and the *touchscreen* on checkers; opening the wrong one succeeds
+  silently and leaves the buttons dead. The same rule already applies to i2c
+  (`als.resolve()` matches `tsl2540` by name, since `0-0039` is an
+  enumeration accident).
+- **A change that makes a vendor blob load-bearing is going the wrong way**,
+  and needs to justify itself as a terminal opt-in for one platform rather
+  than as the path forward. PR #168 (native AFE) is the live example.
+
+**LineageOS is probably the wrong target; postmarketOS already has an
+`amazon-biscuit` port** (its wiki and pmaports kernel config were corroborating
+sources for the ALS second-source diagnosis — see JOURNAL 2026-08-11). There is
+no Lineage port for a 2015 MT8163 on Android 5.1, and building one would mean
+keeping the same MediaTek vendor blobs — swapping Amazon's Android for
+somebody else's without removing the dependency.
+
+The posture is therefore **not to own the OS work, but not to prevent it**:
+keep `pkg/led`, `pkg/mic`, `pkg/speaker` and `pkg/buttons` honest as
+interfaces, and treat each Android call site as something to isolate. Nothing
+here commits the project to shipping a distro.
+
 ## Building the device binary
 
 The Echo Dot runs FireOS 5 (API 22). Standard Go cross-compilation won't work — a custom Docker build environment is required.


### PR DESCRIPTION
A short section near the top of CLAUDE.md stating the direction: **EchoMuse should run on more than one piece of hardware, with minimal change per platform, and should not depend on Amazon's software to work.**

Written down because contributors have sent multi-thousand-line PRs without knowing which project they were contributing to, and the answer changes how a change should be judged. #36 has been blocked on this question since 9 August, and #168 runs against it.

The genuinely useful part is that the dependency is already thin, and that is measured rather than asserted — the whole Android-specific surface in `device/` is about twenty call sites:

```
tinymix           ×10
stop <service>     ×6
svc wifi           ×2
getprop            ×2
```

Everything else is ALSA, i2c, evdev, sysfs and wpa_supplicant. This is a Linux daemon that happens to run on Android because that is what shipped on the box.

Three review consequences, all of which have already bitten once:

- Prefer the Linux interface; isolate the Android call rather than spread it.
- **Resolve hardware by name, not number** — `event2` is the volume button on biscuit and the *touchscreen* on checkers, and opening the wrong one succeeds silently. The same rule already governs i2c, where `0-0039` is an enumeration accident.
- A change that makes a vendor blob load-bearing needs to justify itself as a terminal opt-in for one platform, not as the path forward.

It also records that **LineageOS is probably the wrong target**: postmarketOS already has an `amazon-biscuit` port, whose wiki and pmaports kernel config were corroborating sources for the ALS second-source diagnosis, while a Lineage port for a 2015 MT8163 on Android 5.1 would keep the same MediaTek blobs — swapping Amazon's Android for somebody else's without removing the dependency.

Deliberately does **not** commit the project to shipping a distro. The posture is not to own the OS work, but not to prevent it.