### PR TITLE
Default the bass guard depth to -30dB

### DIFF
--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -518,11 +518,13 @@ the obvious fix and the wrong one, since it costs the full boost in level.
 115Hz, ratio 20:1, threshold −50dB, floor −40dB, release 200ms. Stock's bands
 2–4 are deliberately not implemented — one gentle 2:1 law at −10dB repeated
 three times, which is broadband compression for loudness rather than
-protection. Our default depth is **−20dB rather than stock's −40dB**, because
+protection. Our default depth is **−30dB rather than stock's −40dB**, because
 stock's sits in front of stock's own EQ curve, which we have neither nor have
 measured; copying the depth without the curve it was tuned against is not the
-same setting. It is a starting point for a listening test, the status `duckDb`
-had before it was tuned by ear.
+same setting. It shipped at −20 and moved to −30 after the first listening
+test that heard the chain working (2026-08-20), on the grounds that mid-range
+leaves room to go either way — the depth is very nearly a free choice, since
+the whole range moves the overall level 0.14dB.
 
 **The crossover is Linkwitz-Riley, and the first attempt was not.** LR4's
 lowpass and highpass sum flat (measured: 0.0000dB deviation across 4096

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -225,7 +225,7 @@ DEFAULT_DEVICE_CONFIG = {
     # Dynamic bass guard. Removes low-frequency content the driver cannot
     # deliver, which is what makes the midrange clean — see em_mbc.
     "bassGuardEnabled": True,
-    "bassGuardDb":      -20.0,
+    "bassGuardDb":      -30.0,
     "limiterEnabled":   True,
     "limiterThreshold": -1.0,
     "limiterRelease":   150,

--- a/controller/em_mbc.py
+++ b/controller/em_mbc.py
@@ -66,10 +66,16 @@ BASS_RELEASE_MS   = 200.0
 #
 # We default SHALLOWER, deliberately: stock's -40 sits in front of stock's own
 # EQ, which we do not have and have not measured, so copying the depth without
-# the curve it was tuned against is not the same setting. A starting point for
-# a listening test, not a measurement — the status duckDb had before it was
-# tuned by ear in a real room.
-DEFAULT_BASS_GUARD_DB = -20.0
+# the curve it was tuned against is not the same setting.
+#
+# -30 rather than -20 after the first listening test (2026-08-20, drum and
+# bass on Test Device 01): it sits mid-range, so there is room to move in
+# BOTH directions without hitting an end stop. Note the choice is nearly
+# free either way — across the entire -40..0 range this moves the OVERALL
+# level 0.14dB, so no one will hear the default change. What is audible is
+# the guard being on at all (-5.0dB overall, -17.7dB at 50Hz), which is
+# `bassGuardEnabled`, not this. Tune with the toggle; this is headroom.
+DEFAULT_BASS_GUARD_DB = -30.0
 
 _FULL_SCALE = 32768.0
 _EPS = 1e-9

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5103,7 +5103,7 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
             <div style={inputStyle}>
               <Slider label="Bass guard depth" disabled={!(config.bassGuardEnabled ?? true)}
                 sub="how far below 115 Hz is pulled down when it's loud"
-                value={config.bassGuardDb ?? -20} min={-40} max={0} step={1} unit="dB"
+                value={config.bassGuardDb ?? -30} min={-40} max={0} step={1} unit="dB"
                 onChange={v => set('bassGuardDb', v)}/>
             </div>
             <div style={inputStyle}>

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -10,7 +10,7 @@ class FakeDevice:
         self.eq_bands = [0.0] * 8
         self.eq_loudness = False
         self.bass_guard_enabled = True
-        self.bass_guard_db = -20.0
+        self.bass_guard_db = -30.0
         self.limiter_enabled = True
         self.limiter_threshold = -1.0
         self.limiter_release = 150.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,7 +109,7 @@ going to hear.
 Quiet passages keep their low end. Only loud content is affected, which is why
 this is a guard rather than a filter.
 
-**Depth** sets how far it pulls down, default **−20dB**.
+**Depth** sets how far it pulls down, default **−30dB**.
 
 **Judge this by turning it off and on, not by moving the depth.** Almost all
 of the audible change happens in the first few dB: switching it on takes about


### PR DESCRIPTION
**Moved after the first listening test that actually heard the chain working** — drum and bass on Test Device 01, 2026-08-20, reported as very listenable. `-30` sits mid-range so there is room to move in both directions; `-20` only had room downwards.

**Nobody will hear this change, and that is the point.** Across the entire `-40..0` range the depth moves the OVERALL level **0.14dB**. What is audible is the guard being on at all — −5.0dB overall, −17.7dB at 50Hz, +2.6dB of midrange on loud material where the limiter is working. Tune with `bassGuardEnabled`; the depth is headroom, not a tone control.

**It does reach existing installs.** `get_global_device_config` underlays `DEFAULT_DEVICE_CONFIG`, so a key nobody has explicitly saved picks up the new default. Anyone who has already set a depth keeps theirs.

Four code sites plus two docs, because the dashboard carries its own fallback for an unset key (`config.bassGuardDb ?? -20`) and would otherwise display a different number than the controller applies — the same mirror-drift shape as `CONFIG_SECTIONS`.

591 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)