### PR TITLE
Let the output chain change while a track is playing

### DIFF
--- a/controller/em_eq.py
+++ b/controller/em_eq.py
@@ -184,6 +184,10 @@ class StreamingEQ:
                  guard: "em_mbc.BassGuard | None" = None):
         self._limiter = limiter
         self._guard = guard
+        self._sample_rate = int(sample_rate)   # set_bands rebuilds against it
+        # Last values update() applied; None until it is first called, so the
+        # first call always lands rather than matching a coincidental default.
+        self._applied = None
         if bands is None:
             bands = DEFAULT_BANDS
         if len(bands) != NUM_BANDS:
@@ -193,6 +197,79 @@ class StreamingEQ:
         else:
             self._sos = build_sos(bands, sample_rate, loudness)
             self._zi  = np.zeros((self._sos.shape[0], 2), dtype=np.float64)
+
+    def update(self, *,
+               bands: list | None = None,
+               loudness: bool = False,
+               limiter_enabled: bool | None = None,
+               limiter_threshold: float | None = None,
+               limiter_release: float | None = None,
+               guard_enabled: bool | None = None,
+               guard_db: float | None = None) -> bool:
+        """
+        Re-apply the whole chain's settings mid-stream. Returns True if
+        anything moved.
+
+        Called per chunk by the music feed, so it compares before it acts:
+        the steady-state cost is one tuple comparison, and the processors are
+        only touched when a value actually changed. That matters because the
+        setters are cheap but rebuilding the EQ coefficients is not, and doing
+        it 23 times a second for no reason would be silly.
+
+        Everything here updates state IN PLACE. Nothing is reconstructed, so
+        there is no discontinuity in the filter states, the limiter's held
+        tail or the stream's latency — see the setters for why each of those
+        would otherwise be audible.
+        """
+        wanted = (tuple(bands) if bands is not None else None, loudness,
+                  limiter_enabled, limiter_threshold, limiter_release,
+                  guard_enabled, guard_db)
+        if wanted == self._applied:
+            return False
+
+        prev = self._applied
+        self._applied = wanted
+
+        # EQ only when the curve itself moved — the expensive branch.
+        if prev is None or (prev[0], prev[1]) != (wanted[0], wanted[1]):
+            self.set_bands(bands, loudness)
+
+        if self._limiter is not None:
+            self._limiter.set_params(threshold_db=limiter_threshold,
+                                     release_ms=limiter_release,
+                                     enabled=limiter_enabled)
+        if self._guard is not None:
+            self._guard.set_params(bass_guard_db=guard_db,
+                                   enabled=guard_enabled)
+        return True
+
+    def set_bands(self, bands: list | None, loudness: bool = False) -> None:
+        """
+        Change the EQ curve mid-stream, keeping the filter state.
+
+        The biquad state is carried across the coefficient change rather than
+        zeroed: the section count is fixed by NUM_BANDS, so the state array
+        still fits, and holding it means the filter continues from where the
+        audio actually is. Zeroing would produce a transient at the moment of
+        the change — precisely when someone is listening for the difference
+        the change made.
+
+        Going from flat to shaped allocates fresh (zero) state, which is
+        correct: there was no filter running to carry.
+        """
+        if bands is None:
+            bands = DEFAULT_BANDS
+        if len(bands) != NUM_BANDS:
+            bands = list(bands) + [0.0] * (NUM_BANDS - len(bands))
+
+        if not loudness and all(b == 0.0 for b in bands):
+            self._sos = None
+            return
+
+        sos = build_sos(bands, self._sample_rate, loudness)
+        if self._sos is None or self._zi.shape[0] != sos.shape[0]:
+            self._zi = np.zeros((sos.shape[0], 2), dtype=np.float64)
+        self._sos = sos
 
     def process(self, pcm: bytes) -> bytes:
         if len(pcm) < 2 or (self._sos is None and self._limiter is None

--- a/controller/em_limiter.py
+++ b/controller/em_limiter.py
@@ -110,17 +110,18 @@ class Limiter:
                  sample_rate: int,
                  threshold_db: float = DEFAULT_THRESHOLD_DB,
                  lookahead_ms: float = DEFAULT_LOOKAHEAD_MS,
-                 release_ms: float = DEFAULT_RELEASE_MS):
+                 release_ms: float = DEFAULT_RELEASE_MS,
+                 enabled: bool = True):
         self.sample_rate = int(sample_rate)
-        # Threshold above 0dBFS would ask the limiter to permit clipping,
-        # which is the one thing it exists to prevent.
-        self.threshold_db = float(min(threshold_db, 0.0))
-        self._thresh = _CEILING * (10.0 ** (self.threshold_db / 20.0))
+        # Bypassed rather than absent, so a stream can be toggled without
+        # dropping the instance — see set_params.
+        self.enabled = bool(enabled)
+        self.threshold_db = 0.0
+        self._thresh = _CEILING
 
         self.lookahead = max(1, int(self.sample_rate * lookahead_ms / 1000.0))
-        release_ms = max(1.0, float(release_ms))
-        # dB per sample the gain may rise.
-        self._slew = RELEASE_REFERENCE_DB / (release_ms / 1000.0) / self.sample_rate
+        self._slew = 0.0
+        self.set_params(threshold_db=threshold_db, release_ms=release_ms)
 
         # Carried state.
         #
@@ -139,6 +140,37 @@ class Limiter:
         self.max_reduction_db = 0.0
         self.clipped = 0
 
+    def set_params(self,
+                   threshold_db: float | None = None,
+                   release_ms: float | None = None,
+                   enabled: bool | None = None) -> None:
+        """
+        Change the limiter mid-stream, without touching carried state.
+
+        These are taste parameters tuned by ear in a real room, and the chain
+        used to be built once per stream — so hearing a change meant skipping
+        the track, which makes an A/B nearly impossible to judge. Only scalars
+        move here: `lookahead` is deliberately not settable, because it sizes
+        the held tail and changing it mid-stream would drop or duplicate the
+        samples sitting in it.
+
+        Bypass is a flag rather than a None instance for the same reason. The
+        gain state, the tail and the 5ms of latency all persist while
+        disabled, so toggling costs no click and no realignment.
+        """
+        if threshold_db is not None:
+            # Above 0dBFS would ask the limiter to permit clipping, which is
+            # the one thing it exists to prevent.
+            self.threshold_db = float(min(threshold_db, 0.0))
+            self._thresh = _CEILING * (10.0 ** (self.threshold_db / 20.0))
+        if release_ms is not None:
+            # dB per sample the gain may rise.
+            self._slew = (RELEASE_REFERENCE_DB
+                          / (max(1.0, float(release_ms)) / 1000.0)
+                          / self.sample_rate)
+        if enabled is not None:
+            self.enabled = bool(enabled)
+
     def process(self, samples: np.ndarray) -> np.ndarray:
         """
         Limit one chunk. Returns the same number of samples it was given.
@@ -155,6 +187,14 @@ class Limiter:
         # Prepend whatever the previous call held back, so the look-ahead
         # window spans the boundary.
         buf = np.concatenate([self._tail, x]) if self._tail.size else x
+
+        if not self.enabled:
+            # Bypassed: unity gain, but the tail bookkeeping below runs
+            # unchanged so the stream keeps its latency and its sample
+            # alignment. Dropping the delay instead would shift the audio by
+            # 5ms at the moment of the toggle, which is a click.
+            gain_db = np.zeros(buf.size, dtype=np.float64)
+            return self._emit(buf, gain_db)
 
         # 1. Look-ahead envelope.
         env = _running_max(np.abs(buf), self.lookahead)
@@ -181,6 +221,15 @@ class Limiter:
         gain_db = self._slew * n + np.minimum.accumulate(sheared)
         gain_db = np.minimum(gain_db, 0.0)
 
+        return self._emit(buf, gain_db)
+
+    def _emit(self, buf: np.ndarray, gain_db: np.ndarray) -> np.ndarray:
+        """
+        Apply the gain, hold back the look-ahead, and carry the state.
+
+        Shared by the limiting and bypassed paths so a toggle cannot change
+        the stream's framing or latency — only whether the gain is unity.
+        """
         out = buf * (10.0 ** (gain_db / 20.0))
 
         # 3. Emit everything except the final `lookahead` samples, which have

--- a/controller/em_mbc.py
+++ b/controller/em_mbc.py
@@ -151,8 +151,12 @@ class BassGuard:
 
     def __init__(self, sample_rate: int,
                  bass_guard_db: float = DEFAULT_BASS_GUARD_DB,
-                 crossover_hz: float = CROSSOVER_HZ):
+                 crossover_hz: float = CROSSOVER_HZ,
+                 enabled: bool = True):
         self.sample_rate = int(sample_rate)
+        # Bypassed rather than absent, so a stream can be toggled without
+        # dropping the instance — see set_params.
+        self.enabled = bool(enabled)
         self.bass_guard_db = min(0.0, float(bass_guard_db))
         self.crossover_hz = float(crossover_hz)
 
@@ -171,6 +175,28 @@ class BassGuard:
         anything, and for whether it is doing too much."""
         return round(self._bass.max_reduction_db, 2)
 
+    def set_params(self,
+                   bass_guard_db: float | None = None,
+                   enabled: bool | None = None) -> None:
+        """
+        Change the guard mid-stream, without touching carried state.
+
+        Depth is the parameter that wants tuning by ear in a real room, and
+        the chain used to be built once per stream — so hearing a change meant
+        skipping the track, which makes an A/B nearly impossible to judge.
+
+        The crossover is deliberately NOT settable: it owns the filter state,
+        so moving it mid-stream would mean rebuilding the biquads and either
+        carrying incompatible state or zeroing it, which is an audible thump
+        at exactly the moment someone is listening for a difference. It is a
+        measured value off the hardware, not a taste one.
+        """
+        if bass_guard_db is not None:
+            self.bass_guard_db = min(0.0, float(bass_guard_db))
+            self._bass.floor_db = self.bass_guard_db
+        if enabled is not None:
+            self.enabled = bool(enabled)
+
     def process(self, samples: np.ndarray) -> np.ndarray:
         """Compress one chunk. Returns exactly as many samples as given."""
         if samples.size == 0:
@@ -178,6 +204,17 @@ class BassGuard:
         x = np.asarray(samples, dtype=np.float64)
         low, self._zl = sosfilt(self._lp, x, zi=self._zl)
         high, self._zh = sosfilt(self._hp, x, zi=self._zh)
+        if not self.enabled:
+            # Bypassed, but still filtered. LR4's two halves sum MAGNITUDE-
+            # flat (crossover_flatness_db measures 0.0000dB); the sum is an
+            # allpass, not the identity, so this is not `return x` and must
+            # not be simplified into one. That is the point: the signal takes
+            # the same path in both states, so toggling changes only the gain
+            # law and cannot click. Returning x instead would step the phase
+            # at the toggle, and skipping the filters would leave them cold to
+            # ring on re-enable — both audible as a thump at exactly the
+            # moment someone is listening for the difference.
+            return low + high
         return low * (10.0 ** (self._bass.gains_db(low) / 20.0)) + high
 
 

--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -529,14 +529,28 @@ class MediaSession:
         # gain or lose the capability mid-stream, and this runs ~23×/s.
         frame_type, eos_type = _frame_types(device)
 
+        # Built once for the whole feed and then UPDATED in place, never
+        # rebuilt: both processors carry filter and gain state, so a new
+        # instance mid-track restarts the crossover and clicks. Constructed
+        # even when disabled — a bypassed instance keeps its state warm, which
+        # is what makes toggling one mid-song silent.
+        #
+        # In place because these are taste parameters tuned by ear in a real
+        # room. Reading them once per stream meant every A/B cost a track
+        # skip, which is long enough that nobody can hold the two in their
+        # head (measured against a listening test on 2026-08-19: no audible
+        # difference reported, because none of the changes were reaching the
+        # audio at all).
         eq = em_eq.StreamingEQ(SPEAKER_RATE, device.eq_bands, device.eq_loudness,
-                               limiter=em_limiter.for_stream(
-                                   SPEAKER_RATE, device.limiter_enabled,
-                                   device.limiter_threshold,
-                                   device.limiter_release),
-                               guard=em_mbc.for_stream(
-                                   SPEAKER_RATE, device.bass_guard_enabled,
-                                   device.bass_guard_db))
+                               limiter=em_limiter.Limiter(
+                                   SPEAKER_RATE,
+                                   threshold_db=device.limiter_threshold,
+                                   release_ms=device.limiter_release,
+                                   enabled=device.limiter_enabled),
+                               guard=em_mbc.BassGuard(
+                                   SPEAKER_RATE,
+                                   bass_guard_db=device.bass_guard_db,
+                                   enabled=device.bass_guard_enabled))
         start_pos = self._pos
         proc = None
         seg_start = loop.time()
@@ -600,6 +614,17 @@ class MediaSession:
             await self._push_state()
 
             while True:
+                # Config is pushed live (_apply_live_config), so re-read it
+                # per chunk. update() compares before it touches anything, so
+                # the steady-state cost is a tuple comparison ~23×/s.
+                eq.update(bands=device.eq_bands,
+                          loudness=device.eq_loudness,
+                          limiter_enabled=device.limiter_enabled,
+                          limiter_threshold=device.limiter_threshold,
+                          limiter_release=device.limiter_release,
+                          guard_enabled=device.bass_guard_enabled,
+                          guard_db=device.bass_guard_db)
+
                 try:
                     if pending is not None:
                         chunk, pending = pending, None

--- a/controller/tests/test_chain_live.py
+++ b/controller/tests/test_chain_live.py
@@ -1,0 +1,258 @@
+"""
+Changing the output chain while a track is playing.
+
+The limiter's threshold and release, and the bass guard's depth, are taste
+parameters meant to be tuned by ear in a real room. They were read once, when
+the music feed built its chain, so a change only took effect on the next
+track — and a listening test on 2026-08-19 reported no audible difference from
+any setting, because none of them were reaching the audio.
+
+Everything here updates in place. The rule the tests exist to hold is that a
+change must be AUDIBLE but not ABRUPT: the processors keep their filter state,
+their gain state and the stream's latency across a change, so nothing clicks
+at the moment somebody is listening for a difference.
+"""
+
+import numpy as np
+import pytest
+
+import em_eq
+import em_limiter
+import em_mbc
+
+FS = 48000
+
+
+def _sine(hz, n, amp=8000.0, phase=0.0):
+    t = np.arange(n, dtype=np.float64) / FS
+    return amp * np.sin(2 * np.pi * hz * t + phase)
+
+
+def _pcm(samples):
+    return np.clip(samples, -32768, 32767).astype(np.int16).tobytes()
+
+
+# ── Limiter ───────────────────────────────────────────────────────────────────
+
+def test_a_bypassed_limiter_passes_audio_through_untouched():
+    """
+    Bypass must be unity gain, not a gentler limiter. The signal here is well
+    over the threshold, so anything other than passthrough shows up.
+    """
+    lim = em_limiter.Limiter(FS, threshold_db=-20.0, enabled=False)
+    x = _sine(200, 4800, amp=30000.0)
+    got = np.concatenate([lim.process(x.copy()), lim.flush()])
+
+    # The tail is primed with look-ahead silence, so the stream comes out
+    # delayed by that much — in both states, which is the point.
+    hold = lim.lookahead - 1
+    assert np.allclose(got[:hold], 0.0)
+    assert np.allclose(got[hold:], x, atol=1e-9)
+    assert lim.max_reduction_db == 0.0
+
+
+def test_toggling_the_limiter_keeps_the_stream_aligned():
+    """
+    The look-ahead delays the audio by 5ms. If bypass skipped the delay, the
+    toggle would jump the stream forward by that much — a click, and a
+    permanent 5ms disagreement with anything else being mixed.
+
+    So a bypassed limiter must still emit the same number of samples per call
+    and still hold the same tail.
+    """
+    on = em_limiter.Limiter(FS, enabled=True)
+    off = em_limiter.Limiter(FS, enabled=False)
+    x = _sine(200, 2400)
+    for _ in range(4):
+        assert on.process(x.copy()).size == off.process(x.copy()).size
+
+
+def test_the_threshold_takes_effect_mid_stream():
+    lim = em_limiter.Limiter(FS, threshold_db=-1.0)
+    loud = _sine(200, 2400, amp=30000.0)
+
+    lim.process(loud.copy())
+    gentle = lim.max_reduction_db
+
+    lim.set_params(threshold_db=-20.0)
+    lim.process(loud.copy())
+    assert lim.max_reduction_db > gentle + 5.0
+
+
+def test_toggling_the_limiter_does_not_reset_its_gain():
+    """
+    The gain is carried across chunks and released slowly. Rebuilding the
+    limiter to change a setting would snap it back to unity, which on loud
+    material is a jump of many dB in one sample.
+    """
+    lim = em_limiter.Limiter(FS, threshold_db=-20.0)
+    lim.process(_sine(200, 2400, amp=30000.0))
+    held = lim._gain_db
+    assert held < -5.0
+
+    lim.set_params(release_ms=250.0, threshold_db=-18.0)
+    assert lim._gain_db == held
+
+
+# ── Bass guard ────────────────────────────────────────────────────────────────
+
+def test_bypass_is_zero_depth_on_the_same_path_not_a_skipped_filter():
+    """
+    Bypass runs the crossover and sums it, rather than returning the input.
+
+    Stated exactly: a bypassed guard is bit-identical to an ENABLED guard at
+    zero depth — same filters, same state, no gain. That is what makes a
+    toggle silent, and it is what stops someone "simplifying" the branch to
+    `return x`, which is a different signal: LR4's halves sum magnitude-flat
+    (crossover_flatness_db measures it) but the sum is an ALLPASS, so the
+    phase would step at the toggle.
+    """
+    x = np.random.default_rng(7).normal(0, 4000, 24000)
+
+    bypassed = em_mbc.BassGuard(FS, bass_guard_db=-40.0, enabled=False)
+    zero_depth = em_mbc.BassGuard(FS, bass_guard_db=0.0, enabled=True)
+    assert np.allclose(bypassed.process(x.copy()),
+                       zero_depth.process(x.copy()), atol=1e-9)
+
+    # Magnitude-flat, by the module's own measure rather than a noisy FFT.
+    assert abs(em_mbc.crossover_flatness_db()) < 0.01
+
+    # But NOT the identity — the allpass phase is real, and is exactly why
+    # the bypass must not be rewritten as a passthrough.
+    assert not np.allclose(bypassed.process(x.copy()), x, atol=1.0)
+
+
+def test_a_bypassed_guard_applies_no_reduction():
+    guard = em_mbc.BassGuard(FS, bass_guard_db=-40.0, enabled=False)
+    guard.process(_sine(50, 48000, amp=30000.0))
+    assert guard.max_reduction_db == 0.0
+
+
+def test_the_depth_takes_effect_mid_stream():
+    guard = em_mbc.BassGuard(FS, bass_guard_db=-6.0)
+    bass = _sine(50, 24000, amp=30000.0)
+
+    guard.process(bass.copy())
+    shallow = guard.max_reduction_db
+    assert shallow == pytest.approx(6.0, abs=0.5)
+
+    guard.set_params(bass_guard_db=-30.0)
+    guard.process(bass.copy())
+    assert guard.max_reduction_db > shallow + 10.0
+
+
+def test_toggling_the_guard_keeps_the_crossover_running():
+    """
+    The biquads must stay warm while bypassed. If the filters were skipped,
+    re-enabling would start them from zero state and ring — a thump on the
+    toggle.
+
+    Checked by comparing a guard toggled off then on against one that was
+    never toggled: after the state has settled, the two must agree.
+    """
+    x = _sine(50, 4800, amp=30000.0)
+    steady = em_mbc.BassGuard(FS, bass_guard_db=-20.0)
+    toggled = em_mbc.BassGuard(FS, bass_guard_db=-20.0)
+
+    steady.process(x.copy())
+    toggled.set_params(enabled=False)
+    toggled.process(x.copy())
+    toggled.set_params(enabled=True)
+
+    later = _sine(50, 4800, amp=30000.0, phase=np.pi / 3)
+    a = steady.process(later.copy())
+    b = toggled.process(later.copy())
+    # Same filter state means the same output once both are running.
+    assert np.abs(a - b).max() < np.abs(a).max() * 0.02
+
+
+# ── The chain, as the feed drives it ──────────────────────────────────────────
+
+def _eq():
+    return em_eq.StreamingEQ(
+        FS, [0.0] * em_eq.NUM_BANDS, False,
+        limiter=em_limiter.Limiter(FS),
+        guard=em_mbc.BassGuard(FS))
+
+
+ARGS = dict(bands=[0.0] * em_eq.NUM_BANDS, loudness=False,
+            limiter_enabled=True, limiter_threshold=-1.0,
+            limiter_release=150.0, guard_enabled=True, guard_db=-20.0)
+
+
+def test_update_reports_whether_anything_moved():
+    eq = _eq()
+    assert eq.update(**ARGS) is True          # first call always lands
+    assert eq.update(**ARGS) is False         # nothing changed
+    assert eq.update(**{**ARGS, "guard_db": -12.0}) is True
+
+
+def test_update_does_not_rebuild_the_eq_for_an_unrelated_change():
+    """
+    update() runs per chunk, so rebuilding the biquads whenever anything moved
+    would be needless work — and would discard the filter state mid-track.
+    """
+    eq = _eq()
+    eq.update(**{**ARGS, "bands": [3.0] + [0.0] * (em_eq.NUM_BANDS - 1)})
+    sos = eq._sos
+    zi = eq._zi
+
+    eq.update(**{**ARGS, "bands": [3.0] + [0.0] * (em_eq.NUM_BANDS - 1),
+                 "guard_db": -30.0, "limiter_threshold": -6.0})
+    assert eq._sos is sos, "EQ rebuilt for a change that was not the EQ"
+    assert eq._zi is zi
+
+    assert eq._limiter.threshold_db == -6.0
+    assert eq._guard.bass_guard_db == -30.0
+
+
+def test_a_band_change_keeps_the_filter_running():
+    """
+    Coefficients change; state does not. Zeroing it would be a transient at
+    the exact moment the user is judging the change they just made.
+    """
+    eq = _eq()
+    eq.update(**{**ARGS, "bands": [6.0] + [0.0] * (em_eq.NUM_BANDS - 1)})
+    eq.process(_pcm(_sine(100, 2400)))
+    before = eq._zi.copy()
+
+    eq.update(**{**ARGS, "bands": [-6.0] + [0.0] * (em_eq.NUM_BANDS - 1)})
+    assert np.array_equal(eq._zi, before), "filter state was reset"
+
+
+def test_going_flat_and_back_is_handled():
+    """
+    A flat curve drops _sos entirely, so the way back has to allocate fresh
+    state rather than reuse an array that is no longer there.
+    """
+    eq = _eq()
+    eq.update(**{**ARGS, "bands": [6.0] + [0.0] * (em_eq.NUM_BANDS - 1)})
+    assert eq._sos is not None
+
+    eq.update(**ARGS)                      # back to flat
+    assert eq._sos is None
+
+    eq.update(**{**ARGS, "bands": [4.0] + [0.0] * (em_eq.NUM_BANDS - 1)})
+    assert eq._sos is not None
+    out = eq.process(_pcm(_sine(100, 2400)))
+    assert len(out) == 2400 * 2
+
+
+def test_the_chain_keeps_working_across_a_live_change():
+    """
+    End to end: a stream that changes settings mid-flight still returns the
+    same number of bytes it was given, chunk for chunk. The feed sends what it
+    gets back, so a short read would reshape the frames on the wire.
+    """
+    eq = _eq()
+    eq.update(**ARGS)
+    chunk = _pcm(_sine(60, 2400, amp=25000.0))
+
+    sizes = []
+    for i in range(8):
+        if i == 4:
+            eq.update(**{**ARGS, "guard_enabled": False,
+                         "limiter_enabled": False})
+        sizes.append(len(eq.process(chunk)))
+
+    assert sizes[1:] == [len(chunk)] * 7


### PR DESCRIPTION
**Limiter and bass guard settings now take effect mid-track, instead of on the next one.**

The chain was built once per music feed, so changing a setting did nothing until the track changed. That defeats the tuning it exists for — a track skip is much longer than anyone can hold two versions of a sound in their head. Found in a listening test that reported no audible difference from any setting, correctly: none of the changes were reaching the audio.

**Everything updates in place; nothing is reconstructed.** Three details carry the weight, each otherwise audible at exactly the wrong moment:

- **State is kept.** Both processors carry filter and gain state — a new instance mid-track restarts the crossover and snaps the limiter's gain back to unity.
- **Enable/disable is a flag, not a `None` instance.** A bypassed limiter still holds its tail, so the stream keeps its 5ms latency rather than jumping forward on the toggle. A bypassed guard still runs the crossover and sums it — and that sum is an allpass, not the identity, so it is deliberately *not* `return x`. A test pins the difference.
- **EQ coefficients rebuild only when the curve moves**, carrying filter state across the change.

Crossover frequency and look-ahead are deliberately not settable: both own carried state and both are measured, not taste.

Cost is one tuple comparison ~23×/s — `update()` compares before it acts. Only music needs this; TTS is processed per response and already reads current config.

Tests: 588 pass, 13 new in `tests/test_chain_live.py`. The bypass-path guard was verified by reintroducing the shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)