### PR TITLE
Instrument the output chain, and collapse its controls to one toggle

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -712,6 +712,63 @@ One consequence worth knowing: with mediaserver alive, Android still reacts to j
 
 **Acoustic feedback prevention.** `stream_speaker` completes well ahead of actual playback (the WS write runs ~2× realtime and the device buffers ~5.5s). Without compensation, the mic would restart while the speaker is still playing, and the assistant would hear itself and trigger another turn. The controller sleeps for the remaining playback duration (plus the ~1s prime allowance) after streaming, racing `cancel_event` so barge-in cuts the wait instantly. With barge-in enabled the mic never stops at all — AEC is what keeps the live mic usable during playback.
 
+**Stock's playback processing, measured off a device (2026-08-20).** Amazon's
+own chain for the speaker path, from `/system/vendor/etc/audio-algorithms/`:
+
+```
+UserEQ  ->  Equalizer FIR  ->  MBCL
+(taste)     (driver correction)  (excursion protection)
+```
+
+Our chain is the same order — EQ, bass guard, limiter — with the middle stage
+missing entirely (#247).
+
+`AFE.cfg` selects among six FIR files by volume (`"Volume Boundary": [50, 60,
+70, 80, 90, 100]`), but all six are one curve at six gains (`EQ_100` is
+`EQ_50` x 5.334838 exactly), so **tone is constant across volume and only the
+level is banded**. `EQ_50.cfg` is 1024 FIR taps at 48kHz. Its response,
+normalised to 0dB at 1kHz because the absolute level is that volume banding
+rather than tone:
+
+| Hz | dB | Hz | dB | Hz | dB |
+|---|---|---|---|---|---|
+| 100 | +20.1 | 500 | +2.7 | 2800 | **-14.7** |
+| 125 | +24.8 | 700 | +0.1 | 3500 | -11.9 |
+| 150 | **+26.2** | 1000 | 0.0 | 5000 | -3.5 |
+| 200 | +25.6 | 1400 | -2.1 | 8000 | +3.1 |
+| 250 | +19.9 | 2000 | -7.9 | 10000 | +3.1 |
+| 350 | +12.3 | | | | |
+
+**The design is coherent and the two halves belong together**: boost the
+lowest region the driver *can* radiate (150-250Hz, ~+25dB), and let MBCL band
+1 delete everything below 115Hz that it *cannot* (20:1 from -50dB, floor
+-40dB). Boost what works, remove what does not. Implementing only the removal
+half — which is what `em_mbc` is — protects the driver correctly and leaves
+the output thin, because nothing puts energy back where the driver works.
+
+Two caveats on the numbers. **Below ~100Hz they are not trustworthy**: 1024
+taps at 48kHz is ~47Hz of resolution, so treat the sub-100Hz end as undefined
+rather than as a measurement. And **this is a correction curve, not a driver
+response** — it says what Amazon decided this speaker needed, which is strong
+evidence about the driver but not the same thing. A measured driver response
+is still the open item, and it needs hardware.
+
+The table is recorded here because the same coefficients were read off a
+device on 2026-08-19 and only the *conclusion* was written down, so they had
+to be fetched a second time. The vendor `.cfg` files themselves are Amazon's
+and are deliberately not committed; this derived response is a fact about the
+hardware.
+
+**Stock knows whether something is in the jack, and retunes for it.**
+`AFE.cfg` declares `"Num Max Speakers": 2` with `"Num Internal Speakers": 1`,
+`"default speaker mode": "internal"`, and keys the residual-echo suppressor's
+tuning tables by that mode (only the `internal` block is populated on this
+unit). The second speaker is the 3.5mm line out, and the reason the front end
+cares is echo cancellation: headphones present no acoustic echo path at all,
+and an external speaker presents a completely different one. **EchoMuse has no
+speaker-mode concept** — our AEC assumes the internal speaker always. Worth
+knowing for #117/#141 and before any line-out work.
+
 **Turn timeouts.** The mic-streaming phase of a turn carries a 20s hard cap, and a turn where speech never starts closes locally after 5s (controller-side SNR-relative timeout on wake turns, device `0x05` sentinel on button turns) instead of round-tripping to HA for an empty transcription.
 
 **Stale queue drain.** After each voice turn, the mic queue is drained and the OWW model is reset before wake listening resumes. This prevents the device's own speaker output (buffered during playback) from immediately triggering another wake word detection.

--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -499,6 +499,31 @@ midrange comes up **+2.6dB**. So tune with `bassGuardEnabled`, not with the
 depth; an A/B between −20 and −40 is below audibility and will read as a broken
 feature.
 
+**The guard and the limiter cancel each other's most obvious cue, so "I hear
+no difference" is not evidence.** The guard's effect on OVERALL LEVEL depends
+entirely on whether the limiter is working. Measured 2026-08-20, guard on
+versus off on the same bass-heavy signal:
+
+| EQ            | overall | sub (30–80Hz) | 1kHz  |
+|---------------|---------|---------------|-------|
+| flat          | 7.68dB  | 24.4dB        | 0.0dB |
+| +12 all bands | 0.17dB  | 20.4dB        | 4.2dB |
+
+Under a heavy boost the limiter gives back exactly what the guard takes, so
+the level difference goes to nothing and the whole change moves into the
+midrange. An A/B run at that operating point tests almost nothing, and reads
+as a dead control on a chain that is working perfectly — which is how an
+entire morning went on 2026-08-20, after three earlier listening tests had
+already failed for three unrelated real bugs. **A/B the guard at FLAT EQ**, or
+not at all.
+
+That is also why `em_eq.describe_chain` / `describe_activity` exist and are
+logged per stream. Settings answer "did the config reach the audio"; max
+reduction answers "did the law engage". `n/a` means bypassed and `0.00dB`
+means running but idle — identical from a listening seat, opposite
+investigations. `em_limiter` keeps `release_ms` purely so it can be reported;
+the gain law uses the derived slew.
+
 **Guard before limiter.** Limiting first spends gain reduction on bass that is
 about to be discarded, pulling the midrange down for no reason. Measured on a
 50Hz + 1kHz mix: with the guard on, the 50Hz component drops 17.2dB and the

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -1216,9 +1216,15 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
     audio buffer has drained (or cancel_event fires), so the caller can
     safely restart the mic without acoustic feedback into the next turn.
     """
+    # Built here rather than inside _prepare_pcm so the stages survive the
+    # call and can be asked what they actually did — see em_eq.describe_*.
+    # One response is one buffer, so these are per-response instances and
+    # carry no state between turns.
+    _limiter = _limiter_for(device)
+    _guard   = _guard_for(device)
     log.info(
-        f"[{device.device_id}] EQ: bands={device.eq_bands} "
-        f"loudness={device.eq_loudness} limiter={device.limiter_enabled}"
+        f"[{device.device_id}] Output chain: "
+        f"{em_eq.describe_chain(device.eq_bands, device.eq_loudness, _limiter, _guard)}"
     )
     # EQ is a solid numpy crunch (hundreds of ms for a long response) — run
     # it off the event loop, which otherwise freezes every device's LED
@@ -1226,8 +1232,8 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
     # (observed as spinner stutter and console typing judder).
     def _prepare_pcm() -> bytes:
         return em_eq.apply(voice_response, SPEAKER_RATE, device.eq_bands,
-                           device.eq_loudness, limiter=_limiter_for(device),
-                           guard=_guard_for(device))
+                           device.eq_loudness, limiter=_limiter,
+                           guard=_guard)
 
     _t_eq0 = asyncio.get_event_loop().time()
     speaker_pcm = await asyncio.get_event_loop().run_in_executor(None, _prepare_pcm)
@@ -1236,7 +1242,8 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
     )
     log.info(
         f"[{device.device_id}] Streaming {len(speaker_pcm)} bytes "
-        f"({len(speaker_pcm)//SPEAKER_BYTES} periods)"
+        f"({len(speaker_pcm)//SPEAKER_BYTES} periods) — "
+        f"{em_eq.describe_activity(_limiter, _guard)}"
     )
     cancel_task    = asyncio.create_task(device.cancel_event.wait())
     device.playback_done.clear()

--- a/controller/em_eq.py
+++ b/controller/em_eq.py
@@ -198,6 +198,16 @@ class StreamingEQ:
             self._sos = build_sos(bands, sample_rate, loudness)
             self._zi  = np.zeros((self._sos.shape[0], 2), dtype=np.float64)
 
+    @property
+    def limiter(self):
+        """The chain's limiter, for instrumentation. May be None."""
+        return self._limiter
+
+    @property
+    def guard(self):
+        """The chain's bass guard, for instrumentation. May be None."""
+        return self._guard
+
     def update(self, *,
                bands: list | None = None,
                loudness: bool = False,
@@ -298,3 +308,76 @@ class StreamingEQ:
         if not tail.size:
             return b""
         return np.clip(tail, -32768, 32767).astype(np.int16).tobytes()
+
+
+# ─── Chain instrumentation ────────────────────────────────────────────────
+#
+# Whether the output chain is doing anything has been unanswerable from
+# outside it, and that has now cost four listening tests. The stages
+# interact hard enough that "I hear no difference" is NOT evidence either
+# way: the bass guard is worth ~7.7dB of overall level at a modest EQ and
+# ~0dB under a heavy boost, because the limiter gives back exactly what the
+# guard takes away (measured 2026-08-20 — guard on/off at +12dB on all
+# eight bands is -0.17dB overall, and the whole difference moves into the
+# midrange instead). A listener judging by loudness is then judging the one
+# cue that has been cancelled out.
+#
+# So the settings and the WORK DONE are reported separately. Settings say
+# what reached the audio path, which is the config question; max reduction
+# says whether the law ever engaged, which is the audio question. A guard
+# that is enabled and reports 0.00dB of reduction is being fed content with
+# no bass in it — a different fault from one that never got the setting.
+#
+# Cost is two log lines per stream plus one per live change, so nothing runs
+# per frame. `max_reduction_db` is already maintained by both processors;
+# this only surfaces it.
+
+
+def _stage_state(stage, off="off") -> bool:
+    """
+    Whether a chain stage will actually process.
+
+    Both shapes mean disabled and both occur: the one-shot path (em_eq.apply)
+    takes None from for_stream(), while StreamingEQ always holds an instance
+    and carries an `enabled` flag so a stream can be toggled without dropping
+    filter state.
+    """
+    return stage is not None and getattr(stage, "enabled", True)
+
+
+def describe_chain(bands, loudness, limiter=None, guard=None) -> str:
+    """
+    One line naming what this stream's chain is SET to.
+
+    Emitted when a stream starts and again whenever a live update changes
+    something, so the log shows both the starting point and the fact that a
+    dashboard change reached the audio — which is the half that could not be
+    seen before.
+    """
+    shaped = bands and any(float(b) != 0.0 for b in bands)
+    eq = ("flat" if not shaped
+          else "/".join(f"{float(b):+g}" if float(b) else "0" for b in bands))
+    parts = [f"eq={eq}", f"speech_boost={'on' if loudness else 'off'}"]
+    parts.append(
+        f"guard={f'{guard.bass_guard_db:g}dB' if _stage_state(guard) else 'off'}"
+    )
+    parts.append(
+        f"limiter={f'{limiter.threshold_db:g}dB/{limiter.release_ms:g}ms'}"
+        if _stage_state(limiter) else "limiter=off"
+    )
+    return " ".join(parts)
+
+
+def describe_activity(limiter=None, guard=None) -> str:
+    """
+    One line naming what the chain actually DID, in dB of gain reduction.
+
+    `n/a` distinguishes a stage that was off from one that was on and never
+    engaged — the two look identical from a listening seat and want opposite
+    investigations.
+    """
+    def red(stage):
+        if not _stage_state(stage):
+            return "n/a"
+        return f"{stage.max_reduction_db:.2f}dB"
+    return f"guard_reduction={red(guard)} limiter_reduction={red(limiter)}"

--- a/controller/em_limiter.py
+++ b/controller/em_limiter.py
@@ -118,6 +118,10 @@ class Limiter:
         self.enabled = bool(enabled)
         self.threshold_db = 0.0
         self._thresh = _CEILING
+        # Kept only so the setting can be reported. The gain law uses _slew;
+        # this is the number a user set, which the slew cannot be read back
+        # to without knowing the sample rate and the reference.
+        self.release_ms = float(release_ms)
 
         self.lookahead = max(1, int(self.sample_rate * lookahead_ms / 1000.0))
         self._slew = 0.0
@@ -164,6 +168,7 @@ class Limiter:
             self.threshold_db = float(min(threshold_db, 0.0))
             self._thresh = _CEILING * (10.0 ** (self.threshold_db / 20.0))
         if release_ms is not None:
+            self.release_ms = float(release_ms)
             # dB per sample the gain may rise.
             self._slew = (RELEASE_REFERENCE_DB
                           / (max(1.0, float(release_ms)) / 1000.0)

--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -617,13 +617,22 @@ class MediaSession:
                 # Config is pushed live (_apply_live_config), so re-read it
                 # per chunk. update() compares before it touches anything, so
                 # the steady-state cost is a tuple comparison ~23×/s.
-                eq.update(bands=device.eq_bands,
-                          loudness=device.eq_loudness,
-                          limiter_enabled=device.limiter_enabled,
-                          limiter_threshold=device.limiter_threshold,
-                          limiter_release=device.limiter_release,
-                          guard_enabled=device.bass_guard_enabled,
-                          guard_db=device.bass_guard_db)
+                #
+                # Logged whenever it MOVES, which is once at the start of the
+                # stream and once per dashboard change. That line is the only
+                # proof that a setting reached the audio: the stages cancel
+                # each other's most obvious cue, so "I heard nothing" cannot
+                # distinguish a working chain from a config that never
+                # arrived. See em_eq.describe_chain.
+                if eq.update(bands=device.eq_bands,
+                             loudness=device.eq_loudness,
+                             limiter_enabled=device.limiter_enabled,
+                             limiter_threshold=device.limiter_threshold,
+                             limiter_release=device.limiter_release,
+                             guard_enabled=device.bass_guard_enabled,
+                             guard_db=device.bass_guard_db):
+                    log.info(f"[{self.device_id}] Output chain: "
+                             f"{em_eq.describe_chain(device.eq_bands, device.eq_loudness, eq.limiter, eq.guard)}")
 
                 try:
                     if pending is not None:
@@ -715,7 +724,8 @@ class MediaSession:
                     f"[{self.device_id}] Media feed done: "
                     f"{sent // SPEAKER_BYTES} periods, source max read "
                     f"{src_max_ms:.0f}ms, {src_stalls} stall(s) over "
-                    f"{SOURCE_STALL_MS:.0f}ms")
+                    f"{SOURCE_STALL_MS:.0f}ms, "
+                    f"{em_eq.describe_activity(eq.limiter, eq.guard)}")
             if not eos_sent:
                 # The flush discard stays armed until it sees this stream's
                 # EOS — same contract as barge-in aborting stream_speaker.

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5056,6 +5056,7 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
 
   const [advMics, setAdvMics] = useState(false);
   const [advRing, setAdvRing] = useState(false);
+  const [advPlay, setAdvPlay] = useState(false);
 
   const inputStyle = disabled ? { opacity: 0.45, pointerEvents: 'none' } : {};
   const mono = "'DM Mono',monospace";
@@ -5096,32 +5097,25 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
             <div style={inputStyle}>
               <Toggle label="Speech boost" sub="presence boost for voice" value={config.eqLoudness ?? false} onChange={v => set('eqLoudness', v)}/>
             </div>
-            <div style={inputStyle}>
-              <Toggle label="Bass guard" sub="drops bass the speaker can't produce — clears the midrange"
-                value={config.bassGuardEnabled ?? true} onChange={v => set('bassGuardEnabled', v)}/>
-            </div>
-            <div style={inputStyle}>
-              <Slider label="Bass guard depth" disabled={!(config.bassGuardEnabled ?? true)}
-                sub="how far below 115 Hz is pulled down when it's loud"
-                value={config.bassGuardDb ?? -30} min={-40} max={0} step={1} unit="dB"
-                onChange={v => set('bassGuardDb', v)}/>
-            </div>
-            <div style={inputStyle}>
-              <Toggle label="Limiter" sub="stops EQ boost from clipping — leave on"
-                value={config.limiterEnabled ?? true} onChange={v => set('limiterEnabled', v)}/>
-            </div>
-            <div style={inputStyle}>
-              <Slider label="Limiter ceiling" disabled={!(config.limiterEnabled ?? true)}
-                sub="peak level the output is held below"
-                value={config.limiterThreshold ?? -1} min={-12} max={0} step={0.5} unit="dB"
-                onChange={v => set('limiterThreshold', v)}/>
-            </div>
-            <div style={inputStyle}>
-              <Slider label="Limiter release" disabled={!(config.limiterEnabled ?? true)}
-                sub="time to recover 10 dB — shorter is louder, longer is smoother"
-                value={config.limiterRelease ?? 150} min={20} max={1000} step={10} unit="ms"
-                onChange={v => set('limiterRelease', v)}/>
-            </div>
+            {/* Speaker protection: ONE toggle for the bass guard, and the
+                limiter is not offered at all.
+
+                These were four controls until 2026-08-20, and none of them
+                can be judged by ear. The guard and the limiter cancel each
+                other's most obvious cue — guard on/off is 7.7dB of overall
+                level at a flat EQ and 0.2dB with the bands boosted, because
+                the limiter gives back exactly what the guard takes. The depth
+                moves the overall level 0.14dB across its ENTIRE range. And
+                the guard mostly removes content this driver cannot radiate,
+                so what remains is a second-order cleanliness gain.
+
+                Four controls whose individual effects range from "large" to
+                "nothing" depending on where the other three sit is not a
+                tuning surface; it is a way to conclude the feature is broken,
+                which is what happened. The limiter in particular must stay on
+                — it is what stops the EQ hard-clipping what it boosts (#231),
+                and that is not a preference. Every key still exists and is
+                settable through the API. */}
             <div style={inputStyle}>
               <Slider label="Duck depth" disabled={!mixCapable}
                 sub={mixCapable
@@ -5144,6 +5138,19 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
             </div>
           </div>
         </div>
+        <StageAdvanced open={advPlay} onToggle={() => setAdvPlay(o => !o)} disabledStyle={inputStyle}>
+          <div style={inputStyle}>
+            <Toggle label="Speaker protection"
+              sub="keeps bass the driver can't deliver from muddying the midrange — leave on"
+              value={config.bassGuardEnabled ?? true} onChange={v => set('bassGuardEnabled', v)}/>
+          </div>
+          <div style={{ marginTop: 8, fontFamily: mono, fontSize: 10, color: 'var(--muted)', lineHeight: 1.6 }}>
+            The speaker cannot reproduce the lowest frequencies, and feeding
+            them to it costs cone movement that muddies everything above.
+            Removing them is what keeps the midrange clean. The change is
+            subtle by design and there is no reason to turn it off.
+          </div>
+        </StageAdvanced>
       </Stage>
 
       {/* 02 WAKE WORD */}

--- a/controller/tests/test_chain_instrumentation.py
+++ b/controller/tests/test_chain_instrumentation.py
@@ -1,0 +1,127 @@
+"""
+The output chain has to be able to report what it is set to and what it did.
+
+Both halves are needed and they answer different questions. Settings say
+whether a config change reached the audio path; max reduction says whether the
+law ever engaged. A guard that is enabled and reduced nothing is being fed
+content with no bass — a different fault from one that never got the setting,
+and from a listening seat the two are identical.
+
+That matters because loudness is not a usable cue here: the guard is worth
+~7.7dB of overall level at a modest EQ and ~0dB under a heavy boost, since the
+limiter gives back what the guard takes. Judging by ear at the wrong operating
+point reads as "this control does nothing" for a chain that is working
+perfectly.
+"""
+
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import numpy as np
+import em_eq, em_mbc, em_limiter
+
+FS = 48000
+
+
+def _guard(enabled=True, depth=-30.0):
+    return em_mbc.BassGuard(FS, bass_guard_db=depth, enabled=enabled)
+
+
+def _limiter(enabled=True, thr=-1.0, rel=150.0):
+    return em_limiter.Limiter(FS, threshold_db=thr, release_ms=rel,
+                              enabled=enabled)
+
+
+def _bassy(seconds=1.0, peak_db=-9.0):
+    t = np.arange(int(FS * seconds)) / FS
+    x = np.sin(2 * np.pi * 48 * t) + 0.3 * np.sin(2 * np.pi * 1000 * t)
+    x /= np.abs(x).max()
+    return (x * 10 ** (peak_db / 20) * 32767).astype(np.int16).tobytes()
+
+
+def test_settings_are_reported_for_both_disabled_shapes():
+    """
+    A stage is disabled two ways and both occur: None from for_stream() on the
+    one-shot path, and an instance with enabled=False on the streaming path,
+    which keeps its filter state so a mid-track toggle cannot click.
+    """
+    assert "guard=off" in em_eq.describe_chain([0.0] * 8, False, None, None)
+    assert "limiter=off" in em_eq.describe_chain([0.0] * 8, False, None, None)
+
+    line = em_eq.describe_chain([0.0] * 8, False,
+                                _limiter(enabled=False), _guard(enabled=False))
+    assert "guard=off" in line and "limiter=off" in line
+
+
+def test_settings_name_the_values_not_just_on():
+    """
+    "on" would not have caught the bug this exists for. The depth and the
+    ceiling are what a saved change moves, so the line has to carry them.
+    """
+    line = em_eq.describe_chain([0.0] * 8, False,
+                                _limiter(thr=-6.0, rel=400.0), _guard(depth=-25.0))
+    assert "guard=-25dB" in line
+    assert "limiter=-6dB/400ms" in line
+
+
+def test_flat_eq_says_flat_and_a_shaped_one_lists_bands():
+    assert "eq=flat" in em_eq.describe_chain([0.0] * 8, False)
+    line = em_eq.describe_chain([3.0] + [0.0] * 7, True)
+    assert "eq=+3/0/0/0/0/0/0/0" in line
+    assert "speech_boost=on" in line
+
+
+def test_activity_separates_off_from_on_but_idle():
+    """
+    The distinction the whole module exists for: `n/a` is a stage that was
+    bypassed, `0.00dB` is one that ran and never engaged.
+    """
+    off = em_eq.describe_activity(_limiter(enabled=False), _guard(enabled=False))
+    assert "guard_reduction=n/a" in off
+
+    idle_guard = _guard()
+    em_eq.StreamingEQ(FS, [0.0] * 8, False, guard=idle_guard).process(
+        (np.zeros(4096, dtype=np.int16)).tobytes()
+    )
+    assert "guard_reduction=0.00dB" in em_eq.describe_activity(None, idle_guard)
+
+
+def test_activity_reports_real_work_on_bass():
+    """An enabled guard fed real bass must report a non-zero reduction."""
+    guard = _guard()
+    eq = em_eq.StreamingEQ(FS, [0.0] * 8, False, limiter=_limiter(), guard=guard)
+    pcm = _bassy()
+    for i in range(0, len(pcm), 4096):
+        eq.process(pcm[i:i + 4096])
+    assert guard.max_reduction_db > 10.0
+    assert "guard_reduction=n/a" not in em_eq.describe_activity(eq.limiter, eq.guard)
+
+
+def test_a_live_toggle_is_visible_as_a_settings_change():
+    """
+    update() returning True is what the music feed logs on, so a dashboard
+    change has to make it return True — and a no-op must not, or the log
+    fills at ~23 lines a second.
+    """
+    eq = em_eq.StreamingEQ(FS, [0.0] * 8, False,
+                           limiter=_limiter(), guard=_guard())
+    kw = dict(bands=[0.0] * 8, loudness=False, limiter_enabled=True,
+              limiter_threshold=-1.0, limiter_release=150.0,
+              guard_enabled=True, guard_db=-30.0)
+    assert eq.update(**kw) is True          # first call always lands
+    assert eq.update(**kw) is False         # steady state is silent
+    assert eq.update(**{**kw, "guard_enabled": False}) is True
+    assert "guard=off" in em_eq.describe_chain([0.0] * 8, False,
+                                               eq.limiter, eq.guard)
+
+
+def test_limiter_reports_the_release_it_was_given():
+    """
+    The limiter converts release to a per-sample slew and used to keep no
+    copy of the original, so the setting could not be reported at all.
+    """
+    lim = _limiter(rel=400.0)
+    assert lim.release_ms == 400.0
+    lim.set_params(release_ms=250.0)
+    assert lim.release_ms == 250.0
+    assert "limiter=-1dB/250ms" in em_eq.describe_chain([0.0] * 8, False, lim)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,6 +118,13 @@ changes the overall level by **0.14dB** — below what anyone can hear. If you
 A/B two depths and cannot tell them apart, nothing is broken; there is
 genuinely almost nothing there to hear.
 
+**Set the equalizer flat before you compare.** With the bands boosted hard the
+limiter is already pulling the level down, so removing bass just lets it pull
+down less — the loudness ends up the same and the guard sounds like it is
+doing nothing. Measured: at a flat EQ, turning the guard on is a 7.7dB change
+in overall level; with every band at +12dB it is 0.2dB, and the difference
+shows up as 4dB more midrange instead. Both are the guard working.
+
 Turn the whole thing off if you would rather — nothing else depends on it.
 
 The frequency and the shape of the curve come from measurements of Amazon's


### PR DESCRIPTION
**Whether the output chain is doing anything has been unanswerable from outside it, and that has now cost four listening tests** — three to real bugs, since fixed, and one to a chain that was working correctly the whole time.

## Why it is hard to hear

The guard and the limiter cancel each other's most obvious cue. Guard on versus off, same signal:

| EQ | overall | sub 30–80Hz | 1kHz |
|---|---|---|---|
| flat | **7.68dB** | 24.4dB | 0.0dB |
| +12 all bands | **0.17dB** | 20.4dB | 4.2dB |

Under a heavy boost the limiter gives back exactly what the guard takes, so the level difference vanishes and the change moves into the midrange. A listener judging by loudness is judging the one cue that has been cancelled. The guard also mostly removes content this driver cannot radiate, so the audible part is a second-order cleanliness gain rather than a level change.

## Instrumentation

`em_eq.describe_chain` names what reached the audio path — logged when a stream starts **and whenever a live update moves something**, which is the only proof a dashboard toggle arrived. `em_eq.describe_activity` names the gain reduction each stage applied. `n/a` means bypassed, `0.00dB` means it ran and never engaged: identical from a listening seat, opposite investigations.

```
Output chain: eq=flat speech_boost=off guard=-30dB limiter=-1dB/150ms
Media feed done: 412 periods, ..., guard_reduction=30.00dB limiter_reduction=0.00dB
```

Both playback paths get it, since both were blind. `em_mbc` already maintained `max_reduction_db` and its docstring already called it "the instrument for whether this is doing anything" — nothing surfaced it. `em_limiter` now keeps `release_ms` purely so the setting can be reported.

Cost is two lines per stream plus one per live change. Nothing per frame.

## UI

Five controls become one **Speaker protection** toggle, behind the Advanced disclosure the mic and ring stages already use. None of the five could be judged by ear — the depth moves the overall level 0.14dB across its entire range — and four controls whose effects range from "large" to "nothing" depending on where the other three sit is a way to conclude the feature is broken, which is what happened.

The limiter is not offered at all now: switching it off only re-introduces #231's clipping (4.74% of samples with a modest bass boost), so it is not a preference.

**Nothing is removed from the config model.** All five keys still exist, still scope per section, and are still settable through the API.

598 tests pass, 7 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)