### PR TITLE
Stop the device barging in on its own response

### DIFF
--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -295,6 +295,39 @@ halves, both required:
   swallowed; eating it would leave `_run_started` False and re-arm the same bug
   for the turn's own terminal `RUN_END`.
 
+**A low barge threshold needs TWO consecutive frames, and the reason it went
+unnoticed is that responses used to be short.** The watcher scores 80ms frames
+of the device's own microphone during playback, at a bar ~10x below the wake
+threshold (speech over TTS is depressed ~25dB by the echo). It fired on ONE
+frame. Measured 2026-08-20 on a conversational agent asked for a story:
+
+| turn | frames scored | peak | outcome |
+|---|---|---|---|
+| short reply | 353 | 0.029 | fine, under the bar |
+| story | 336 | 0.091 | **false barge at 8s** |
+| story | 604 | 0.184 | **false barge at 24s** |
+
+Long-form narration scores higher — continuous speech offers far more
+phoneme sequences resembling a wake word — and gets hundreds more chances.
+Note the shape of the old code: the careful two-consecutive-frame rule
+guarded the **thinking** phase, where the threshold is the full wake bar and
+nothing is playing, while the phase with the low bar scoring the assistant's
+own voice had no debounce at all.
+
+`em_barge.decide` now owns both phases, pure and tested — the suite cannot
+import `em_controller`, which is why this shipped untested. `bargeInThreshold`
+also moved 0.05 → 0.25, measured against real speech-over-TTS scores of
+0.3–0.5. **The two are meant to move together**: the frame rule is what makes
+a low bar survivable, and the threshold is what buys margin when it is not.
+The old default's comment predicted this exact symptom ("a device cutting its
+own response short") and asserted the fleet did not do it — the measurement
+had simply never included a long answer.
+
+**The user-visible damage is bigger than the interruption**, because a false
+barge starts a phantom turn that hears nothing and runs 20–46s, and
+`oww_paused` covers the whole turn — so the device is deaf throughout. It
+reads as "it stopped talking and then ignored me". Bounding that is #195.
+
 **Announcements: HA has TWO paths and only one waits for a reply.**
 `VoiceAssistantAnnounceRequest` blocks —
 `assist_satellite.entity.async_internal_announce` holds `_is_announcing` and

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -66,6 +66,7 @@ COPY em_mbc.py .
 COPY em_scenes.py .
 COPY em_support.py .
 COPY em_shadow.py .
+COPY em_barge.py .
 COPY em_ns.py .
 COPY em_pki.py .
 COPY em_hostip.py .

--- a/controller/em_barge.py
+++ b/controller/em_barge.py
@@ -1,0 +1,112 @@
+"""
+em_barge.py — when a wake-word score during a response counts as a barge-in.
+
+Pure, so it can be tested: the suite cannot import em_controller, and this
+decision shipped untested and wrong. See em_linkauth for the same reasoning.
+
+WHY A SINGLE FRAME IS NOT ENOUGH
+--------------------------------
+The watcher scores 80ms frames of the device's own microphone while the
+device is playing a response, at `bargeInThreshold` — a bar roughly ten times
+lower than the normal wake threshold, because the echo at the mic is ~25dB
+louder than a person talking over it, so speech-over-TTS scores are depressed.
+
+A low bar plus one frame is a poor combination, and it stayed hidden because
+responses used to be short. Measured 2026-08-20 on Test Device 01, asking a
+conversational agent for a story with a raised token limit:
+
+    turn        frames scored   peak score   outcome
+    short reply       353          0.029      fine, under the bar
+    story             336          0.091      FALSE BARGE at 8s
+    story             604          0.184      FALSE BARGE at 24s
+
+Long-form narration both scores higher — continuous synthetic speech offers
+far more phoneme sequences that resemble a wake word — and gets hundreds more
+chances at it. Both stories were cut off mid-sentence, and each was followed
+by a phantom interrupting turn that heard nothing and ran 20-46s, during which
+the device is deaf because oww_paused covers the whole turn. From the outside
+that reads as "it stopped talking and then ignored me".
+
+So the playback branch requires TWO CONSECUTIVE frames over the bar. The
+thinking branch already worked this way, which is the part worth noticing:
+the careful rule guarded the phase with the HIGH threshold and no audio
+playing, while the phase with the low threshold, scoring against the
+assistant's own continuous speech, had no debounce at all.
+
+This does not make a false barge impossible; it makes it need two adjacent
+frames rather than one, which the observed events — isolated transients well
+above a much lower mean — do not look like. The threshold is the other lever
+and they are complementary: the default moved to 0.25 the same day, measured
+against real speech-over-TTS scores of 0.3-0.5.
+
+The cost is one frame of latency, 80ms, on a genuine barge. A real wake word
+holds a high score across several consecutive hops as the phrase completes,
+so it is not close.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class BargeDecision(NamedTuple):
+    fired: bool
+    # Why, for the log line. Empty when nothing fired, so a caller cannot
+    # accidentally log a reason for a decision that did not happen.
+    note: str
+
+
+def decide(*,
+           score: float,
+           prev_score: float,
+           in_playback: bool,
+           barge_threshold: float,
+           wake_threshold: float) -> BargeDecision:
+    """
+    Whether this frame should cancel the response in progress.
+
+    `prev_score` is the previous frame's score, and must be 0.0 for the first
+    frame of a watcher run — a carried-over value from an earlier turn would
+    let one frame of the new turn fire on evidence from the old one.
+
+    Two phases, because they are not the same problem:
+
+    * **playback** — the response is audible, so the microphone is dominated
+      by the device's own speech. Low bar, two consecutive frames.
+    * **thinking** — nothing is playing yet, so the bar is the normal wake
+      threshold. One frame clears it outright; two consecutive frames at a
+      low tier also count, because a person repeating themselves into a
+      silent device is a strong signal and the cost of missing it is a turn
+      that ignores them.
+    """
+    if in_playback:
+        if score >= barge_threshold and prev_score >= barge_threshold:
+            return BargeDecision(
+                True,
+                f"scores {prev_score:.3f}/{score:.3f} — two consecutive "
+                f"frames >= {barge_threshold:.2f}",
+            )
+        return BargeDecision(False, "")
+
+    if score >= wake_threshold:
+        return BargeDecision(True, f"score={score:.3f} >= {wake_threshold:.2f}")
+
+    low_tier = low_tier_for(wake_threshold)
+    if score >= low_tier and prev_score >= low_tier:
+        return BargeDecision(
+            True,
+            f"scores {prev_score:.3f}/{score:.3f} — two consecutive frames "
+            f">= low tier {low_tier:.2f}",
+        )
+    return BargeDecision(False, "")
+
+
+def low_tier_for(wake_threshold: float) -> float:
+    """
+    The lower bar used during thinking, when two frames agree.
+
+    Floored at 0.2 so that lowering the wake threshold cannot drag this down
+    to somewhere noise reaches — the floor is what stops a sensitivity
+    setting quietly becoming a self-trigger setting.
+    """
+    return max(0.2, 0.4 * wake_threshold)

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -76,6 +76,7 @@ import em_mbc
 import em_scenes
 import em_shadow
 import em_oww_warmup
+import em_barge
 import em_arbiter
 import em_button
 import em_tap_burst
@@ -1087,7 +1088,7 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
     # threshold (~0.10) is both safe and necessary. Thinking phase uses the
     # normal wake threshold (see docstring).
     threshold = device.barge_threshold  # refined per-frame by phase below
-    prev_score = 0.0  # previous frame's score — two-frame low tier (thinking)
+    prev_score = 0.0  # previous frame's score — both phases need two
     buf = bytearray()
     # Observability: the watcher used to log only on detection, which made a
     # failed barge-in attempt indistinguishable from "no frames arrived at
@@ -1108,7 +1109,7 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
             if payload is None or isinstance(payload, str):
                 buf.clear()
                 prev_score = 0.0  # sentinel = stream discontinuity; frames
-                # across it aren't consecutive for the two-frame low tier
+                # across it are not consecutive for either two-frame rule
                 continue
             buf.extend(payload)
             while len(buf) >= CHUNK_BYTES:
@@ -1123,27 +1124,20 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
                 frames += 1
                 trusted = warmup.feed()
                 in_playback = playback_started.is_set()
-                if in_playback:
-                    threshold = device.barge_threshold
-                    fired     = score >= threshold
-                    fire_note = f"score={score:.3f} >= {threshold:.2f}"
-                else:
-                    # Two-tier thinking detection (see docstring): full wake
-                    # threshold on a single frame, OR two consecutive frames
-                    # at the low tier.
-                    threshold = device.oww_threshold
-                    low_tier  = max(0.2, 0.4 * device.oww_threshold)
-                    if score >= threshold:
-                        fired     = True
-                        fire_note = f"score={score:.3f} >= {threshold:.2f}"
-                    elif score >= low_tier and prev_score >= low_tier:
-                        fired     = True
-                        fire_note = (
-                            f"scores {prev_score:.3f}/{score:.3f} — two "
-                            f"consecutive frames >= low tier {low_tier:.2f}"
-                        )
-                    else:
-                        fired = False
+                # em_barge owns both phases. Extracted because this shipped
+                # untested and wrong: the playback branch fired on ONE frame
+                # at a bar ten times lower than the wake threshold, while
+                # scoring the device's own speech, and cut long responses off
+                # mid-sentence (measured 2026-08-20).
+                threshold = (device.barge_threshold if in_playback
+                             else device.oww_threshold)
+                fired, fire_note = em_barge.decide(
+                    score=score,
+                    prev_score=prev_score,
+                    in_playback=in_playback,
+                    barge_threshold=device.barge_threshold,
+                    wake_threshold=device.oww_threshold,
+                )
                 if fired and not trusted:
                     log.info(
                         f"[{device.device_id}] Barge watcher: {fire_note} "

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -118,30 +118,31 @@ DEFAULT_DEVICE_CONFIG = {
     # cancels it and starts a fresh turn. Requires device AEC (aecEnabled)
     # on — with barge-in the mic streams through playback, and AEC is what
     # stops the device hearing itself — so aecEnabled above defaults on with
-    # it, and the two move together. bargeInThreshold is used as-is,
-    # deliberately BELOW the normal wake threshold: the echo at the mic is
-    # ~25dB louder than the person talking over it, so speech-over-TTS wake
-    # scores are inherently depressed (~0.10–0.12 measured), while post-AEC
-    # self-echo scores only 0.004 (0.055 worst-case unconverged) — there is
-    # no self-trigger risk down to ~0.08.
+    # it, and the two move together.
     #
-    # That 0.004 is STALE and the margin is wider than it says: v2.7.8 made
-    # the filter hold convergence across turns, so self-echo measures
-    # 0.002–0.003. 0.10 sat awkwardly close to real speech-over-TTS scores,
-    # which is the wrong way to be wrong — barge-in that never fires is
-    # undiagnosable from the outside ("it just ignores me"), while barge-in
-    # that fires too eagerly is self-evident and adjustable. 0.05 is the
-    # dashboard slider floor, so the only way to tune from here is UP, which
-    # is the direction the visible failure asks for.
+    # 0.25, raised from 0.05 on 2026-08-20 after the device interrupted
+    # ITSELF. The old value was chosen against short responses, where the
+    # watcher's peak score over a whole turn measured 0.029, and against a
+    # post-AEC self-echo figure of 0.002–0.003. Long-form speech breaks both
+    # premises: a story peaked at 0.091 and 0.184 on the same hardware, and
+    # was cut off mid-sentence twice in a row. Continuous synthetic narration
+    # offers far more phoneme sequences resembling a wake word than a short
+    # factual reply, and hundreds more frames to find one in.
     #
-    # Watch one interaction: the beamformer locks a different mic per turn
-    # and each has its own echo path, so AEC re-converges per turn (per-
-    # channel filter states are the unbuilt fix) — and the one measured
-    # self-echo figure above 0.05 is that unconverged case at 0.055. The
-    # symptom would be a device cutting its own response short. This fleet
-    # runs 0.05 with beamforming and AEC both on and does not do that.
+    # The comment this replaces predicted exactly that symptom — "a device
+    # cutting its own response short" — and asserted the fleet did not do it.
+    # It does; the measurement had simply never included a long answer.
+    #
+    # 0.25 sits below real speech-over-TTS scores (0.3–0.5 observed, depressed
+    # because the echo at the mic is ~25dB louder than the person) so genuine
+    # barge-in still fires, and above the 0.184 that was self-triggering. The
+    # margin at the top is thinner than it was: if barge-in starts being
+    # missed, that is this trade, and the answer is a per-channel AEC filter
+    # state rather than creeping back down. em_barge's two-consecutive-frame
+    # rule is the other half — it is what makes a low bar survivable at all,
+    # and the two are meant to move together.
     "bargeInEnabled":   True,
-    "bargeInThreshold": 0.05,
+    "bargeInThreshold": 0.25,
     # How far music is attenuated while a voice turn plays OVER it, on
     # firmware that can mix the two planes (the "audio_mix" capability).
     # Ducking replaces pausing there: the music feed runs 4s ahead of

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5221,7 +5221,7 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
             <div style={{ marginTop: 16, ...inputStyle }}>
               <Toggle label="Speex denoise" sub="cleans audio before scoring — try in noisy rooms" value={config.owwSpeexNs ?? false} onChange={v => set('owwSpeexNs', v)}/>
               <Toggle label="Barge-in" sub="wake word interrupts playback — enable AEC first" value={config.bargeInEnabled ?? false} onChange={v => set('bargeInEnabled', v)}/>
-              <Slider label="Barge threshold" sub="wake confidence needed during playback — raise it if a response cuts itself short" value={config.bargeInThreshold ?? 0.05} min={0.05} max={0.9} step={0.05} onChange={v => set('bargeInThreshold', v)}/>
+              <Slider label="Barge threshold" sub="wake confidence needed during playback — raise it if a response cuts itself short" value={config.bargeInThreshold ?? 0.25} min={0.05} max={0.9} step={0.05} onChange={v => set('bargeInThreshold', v)}/>
               <Slider label="Arbitration window" sub="ms that the first Echo to hear you silences the others — no added delay; 0 disables" value={config.wakeArbitrationMs ?? 700} min={0} max={2000} step={50} unit="ms" onChange={v => set('wakeArbitrationMs', v)}/>
               {/* Three modes, so a select rather than a toggle. Each option is
                   offered only when the device says it can do it — capability,

--- a/controller/tests/test_barge.py
+++ b/controller/tests/test_barge.py
@@ -1,0 +1,109 @@
+"""
+When a wake-word score during a response counts as a barge-in.
+
+This decision shipped untested and wrong, and the failure was invisible until
+responses got long: the playback branch fired on ONE 80ms frame at a bar ten
+times below the wake threshold, while scoring the device's own speech. Asking
+for a story cut it off mid-sentence twice in a row (2026-08-20).
+"""
+
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+
+import em_barge
+
+BARGE = 0.25
+WAKE = 0.5
+
+
+def playback(score, prev=0.0, barge=BARGE):
+    return em_barge.decide(score=score, prev_score=prev, in_playback=True,
+                           barge_threshold=barge, wake_threshold=WAKE)
+
+
+def thinking(score, prev=0.0):
+    return em_barge.decide(score=score, prev_score=prev, in_playback=False,
+                           barge_threshold=BARGE, wake_threshold=WAKE)
+
+
+# ── Playback: the bug ─────────────────────────────────────────────────────────
+
+def test_one_loud_frame_during_playback_does_not_fire():
+    """
+    The whole bug. An isolated transient in the assistant's own narration
+    scored 0.091 and 0.184 against a 0.05 bar and cancelled the response.
+    """
+    assert playback(0.9, prev=0.0).fired is False
+    assert playback(0.184, prev=0.02, barge=0.05).fired is False
+
+
+def test_two_consecutive_frames_fire():
+    d = playback(0.4, prev=0.3)
+    assert d.fired is True
+    assert "two consecutive" in d.note
+
+
+def test_a_frame_below_the_bar_breaks_the_pair():
+    """Consecutive means adjacent — a dip resets the evidence."""
+    assert playback(0.4, prev=BARGE - 0.01).fired is False
+
+
+def test_exactly_at_the_threshold_counts():
+    assert playback(BARGE, prev=BARGE).fired is True
+
+
+def test_the_first_frame_of_a_run_cannot_fire():
+    """
+    The caller seeds prev_score at 0.0 for a fresh watcher and again after a
+    stream discontinuity. A carried-over score would let one frame of a new
+    turn fire on evidence from the previous one.
+    """
+    assert playback(0.99, prev=0.0).fired is False
+
+
+def test_a_genuine_barge_still_fires_at_realistic_scores():
+    """
+    Speech over TTS is depressed to ~0.3-0.5 by the echo, which is what the
+    0.25 default is set against. Raising the bar must not stop barge-in.
+    """
+    for s in (0.30, 0.42, 0.55, 0.9):
+        assert playback(s, prev=s).fired is True
+
+
+# ── Thinking: unchanged behaviour ─────────────────────────────────────────────
+
+def test_one_frame_at_the_full_wake_threshold_fires_while_thinking():
+    """Nothing is playing, so there is no self-echo to guard against."""
+    d = thinking(WAKE)
+    assert d.fired is True
+    assert "two consecutive" not in d.note
+
+
+def test_two_low_tier_frames_fire_while_thinking():
+    d = thinking(0.25, prev=0.25)
+    assert d.fired is True
+    assert "low tier" in d.note
+
+
+def test_one_low_tier_frame_does_not_fire_while_thinking():
+    assert thinking(0.25, prev=0.0).fired is False
+
+
+def test_the_low_tier_has_a_floor():
+    """
+    A sensitivity setting must not quietly become a self-trigger setting:
+    0.4 x a low wake threshold would otherwise reach down into noise.
+    """
+    assert em_barge.low_tier_for(0.1) == 0.2
+    assert em_barge.low_tier_for(0.5) == 0.2
+    assert em_barge.low_tier_for(0.9) == pytest.approx(0.36)
+
+
+# ── Shape ─────────────────────────────────────────────────────────────────────
+
+def test_a_decision_that_did_not_fire_carries_no_reason():
+    """So a caller cannot log a justification for something that never fired."""
+    assert playback(0.9, prev=0.0).note == ""
+    assert thinking(0.0).note == ""


### PR DESCRIPTION
**Asking for a story cut it off mid-sentence, twice in a row.** Both died to a false barge-in: the watcher scored the device's own narration and cancelled the turn it was playing. Measured 2026-08-20 on Test Device 01:

| turn | frames scored | peak | outcome |
|---|---|---|---|
| short reply | 353 | 0.029 | fine, under the bar |
| story | 336 | 0.091 | **false barge at 8s** |
| story | 604 | 0.184 | **false barge at 24s** |

Long-form narration scores higher — continuous speech offers far more phoneme sequences resembling a wake word — and gets hundreds more chances at it. Short replies never reached the bar, which is why this survived.

## Two things were wrong, and neither is sufficient alone

**The playback branch fired on ONE 80ms frame**, at a bar ~10× below the wake threshold, while scoring continuous synthetic speech. The shape of the old code is the part worth noticing: the careful two-consecutive-frame rule guarded the **thinking** phase — full wake threshold, nothing playing — while the phase with the low bar scoring the assistant's own voice had no debounce at all. `em_barge.decide` now owns both phases and requires two adjacent frames during playback.

That doesn't make a false barge impossible; it makes it need two adjacent frames rather than one, which the observed events — isolated transients well above a much lower mean — don't look like. Cost is 80ms on a genuine barge; a real wake word holds a high score across several consecutive hops.

**`bargeInThreshold` moves 0.05 → 0.25.** The old value was chosen against short responses (peak 0.029 over a whole turn) and a post-AEC self-echo figure of 0.002–0.003. Long-form speech breaks both premises. 0.25 sits below real speech-over-TTS scores (0.3–0.5, depressed by the echo) so genuine barge-in still fires, and above the 0.184 that was self-triggering. Confirmed working on hardware before this PR.

The margin at the top is thinner than it was. If barge-in starts being missed, that's this trade, and the answer is per-channel AEC filter state rather than creeping back down.

**The old comment predicted this exact symptom** — "a device cutting its own response short" — and asserted the fleet did not do it. It does; the measurement had never included a long answer.

## Why it had no tests

Extracted as a pure module for `em_linkauth`'s reason: the suite cannot import `em_controller`, so this was live behaviour with no coverage. Tests pin the transient, the pair, the dip that breaks a pair, the first frame of a run, and that a genuine barge at realistic scores still fires.

## Worth knowing

The visible damage is bigger than the interruption. A false barge starts a phantom turn that hears nothing and runs **20–46s**, and `oww_paused` covers the whole turn — so the device is deaf throughout. It reads as "it stopped talking and then ignored me". Bounding that is #195.

`test_deploy` caught `em_barge.py` missing from the Dockerfile's explicit COPY list — the new module would have passed every test and not shipped.

615 tests pass, 11 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)