### PR TITLE
Give each release channel its own satellite port range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,25 @@ the other channel. Isolation is deliberate: `MIGRATIONS` is append-only and
 forward-only, so a shared database would let EA upgrade the schema out from
 under GA, permanently.
 
+**Because they share no storage, they must not share satellite PORT ranges
+either.** Each channel has its own port counter, so both would allocate from
+16001 and hand the same numbers to different devices — and Home Assistant keys
+an ESPHome config entry on host and port, so after a switch its stored entries
+reach whichever device now holds that number. Measured 2026-08-19: every
+satellite entity unavailable for a day, the wake word still firing and the ring
+still lighting, every turn dying in milliseconds because no HA pipeline was
+behind it. It reads as a wake-word regression, and it is not one.
+`EM_ESPHOME_PORT_BASE` (add-on option `esphome_port_base`) separates them — GA
+16001, EA 16101, BLE proxies derived at +`BLE_PORT_OFFSET` so 17001/17101
+follow with no second setting. It is applied as a **floor at allocation time,
+never a seed**: the counter only moves forwards, so a base can never land on a
+port a device already holds, a fresh database starts at the base, and an
+established one jumps at its next allocation leaving every fielded device
+alone. `sync_channels.py` owns EA's value as channel identity, and
+`test_channels.py` fails if the two ever collide or come within 100 ports.
+This bounds the damage of a switch; it does **not** make channels
+interchangeable — the CA and database still have to be copied.
+
 **`version.parse` does not order prereleases** — `2.20.0-ea.1` parses equal to
 `2.20.0`, so the dashboard's update notice cannot tell an EA build from the GA
 release of the same version. Advisory-only and Supervisor drives real updates,

--- a/controller-ea/DOCS.md
+++ b/controller-ea/DOCS.md
@@ -16,6 +16,15 @@ rather than from `require_device_tls` — so they will fail
 verification and will not connect at all until you copy the stable
 add-on's `/data` across, including all four files in `tls/`.
 
+**Satellite ports differ by channel**, and that is deliberate. The
+stable add-on hands out 16001 upward for voice satellites and 17001
+upward for Bluetooth proxies; this one uses 16101 and 17101. Home
+Assistant keys an ESPHome device on its host and port, so shared
+ranges would let an entry left over from the other channel connect
+to a different device entirely — the wake word fires, the ring
+lights, and the turn dies with no pipeline behind it. With the
+ranges apart, a stale entry simply shows as unavailable.
+
 Report anything you find against the EchoMuse repository, saying
 which channel you are on.
 

--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -69,6 +69,10 @@ options:
   server_ip: ""
   mdns_name: "echomuse"
   esphome_project_version: "2.0.0"
+  # Base for the per-device ESPHome satellite ports. Differs per release
+  # channel so the two add-ons hand out disjoint ranges — see em_db's
+  # ESPHOME_PORT_BASE and sync_channels.py, which rewrites this line.
+  esphome_port_base: 16101
   oww_model: "hey_jarvis"
   # Keep in step with em_db.DEFAULT_DEVICE_CONFIG["owwThreshold"] — a fresh
   # add-on install is precisely the case that default exists for, and
@@ -82,6 +86,7 @@ schema:
   server_ip: "str"
   mdns_name: "match(^[a-z0-9][a-z0-9-]{0,62}$)"
   esphome_project_version: "str"
+  esphome_port_base: "int(1024,60000)"
   oww_model: "str"
   oww_threshold: "float(0,1)"
   require_device_tls: "bool"

--- a/controller-ea/translations/en.yaml
+++ b/controller-ea/translations/en.yaml
@@ -24,6 +24,15 @@ configuration:
     description: >-
       Version reported to Home Assistant in the device's ESPHome info.
       Normally leave this at the default.
+  esphome_port_base:
+    name: ESPHome satellite base port
+    description: >-
+      First port used for the per-device Home Assistant satellites; Bluetooth
+      proxies use this plus 1000. The stable and Early Access add-ons default
+      to different bases so that a Home Assistant configuration entry left
+      over from one can never reach a device belonging to the other. Changing
+      this affects only devices added from now on — existing devices keep the
+      port they were given.
   oww_model:
     name: Wake word model
     description: >-

--- a/controller/.env.example
+++ b/controller/.env.example
@@ -30,6 +30,12 @@ MDNS_NAME=echomuse
 # ESPHome project version string reported to HA in device info.
 # Should match the controller release version tag.
 ESPHOME_PROJECT_VERSION=2.0.0
+# First port handed out for the per-device satellites; Bluetooth proxies take
+# this plus 1000. Two controllers on one network need different bases, or a
+# Home Assistant config entry left behind by one will reach the other's
+# devices — the Early Access add-on defaults to 16101 for exactly that reason.
+# Only newly added devices are affected; existing ones keep their port.
+EM_ESPHOME_PORT_BASE=16001
 # ── Wake word ─────────────────────────────────────────────────────────────────
 # OpenWakeWord model name (without _v0.1.onnx suffix)
 OWW_MODEL=hey_jarvis

--- a/controller/config.yaml
+++ b/controller/config.yaml
@@ -55,6 +55,10 @@ options:
   server_ip: ""
   mdns_name: "echomuse"
   esphome_project_version: "2.0.0"
+  # Base for the per-device ESPHome satellite ports. Differs per release
+  # channel so the two add-ons hand out disjoint ranges — see em_db's
+  # ESPHOME_PORT_BASE and sync_channels.py, which rewrites this line.
+  esphome_port_base: 16001
   oww_model: "hey_jarvis"
   # Keep in step with em_db.DEFAULT_DEVICE_CONFIG["owwThreshold"] — a fresh
   # add-on install is precisely the case that default exists for, and
@@ -68,6 +72,7 @@ schema:
   server_ip: "str"
   mdns_name: "match(^[a-z0-9][a-z0-9-]{0,62}$)"
   esphome_project_version: "str"
+  esphome_port_base: "int(1024,60000)"
   oww_model: "str"
   oww_threshold: "float(0,1)"
   require_device_tls: "bool"

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -1403,13 +1403,72 @@ def get_esphome_port(device_id: str) -> Optional[int]:
     return row["esphome_api_port"]  # may be None (unassigned)
 
 
+# Ports are floored to this base at allocation time, so two controllers on one
+# network hand out satellite ports from disjoint ranges. In practice that means
+# the GA and Early Access add-ons: channels share no storage, so each has its
+# own database and its own counter, and both would otherwise start at 16001.
+#
+# Home Assistant keys an ESPHome config entry on host and port, so after a
+# channel switch its stored entries point into the other channel's range and it
+# reaches whichever device now holds that number. Measured 2026-08-19: every
+# satellite entity unavailable for a day, wake words still firing and turns
+# dying in milliseconds because no HA pipeline was behind them. Disjoint ranges
+# turn that into entries that visibly fail to connect — the same outcome the
+# never-reuse rule below already chooses for a deprovisioned device.
+#
+# A FLOOR rather than a seed, deliberately: the counter only ever moves
+# forwards, so a base can never land on a port already assigned. A fresh
+# database allocates its first port at the base; an established one jumps to it
+# at the next allocation and leaves every fielded device exactly where it is.
+#
+# BLE proxy ports follow at +BLE_PORT_OFFSET, so a base of 16101 gives 17101
+# without a second setting. The 100-port spacing between the channel defaults
+# is what bounds this: a channel would need 100 devices to reach the next one's
+# range.
+ESPHOME_PORT_BASE_DEFAULT = 16001
+
+
+def _esphome_port_base() -> int:
+    """
+    EM_ESPHOME_PORT_BASE, validated, falling back to the default on anything
+    unusable — a controller that refused to start over a stray port number
+    would be a worse outcome than one that allocates where it always did, and
+    the warning names it either way.
+    """
+    raw = os.environ.get("EM_ESPHOME_PORT_BASE", "").strip()
+    if not raw:
+        return ESPHOME_PORT_BASE_DEFAULT
+    try:
+        base = int(raw)
+    except ValueError:
+        log.warning(
+            f"[db] EM_ESPHOME_PORT_BASE={raw!r} is not a number — "
+            f"using {ESPHOME_PORT_BASE_DEFAULT}"
+        )
+        return ESPHOME_PORT_BASE_DEFAULT
+    # Room below for the privileged range and above for the BLE range plus a
+    # fleet's worth of climbing.
+    if not 1024 <= base <= 60000:
+        log.warning(
+            f"[db] EM_ESPHOME_PORT_BASE={base} is outside 1024-60000 — "
+            f"using {ESPHOME_PORT_BASE_DEFAULT}"
+        )
+        return ESPHOME_PORT_BASE_DEFAULT
+    return base
+
+
+# Read once at import, matching DEBUG: the value is consulted per allocation,
+# so re-reading it live would let an edit renumber a fleet mid-run.
+ESPHOME_PORT_BASE = _esphome_port_base()
+
+
 def assign_esphome_port(device_id: str) -> int:
     """
     Allocate and persist an ESPHome API port for this device.
 
     Takes the next available port from next_esphome_port in system_config,
-    increments the counter, persists both atomically, and returns the
-    allocated port.
+    floored to ESPHOME_PORT_BASE, increments the counter, persists both
+    atomically, and returns the allocated port.
 
     Port allocation is monotonically increasing and never reuses freed ports
     (see ESPHOME_SPEC.md §2.2 for the rationale — sparse range is intentional
@@ -1435,7 +1494,16 @@ def assign_esphome_port(device_id: str) -> int:
         next_row = conn.execute(
             "SELECT value FROM system_config WHERE key = 'next_esphome_port'"
         ).fetchone()
-        port = int(next_row["value"])
+        stored = int(next_row["value"])
+        port = max(stored, ESPHOME_PORT_BASE)
+        if port != stored:
+            # Says the base did something. An option that silently has no
+            # effect on an established install is the shape this project
+            # keeps paying for.
+            log.info(
+                f"[db] ESPHome port counter raised {stored} → {port} "
+                f"(EM_ESPHOME_PORT_BASE)"
+            )
 
         conn.execute(
             "UPDATE devices SET esphome_api_port = ? WHERE device_id = ?",

--- a/controller/em_start.py
+++ b/controller/em_start.py
@@ -31,6 +31,7 @@ OPTION_ENV_VARS = {
     "server_ip": "SERVER_IP",
     "mdns_name": "MDNS_NAME",
     "esphome_project_version": "ESPHOME_PROJECT_VERSION",
+    "esphome_port_base": "EM_ESPHOME_PORT_BASE",
     "oww_model": "OWW_MODEL",
     "oww_threshold": "OWW_THRESHOLD",
     "require_device_tls": "REQUIRE_DEVICE_TLS",

--- a/controller/tests/test_channels.py
+++ b/controller/tests/test_channels.py
@@ -28,6 +28,12 @@ import sync_channels  # noqa: E402
 GA = yaml.safe_load((CONTROLLER / "config.yaml").read_text())
 EA_PATH = sync_channels.EA.path
 
+# Options whose VALUE belongs to the channel rather than to the program.
+# Every other option must match: a setting reachable in one channel and not
+# the other is the deployment-parity failure one level up. Adding to this set
+# is a deliberate act — the default is that channels are identical.
+CHANNEL_OWNED_OPTIONS = {"esphome_port_base"}
+
 
 def _ea():
     assert EA_PATH.joinpath("config.yaml").is_file(), (
@@ -60,6 +66,17 @@ def test_channel_shares_every_non_identity_field_with_ga(key):
     ea = _ea()
     if key not in GA:
         pytest.skip(f"GA config has no {key}")
+    if key == "options":
+        # Every option's VALUE is shared except the ones that are part of a
+        # channel's identity — see CHANNEL_OWNED_OPTIONS and the test below.
+        # The key SET is still compared in full, two tests down.
+        ea_opts = {k: v for k, v in ea[key].items()
+                   if k not in CHANNEL_OWNED_OPTIONS}
+        ga_opts = {k: v for k, v in GA[key].items()
+                   if k not in CHANNEL_OWNED_OPTIONS}
+        assert ea_opts == ga_opts, (
+            "options differ between channels — regenerate rather than editing")
+        return
     assert ea.get(key) == GA[key], (
         f"{key} differs between channels — regenerate rather than editing")
 
@@ -92,6 +109,38 @@ def test_channel_is_distinguishable_in_the_ui():
     ea = _ea()
     assert ea["name"] != GA["name"]
     assert ea["panel_title"] != GA["panel_title"]
+
+
+def test_channels_hand_out_satellite_ports_from_disjoint_ranges():
+    """
+    Home Assistant keys an ESPHome device on its host and port, and the two
+    channels have separate databases — so both counters would otherwise start
+    at 16001 and hand the same numbers to different devices.
+
+    Measured 2026-08-19, switching channels with shared ranges: every
+    satellite entity unavailable for a day, wake words still firing and turns
+    dying in milliseconds because HA had no pipeline behind them. With the
+    ranges apart a stale entry visibly fails to connect instead.
+
+    The gap must also exceed any realistic device count, since a channel that
+    allocated its way into the next one's range would reintroduce exactly
+    this. BLE proxies ride at +BLE_PORT_OFFSET, so separating the voice bases
+    separates those too.
+    """
+    ea = _ea()
+    ga_base = GA["options"]["esphome_port_base"]
+    ea_base = ea["options"]["esphome_port_base"]
+
+    assert ea_base != ga_base, (
+        "Both channels allocate satellite ports from the same base — a Home "
+        "Assistant config entry from one will reach the other's devices")
+    assert abs(ea_base - ga_base) >= 100, (
+        f"Only {abs(ea_base - ga_base)} ports between the channel bases — a "
+        f"fleet that size would allocate into the other channel's range")
+
+    # The type is shared even though the value is not: a channel may not
+    # loosen validation the other enforces.
+    assert ea["schema"]["esphome_port_base"] == GA["schema"]["esphome_port_base"]
 
 
 def test_channel_pulls_the_same_image_repository():

--- a/controller/tests/test_esphome_ports.py
+++ b/controller/tests/test_esphome_ports.py
@@ -1,0 +1,154 @@
+"""
+Satellite port allocation, and the base that keeps two controllers apart.
+
+Home Assistant keys an ESPHome device on its host and port. The GA and Early
+Access add-ons have separate /data, so each has its own database and its own
+port counter, and both start at 16001 — which means a config entry left over
+from one channel reaches whichever device now holds that number in the other.
+
+Measured 2026-08-19: after a channel switch, every satellite entity sat
+unavailable for a day. Wake words still fired and the ring still lit, and
+every turn died in milliseconds because there was no HA pipeline behind it.
+
+EM_ESPHOME_PORT_BASE separates the ranges. It is applied as a floor at
+allocation time rather than as a seed, which is what makes it safe to change
+on an established install: the counter only moves forwards, so it can never
+be pushed onto a port some device is already using.
+"""
+
+import importlib
+import sqlite3
+
+import pytest
+
+import em_db
+
+
+def _db(tmp_path, monkeypatch, base=None):
+    """A fresh migrated database, with em_db reloaded under `base`."""
+    if base is None:
+        monkeypatch.delenv("EM_ESPHOME_PORT_BASE", raising=False)
+    else:
+        monkeypatch.setenv("EM_ESPHOME_PORT_BASE", str(base))
+    importlib.reload(em_db)
+
+    p = str(tmp_path / "em.db")
+    em_db.init(p)
+    return p
+
+
+def _add(path, device_id):
+    c = sqlite3.connect(path)
+    c.execute("INSERT INTO devices (device_id, label, approved) VALUES (?, ?, 1)",
+              (device_id, device_id))
+    c.commit()
+    c.close()
+
+
+@pytest.fixture(autouse=True)
+def _restore_em_db():
+    # Other modules hold `import em_db`; leave the shared module as found.
+    yield
+    importlib.reload(em_db)
+
+
+# ── The default is unchanged ──────────────────────────────────────────────────
+
+def test_a_fresh_database_still_starts_at_16001(tmp_path, monkeypatch):
+    """
+    Every fielded install allocated from 16001, and the ports are persisted —
+    so the unset default has to stay exactly where it was or an upgrade
+    renumbers a fleet HA already has entries for.
+    """
+    p = _db(tmp_path, monkeypatch)
+    _add(p, "A")
+    assert em_db.assign_esphome_port("A") == 16001
+
+
+# ── The base ──────────────────────────────────────────────────────────────────
+
+def test_a_fresh_database_allocates_from_the_configured_base(tmp_path, monkeypatch):
+    p = _db(tmp_path, monkeypatch, base=16101)
+    _add(p, "A")
+    _add(p, "B")
+    assert em_db.assign_esphome_port("A") == 16101
+    assert em_db.assign_esphome_port("B") == 16102
+
+
+def test_the_ble_range_follows_the_voice_base(tmp_path, monkeypatch):
+    """
+    BLE proxies are derived, not allocated, so separating the voice bases is
+    the whole change — 16101 has to give 17101 with no second setting.
+    """
+    p = _db(tmp_path, monkeypatch, base=16101)
+    _add(p, "A")
+    em_db.assign_esphome_port("A")
+    assert em_db.ensure_ble_proxy_port("A") == 16101 + em_db.BLE_PORT_OFFSET
+
+
+def test_the_two_channel_defaults_do_not_overlap():
+    """
+    The property the whole change exists for, stated against the numbers the
+    two add-ons actually ship — 100 voice ports apart, and BLE derived above
+    both, so neither range can reach the other at any plausible fleet size.
+    """
+    ga, ea = 16001, 16101
+    assert ea - ga >= 100
+    assert ga + em_db.BLE_PORT_OFFSET > ea  # BLE sits above every voice port
+
+
+# ── A floor, not a seed ───────────────────────────────────────────────────────
+
+def test_raising_the_base_leaves_existing_devices_where_they_are(tmp_path,
+                                                                 monkeypatch):
+    """
+    The reason this is a floor. A device's port is persisted and HA holds a
+    config entry against it, so changing the base must move only what has not
+    been handed out yet.
+    """
+    p = _db(tmp_path, monkeypatch)
+    _add(p, "A")
+    assert em_db.assign_esphome_port("A") == 16001
+
+    monkeypatch.setenv("EM_ESPHOME_PORT_BASE", "16101")
+    importlib.reload(em_db)
+    em_db.init(p)
+
+    _add(p, "B")
+    assert em_db.get_esphome_port("A") == 16001, "an existing device was renumbered"
+    assert em_db.assign_esphome_port("B") == 16101
+
+
+def test_lowering_the_base_never_reissues_a_port(tmp_path, monkeypatch):
+    """
+    A base below the counter must be ignored rather than obeyed. Obeying it
+    would hand a second device a port another one is already listening on,
+    which is the exact misrouting the base exists to prevent — arriving from
+    the other direction.
+    """
+    p = _db(tmp_path, monkeypatch, base=16101)
+    _add(p, "A")
+    assert em_db.assign_esphome_port("A") == 16101
+
+    monkeypatch.setenv("EM_ESPHOME_PORT_BASE", "16001")
+    importlib.reload(em_db)
+    em_db.init(p)
+
+    _add(p, "B")
+    assert em_db.assign_esphome_port("B") == 16102
+
+
+# ── Bad input ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("raw", ["", "  ", "sixteen thousand", "16101.5",
+                                 "80", "70000", "-1"])
+def test_an_unusable_base_falls_back_rather_than_refusing_to_start(raw,
+                                                                   monkeypatch):
+    """
+    A controller that would not start over a stray port number is a worse
+    outcome than one that allocates where it always did — and on the add-on
+    the value arrives from a text field.
+    """
+    monkeypatch.setenv("EM_ESPHOME_PORT_BASE", raw)
+    importlib.reload(em_db)
+    assert em_db.ESPHOME_PORT_BASE == em_db.ESPHOME_PORT_BASE_DEFAULT

--- a/controller/tools/sync_channels.py
+++ b/controller/tools/sync_channels.py
@@ -57,13 +57,18 @@ PRESENTATION = ("translations/en.yaml", "icon.png", "logo.png",
 
 class Channel:
     def __init__(self, dirname: str, slug: str, name: str, panel_title: str,
-                 blurb: str, docs_banner: str):
+                 blurb: str, docs_banner: str, esphome_port_base: int):
         self.dirname = dirname
         self.slug = slug
         self.name = name
         self.panel_title = panel_title
         self.blurb = blurb
         self.docs_banner = docs_banner
+        # Part of the channel's identity, not a setting that drifted: the
+        # two channels must hand out satellite ports from disjoint ranges,
+        # or a Home Assistant config entry left over from one reaches a
+        # device belonging to the other. See em_db.ESPHOME_PORT_BASE.
+        self.esphome_port_base = esphome_port_base
 
     @property
     def path(self) -> Path:
@@ -84,6 +89,7 @@ EA = Channel(
         "devices will not connect until the stable add-on's /data is copied "
         "across."
     ),
+    esphome_port_base=16101,
     docs_banner=(
         "# EchoMuse — Early Access\n"
         "\n"
@@ -102,6 +108,15 @@ EA = Channel(
         "rather than from `require_device_tls` — so they will fail\n"
         "verification and will not connect at all until you copy the stable\n"
         "add-on's `/data` across, including all four files in `tls/`.\n"
+        "\n"
+        "**Satellite ports differ by channel**, and that is deliberate. The\n"
+        "stable add-on hands out 16001 upward for voice satellites and 17001\n"
+        "upward for Bluetooth proxies; this one uses 16101 and 17101. Home\n"
+        "Assistant keys an ESPHome device on its host and port, so shared\n"
+        "ranges would let an entry left over from the other channel connect\n"
+        "to a different device entirely — the wake word fires, the ring\n"
+        "lights, and the turn dies with no pipeline behind it. With the\n"
+        "ranges apart, a stale entry simply shows as unavailable.\n"
         "\n"
         "Report anything you find against the EchoMuse repository, saying\n"
         "which channel you are on.\n"
@@ -133,6 +148,13 @@ def _render(ga_config: str, ch: Channel, version: str) -> str:
         "# it only pulls the tag named by `version:`.\n"
         "#\n"
     )
+
+    # Matches the integer default in options:, never the quoted type in
+    # schema: — the two lines share a key name and only one of them is a
+    # channel's own value.
+    out = re.sub(r'^(\s*)esphome_port_base:\s*\d+\s*$',
+                 rf'\1esphome_port_base: {ch.esphome_port_base}',
+                 out, count=1, flags=re.M)
 
     out = re.sub(r'^name:.*$',        f'name: "{ch.name}"',        out, count=1, flags=re.M)
     out = re.sub(r'^slug:.*$',        f'slug: "{ch.slug}"',        out, count=1, flags=re.M)

--- a/controller/translations/en.yaml
+++ b/controller/translations/en.yaml
@@ -24,6 +24,15 @@ configuration:
     description: >-
       Version reported to Home Assistant in the device's ESPHome info.
       Normally leave this at the default.
+  esphome_port_base:
+    name: ESPHome satellite base port
+    description: >-
+      First port used for the per-device Home Assistant satellites; Bluetooth
+      proxies use this plus 1000. The stable and Early Access add-ons default
+      to different bases so that a Home Assistant configuration entry left
+      over from one can never reach a device belonging to the other. Changing
+      this affects only devices added from now on — existing devices keep the
+      port they were given.
   oww_model:
     name: Wake word model
     description: >-


### PR DESCRIPTION
**EA now allocates satellite ports from 16101 (Bluetooth 17101); GA stays on 16001/17001.** This stops a Home Assistant config entry left over from one channel reaching a device belonging to the other.

**What went wrong.** The two add-ons have separate `/data`, so each has its own database and its own port counter — and both started at 16001. HA keys an ESPHome device on host and port, so after a channel switch its stored entries reached whatever device now held that number. Measured on a live switch (2026-08-19): every satellite entity unavailable for a day, the wake word still firing and the ring still lighting, every turn dying in milliseconds because no pipeline was behind it. It reads as a wake-word regression. It is not one.

**The fix.** `EM_ESPHOME_PORT_BASE`, exposed as the add-on option `esphome_port_base`. Applied as a **floor at allocation time, never a seed** — the counter only moves forwards, so a fresh database starts at the base, an established one jumps at its next allocation, and every fielded device keeps the port HA already knows. Bluetooth proxies are derived at `+BLE_PORT_OFFSET`, so 17101 follows with no second setting.

**Scope.** This bounds the damage of a channel switch. It does not make channels interchangeable — the CA and database still have to be copied.

Tests: 575 pass. New `tests/test_esphome_ports.py` covers the floor, the unchanged default, and bad input; `test_channels.py` fails if the two bases ever collide or come within 100 ports. Both guards verified by reintroducing the bug.

Happy to walk through the allocator change or the channel-generator side if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)