### PR TITLE
Add a look-ahead limiter to the speaker path, so EQ boost stops clipping

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -61,6 +61,7 @@ COPY em_api.py .
 COPY em_db.py .
 COPY em_auth.py .
 COPY em_eq.py .
+COPY em_limiter.py .
 COPY em_scenes.py .
 COPY em_support.py .
 COPY em_shadow.py .

--- a/controller/em_config_sections.py
+++ b/controller/em_config_sections.py
@@ -23,7 +23,8 @@ config key ends up belonging to no section.
 SECTIONS: dict[str, dict] = {
     "playback": {
         "label": "Playback",
-        "keys": ["eqBands", "eqLoudness", "duckDb"],
+        "keys": ["eqBands", "eqLoudness", "duckDb",
+                 "limiterEnabled", "limiterThreshold", "limiterRelease"],
     },
     "wakeword": {
         "label": "Wake word",

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -71,6 +71,7 @@ import em_pki
 import em_hostip
 import em_linkauth
 import em_eq
+import em_limiter
 import em_scenes
 import em_shadow
 import em_oww_warmup
@@ -317,6 +318,9 @@ class Device:
         self.last_utterance_pcm: bytes | None = None
         self.eq_bands:      list  = [0.0] * 8
         self.eq_loudness:   bool  = False
+        self.limiter_enabled:   bool  = True
+        self.limiter_threshold: float = em_limiter.DEFAULT_THRESHOLD_DB
+        self.limiter_release:   float = em_limiter.DEFAULT_RELEASE_MS
         # LED ring scene — render-ready palette/spinner from em_scenes,
         # refreshed on connect and on any config push carrying led* keys.
         self.led_scene:     dict  = em_scenes.resolve({})
@@ -809,6 +813,13 @@ class Device:
                     await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
                     send_seconds += asyncio.get_event_loop().time() - _t_send
 
+            # The limiter holds a look-ahead tail; without this the last few
+            # ms of every response are dropped. Inaudible on a long track and
+            # obvious on a short announcement, which is the kind of thing that
+            # goes unnoticed for months.
+            if not self.cancel_event.is_set():
+                pending.extend(stream_eq.flush())
+
             if pending and not self.cancel_event.is_set():
                 chunk = bytes(pending)
                 chunk += bytes(SPEAKER_BYTES - len(chunk))
@@ -857,6 +868,20 @@ _shell_dashboard:  dict[str, object]         = {}
 
 def get_device(device_id: str) -> Device | None:
     return _devices.get(device_id)
+
+
+
+
+
+
+def _limiter_for(device):
+    """Adapter: a Device's limiter config -> em_limiter.for_stream."""
+    return em_limiter.for_stream(
+        SPEAKER_RATE,
+        device.limiter_enabled,
+        device.limiter_threshold,
+        device.limiter_release,
+    )
 
 
 async def _push_device_state(device: Device) -> None:
@@ -1185,14 +1210,15 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
     """
     log.info(
         f"[{device.device_id}] EQ: bands={device.eq_bands} "
-        f"loudness={device.eq_loudness}"
+        f"loudness={device.eq_loudness} limiter={device.limiter_enabled}"
     )
     # EQ is a solid numpy crunch (hundreds of ms for a long response) — run
     # it off the event loop, which otherwise freezes every device's LED
     # frames, shell proxying, and WS handling right as playback starts
     # (observed as spinner stutter and console typing judder).
     def _prepare_pcm() -> bytes:
-        return em_eq.apply(voice_response, SPEAKER_RATE, device.eq_bands, device.eq_loudness)
+        return em_eq.apply(voice_response, SPEAKER_RATE, device.eq_bands,
+                           device.eq_loudness, limiter=_limiter_for(device))
 
     _t_eq0 = asyncio.get_event_loop().time()
     speaker_pcm = await asyncio.get_event_loop().run_in_executor(None, _prepare_pcm)
@@ -1330,6 +1356,7 @@ async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
         SPEAKER_RATE,
         device.eq_bands,
         device.eq_loudness,
+        limiter=_limiter_for(device),
     )
     # Cleared BEFORE streaming starts: the device sets it when its audio
     # channel drains after EOS, and a stale set from the previous response
@@ -2524,6 +2551,11 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
         )
         device.eq_bands      = config.get("eqBands", [0.0] * 8)
         device.eq_loudness   = bool(config.get("eqLoudness", False))
+        device.limiter_enabled   = bool(config.get("limiterEnabled", True))
+        device.limiter_threshold = float(config.get(
+            "limiterThreshold", em_limiter.DEFAULT_THRESHOLD_DB))
+        device.limiter_release   = float(config.get(
+            "limiterRelease", em_limiter.DEFAULT_RELEASE_MS))
         device.led_scene     = em_scenes.resolve(config)
         # Initialise volume from stored config — device will report its real
         # value via volume_state on connect, but this seeds a sane default

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -217,6 +217,14 @@ DEFAULT_DEVICE_CONFIG = {
     "beamAngle":        -1,
     "eqBands":          [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
     "eqLoudness":       False,
+    # Output limiter. On by default: the EQ chain hard-clipped anything it
+    # boosted past full scale (#231), and a default that leaves that in place
+    # protects nobody. Threshold/release are config rather than constants
+    # because limiter character wants tuning by ear in a real room — the same
+    # reasoning as duckDb and the LED meter curve.
+    "limiterEnabled":   True,
+    "limiterThreshold": -1.0,
+    "limiterRelease":   150,
     # LED ring scene (controller-side rendering — see em_scenes.py).
     # ledListenColor/ledThinkColor only apply when ledScene is "custom".
     "ledScene":         "standard",

--- a/controller/em_eq.py
+++ b/controller/em_eq.py
@@ -31,6 +31,8 @@ import logging
 import numpy as np
 from scipy.signal import sosfilt
 
+import em_limiter
+
 log = logging.getLogger("echomuse.eq")
 
 EQ_FREQUENCIES = [125, 250, 500, 1000, 2000, 3500, 5500, 8000]
@@ -116,6 +118,7 @@ def apply(
     sample_rate: int,
     bands: list | None = None,
     loudness: bool = False,
+    limiter: "em_limiter.Limiter | None" = None,
 ) -> bytes:
     """
     Apply EQ to mono S16_LE PCM. Returns mono S16_LE PCM at the same rate.
@@ -126,6 +129,10 @@ def apply(
                      playback pipeline since the 48k decode change).
         bands:       List of NUM_BANDS (8) gain values in dB. None = flat.
         loudness:    Add a +5dB speech-range presence boost if True.
+        limiter:     Optional peak limiter applied AFTER the EQ, in float, so
+                     nothing is quantised twice. Without one this function
+                     hard-clips whatever the EQ boosted past full scale, which
+                     is #231.
 
     Returns:
         EQ-processed mono S16_LE PCM bytes, same length as input.
@@ -140,15 +147,19 @@ def apply(
         log.warning(f"[eq] Expected {NUM_BANDS} bands, got {len(bands)} — padding with zeros")
         bands = list(bands) + [0.0] * (NUM_BANDS - len(bands))
 
-    # Short-circuit if everything is flat and loudness is off
-    if not loudness and all(b == 0.0 for b in bands):
+    flat = not loudness and all(b == 0.0 for b in bands)
+    if flat and limiter is None:
         return pcm
 
-    samples  = np.frombuffer(pcm, dtype=np.int16).astype(np.float32)
-    sos      = build_sos(bands, sample_rate, loudness)
-    filtered = sosfilt(sos, samples)
-    filtered = np.clip(filtered, -32768, 32767).astype(np.int16)
-    return filtered.tobytes()
+    samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float64)
+    if not flat:
+        samples = sosfilt(build_sos(bands, sample_rate, loudness), samples)
+    if limiter is not None:
+        samples = np.concatenate([limiter.process(samples), limiter.flush()])
+    # Backstop only. With a limiter attached this must never engage; without
+    # one it is the historical behaviour, preserved so a caller that passes no
+    # limiter is no worse off than before.
+    return np.clip(samples, -32768, 32767).astype(np.int16).tobytes()
 
 
 class StreamingEQ:
@@ -160,7 +171,9 @@ class StreamingEQ:
     """
 
     def __init__(self, sample_rate: int, bands: list | None = None,
-                 loudness: bool = False):
+                 loudness: bool = False,
+                 limiter: "em_limiter.Limiter | None" = None):
+        self._limiter = limiter
         if bands is None:
             bands = DEFAULT_BANDS
         if len(bands) != NUM_BANDS:
@@ -172,8 +185,26 @@ class StreamingEQ:
             self._zi  = np.zeros((self._sos.shape[0], 2), dtype=np.float64)
 
     def process(self, pcm: bytes) -> bytes:
-        if self._sos is None or len(pcm) < 2:
+        if len(pcm) < 2 or (self._sos is None and self._limiter is None):
             return pcm
-        samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float32)
-        filtered, self._zi = sosfilt(self._sos, samples, zi=self._zi)
-        return np.clip(filtered, -32768, 32767).astype(np.int16).tobytes()
+        samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float64)
+        if self._sos is not None:
+            samples, self._zi = sosfilt(self._sos, samples, zi=self._zi)
+        if self._limiter is not None:
+            samples = self._limiter.process(samples)
+        return np.clip(samples, -32768, 32767).astype(np.int16).tobytes()
+
+    def flush(self) -> bytes:
+        """
+        Emit the limiter's held look-ahead tail at end of stream.
+
+        Returns empty when there is no limiter, so callers can call it
+        unconditionally. Without it the last few ms of every music stream are
+        dropped — inaudible on a track, obvious on a short announcement.
+        """
+        if self._limiter is None:
+            return b""
+        tail = self._limiter.flush()
+        if not tail.size:
+            return b""
+        return np.clip(tail, -32768, 32767).astype(np.int16).tobytes()

--- a/controller/em_limiter.py
+++ b/controller/em_limiter.py
@@ -1,0 +1,246 @@
+"""
+em_limiter.py — look-ahead peak limiter for the speaker path.
+
+Sits after the EQ and before int16 conversion, so the whole chain stays in
+float and nothing is quantised twice.
+
+WHY THIS EXISTS
+---------------
+`em_eq` used to end in `np.clip`, which is a hard clipper. The dashboard
+offers eight ±12dB faders plus a presence boost, so any combination that
+pushed past full scale was square-waved sample by sample, silently. Measured
+on a speech-like signal at −1dBFS with a modest bass boost: 4.74% of samples
+clipped (#231). That is the same failure as the DAC clipping fixed in #162,
+one stage earlier and in our own software.
+
+A gain trim is the obvious fix and the wrong one: attenuating by the chain's
+peak response makes a +12dB bass boost 12dB quieter overall, which the user
+experiences as "the EQ made it quiet". A limiter keeps the loudness and
+controls only the peaks — which is why the stock firmware carries a
+multiband compressor-limiter rather than a trim.
+
+DESIGN
+------
+Three stages, all vectorised — this runs on every audio chunk, so a
+per-sample Python loop is not available to us.
+
+1. **Look-ahead.** The gain is computed from a running MAXIMUM of |x| over
+   the next `lookahead` samples, so it has already come down by the time the
+   peak arrives. That is what makes the attack inaudible without a separate
+   attack filter, and it is why the limiter is not a clipper with extra
+   steps.
+
+2. **Slew-limited release, in dB.** Gain may fall instantly but may only
+   RISE at `release_db_per_s`. Written as a recursion that would be
+   sequential:
+
+       g[n] = min(target[n], g[n-1] + slew)
+
+   which is a running minimum in a sheared coordinate system, so it is exact
+   and vectorised rather than approximated:
+
+       e[k] = target_db[k] − slew·k
+       g_db[n] = slew·n + min(e[0..n])            (np.minimum.accumulate)
+
+   The shear is rebased per chunk so `slew·n` cannot grow without bound
+   across a long stream.
+
+3. **A final clip that must never engage.** Kept as a backstop, and it is
+   counted: if `clipped` is ever non-zero the limiter has a bug, and a
+   silent backstop is how the original problem survived.
+
+STATE
+-----
+Carried across chunks: the tail of the previous chunk (for the look-ahead
+window) and the last gain. Without it, every chunk boundary would restart
+the release and the music path would pump audibly at each one — the same
+reason `em_eq.StreamingEQ` carries its biquad states.
+"""
+
+import numpy as np
+
+# Full-scale for S16_LE, and the ceiling the threshold is measured against.
+# They differ by one: int16 runs -32768..+32767, so a threshold of 0dBFS
+# taken against 32768 produces a sample that WRAPS to full-scale negative on
+# the cast — the single worst artefact available, and the one this module
+# exists to prevent.
+_FULL_SCALE = 32768.0
+_CEILING    = 32767.0
+
+# Below this the signal is silence and the gain is left alone — dividing a
+# threshold by a near-zero envelope produces a huge gain that then has to be
+# clamped, and the clamp is where a click comes from.
+_EPS = 1e-9
+
+DEFAULT_THRESHOLD_DB    = -1.0
+DEFAULT_LOOKAHEAD_MS    = 5.0
+DEFAULT_RELEASE_MS      = 150.0
+
+# `release_ms` is the time to recover THIS many dB of gain reduction, which
+# is the only way to state a slew rate that means the same thing whether the
+# limiter is pulling 1dB or 12dB. Documented on the dashboard control too.
+RELEASE_REFERENCE_DB = 10.0
+
+
+def _running_max(x: np.ndarray, window: int) -> np.ndarray:
+    """
+    Maximum over [n, n+window) for each n, with the tail padded by the last
+    value rather than by zeros: a zero pad would let the gain spring back up
+    inside the final samples of a chunk and undo the look-ahead exactly where
+    the next chunk's peak is about to arrive.
+    """
+    if window <= 1:
+        return x
+    padded = np.concatenate([x, np.full(window - 1, x[-1] if len(x) else 0.0)])
+    # Sliding window view is O(n·window) in memory but O(n) in time and needs
+    # no scipy; window is ~240 samples at 5ms/48kHz, so this is cheap.
+    strides = np.lib.stride_tricks.sliding_window_view(padded, window)
+    return strides.max(axis=1)
+
+
+class Limiter:
+    """
+    Streaming look-ahead peak limiter. One instance per audio stream.
+
+    `process` takes and returns float samples in S16 units (±32768), matching
+    what em_eq works in, so callers do not shuffle scales around.
+    """
+
+    def __init__(self,
+                 sample_rate: int,
+                 threshold_db: float = DEFAULT_THRESHOLD_DB,
+                 lookahead_ms: float = DEFAULT_LOOKAHEAD_MS,
+                 release_ms: float = DEFAULT_RELEASE_MS):
+        self.sample_rate = int(sample_rate)
+        # Threshold above 0dBFS would ask the limiter to permit clipping,
+        # which is the one thing it exists to prevent.
+        self.threshold_db = float(min(threshold_db, 0.0))
+        self._thresh = _CEILING * (10.0 ** (self.threshold_db / 20.0))
+
+        self.lookahead = max(1, int(self.sample_rate * lookahead_ms / 1000.0))
+        release_ms = max(1.0, float(release_ms))
+        # dB per sample the gain may rise.
+        self._slew = RELEASE_REFERENCE_DB / (release_ms / 1000.0) / self.sample_rate
+
+        # Carried state.
+        #
+        # The tail is PRIMED with look-ahead silence so that every process()
+        # call returns exactly as many samples as it was given. Without the
+        # priming the first call comes up short by the look-ahead, which is
+        # invisible in a byte-accumulating caller and reshapes the frames of
+        # one that sends what it gets back — em_player does the latter, so its
+        # first period arrived 478 bytes short. A limiter must be a drop-in;
+        # the cost is that the audio is delayed by 5ms, which nothing here can
+        # perceive, and that the final 5ms lives in the tail until flush().
+        self._tail = np.zeros(max(0, self.lookahead - 1), dtype=np.float64)
+        self._gain_db = 0.0                          # last gain, dB (≤ 0)
+
+        # Instrumentation. `clipped` must stay zero; see the module docstring.
+        self.max_reduction_db = 0.0
+        self.clipped = 0
+
+    def process(self, samples: np.ndarray) -> np.ndarray:
+        """
+        Limit one chunk. Returns the same number of samples it was given.
+
+        Internally the chunk is delayed by `lookahead`, which is what lets the
+        gain lead the audio; the delay is absorbed by holding a tail rather
+        than by returning short reads, so callers see a pure 1:1 transform.
+        """
+        if samples.size == 0:
+            return samples
+
+        x = np.asarray(samples, dtype=np.float64)
+
+        # Prepend whatever the previous call held back, so the look-ahead
+        # window spans the boundary.
+        buf = np.concatenate([self._tail, x]) if self._tail.size else x
+
+        # 1. Look-ahead envelope.
+        env = _running_max(np.abs(buf), self.lookahead)
+
+        # 2. Target gain, then slew-limited release in dB.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            target = np.where(env > _EPS, self._thresh / np.maximum(env, _EPS), 1.0)
+        target = np.minimum(target, 1.0)
+        target_db = 20.0 * np.log10(np.maximum(target, 1e-12))
+
+        n = np.arange(target_db.size, dtype=np.float64)
+        # Shear, take the running minimum, unshear.
+        #
+        # The seed carries the previous chunk's history into this one. It is
+        # `_gain_db + _slew`, NOT `_gain_db`: the shear is rebased to local
+        # index 0, and the release permits one sample of rise between the last
+        # emitted sample and this one. Seeding with `_gain_db` alone withholds
+        # that single step, which is inaudible on its own (~0.0014dB) and
+        # makes the streaming path drift from the one-shot path — so the music
+        # feed and TTS would no longer produce identical audio. Caught by
+        # test_chunked_is_identical_to_one_shot at 37 chunks and above.
+        sheared = target_db - self._slew * n
+        sheared[0] = min(sheared[0], self._gain_db + self._slew)
+        gain_db = self._slew * n + np.minimum.accumulate(sheared)
+        gain_db = np.minimum(gain_db, 0.0)
+
+        out = buf * (10.0 ** (gain_db / 20.0))
+
+        # 3. Emit everything except the final `lookahead` samples, which have
+        # not yet seen their whole window; hold them for next time.
+        hold = self.lookahead - 1
+        if hold > 0:
+            emit, self._tail = out[:-hold], buf[-hold:]
+            self._gain_db = float(gain_db[-hold - 1]) if gain_db.size > hold else self._gain_db
+        else:
+            emit, self._tail = out, np.zeros(0, dtype=np.float64)
+            self._gain_db = float(gain_db[-1])
+
+        if emit.size:
+            self.max_reduction_db = max(self.max_reduction_db,
+                                        float(-gain_db[:emit.size].min()))
+            self.clipped += int(np.count_nonzero(np.abs(emit) > _CEILING))
+
+        # The first call emits `lookahead-1` fewer samples than it was given
+        # (they are in the tail) and every later call emits that many more.
+        # Callers stream, so a constant few-ms latency is invisible — but a
+        # caller that expects 1:1 on a single short buffer would see a short
+        # read, which `flush()` exists to settle.
+        return emit
+
+    def flush(self) -> np.ndarray:
+        """
+        Emit the held tail at the end of a stream.
+
+        Without this the last few milliseconds of every response are dropped —
+        inaudible on a long track and exactly the kind of thing that goes
+        unnoticed until someone plays a very short announcement.
+        """
+        if not self._tail.size:
+            return np.zeros(0, dtype=np.float64)
+        tail, self._tail = self._tail, np.zeros(0, dtype=np.float64)
+        # No further look-ahead is possible, so hold the last gain rather than
+        # springing back to unity, which would be an audible step.
+        out = tail * (10.0 ** (self._gain_db / 20.0))
+        self.clipped += int(np.count_nonzero(np.abs(out) > _CEILING))
+        return out
+
+
+def for_stream(sample_rate: int,
+               enabled: bool,
+               threshold_db: float = DEFAULT_THRESHOLD_DB,
+               release_ms: float = DEFAULT_RELEASE_MS) -> "Limiter | None":
+    """
+    Build a limiter for one stream, or None when disabled.
+
+    ONE INSTANCE PER STREAM, never shared: it carries look-ahead and gain
+    state, so two streams through one limiter would duck each other — a voice
+    response would pull the gain down on the music playing underneath it.
+
+    Lives here rather than in em_controller so em_player can use it too
+    without importing em_controller, which would be circular. It takes plain
+    values rather than a Device for the same reason every other pure module
+    in this tree does: the test suite cannot import em_controller.
+    """
+    if not enabled:
+        return None
+    return Limiter(sample_rate,
+                   threshold_db=threshold_db,
+                   release_ms=release_ms)

--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -47,6 +47,7 @@ import asyncio
 import logging
 
 import em_eq
+import em_limiter
 
 log = logging.getLogger("player")
 
@@ -527,7 +528,11 @@ class MediaSession:
         # gain or lose the capability mid-stream, and this runs ~23×/s.
         frame_type, eos_type = _frame_types(device)
 
-        eq = em_eq.StreamingEQ(SPEAKER_RATE, device.eq_bands, device.eq_loudness)
+        eq = em_eq.StreamingEQ(SPEAKER_RATE, device.eq_bands, device.eq_loudness,
+                               limiter=em_limiter.for_stream(
+                                   SPEAKER_RATE, device.limiter_enabled,
+                                   device.limiter_threshold,
+                                   device.limiter_release))
         start_pos = self._pos
         proc = None
         seg_start = loop.time()

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -4818,7 +4818,7 @@ const STAGE_MONO = "'DM Mono',monospace";
 // control sitting under a toggle that does not govern it would look fine and
 // be silently wrong.
 const CONFIG_SECTIONS = {
-  "playback": ["eqBands", "eqLoudness", "duckDb"],
+  "playback": ["eqBands", "eqLoudness", "duckDb", "limiterEnabled", "limiterThreshold", "limiterRelease"],
   "wakeword": ["owwModel", "owwThreshold", "owwSpeexNs", "bargeInEnabled", "bargeInThreshold", "wakeArbitrationMs", "owwOnDevice"],
   "microphones": ["adcMicpga", "adcDigitalGain", "micGainDb", "beamformingEnabled", "beamAngle", "aecEnabled", "aecDelayMs", "aecTailMs", "nsAsr", "saveUtterances"],
   "ring": ["ledScene", "ledListenColor", "ledThinkColor", "meterAttack", "meterDecay", "meterFloor", "meterGamma", "meterRef", "meterCurve"],
@@ -5095,6 +5095,22 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
           <div>
             <div style={inputStyle}>
               <Toggle label="Speech boost" sub="presence boost for voice" value={config.eqLoudness ?? false} onChange={v => set('eqLoudness', v)}/>
+            </div>
+            <div style={inputStyle}>
+              <Toggle label="Limiter" sub="stops EQ boost from clipping — leave on"
+                value={config.limiterEnabled ?? true} onChange={v => set('limiterEnabled', v)}/>
+            </div>
+            <div style={inputStyle}>
+              <Slider label="Limiter ceiling" disabled={!(config.limiterEnabled ?? true)}
+                sub="peak level the output is held below"
+                value={config.limiterThreshold ?? -1} min={-12} max={0} step={0.5} unit="dB"
+                onChange={v => set('limiterThreshold', v)}/>
+            </div>
+            <div style={inputStyle}>
+              <Slider label="Limiter release" disabled={!(config.limiterEnabled ?? true)}
+                sub="time to recover 10 dB — shorter is louder, longer is smoother"
+                value={config.limiterRelease ?? 150} min={20} max={1000} step={10} unit="ms"
+                onChange={v => set('limiterRelease', v)}/>
             </div>
             <div style={inputStyle}>
               <Slider label="Duck depth" disabled={!mixCapable}

--- a/controller/tests/test_limiter.py
+++ b/controller/tests/test_limiter.py
@@ -1,0 +1,241 @@
+"""
+Tests for the speaker-path limiter.
+
+The limiter exists because em_eq hard-clipped anything the EQ boosted past
+full scale (#231). So the tests that matter are the ones that would have
+caught THAT: does a boosted signal come out unclipped, and does the streaming
+path behave identically to the one-shot path — because the music feed uses
+one and TTS the other, and a limiter that pumps at chunk boundaries is a new
+artefact rather than a fix.
+"""
+
+import numpy as np
+import pytest
+
+import em_limiter as L
+
+FS = 48000
+FULL = 32768.0
+
+
+def _sine(freq=440.0, seconds=0.5, amp=1.0, fs=FS):
+    t = np.arange(int(fs * seconds)) / fs
+    return np.sin(2 * np.pi * freq * t) * FULL * amp
+
+
+def _run(lim, x, chunks=1):
+    """Full stream through the limiter, including the flushed tail."""
+    parts = [lim.process(c) for c in np.array_split(x, chunks)]
+    parts.append(lim.flush())
+    return np.concatenate(parts)
+
+
+def _delay(lim):
+    """
+    Samples of look-ahead latency. The limiter primes its tail with silence so
+    process() is 1:1, which means the audio comes out shifted by this much.
+    """
+    return lim.lookahead - 1
+
+
+def _aligned(lim, out):
+    """Output with the look-ahead delay removed, for comparing against input."""
+    return out[_delay(lim):]
+
+
+# ─── The thing it was built for ──────────────────────────────────────────────
+
+def test_a_signal_over_full_scale_comes_out_under_threshold():
+    lim = L.Limiter(FS)
+    out = _run(lim, _sine(amp=2.0))
+    ceiling = FULL * 10 ** (L.DEFAULT_THRESHOLD_DB / 20.0)
+    assert np.abs(out).max() <= ceiling + 1e-6
+    assert lim.clipped == 0
+
+
+@pytest.mark.parametrize("amp", [1.2, 2.0, 4.0, 16.0])
+def test_nothing_clips_however_hard_it_is_driven(amp):
+    """
+    The EQ can apply +12dB and the presence boost stacks on top, so the
+    limiter must hold for inputs far above full scale rather than for a
+    plausible range.
+    """
+    lim = L.Limiter(FS)
+    out = _run(lim, _sine(amp=amp))
+    assert lim.clipped == 0, "the backstop clip engaged, so the limiter has a bug"
+    assert np.abs(out).max() <= FULL
+
+
+def test_the_backstop_clip_is_counted_not_silent():
+    """
+    `clipped` must stay zero in every other test. It is asserted here as a
+    real attribute rather than assumed, because a silent backstop is exactly
+    how the original hard clip survived unnoticed.
+    """
+    lim = L.Limiter(FS)
+    assert lim.clipped == 0
+    _run(lim, _sine(amp=3.0))
+    assert lim.clipped == 0
+
+
+# ─── Transparency: it must not touch audio that does not need it ─────────────
+
+def test_signal_below_threshold_is_returned_unchanged():
+    """Transparency: below the threshold the limiter is a pure delay."""
+    lim = L.Limiter(FS)
+    x = _sine(amp=0.5)
+    out = _aligned(lim, _run(lim, x))
+    assert np.allclose(out, x, atol=1e-6), "quiet audio must pass through untouched"
+    assert lim.max_reduction_db == 0.0
+
+
+def test_silence_does_not_produce_a_gain_excursion():
+    """
+    A near-zero envelope divides into a huge target gain, and clamping that
+    is where a click comes from. Silence must simply stay silent.
+    """
+    lim = L.Limiter(FS)
+    out = _run(lim, np.zeros(FS // 10))
+    assert np.abs(out).max() == 0.0
+
+
+# ─── Streaming parity ────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("chunks", [2, 7, 37, 512])
+def test_chunked_is_identical_to_one_shot(chunks):
+    """
+    TTS goes through one call and music through many. If they differ, the
+    music path has an artefact at every chunk boundary — the same failure
+    em_eq.StreamingEQ carries its biquad state to avoid.
+    """
+    x = _sine(amp=2.0, seconds=0.3)
+    one = _run(L.Limiter(FS), x, chunks=1)
+    many = _run(L.Limiter(FS), x, chunks=chunks)
+    assert one.shape == many.shape
+    assert np.allclose(one, many)
+
+
+def test_process_returns_exactly_what_it_was_given():
+    """
+    1:1 per call, which is what makes this a drop-in.
+
+    em_player sends back whatever the EQ chain returns, so a short buffer
+    becomes a short audio frame on the wire — its first period arrived 478
+    bytes short before the look-ahead was primed with silence.
+    """
+    lim = L.Limiter(FS)
+    for chunk in np.array_split(_sine(amp=2.0, seconds=0.25), 11):
+        assert lim.process(chunk).size == chunk.size
+
+
+def test_the_stream_gains_only_the_lookahead_tail():
+    """
+    Total out = total in + the flushed tail. Any other relationship means
+    playback drifts against the durations the controller computes.
+    """
+    lim = L.Limiter(FS)
+    x = _sine(amp=2.0, seconds=0.25)
+    out = _run(lim, x, chunks=11)
+    assert out.size == x.size + _delay(lim)
+
+
+def test_flush_emits_the_tail_and_can_be_called_once():
+    """
+    Without flush the last few ms of every response are dropped — inaudible
+    on a track and obvious on a short announcement.
+    """
+    lim = L.Limiter(FS)
+    x = _sine(amp=2.0, seconds=0.05)
+    body = lim.process(x)
+    tail = lim.flush()
+    assert body.size == x.size
+    assert tail.size == _delay(lim)
+    assert lim.flush().size == 0, "a second flush must not re-emit"
+
+
+def test_a_buffer_shorter_than_the_lookahead_is_not_lost():
+    lim = L.Limiter(FS)
+    x = _sine(amp=2.0, seconds=0.001)          # ~48 samples, under a 5ms window
+    out = np.concatenate([lim.process(x), lim.flush()])
+    assert out.size == x.size + _delay(lim)
+    assert np.abs(out).max() <= 32767.0 + 1e-6
+
+
+# ─── Attack and release character ────────────────────────────────────────────
+
+def test_the_gain_is_already_down_when_the_peak_arrives():
+    """
+    This is the whole point of the look-ahead. A limiter that reacts on the
+    peak itself has already let the peak through, which is a clipper.
+    """
+    x = np.zeros(FS // 10)
+    x[FS // 20:] = FULL * 4.0                  # step into heavy overload
+    lim = L.Limiter(FS)
+    out = np.concatenate([lim.process(x), lim.flush()])
+    ceiling = FULL * 10 ** (L.DEFAULT_THRESHOLD_DB / 20.0)
+    assert np.abs(out).max() <= ceiling + 1e-6, "a peak got through unlimited"
+
+
+def test_release_is_gradual_rather_than_instant():
+    """
+    Gain must fall fast and rise slowly. An instant return to unity after a
+    transient is what pumping sounds like.
+
+    Measured on the OUTPUT rather than on internal state: a steady tone after
+    a burst should still be attenuated shortly afterwards, and back to its
+    true level later. Reading `_gain_db` at the end of a long silence proves
+    nothing, since by then it has correctly recovered.
+    """
+    # The burst needs ~12dB of reduction and release is 10dB per 400ms, so the
+    # tone has to run past ~480ms for full recovery to be reachable at all.
+    burst = np.full(2000, FULL * 4.0)
+    tone = _sine(freq=200.0, seconds=1.2, amp=0.5)      # well under threshold
+    x = np.concatenate([burst, tone])
+    lim = L.Limiter(FS, release_ms=400.0)
+    out = _run(lim, x)
+
+    after = out[2000 + _delay(lim):]
+    early = np.abs(after[:2000]).max()               # ~40ms after the burst
+    late = np.abs(after[-2000:]).max()               # ~1.16s after
+    assert early < late, "gain snapped back instantly — that is pumping"
+    assert late == pytest.approx(np.abs(tone).max(), rel=0.02), \
+        "the tone never returned to its own level"
+
+
+def test_a_faster_release_recovers_sooner():
+    """Pins the direction of the knob, which is what a user is choosing."""
+    x = np.concatenate([np.full(2000, FULL * 4.0),
+                        _sine(freq=200.0, seconds=0.2, amp=0.5)])
+    s_lim, f_lim = L.Limiter(FS, release_ms=4000.0), L.Limiter(FS, release_ms=20.0)
+    slow = np.abs(_run(s_lim, x)[2000 + _delay(s_lim):]).max()
+    fast = np.abs(_run(f_lim, x)[2000 + _delay(f_lim):]).max()
+    assert fast > slow
+
+
+# ─── Parameter handling ──────────────────────────────────────────────────────
+
+def test_threshold_above_zero_dbfs_is_refused():
+    """
+    A threshold over full scale asks the limiter to permit clipping, which is
+    the one thing it exists to prevent. Clamped rather than raising, so a bad
+    stored config degrades to safe behaviour instead of killing playback.
+    """
+    lim = L.Limiter(FS, threshold_db=6.0)
+    assert lim.threshold_db == 0.0
+    out = _run(lim, _sine(amp=2.0))
+    # 32767, not 32768: int16 is asymmetric and 32768 wraps on the cast.
+    assert np.abs(out).max() <= 32767.0 + 1e-6
+
+
+def test_a_lower_threshold_pulls_the_peak_lower():
+    for db in (-1.0, -3.0, -6.0):
+        lim = L.Limiter(FS, threshold_db=db)
+        out = _run(lim, _sine(amp=2.0))
+        assert np.abs(out).max() <= FULL * 10 ** (db / 20.0) + 1e-6
+
+
+def test_reduction_is_reported():
+    """Gain reduction has to be visible, or the limiter is another silent stage."""
+    lim = L.Limiter(FS)
+    _run(lim, _sine(amp=2.0))
+    assert lim.max_reduction_db == pytest.approx(6.0 + 1.0, abs=0.3)

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -9,6 +9,9 @@ class FakeDevice:
         self.device_id = device_id
         self.eq_bands = [0.0] * 8
         self.eq_loudness = False
+        self.limiter_enabled = True
+        self.limiter_threshold = -1.0
+        self.limiter_release = 150.0
         self.data_frames: list[bytes] = []
         self.control_msgs: list[dict] = []
 


### PR DESCRIPTION
Closes #231. First step of #229 — the volume-banded EQ work cannot be built on a chain that hard-clips whatever it boosts.

## Before and after, same measurement

Speech-like signal through `em_eq.apply`, share of samples hard-clipped:

| EQ setting | input peak | before | after | gain reduction |
|---|---|---|---|---|
| bass +6/+3 | −3 dBFS | 0.04% | **0.00%** | 1.0 dB |
| bass +6/+3 | −1 dBFS | 4.74% | **0.00%** | 3.0 dB |
| bass +6/+3 + Speech boost | −1 dBFS | 4.93% | **0.00%** | 3.2 dB |
| bass +12/+6 + Speech boost | −3 dBFS | 9.35% | **0.00%** | 4.2 dB |
| bass +12/+6 + Speech boost | −1 dBFS | 17.95% | **0.00%** | 6.2 dB |

The gain-reduction column is the argument against the obvious one-line fix. Pre-attenuating by the chain's peak response would have cost the full boost — 12 dB quieter for the last row — which the user experiences as "the EQ made it quiet". That is why stock carries a multiband compressor-limiter rather than a trim (#229).

## Design

`em_limiter` is pure and unit-tested, following `em_linkauth` / `em_button` / `em_turnclock`: the suite cannot import `em_controller`, so a decision left in there has no coverage. Three stages, all vectorised because this runs on every audio chunk:

1. **Look-ahead running maximum**, so the gain is already down when the peak arrives. That is what separates a limiter from a clipper with extra steps.
2. **Slew-limited release in dB.** The natural form is a sequential recursion (`g[n] = min(target[n], g[n-1] + slew)`); written instead as a running minimum in a sheared coordinate system, so it is exact and vectorised rather than approximated.
3. **A backstop clip that must never engage — and is counted.** A silent backstop is precisely how the original problem survived.

## Three things found by building it

- **The chunk seed must be `_gain_db + _slew`, not `_gain_db`.** Withholding that single sample of release made the streaming path drift from the one-shot path, so music and TTS would no longer produce identical audio. Caught by `test_chunked_is_identical_to_one_shot` at 37 chunks and not at 7 — a coarser parametrisation would have shipped it.
- **The threshold is taken against 32767, not 32768.** int16 is asymmetric, so a 0 dBFS threshold against 32768 yields a sample that **wraps to full-scale negative** on the cast — the worst artefact available, produced by the module meant to prevent it.
- **The look-ahead tail is primed with silence so `process()` is 1:1.** Without it the first call comes up short, which is invisible to a byte-accumulating caller and reshapes the frames of one that sends back what it gets — `em_player` does the latter, and its first period arrived 478 bytes short. Found because `test_play_streams_frames_then_eos` failed, not by reading the code.

## Config, not constants

`limiterEnabled` / `limiterThreshold` / `limiterRelease`, in the Playback section. Limiter character wants tuning by ear in a real room — the same reasoning as `duckDb` and the LED meter response curve, and the reason those are config too.

Release is stated as **time to recover 10 dB**, which is the only phrasing that means the same thing whether the limiter is pulling 1 dB or 12 dB.

On by default: a default that leaves the clipping in place protects nobody.

## Also

`StreamingEQ.flush()` emits the held tail at end of stream, wired into `stream_speaker_chunks`. Without it the last few ms of every response are dropped — inaudible on a track, obvious on a short announcement, and the kind of thing that goes unnoticed for months.

## Testing

- `tests/test_limiter.py` — 22 tests: the overload cases from #231, transparency below threshold, silence, streaming/one-shot parity at four chunk sizes, sample-count contract, flush semantics, look-ahead correctness against a step into overload, release direction, and parameter clamping.
- Full suite **538 passed**, dashboard node tests pass, pyflakes clean.