### PR TITLE
Stop the wake listener dying quietly, and recover a stuck pause

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -180,6 +180,12 @@ SPEAKER_PRIME_SECONDS = 1.1
 # per 5s is negligible next to the 256 kbps continuous mic upload each
 # device already holds open. Samples are aggregated in memory and flushed on
 # the existing ~30s stats report, so the DB cost is unchanged.
+# How long oww_paused may be set with NO turn holding voice_lock before
+# the wake loop treats it as stuck and clears it. Generous: a genuine
+# turn can run to the spinner's 135s TTL, and this only ever fires when
+# the lock is ALSO free, which no running turn allows.
+OWW_PAUSE_STUCK_S = 180.0
+
 PING_INTERVAL_SEC = 5.0
 # A sample at or above this counts as an excursion. 200ms is well clear of a
 # healthy hop (Office measures 264ms median for a whole audio round trip
@@ -272,6 +278,15 @@ class Device:
         self.mic_queue:   asyncio.Queue[bytes] = asyncio.Queue(maxsize=64)
         self.voice_queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=256)
         self.oww_paused   = asyncio.Event()  # set during voice turn
+        # Monotonic instant oww_paused was set, or None. Only used to
+        # recognise a state that cannot be legitimate: paused, with no turn
+        # holding voice_lock, for longer than any turn can run. While paused
+        # the wake loop routes every frame to voice_queue and the no-frames
+        # watchdog deliberately stands down, so a stuck flag is SILENT
+        # deafness with nothing to end it.
+        self.oww_paused_since: float | None = None
+        # The live wake listener, replaced when supervision restarts it.
+        self.oww_task: asyncio.Task | None = None
 
         # Transient state — read by em_api._merge_device()
         self.speaking  = False
@@ -1797,6 +1812,7 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
                 f"{_drained} stale frames cleared before routing flip"
             )
         device.oww_paused.clear()
+        device.oww_paused_since = None
         log.info(f"[{device.device_id}] oww_paused cleared")
         # Release the arbitration claim so another device answering a
         # genuinely new utterance isn't suppressed by a stale window.
@@ -1806,6 +1822,62 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
 
 
 # ─── Wake word listener ───────────────────────────────────────────────────────
+
+def _supervise_wake_listener(device: "Device") -> asyncio.Task:
+    """
+    Run wake_word_listener, and put it back if it ever falls over.
+
+    A bare create_task was the whole failure mode. wake_word_listener catches
+    only CancelledError, so ANY other exception ended the task — and because
+    the connection handler holds a reference, asyncio never garbage-collects
+    it and never logs "Task exception was never retrieved". The device then
+    scores wake words, reports them, and nothing consumes them: `pending_wake`
+    is read inside the dead loop. From the outside the device looks healthy
+    and simply stops answering, with not one line to say so. Only a device
+    reconnect or a controller restart brought it back.
+
+    This is the second time this shape has bitten. A NameError in this module
+    once killed wake listening fleet-wide, and the response was to fix the
+    NameError — which leaves the fragility. The most important loop in the
+    controller should not be able to die quietly.
+
+    Restarts are logged at ERROR and are NOT rate-limited into silence: a loop
+    that keeps dying is worth a noisy log, because the alternative is a device
+    that is deaf and says nothing. Cancellation is the ordinary teardown path
+    and is left alone.
+    """
+    def _restart(task: asyncio.Task) -> None:
+        if task.cancelled():
+            return                      # ordinary teardown
+        exc = task.exception()
+        if exc is None:
+            # Returned normally, which the loop never does — it is `while
+            # True`. Still a death, so treat it as one.
+            log.error(
+                f"[{device.device_id}] wake word listener returned "
+                f"unexpectedly — restarting. The device was deaf until now."
+            )
+        else:
+            log.error(
+                f"[{device.device_id}] wake word listener crashed — "
+                f"restarting. The device was deaf until now.",
+                exc_info=exc,
+            )
+        if _devices.get(device.device_id) is not device:
+            # Gone, or replaced by a newer connection that has its own
+            # listener. Restarting here would leave an orphan scoring frames
+            # for a device this object no longer represents.
+            log.warning(
+                f"[{device.device_id}] not restarting the wake listener — "
+                f"the device is no longer connected"
+            )
+            return
+        device.oww_task = _supervise_wake_listener(device)
+
+    t = asyncio.create_task(wake_word_listener(device))
+    t.add_done_callback(_restart)
+    return t
+
 
 async def wake_word_listener(device: Device):
     loop = asyncio.get_event_loop()
@@ -1889,6 +1961,38 @@ async def wake_word_listener(device: Device):
                 # voice turn frames route to voice_queue instead, so an idle
                 # mic_queue is expected while oww_paused is set.
                 if device.oww_paused.is_set():
+                    # Normally correct: during a turn the frames go to
+                    # voice_queue, so an idle mic_queue means nothing.
+                    #
+                    # But this branch is also why a stuck flag is INVISIBLE.
+                    # While it is set the wake loop drops every frame and this
+                    # watchdog stands down, so the device is deaf with nothing
+                    # to notice or end it — no error, no warning, and the
+                    # device itself keeps scoring happily and reporting wakes
+                    # that nothing consumes (`pending_wake` is read further
+                    # down this same loop). Seen on 2026-08-20; only an add-on
+                    # restart brought it back.
+                    #
+                    # Paused with NO turn holding voice_lock is a state that
+                    # cannot be legitimate, so it is safe to end. The lock is
+                    # the discriminator rather than the elapsed time alone: a
+                    # long turn is fine, and the spinner TTL alone runs to
+                    # 135s. Only the combination is broken.
+                    stuck_for = (
+                        loop.time() - device.oww_paused_since
+                        if device.oww_paused_since is not None else 0.0
+                    )
+                    if (not device.voice_lock.locked()
+                            and stuck_for > OWW_PAUSE_STUCK_S):
+                        log.error(
+                            f"[{device.device_id}] oww_paused stuck for "
+                            f"{stuck_for:.0f}s with no voice turn holding the "
+                            f"lock — clearing. The device was deaf for that "
+                            f"long; this is a bug, please report it with the "
+                            f"lines above."
+                        )
+                        device.oww_paused.clear()
+                        device.oww_paused_since = None
                     continue
                 if device.muted:
                     # Hardware mute is device-sovereign: the device rejects
@@ -2154,6 +2258,7 @@ async def wake_word_listener(device: Device):
                             "noise_floor": round(device.noise_floor, 5),
                         }
                         device.oww_paused.set()
+                        device.oww_paused_since = asyncio.get_event_loop().time()
                         log.debug(
                             f"[{device.device_id}] OWW: oww_paused set, "
                             f"routing to voice_queue (no mic_stop/mic_start_turn)"
@@ -2184,6 +2289,7 @@ async def wake_word_listener(device: Device):
                             )
                         if won_by != device.device_id:
                             device.oww_paused.clear()
+                            device.oww_paused_since = None
                             device.last_wake = None
                             await device.beam_unlock()
                             ceded = 0
@@ -2331,6 +2437,7 @@ async def handle_button_event(device: Device, event: dict):
             log.info(f"[{device.device_id}] Dot button → voice turn")
             device.cancel_event.clear()
             device.oww_paused.set()
+            device.oww_paused_since = asyncio.get_event_loop().time()
             async def _button_voice_turn():
                 # Button is a deliberate act with no dead zone cost — nothing
                 # is being said at the moment of press, so stop/start RTT is
@@ -2657,7 +2764,8 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                 await device.send_control({"type": "ping", "id": seq})
 
         ping_task = asyncio.create_task(ping_loop())
-        oww_task  = asyncio.create_task(wake_word_listener(device))
+        oww_task  = _supervise_wake_listener(device)
+        device.oww_task = oww_task
 
         try:
             async for raw in ws:
@@ -3045,7 +3153,10 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
 
         finally:
             ping_task.cancel()
-            oww_task.cancel()
+            # device.oww_task, not the local: a supervised restart replaces
+            # the task object, and cancelling the stale one would leave the
+            # live listener running against a closed connection.
+            (device.oww_task or oww_task).cancel()
 
     except asyncio.TimeoutError:
         log.warning(f"[control] Registration timeout from {remote}")

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1636,3 +1636,78 @@ def test_the_speaking_push_cannot_fail_a_speaker_stream():
         "a bare `except Exception` does not catch the CancelledError this sees "
         "during barge-in"
     )
+
+
+# ── The wake listener must not be able to die quietly ─────────────────────────
+#
+# Source-shape tests, because the suite cannot import em_controller — which is
+# precisely why this had no coverage. On 2026-08-20 a device went deaf with no
+# error line and stayed that way until the add-on was restarted: the listener
+# is started with create_task and catches only CancelledError, so any other
+# exception ends it, and the connection handler holding a reference means
+# asyncio never even logs "Task exception was never retrieved". The device
+# meanwhile scores wake words and reports them into a dead loop, so it looks
+# healthy from every side.
+
+def test_the_wake_listener_is_started_through_its_supervisor():
+    """
+    A bare create_task(wake_word_listener(...)) is the bug. The whole guard is
+    that the call site goes through the supervisor, and nothing else enforces
+    that.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    # The supervisor's OWN create_task is the one legitimate use, so check
+    # everywhere else. Splitting on the def keeps this honest if the helper
+    # moves.
+    start = src.index("def _supervise_wake_listener")
+    end = src.index("async def wake_word_listener")
+    outside = src[:start] + src[end:]
+    assert "create_task(wake_word_listener(" not in outside, (
+        "wake_word_listener started with a bare create_task outside its "
+        "supervisor — an exception would end it silently and nothing would "
+        "restart it. Use _supervise_wake_listener()."
+    )
+    assert "_supervise_wake_listener(device)" in outside
+
+
+def test_the_supervisor_attaches_a_done_callback():
+    """Without one the task ends and no code ever learns that it did."""
+    src = (CONTROLLER / "em_controller.py").read_text()
+    body = src[src.index("def _supervise_wake_listener"):]
+    body = body[:body.index("async def wake_word_listener")]
+    assert "add_done_callback" in body
+    # A restart that ignores cancellation would fight ordinary teardown.
+    assert "cancelled()" in body
+    # It must say so — silent recovery hides a recurring fault.
+    assert "log.error" in body
+
+
+def test_teardown_cancels_the_live_listener_not_a_stale_handle():
+    """
+    A supervised restart replaces the task object, so cancelling the variable
+    captured at connect time would leave the live listener running against a
+    closed connection.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    assert "(device.oww_task or oww_task).cancel()" in src
+
+
+def test_a_stuck_pause_can_be_recovered():
+    """
+    The other silent-deafness path. While oww_paused is set the wake loop
+    routes every frame away and the no-frames watchdog stands down, so a flag
+    that is never cleared is deafness with nothing to end it.
+
+    Recovery is gated on voice_lock being free as well as time, because a long
+    turn is legitimate — the spinner TTL alone runs to 135s — and only the
+    combination is impossible.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    assert "OWW_PAUSE_STUCK_S" in src
+    assert "oww_paused_since" in src
+    stuck = src[src.index("oww_paused stuck for") - 2000:
+                src.index("oww_paused stuck for") + 500]
+    assert "voice_lock.locked()" in stuck, (
+        "the stuck-pause recovery must check that no turn holds the lock — "
+        "time alone would cut a long but healthy turn"
+    )


### PR DESCRIPTION
**A device went deaf tonight with no error line, and stayed deaf until the add-on was restarted** — while still scoring wake words locally and reporting them. Two independent paths produce exactly that, and neither is visible from outside.

## The listener could end silently

`wake_word_listener` was started with a bare `create_task` and catches only `CancelledError`, so **any** other exception ended it. The connection handler holds a reference, so asyncio never garbage-collects the task and never logs `Task exception was never retrieved` — the loop just stops.

With `owwOnDevice=on` the device keeps detecting and sending `oww_wake`, and the only consumer of `pending_wake` is **inside that dead loop**. Every side of the system looks healthy while nothing answers. That matches the report exactly: *"wake word is running on the device though?"*

**This is the second time this shape has bitten.** A `NameError` in this module once killed wake listening fleet-wide, and the fix then was to correct the `NameError` — which leaves the fragility. `_supervise_wake_listener` now logs at ERROR and restarts. Cancellation is ordinary teardown and left alone; a device no longer in the registry isn't restarted, which would orphan a listener onto a connection the object no longer represents.

## A stuck `oww_paused` is equally silent

While it's set the wake loop routes every frame to `voice_queue` **and** the no-frames watchdog deliberately stands down — so a flag that's never cleared is deafness with nothing to end it. It's set *outside* the `try/finally` that clears it, so anything raising in between (`beam_lock` and the arbiter both await on a link this fleet has measured at 1–2s excursions) strands it permanently.

Recovery is gated on `voice_lock` being free **as well as** elapsed time. A long turn is legitimate — the spinner TTL alone runs to 135s — so time alone would cut a healthy turn. Paused with no turn holding the lock cannot be legitimate.

## Tested two ways

The suite cannot import `em_controller`, which is exactly why none of this had coverage. Source-shape tests pin the call site, the done callback, the teardown handle and the lock check. The supervisor was then **exercised for real inside the built image**:

```
import em_controller: OK
crashes survived: 2, listener alive: True
after cancel — restarts: 0 (expect 0)
disconnected device — attempts: 1 (expect 1, no restart loop)
```

## What this does not do

**It does not explain why the listener stopped tonight.** Restarting the add-on cleared every candidate state at once, so the discriminating evidence is gone. What changes is that the next occurrence leaves an ERROR with a traceback and recovers itself, instead of a device that is deaf and says nothing.

619 tests pass, 4 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)