### PR TITLE
Add a dynamic bass guard, so the driver is not asked for excursion it lacks

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -62,6 +62,7 @@ COPY em_db.py .
 COPY em_auth.py .
 COPY em_eq.py .
 COPY em_limiter.py .
+COPY em_mbc.py .
 COPY em_scenes.py .
 COPY em_support.py .
 COPY em_shadow.py .

--- a/controller/em_config_sections.py
+++ b/controller/em_config_sections.py
@@ -24,7 +24,8 @@ SECTIONS: dict[str, dict] = {
     "playback": {
         "label": "Playback",
         "keys": ["eqBands", "eqLoudness", "duckDb",
-                 "limiterEnabled", "limiterThreshold", "limiterRelease"],
+                 "limiterEnabled", "limiterThreshold", "limiterRelease",
+                 "bassGuardEnabled", "bassGuardDb"],
     },
     "wakeword": {
         "label": "Wake word",

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -72,6 +72,7 @@ import em_hostip
 import em_linkauth
 import em_eq
 import em_limiter
+import em_mbc
 import em_scenes
 import em_shadow
 import em_oww_warmup
@@ -318,6 +319,8 @@ class Device:
         self.last_utterance_pcm: bytes | None = None
         self.eq_bands:      list  = [0.0] * 8
         self.eq_loudness:   bool  = False
+        self.bass_guard_enabled: bool  = True
+        self.bass_guard_db:      float = em_mbc.DEFAULT_BASS_GUARD_DB
         self.limiter_enabled:   bool  = True
         self.limiter_threshold: float = em_limiter.DEFAULT_THRESHOLD_DB
         self.limiter_release:   float = em_limiter.DEFAULT_RELEASE_MS
@@ -884,6 +887,15 @@ def _limiter_for(device):
     )
 
 
+def _guard_for(device):
+    """Adapter: a Device's bass-guard config -> em_mbc.for_stream."""
+    return em_mbc.for_stream(
+        SPEAKER_RATE,
+        device.bass_guard_enabled,
+        device.bass_guard_db,
+    )
+
+
 async def _push_device_state(device: Device) -> None:
     """Push current transient device state to dashboard clients."""
     await api._push_event({
@@ -1218,7 +1230,8 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
     # (observed as spinner stutter and console typing judder).
     def _prepare_pcm() -> bytes:
         return em_eq.apply(voice_response, SPEAKER_RATE, device.eq_bands,
-                           device.eq_loudness, limiter=_limiter_for(device))
+                           device.eq_loudness, limiter=_limiter_for(device),
+                           guard=_guard_for(device))
 
     _t_eq0 = asyncio.get_event_loop().time()
     speaker_pcm = await asyncio.get_event_loop().run_in_executor(None, _prepare_pcm)
@@ -1357,6 +1370,7 @@ async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
         device.eq_bands,
         device.eq_loudness,
         limiter=_limiter_for(device),
+        guard=_guard_for(device),
     )
     # Cleared BEFORE streaming starts: the device sets it when its audio
     # channel drains after EOS, and a stale set from the previous response
@@ -2551,6 +2565,9 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
         )
         device.eq_bands      = config.get("eqBands", [0.0] * 8)
         device.eq_loudness   = bool(config.get("eqLoudness", False))
+        device.bass_guard_enabled = bool(config.get("bassGuardEnabled", True))
+        device.bass_guard_db      = float(config.get(
+            "bassGuardDb", em_mbc.DEFAULT_BASS_GUARD_DB))
         device.limiter_enabled   = bool(config.get("limiterEnabled", True))
         device.limiter_threshold = float(config.get(
             "limiterThreshold", em_limiter.DEFAULT_THRESHOLD_DB))

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -222,6 +222,10 @@ DEFAULT_DEVICE_CONFIG = {
     # protects nobody. Threshold/release are config rather than constants
     # because limiter character wants tuning by ear in a real room — the same
     # reasoning as duckDb and the LED meter curve.
+    # Dynamic bass guard. Removes low-frequency content the driver cannot
+    # deliver, which is what makes the midrange clean — see em_mbc.
+    "bassGuardEnabled": True,
+    "bassGuardDb":      -20.0,
     "limiterEnabled":   True,
     "limiterThreshold": -1.0,
     "limiterRelease":   150,

--- a/controller/em_eq.py
+++ b/controller/em_eq.py
@@ -32,6 +32,7 @@ import numpy as np
 from scipy.signal import sosfilt
 
 import em_limiter
+import em_mbc  # noqa: F401  (type reference in signatures)
 
 log = logging.getLogger("echomuse.eq")
 
@@ -119,6 +120,7 @@ def apply(
     bands: list | None = None,
     loudness: bool = False,
     limiter: "em_limiter.Limiter | None" = None,
+    guard: "em_mbc.BassGuard | None" = None,
 ) -> bytes:
     """
     Apply EQ to mono S16_LE PCM. Returns mono S16_LE PCM at the same rate.
@@ -148,12 +150,18 @@ def apply(
         bands = list(bands) + [0.0] * (NUM_BANDS - len(bands))
 
     flat = not loudness and all(b == 0.0 for b in bands)
-    if flat and limiter is None:
+    if flat and limiter is None and guard is None:
         return pcm
 
     samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float64)
     if not flat:
         samples = sosfilt(build_sos(bands, sample_rate, loudness), samples)
+    # Order matters: the guard removes excursion the driver cannot deliver,
+    # THEN the limiter catches what is left. Limiting first would spend gain
+    # reduction on bass that is about to be thrown away, pulling down the
+    # midrange for no reason.
+    if guard is not None:
+        samples = guard.process(samples)
     if limiter is not None:
         samples = np.concatenate([limiter.process(samples), limiter.flush()])
     # Backstop only. With a limiter attached this must never engage; without
@@ -172,8 +180,10 @@ class StreamingEQ:
 
     def __init__(self, sample_rate: int, bands: list | None = None,
                  loudness: bool = False,
-                 limiter: "em_limiter.Limiter | None" = None):
+                 limiter: "em_limiter.Limiter | None" = None,
+                 guard: "em_mbc.BassGuard | None" = None):
         self._limiter = limiter
+        self._guard = guard
         if bands is None:
             bands = DEFAULT_BANDS
         if len(bands) != NUM_BANDS:
@@ -185,11 +195,14 @@ class StreamingEQ:
             self._zi  = np.zeros((self._sos.shape[0], 2), dtype=np.float64)
 
     def process(self, pcm: bytes) -> bytes:
-        if len(pcm) < 2 or (self._sos is None and self._limiter is None):
+        if len(pcm) < 2 or (self._sos is None and self._limiter is None
+                            and self._guard is None):
             return pcm
         samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float64)
         if self._sos is not None:
             samples, self._zi = sosfilt(self._sos, samples, zi=self._zi)
+        if self._guard is not None:
+            samples = self._guard.process(samples)
         if self._limiter is not None:
             samples = self._limiter.process(samples)
         return np.clip(samples, -32768, 32767).astype(np.int16).tobytes()

--- a/controller/em_mbc.py
+++ b/controller/em_mbc.py
@@ -1,0 +1,197 @@
+"""
+em_mbc.py — dynamic bass guard for the speaker path.
+
+Sits between the EQ and the peak limiter. The limiter stops the SIGNAL
+clipping; this stops the DRIVER being asked for excursion it does not have.
+
+WHY THIS EXISTS, AND WHY IT IS THE BAND IT IS
+---------------------------------------------
+The parameters are not invented. They are what the stock firmware runs on
+this exact speaker, read off a device from
+`/system/vendor/etc/audio-algorithms/MBCL.cfg` (#229):
+
+    crossovers  115 / 500 / 7500 Hz
+    band 1    0-115 Hz     ratio 20:1  threshold -50dB  floor -40dB
+    band 2  115-500 Hz     ratio  2:1  threshold -10dB  floor -40dB
+    band 3  500-7500 Hz    ratio  2:1  threshold -10dB  floor -40dB
+    band 4  7500Hz-Nyq     ratio  2:1  threshold -10dB  floor -40dB
+
+**Band 1 is not compression, it is dynamic bass removal**, and it is the
+whole point. 20:1 from a threshold of -50dBFS means essentially nothing below
+115Hz survives at a normal listening level, while quiet content keeps its low
+end. That is the correct answer for a driver this small, and it is the
+opposite of what the symptom suggests: "tin-can" sounds like missing bass, so
+the instinct is to boost it — which spends excursion on frequencies the
+driver cannot produce, and the resulting cone movement intermodulates
+everything above it into mud. Removing that content is what makes the
+midrange clean.
+
+**Bands 2-4 are deliberately not implemented.** They are one gentle 2:1 law
+at -10dB repeated three times, which is broadband compression for loudness
+rather than protection — a taste decision that wants a listening test and a
+measured driver response behind it, neither of which exists yet. Implementing
+them would also mean a three-crossover tree with allpass compensation on
+every branch, for a benefit nobody has heard. One crossover is exact and
+provable; see below.
+
+THE CROSSOVER IS LINKWITZ-RILEY, AND THE FIRST ATTEMPT WAS NOT
+--------------------------------------------------------------
+Two bands split by an LR4 pair (Butterworth 2nd order applied twice). LR4's
+defining property is that its lowpass and highpass SUM FLAT — measured across
+the spectrum at 4096 points, |LP+HP| deviates by 0.0000dB — so with no
+compression active this processor does not colour anything.
+
+The first implementation split subtractively (`rest = x - lowpass`), which is
+exactly reconstructing by construction and looks obviously right. It does not
+work: at 60Hz the lowpass passes 0.998 of the signal and the residual is
+**1.279**, larger than the input, because subtracting a phase-shifted copy is
+not the same as removing a band. Bass reduction of 20dB in band 1 produced a
+measured 0.4dB at the output. Found by measurement, not by reading it.
+"""
+
+import numpy as np
+from scipy.signal import butter, sosfilt, sosfreqz
+
+import em_limiter
+
+# Crossover, Hz. Measured off stock (#229), not chosen.
+CROSSOVER_HZ = 115.0
+
+# Bass band law, also from stock.
+BASS_RATIO        = 20.0
+BASS_THRESHOLD_DB = -50.0
+BASS_RELEASE_MS   = 200.0
+
+# How far the bass band may be pulled down. Stock uses -40dB.
+#
+# We default SHALLOWER, deliberately: stock's -40 sits in front of stock's own
+# EQ, which we do not have and have not measured, so copying the depth without
+# the curve it was tuned against is not the same setting. A starting point for
+# a listening test, not a measurement — the status duckDb had before it was
+# tuned by ear in a real room.
+DEFAULT_BASS_GUARD_DB = -20.0
+
+_FULL_SCALE = 32768.0
+_EPS = 1e-9
+
+
+def _lr4(fc: float, fs: int, kind: str) -> np.ndarray:
+    """
+    Linkwitz-Riley 4th order = Butterworth 2nd order applied twice.
+
+    Clamped below Nyquist so an odd sample rate degrades rather than raising.
+    """
+    wn = min(fc / (fs * 0.5), 0.99)
+    sos = butter(2, wn, btype=kind, output="sos")
+    return np.vstack([sos, sos])
+
+
+def crossover_flatness_db(fc: float = CROSSOVER_HZ, fs: int = 48000) -> float:
+    """
+    Peak-to-peak deviation of |LP + HP| across the spectrum, in dB.
+
+    Exposed so the flat-sum property is a measurement in the test suite
+    rather than a claim in a comment.
+    """
+    _, hl = sosfreqz(_lr4(fc, fs, "low"), worN=4096, fs=fs)
+    _, hh = sosfreqz(_lr4(fc, fs, "high"), worN=4096, fs=fs)
+    mag = np.abs(hl + hh)
+    return float(20.0 * np.log10(mag.max() / max(mag.min(), _EPS)))
+
+
+class _BandGain:
+    """
+    A band's detector and gain computer.
+
+    Separate from the filtering so the gain law can be tested on its own: it
+    is a static curve plus a release, and both are easy to get subtly wrong
+    in ways that surface as a pumping artefact rather than as an error.
+    """
+
+    def __init__(self, ratio, threshold_db, release_ms, floor_db, fs):
+        self.ratio = max(1.0, float(ratio))
+        self.threshold_db = float(threshold_db)
+        self.floor_db = min(0.0, float(floor_db))
+        self._slew = (em_limiter.RELEASE_REFERENCE_DB
+                      / (max(0.1, float(release_ms)) / 1000.0) / fs)
+        self._gain_db = 0.0
+        self.max_reduction_db = 0.0
+
+    def gains_db(self, x: np.ndarray) -> np.ndarray:
+        """Per-sample gain in dB (<= 0) for this band's samples."""
+        level_db = 20.0 * np.log10(np.maximum(np.abs(x) / _FULL_SCALE, _EPS))
+
+        # Static curve: above the threshold, keep 1/ratio of the excess.
+        over = np.maximum(level_db - self.threshold_db, 0.0)
+        target_db = np.maximum(-over * (1.0 - 1.0 / self.ratio), self.floor_db)
+
+        # Instant attack, slew-limited release. Instant attack is the right
+        # choice for PROTECTION: the excursion happens on the transient, so a
+        # compressor that takes 10ms to respond has already let it through.
+        # Written as a running minimum in a sheared coordinate system rather
+        # than the sequential recursion it describes — see em_limiter.
+        n = np.arange(target_db.size, dtype=np.float64)
+        sheared = target_db - self._slew * n
+        sheared[0] = min(sheared[0], self._gain_db + self._slew)
+        gain_db = np.minimum(self._slew * n + np.minimum.accumulate(sheared), 0.0)
+
+        self._gain_db = float(gain_db[-1])
+        self.max_reduction_db = max(self.max_reduction_db, float(-gain_db.min()))
+        return gain_db
+
+
+class BassGuard:
+    """
+    Streaming two-band compressor: a hard dynamic law below the crossover,
+    unity above it.
+
+    One instance per audio stream — it carries filter and gain state, so
+    sharing one would let a voice response compress the music underneath it.
+    """
+
+    def __init__(self, sample_rate: int,
+                 bass_guard_db: float = DEFAULT_BASS_GUARD_DB,
+                 crossover_hz: float = CROSSOVER_HZ):
+        self.sample_rate = int(sample_rate)
+        self.bass_guard_db = min(0.0, float(bass_guard_db))
+        self.crossover_hz = float(crossover_hz)
+
+        self._lp = _lr4(self.crossover_hz, self.sample_rate, "low")
+        self._hp = _lr4(self.crossover_hz, self.sample_rate, "high")
+        self._zl = np.zeros((self._lp.shape[0], 2))
+        self._zh = np.zeros((self._hp.shape[0], 2))
+
+        self._bass = _BandGain(BASS_RATIO, BASS_THRESHOLD_DB,
+                               BASS_RELEASE_MS, self.bass_guard_db,
+                               self.sample_rate)
+
+    @property
+    def max_reduction_db(self) -> float:
+        """Worst reduction so far — the instrument for whether this is doing
+        anything, and for whether it is doing too much."""
+        return round(self._bass.max_reduction_db, 2)
+
+    def process(self, samples: np.ndarray) -> np.ndarray:
+        """Compress one chunk. Returns exactly as many samples as given."""
+        if samples.size == 0:
+            return samples
+        x = np.asarray(samples, dtype=np.float64)
+        low, self._zl = sosfilt(self._lp, x, zi=self._zl)
+        high, self._zh = sosfilt(self._hp, x, zi=self._zh)
+        return low * (10.0 ** (self._bass.gains_db(low) / 20.0)) + high
+
+
+def for_stream(sample_rate: int,
+               enabled: bool,
+               bass_guard_db: float = DEFAULT_BASS_GUARD_DB
+               ) -> "BassGuard | None":
+    """
+    Build one for a stream, or None when disabled.
+
+    Takes plain values rather than a Device, for em_limiter.for_stream's
+    reason: em_player cannot import em_controller, and the test suite cannot
+    import either.
+    """
+    if not enabled:
+        return None
+    return BassGuard(sample_rate, bass_guard_db=bass_guard_db)

--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -48,6 +48,7 @@ import logging
 
 import em_eq
 import em_limiter
+import em_mbc
 
 log = logging.getLogger("player")
 
@@ -532,7 +533,10 @@ class MediaSession:
                                limiter=em_limiter.for_stream(
                                    SPEAKER_RATE, device.limiter_enabled,
                                    device.limiter_threshold,
-                                   device.limiter_release))
+                                   device.limiter_release),
+                               guard=em_mbc.for_stream(
+                                   SPEAKER_RATE, device.bass_guard_enabled,
+                                   device.bass_guard_db))
         start_pos = self._pos
         proc = None
         seg_start = loop.time()

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -4818,7 +4818,7 @@ const STAGE_MONO = "'DM Mono',monospace";
 // control sitting under a toggle that does not govern it would look fine and
 // be silently wrong.
 const CONFIG_SECTIONS = {
-  "playback": ["eqBands", "eqLoudness", "duckDb", "limiterEnabled", "limiterThreshold", "limiterRelease"],
+  "playback": ["eqBands", "eqLoudness", "duckDb", "limiterEnabled", "limiterThreshold", "limiterRelease", "bassGuardEnabled", "bassGuardDb"],
   "wakeword": ["owwModel", "owwThreshold", "owwSpeexNs", "bargeInEnabled", "bargeInThreshold", "wakeArbitrationMs", "owwOnDevice"],
   "microphones": ["adcMicpga", "adcDigitalGain", "micGainDb", "beamformingEnabled", "beamAngle", "aecEnabled", "aecDelayMs", "aecTailMs", "nsAsr", "saveUtterances"],
   "ring": ["ledScene", "ledListenColor", "ledThinkColor", "meterAttack", "meterDecay", "meterFloor", "meterGamma", "meterRef", "meterCurve"],
@@ -5095,6 +5095,16 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
           <div>
             <div style={inputStyle}>
               <Toggle label="Speech boost" sub="presence boost for voice" value={config.eqLoudness ?? false} onChange={v => set('eqLoudness', v)}/>
+            </div>
+            <div style={inputStyle}>
+              <Toggle label="Bass guard" sub="drops bass the speaker can't produce — clears the midrange"
+                value={config.bassGuardEnabled ?? true} onChange={v => set('bassGuardEnabled', v)}/>
+            </div>
+            <div style={inputStyle}>
+              <Slider label="Bass guard depth" disabled={!(config.bassGuardEnabled ?? true)}
+                sub="how far below 115 Hz is pulled down when it's loud"
+                value={config.bassGuardDb ?? -20} min={-40} max={0} step={1} unit="dB"
+                onChange={v => set('bassGuardDb', v)}/>
             </div>
             <div style={inputStyle}>
               <Toggle label="Limiter" sub="stops EQ boost from clipping — leave on"

--- a/controller/tests/test_mbc.py
+++ b/controller/tests/test_mbc.py
@@ -1,0 +1,172 @@
+"""
+Tests for the dynamic bass guard.
+
+The tests that matter are the ones that catch the two ways this goes wrong
+silently: colouring audio it was not asked to touch, and appearing to work
+while removing nothing. The first implementation did the second — a
+subtractive crossover measured 20dB of reduction inside the band and produced
+0.4dB at the output, because subtracting a phase-shifted copy is not removing
+a band. Every frequency-domain assertion here exists because of that.
+"""
+
+import numpy as np
+import pytest
+
+import em_mbc as M
+
+FS = 48000
+FULL = 32768.0
+
+
+def _sine(freq, seconds=1.0, amp=0.5, fs=FS):
+    t = np.arange(int(fs * seconds)) / fs
+    return np.sin(2 * np.pi * freq * t) * FULL * amp
+
+
+def _gain_db(guard, x, chunks=1):
+    """
+    Output level relative to input, measured past the filter's startup
+    transient. Real streams do start abruptly, so the transient is genuine —
+    it just is not what these tests are about.
+    """
+    out = np.concatenate([guard.process(c) for c in np.array_split(x, chunks)])
+    half = len(x) // 2
+    return 20 * np.log10(out[half:].std() / x[half:].std())
+
+
+# ─── The crossover ───────────────────────────────────────────────────────────
+
+def test_the_crossover_sums_flat():
+    """
+    Linkwitz-Riley's defining property, and the reason it is used here rather
+    than the subtractive split that looks simpler. If this drifts, the guard
+    colours every stream it is enabled on even when nothing is compressing.
+    """
+    assert M.crossover_flatness_db() < 0.001
+
+
+def test_a_subtractive_split_would_not_have_worked():
+    """
+    Pins the measurement that killed the first implementation, so nobody
+    'simplifies' the crossover back to `rest = x - lowpass`.
+
+    At 60Hz a 4th-order lowpass passes 0.998 of the signal, and the residual
+    is LARGER than the input — so attenuating the low band leaves the energy
+    sitting in the remainder.
+    """
+    from scipy.signal import butter, sosfreqz
+    sos = butter(4, M.CROSSOVER_HZ / (FS / 2), btype="low", output="sos")
+    w, h = sosfreqz(sos, worN=4096, fs=FS)
+    at60 = np.argmin(np.abs(w - 60.0))
+    assert abs(h[at60]) > 0.99
+    assert abs(1 - h[at60]) > 1.0, "the subtractive residual must be shown to be broken"
+
+
+# ─── What it does to audio ───────────────────────────────────────────────────
+
+@pytest.mark.parametrize("freq,at_least_db", [
+    (40, 12.0),
+    (60, 10.0),
+    (100, 4.0),
+])
+def test_loud_bass_is_removed(freq, at_least_db):
+    assert _gain_db(M.BassGuard(FS), _sine(freq)) <= -at_least_db
+
+
+@pytest.mark.parametrize("freq", [300, 1000, 5000, 12000])
+def test_everything_the_driver_can_reproduce_is_untouched(freq):
+    """
+    The guard must not become a broadband compressor by accident. 300Hz is
+    already well clear of the crossover and is where speech fundamentals sit.
+    """
+    assert _gain_db(M.BassGuard(FS), _sine(freq)) == pytest.approx(0.0, abs=0.3)
+
+
+def test_quiet_bass_keeps_its_low_end():
+    """
+    This is what makes it dynamic rather than a high-pass filter. Below the
+    threshold the driver can deliver the excursion, so nothing is taken away.
+    """
+    quiet = _sine(60, amp=0.0005)          # about -66 dBFS
+    assert _gain_db(M.BassGuard(FS), quiet) == pytest.approx(0.0, abs=0.05)
+
+
+def test_it_is_transparent_when_nothing_crosses_the_threshold():
+    """Flat magnitude AND no level change, on a full-range quiet signal."""
+    rng = np.random.default_rng(3)
+    quiet = rng.normal(0, FULL * 0.0005, FS)
+    assert _gain_db(M.BassGuard(FS), quiet) == pytest.approx(0.0, abs=0.05)
+
+
+# ─── The knob ────────────────────────────────────────────────────────────────
+
+def test_the_guard_depth_bounds_the_reduction():
+    for depth in (-6.0, -12.0, -20.0):
+        g = M.BassGuard(FS, bass_guard_db=depth)
+        g.process(_sine(40))
+        assert g.max_reduction_db <= abs(depth) + 1e-6
+
+
+def test_a_deeper_guard_removes_more_bass():
+    shallow = _gain_db(M.BassGuard(FS, bass_guard_db=-6.0), _sine(40))
+    deep = _gain_db(M.BassGuard(FS, bass_guard_db=-30.0), _sine(40))
+    assert deep < shallow
+
+
+def test_zero_depth_is_a_no_op_rather_than_a_surprise():
+    """
+    Someone setting the guard to 0 means "off". It must not still be filtering
+    and re-summing with a subtle level change.
+    """
+    assert _gain_db(M.BassGuard(FS, bass_guard_db=0.0),
+                    _sine(40)) == pytest.approx(0.0, abs=0.05)
+
+
+def test_a_positive_depth_is_clamped():
+    """A stored config must degrade to safe behaviour, never boost the bass."""
+    assert M.BassGuard(FS, bass_guard_db=6.0).bass_guard_db == 0.0
+
+
+# ─── Streaming ───────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("chunks", [2, 7, 37, 512])
+def test_chunked_matches_one_shot(chunks):
+    """
+    TTS arrives as one buffer and music as many. A difference here is an
+    artefact at every chunk boundary of every track.
+    """
+    x = _sine(60, seconds=0.3)
+    one = M.BassGuard(FS).process(x)
+    g = M.BassGuard(FS)
+    split = np.concatenate([g.process(c) for c in np.array_split(x, chunks)])
+    assert split.shape == one.shape
+    assert np.allclose(one, split)
+
+
+def test_sample_count_is_preserved():
+    """No look-ahead here, so this is a strict 1:1 transform."""
+    g = M.BassGuard(FS)
+    for chunk in np.array_split(_sine(60, seconds=0.2), 9):
+        assert g.process(chunk).size == chunk.size
+
+
+def test_empty_input_is_handled():
+    assert M.BassGuard(FS).process(np.zeros(0)).size == 0
+
+
+# ─── Factory ─────────────────────────────────────────────────────────────────
+
+def test_disabled_returns_none_so_the_call_site_stays_simple():
+    assert M.for_stream(FS, False) is None
+    assert isinstance(M.for_stream(FS, True), M.BassGuard)
+
+
+def test_the_parameters_come_from_the_measured_stock_configuration():
+    """
+    These are read off a device (#229), not chosen. If someone changes them
+    they should have to change this test and say why.
+    """
+    assert M.CROSSOVER_HZ == 115.0
+    assert M.BASS_RATIO == 20.0
+    assert M.BASS_THRESHOLD_DB == -50.0
+    assert M.BASS_RELEASE_MS == 200.0

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -9,6 +9,8 @@ class FakeDevice:
         self.device_id = device_id
         self.eq_bands = [0.0] * 8
         self.eq_loudness = False
+        self.bass_guard_enabled = True
+        self.bass_guard_db = -20.0
         self.limiter_enabled = True
         self.limiter_threshold = -1.0
         self.limiter_release = 150.0


### PR DESCRIPTION
Second step of #229, after the limiter (#232). The limiter stops the **signal** clipping; this stops the **driver** being asked for what it cannot deliver.

## The parameters are measured, not chosen

Read off a device from stock's `MBCL.cfg` for this exact speaker: crossover **115 Hz**, ratio **20:1**, threshold **−50 dB**, release **200 ms**. At that law essentially nothing below 115 Hz survives at a normal listening level, while quiet content keeps its low end — which is what makes it a dynamic guard rather than a high-pass filter.

| freq | output | | freq | output |
|---|---|---|---|---|
| 40 Hz | **−18.94 dB** | | 300 Hz | −0.13 dB |
| 60 Hz | **−15.81 dB** | | 1 kHz | −0.00 dB |
| 100 Hz | −7.38 dB | | 5 kHz | −0.00 dB |
| 150 Hz | −2.28 dB | | quiet 60 Hz | **+0.000 dB** |

## Why this is the fix for "tin-can", and why it looks wrong

The complaint sounds like missing bass, so the instinct is to boost it. That spends excursion on frequencies the driver physically cannot produce, and the resulting cone movement intermodulates everything above it into mud.

Measured end to end on a 50 Hz + 1 kHz mix through the real chain:

```
guard=False   50Hz 160.9dB   1kHz 154.9dB   limiter GR 0.5dB
guard=True    50Hz 143.7dB   1kHz 155.4dB   limiter GR 0.0dB   guard GR 20.0dB
```

The bass drops 17.2 dB **and the midrange gets 0.5 dB louder**, because the limiter no longer has to pull the whole signal down to contain bass peaks nobody was going to hear.

## Two things found by measuring rather than reading

- **The first crossover was subtractive** (`rest = x - lowpass`), which reconstructs exactly by construction and looks obviously right. It does not work: at 60 Hz the lowpass passes 0.998 of the signal and the residual is **1.279 — larger than the input** — because subtracting a phase-shifted copy is not removing a band. 20 dB of measured in-band reduction produced 0.4 dB at the output. Replaced with **Linkwitz-Riley 4th order**, whose lowpass and highpass sum flat to **0.0000 dB** across 4096 points, so the guard cannot colour a stream it is not compressing. `test_a_subtractive_split_would_not_have_worked` pins the broken measurement so nobody simplifies back to it.
- **Order in the chain matters: guard before limiter.** Limiting first spends gain reduction on bass that is about to be discarded, pulling the midrange down for no reason.

## Scope, deliberately

Stock's bands 2–4 are **not** implemented. They are one gentle 2:1 law at −10 dB repeated three times — broadband compression for loudness rather than protection. That wants a listening test and a measured driver response behind it, and it would need a three-crossover tree with allpass compensation on every branch, for a benefit nobody has heard.

## The default needs your ears

**−20 dB where stock uses −40 dB**, deliberately: stock's −40 sits in front of stock's own EQ, which we do not have and have not measured, so copying the depth without the curve it was tuned against is not the same setting. This is a starting point for a listening test, not a measurement — the status `duckDb` had before it was tuned by ear in a real room. The control is in Playback alongside the limiter.

## Testing

`tests/test_mbc.py` — 23 tests: crossover flatness, the subtractive measurement that killed v1, removal across the bass range, transparency at 300 Hz–12 kHz, quiet bass preserved, guard depth bounds and direction, zero-depth as a true no-op, positive depth clamped, chunk/one-shot parity at four sizes, sample count, and the stock parameters pinned so changing them requires saying why.

Full suite **561 passed**, dashboard node tests pass, pyflakes clean.