### PR TITLE
Count reachable admins, not user rows, when provisioning a Home Assistant user

### DIFF
--- a/controller/em_auth.py
+++ b/controller/em_auth.py
@@ -166,9 +166,12 @@ async def login_via_ingress(identity) -> tuple[str, str]:
         None, db.get_user_by_ha_id, identity.user_id)
 
     if user is None:
-        existing = await loop.run_in_executor(None, db.user_count)
+        # Reachable admins, not rows: a local password account cannot be
+        # signed into under ingress, so counting it denied admin to every
+        # Home Assistant user with no way back (#235).
+        existing = await loop.run_in_executor(None, db.ha_admin_count)
         role = em_ingressauth.role_for(
-            existing_users=existing,
+            existing_ha_admins=existing,
             configured_default=db.get_config("ingress_default_role", "readonly"),
         )
         user_id = await loop.run_in_executor(

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -2257,6 +2257,28 @@ def user_count() -> int:
     return row["n"] if row else 0
 
 
+def ha_admin_count() -> int:
+    """
+    Admins who can actually sign in through Home Assistant ingress.
+
+    Local password accounts are UNREACHABLE under the add-on — the landing
+    page authenticates through ingress before rendering any form, and there
+    is deliberately no Sign out — so a local admin is an admin nobody can
+    use. Counting rows instead of reachable admins is what stranded #235:
+    a local admin created first made every Home Assistant user read-only,
+    permanently, with hand-editing the database as the only way back.
+
+    Keyed on ha_user_id rather than on the password sentinel, because the
+    sentinel is a detail of how HA rows are stored and this is a question
+    about how someone gets in.
+    """
+    row = _q1(
+        "SELECT COUNT(*) AS n FROM users "
+        "WHERE ha_user_id IS NOT NULL AND role = 'admin'"
+    )
+    return row["n"] if row else 0
+
+
 # ─── Sessions ─────────────────────────────────────────────────────────────────
 
 def create_session(token: str, user_id: int, expiry_days: int = 30) -> None:

--- a/controller/em_ingressauth.py
+++ b/controller/em_ingressauth.py
@@ -46,19 +46,37 @@ class IngressIdentity(NamedTuple):
 VALID_ROLES = ("admin", "readonly")
 
 
-def role_for(*, existing_users: int, configured_default: Optional[str]) -> str:
+def role_for(*, existing_ha_admins: int, configured_default: Optional[str]) -> str:
     """
     The role a newly-seen Home Assistant user is given.
 
-    The first user through the door is admin. That mirrors the standalone
-    container, where whoever holds the bootstrap token becomes the owner, and
-    it is what removes the bootstrap step under the add-on.
+    Admin when nobody can already administer this controller THROUGH INGRESS;
+    read-only otherwise.
 
-    Everyone after that is read-only. Home Assistant's ingress view sets
-    requires_auth=False and `panel_admin` only hides the sidebar entry, so
-    reaching this dashboard is NOT evidence of being trusted with a root
-    shell to every device. Promotion is recoverable (PATCH /api/users/{id});
-    the reverse mistake is not recoverable by the person who suffers it.
+    The question this asks is "is there already someone who can administer
+    this?", and until 2026-08-20 it asked "are there any user rows?" instead.
+    Those differ in exactly one case, and it is a case our own migration guide
+    walks people into (#235): local password accounts are UNREACHABLE under
+    the add-on — the landing page authenticates through ingress before it
+    renders any form, and there is deliberately no Sign out — so a local
+    admin counted as a user while being an admin nobody could use. Copy a
+    container's /data across, as docs/migrate-to-addon.md tells you to so
+    your devices keep working, and every Home Assistant user was read-only
+    forever, recoverable only by hand-editing the database.
+
+    So this is a corrected count, NOT a loosened rule. The property worth
+    protecting is unchanged: the second person through the door is read-only,
+    because Home Assistant's ingress view sets requires_auth=False and
+    `panel_admin` only hides the sidebar entry, so reaching this dashboard is
+    NOT evidence of being trusted with a root shell to every device.
+    Promotion is recoverable (PATCH /api/users/{id}); the reverse mistake is
+    not recoverable by the person who suffers it.
+
+    A consequence worth stating: if every HA admin is demoted or deleted, the
+    next new HA user becomes admin. That is the recovery path working rather
+    than a hole — a controller with no reachable admin is the broken state
+    this exists to escape, and it is exactly what a fresh install already
+    grants the first person through.
 
     Roles are deliberately NOT mirrored from Home Assistant. Supervisor
     forwards no admin flag, so asking would mean taking `auth_api` — which
@@ -68,7 +86,7 @@ def role_for(*, existing_users: int, configured_default: Optional[str]) -> str:
     An unrecognised configured value falls back to read-only — a typo in a
     config row must never be the thing that grants admin.
     """
-    if existing_users == 0:
+    if existing_ha_admins == 0:
         return "admin"
     value = (configured_default or "").strip()
     return value if value in VALID_ROLES else "readonly"

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5813,6 +5813,32 @@ function App() {
   // Restore token on mount
   useEffect(() => { if (token) API.token = token; }, []);
 
+  // Reconcile the cached role against the server's.
+  //
+  // `role` seeds from localStorage, written once at sign-in, and nothing used
+  // to re-read it — so a role that changed server-side never reached the UI.
+  // That is not an edge case: it is what every PATCH /api/users/{id}
+  // promotion looks like to the promoted person, who stays read-only until
+  // they happen to sign out. Under ingress there is deliberately no Sign out
+  // at all, so the stale value had nothing to clear it and correcting the
+  // database by hand still left the panel read-only (#235).
+  //
+  // The symptom is precise and confusing: the SERVER accepts the writes, so
+  // saving config works, while the UI hides every admin-only control. It
+  // reads as half-broken rather than as stale state.
+  //
+  // /api/auth/me is the authority and it is already there. A failure is
+  // deliberately ignored — the periodic loads below surface a dead session,
+  // and a transient blip must not silently demote a working dashboard.
+  useEffect(() => {
+    if (!token) return;
+    API.get('/api/auth/me').then(me => {
+      if (!me || !me.role || me.role === role) return;
+      setRole(me.role);
+      localStorage.setItem('em_role', me.role);
+    }).catch(() => {});
+  }, [token]);
+
   // Load initial data
   useEffect(() => {
     if (!token) return;

--- a/controller/tests/test_db_users.py
+++ b/controller/tests/test_db_users.py
@@ -42,3 +42,61 @@ def test_ha_user_found_by_ha_id(fresh_db):
 
 def test_unknown_ha_id_returns_none(fresh_db):
     assert db.get_user_by_ha_id("no-such-id") is None
+
+
+# ── Reachable admins (#235) ───────────────────────────────────────────────────
+#
+# The bug that stranded a live add-on was a COUNT of the wrong thing: user
+# rows rather than admins who can actually sign in through ingress. These run
+# against a real database because the distinction is a SQL predicate, and the
+# pure-function tests in test_ingressauth.py cannot see it.
+
+
+def test_a_local_admin_is_not_a_reachable_admin(fresh_db):
+    """
+    The exact #235 shape. A local password admin cannot be signed into under
+    ingress — the landing page authenticates through ingress before rendering
+    any form — so it must not count, or the first Home Assistant user is
+    created read-only and there is no way back.
+    """
+    db.create_user("admin", "$2b$dummy", "admin")
+    assert db.user_count() == 1
+    assert db.ha_admin_count() == 0
+
+
+def test_an_ha_admin_counts(fresh_db):
+    db.create_ha_user("ha-abc123", "Wil", "admin")
+    assert db.ha_admin_count() == 1
+
+
+def test_a_readonly_ha_user_is_not_an_admin(fresh_db):
+    """Reachable is not enough — they have to be able to administer."""
+    db.create_ha_user("ha-readonly", "Guest", "readonly")
+    assert db.ha_admin_count() == 0
+
+
+def test_the_migrator_case_end_to_end(fresh_db):
+    """
+    Carrying a container's /data across is what docs/migrate-to-addon.md
+    tells people to do so their devices keep working, and it is what made
+    every Home Assistant user read-only forever.
+    """
+    db.create_user("admin", "$2b$dummy", "admin")       # from the container
+    db.create_user("family", "$2b$dummy", "readonly")
+    assert db.user_count() == 2
+    assert db.ha_admin_count() == 0                      # nobody can get in
+
+    import em_ingressauth
+    assert em_ingressauth.role_for(
+        existing_ha_admins=db.ha_admin_count(),
+        configured_default="readonly",
+    ) == "admin"
+
+    # ...and the SECOND Home Assistant user is still read-only, which is the
+    # property the fix must not trade away.
+    db.create_ha_user("ha-first", "Wil", "admin")
+    assert db.ha_admin_count() == 1
+    assert em_ingressauth.role_for(
+        existing_ha_admins=db.ha_admin_count(),
+        configured_default=None,
+    ) == "readonly"

--- a/controller/tests/test_design_tokens.py
+++ b/controller/tests/test_design_tokens.py
@@ -53,6 +53,31 @@ _VAR_USE = re.compile(r"var\((--[a-z0-9-]+)\)")
 _VAR_DEF = re.compile(r"^\s*(--[a-z0-9-]+)\s*:", re.M)
 
 
+# Comments are stripped before tallying, because a GitHub issue reference is
+# not a colour: `#235` matches the 3-digit hex form exactly, so citing an
+# issue beside a component pushed its tally up and failed the ratchet. Left
+# alone that trains people out of citing issues in this file, which is the
+# opposite of what the project wants.
+#
+# Filtering by CONTENT does not work — the obvious "require a letter" rule
+# lets `#286040` through, a real colour that happens to be all digits, and a
+# ratchet with a false negative is worse than one with a false positive.
+# Context is the reliable discriminator: colours live in code, issue numbers
+# live in prose.
+#
+# Line comments are matched only when `//` is not preceded by a colon, so a
+# URL inside a string is not mistaken for the start of a comment.
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+_LINE_COMMENT = re.compile(r"(?<!:)//[^\n]*")
+
+
+def _strip_comments(text: str) -> str:
+    """Blank out comments, preserving line numbering so owners still resolve."""
+    def blank(m):
+        return "".join(c if c == "\n" else " " for c in m.group(0))
+    return _LINE_COMMENT.sub(blank, _BLOCK_COMMENT.sub(blank, text))
+
+
 def _owner_map(text: str):
     comps = [
         (i, m.group(1))
@@ -77,7 +102,7 @@ def scan() -> dict[str, int]:
     text = JSX.read_text()
     owner = _owner_map(text)
     tally: Counter = Counter()
-    for i, line in enumerate(text.split("\n"), 1):
+    for i, line in enumerate(_strip_comments(text).split("\n"), 1):
         who = owner(i)
         if who in EXEMPT:
             continue

--- a/controller/tests/test_ingressauth.py
+++ b/controller/tests/test_ingressauth.py
@@ -111,37 +111,63 @@ def test_whitespace_is_stripped_from_identity_fields():
 def test_first_home_assistant_user_becomes_admin():
     # Mirrors the standalone container, where whoever holds the bootstrap
     # token becomes the owner. This is what removes the bootstrap step.
-    assert ia.role_for(existing_users=0, configured_default=None) == "admin"
+    assert ia.role_for(existing_ha_admins=0, configured_default=None) == "admin"
 
 
 def test_first_user_is_admin_regardless_of_the_configured_default():
-    assert ia.role_for(existing_users=0, configured_default="readonly") == "admin"
+    assert ia.role_for(
+        existing_ha_admins=0, configured_default="readonly") == "admin"
 
 
 def test_later_users_are_readonly():
     # HA's ingress view does not gate on admin (requires_auth=False;
     # panel_admin only hides the sidebar entry), so reaching the dashboard is
     # not evidence of being trusted with a root shell to every device.
-    assert ia.role_for(existing_users=1, configured_default=None) == "readonly"
+    assert ia.role_for(
+        existing_ha_admins=1, configured_default=None) == "readonly"
 
 
+def test_a_local_admin_does_not_deny_admin_to_the_first_ha_user():
+    """
+    #235, and the whole reason this counts HA admins rather than user rows.
+
+    Local password accounts cannot be signed into under ingress at all, so a
+    local admin is an admin nobody can use. Counting it made every Home
+    Assistant user read-only forever, reachable by the ordinary documented
+    act of copying a container's /data across when moving to the add-on.
+
+    The caller passes ha_admin_count(), so a database full of local users
+    still presents zero here.
+    """
+    assert ia.role_for(existing_ha_admins=0, configured_default=None) == "admin"
+    assert ia.role_for(
+        existing_ha_admins=0, configured_default="readonly") == "admin"
 
 
-
+def test_a_controller_with_no_reachable_admin_can_recover():
+    """
+    If every HA admin is demoted or deleted, the next new HA user becomes
+    admin. That is the recovery path working, not a hole: a controller nobody
+    can administer is the broken state this exists to escape, and it grants
+    exactly what a fresh install already grants the first person through.
+    """
+    assert ia.role_for(existing_ha_admins=0, configured_default=None) == "admin"
 
 
 def test_an_operator_can_opt_into_auto_admin():
-    assert ia.role_for(existing_users=3, configured_default="admin") == "admin"
+    assert ia.role_for(
+        existing_ha_admins=3, configured_default="admin") == "admin"
 
 
 def test_an_unrecognised_configured_role_falls_back_to_readonly():
     # A typo in a config row must never be the thing that grants admin.
     for bad in ("Admin", "administrator", "root", "", "   ", "None"):
-        assert ia.role_for(existing_users=1, configured_default=bad) == "readonly"
+        assert ia.role_for(
+            existing_ha_admins=1, configured_default=bad) == "readonly"
 
 
 def test_role_for_only_ever_returns_a_known_role():
     for n in (0, 1, 99):
         for d in (None, "admin", "readonly", "nonsense"):
             assert ia.role_for(
-                existing_users=n, configured_default=d) in ia.VALID_ROLES
+                existing_ha_admins=n, configured_default=d) in ia.VALID_ROLES


### PR DESCRIPTION
Fixes #235.

**Installing the add-on with a local admin already in the database made every Home Assistant user read-only, permanently** — recoverable only by hand-editing SQLite through the Terminal add-on with Protection mode off. Copying a container's `/data` across is exactly what `docs/migrate-to-addon.md` tells people to do so their devices keep working, so **our own documented migration path walked people into it.**

## The bug is a count of the wrong thing

The rule was trying to ask *"is there already someone who can administer this?"* and asked *"are there any user rows?"* instead. Those differ in one case, and it is the case that matters: **local password accounts are unreachable under ingress** — the landing page authenticates through Home Assistant before rendering any form, and there is deliberately no Sign out. A local admin counted as a user while being an admin nobody could use.

`role_for` now takes `existing_ha_admins`, from a new `db.ha_admin_count()` counting users that have an `ha_user_id` **and** the admin role.

| | before | after |
|---|---|---|
| Fresh add-on install | first HA user is admin | unchanged |
| Migrated `/data` with a local admin | **every HA user read-only forever** | first HA user is admin |
| Second person in a household | read-only | **unchanged** |

**This is a corrected count, not a loosened rule.** The property worth protecting is untouched: HA's ingress view sets `requires_auth=False` and `panel_admin` only hides the sidebar entry, so reaching this dashboard is not evidence of being trusted with a root shell to every device.

One consequence stated rather than left to be discovered: if every HA admin is demoted or deleted, the next new HA user becomes admin. That's the recovery path working — a controller nobody can administer is the broken state this exists to escape.

## The client half, because the server fix alone rescues nobody already stranded

The dashboard seeded `role` from `localStorage` at sign-in and nothing re-read it, so a role corrected server-side never reached the UI. That isn't an edge case — it's what **every** `PATCH /api/users/{id}` promotion looks like to the promoted person, who stayed read-only until they happened to sign out, and under ingress there is no Sign out to clear it.

The symptom is precise and confusing because the *server* accepts the writes: config saves work while the UI hides every admin-only control, reading as half-broken rather than as stale state. `App` now reconciles against `/api/auth/me` on load, which already returned the live role. A failed call is ignored rather than treated as a demotion.

## Also

A false positive in the design-token ratchet that this change tripped: `#235` matches the 3-digit hex colour form, so citing an issue beside a component raised its literal-colour tally — which would train people out of citing issues in `dashboard.jsx`. Filtering by content doesn't work (the obvious "require a letter" rule lets `#286040` through, a real colour that's all digits, and a false negative in a ratchet is worse than a false positive), so comments are stripped before tallying instead.

604 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)