### PR TITLE
Carry the output chain to the running controller on a config save

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -1009,6 +1009,23 @@ async def _apply_live_config(device_id: str, live, effective: dict) -> None:
         live.eq_bands = effective["eqBands"]
     if "eqLoudness" in effective:
         live.eq_loudness = bool(effective["eqLoudness"])
+    # The output chain is consumed HERE, not on the device — it ignores these
+    # five keys entirely — so this mirror is the only thing that carries them.
+    # Missing it meant a push wrote the database, sent JSON the device threw
+    # away, and changed nothing audible until the device happened to
+    # reconnect. Exactly the shape this function's docstring warns about, and
+    # it cost a whole listening test on 2026-08-19: every setting appeared to
+    # do nothing, because every setting WAS doing nothing.
+    if "limiterEnabled" in effective:
+        live.limiter_enabled = bool(effective["limiterEnabled"])
+    if "limiterThreshold" in effective:
+        live.limiter_threshold = float(effective["limiterThreshold"])
+    if "limiterRelease" in effective:
+        live.limiter_release = float(effective["limiterRelease"])
+    if "bassGuardEnabled" in effective:
+        live.bass_guard_enabled = bool(effective["bassGuardEnabled"])
+    if "bassGuardDb" in effective:
+        live.bass_guard_db = float(effective["bassGuardDb"])
     live.led_scene = em_scenes.resolve(effective)
 
 

--- a/controller/tests/test_config_mirrors.py
+++ b/controller/tests/test_config_mirrors.py
@@ -1,0 +1,88 @@
+"""
+The two places a config value reaches the running controller.
+
+Some config keys are consumed by the CONTROLLER rather than the device — the
+output chain, the wake threshold, the barge settings. For those, the JSON sent
+down the wire is not what makes them work; an attribute on the Device object
+is. That attribute is set in two places, and both have to agree:
+
+  - `em_controller.handle_control`, when a device registers, and
+  - `em_api._apply_live_config`, when someone saves config in the dashboard.
+
+A key mirrored in the first but not the second reads as working. The database
+is written, the device is sent the value and throws it away, and the setting
+takes effect the next time the device happens to reconnect — so it works after
+a restart, which is exactly when someone would stop investigating.
+
+That is what happened to the limiter and the bass guard (2026-08-19): a whole
+listening test produced no audible difference from any setting, because none
+of them were reaching the audio. `_apply_live_config`'s own docstring warned
+about this shape — "a mirror added to one but not the other is a bug that
+reads as working" — and it happened anyway, which is why it is now a test
+rather than a comment.
+"""
+
+import re
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+# Keys deliberately mirrored only at registration.
+#
+# startupVolume is device STATE, not a setting (em_config_sections.STATE_KEYS):
+# it seeds the device's level in the window before its first volume_state
+# report, and a later push must NOT stomp a volume somebody has since changed
+# by hand.
+REGISTRATION_ONLY = {"startupVolume"}
+
+
+def _registration_keys() -> set[str]:
+    src = (CONTROLLER / "em_controller.py").read_text()
+    block = src.split('await device.send_control({"type": "config", **config})')
+    assert len(block) > 1, "registration config push not found — has it moved?"
+    return set(re.findall(r'config\.get\(\s*["\']([A-Za-z]+)["\']', block[1][:2500]))
+
+
+def _live_push_keys() -> set[str]:
+    src = (CONTROLLER / "em_api.py").read_text()
+    block = src.split("async def _apply_live_config")
+    assert len(block) > 1, "_apply_live_config not found — has it been renamed?"
+    body = block[1].split("\n@auth")[0]
+    return set(re.findall(r'effective\[?["\']([A-Za-z]+)["\']', body))
+
+
+def test_every_registration_mirror_is_also_applied_on_a_live_push():
+    reg = _registration_keys()
+    live = _live_push_keys()
+    missing = reg - live - REGISTRATION_ONLY
+    assert not missing, (
+        "These config keys update the controller when a device registers but "
+        "NOT when config is saved:\n  " + "\n  ".join(sorted(missing)) +
+        "\n\nThey will appear to do nothing until the device reconnects. Add "
+        "them to em_api._apply_live_config, or to REGISTRATION_ONLY with a "
+        "reason."
+    )
+
+
+def test_the_output_chain_is_carried_by_both():
+    """
+    Named explicitly, because these five are the ones with no device-side
+    fallback at all: the firmware ignores them, so the controller-side mirror
+    is the ONLY thing that makes them work.
+    """
+    chain = {"limiterEnabled", "limiterThreshold", "limiterRelease",
+             "bassGuardEnabled", "bassGuardDb"}
+    assert chain <= _registration_keys()
+    assert chain <= _live_push_keys()
+
+
+def test_registration_only_keys_are_really_absent():
+    """
+    Keeps the exemption list honest: an entry that IS mirrored live should be
+    removed from it rather than sitting there implying a rule that no longer
+    holds.
+    """
+    stale = REGISTRATION_ONLY & _live_push_keys()
+    assert not stale, (
+        f"REGISTRATION_ONLY lists {sorted(stale)}, but they are applied on a "
+        f"live push — drop them from the exemption")


### PR DESCRIPTION
**Saving limiter or bass guard settings never reached the running controller.** They only took effect when a device reconnected.

The five output-chain keys are consumed by the controller — the firmware ignores them — so the `Device` attributes are the only thing that makes them work. Those attributes were set when a device registers, and **not** in `_apply_live_config`. So a save wrote the database, sent the device JSON it discarded, and changed nothing audible.

It reads as working, because reconnecting fixes it — which is what anyone does before investigating further. It is the exact shape `_apply_live_config`'s own docstring warns about.

**Cost:** a full listening test on 2026-08-19 that found no audible difference from any setting. That was the correct observation. It also means #239, which made the chain updatable mid-track, was necessary but not sufficient — it re-reads these attributes per chunk and nothing was updating them.

`tests/test_config_mirrors.py` now diffs the two mirror sites and fails on any key present in one and not the other. `startupVolume` is exempted with a reason: it is device state, and must not stomp a volume changed by hand. Verified by reintroducing the omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)