### PR TITLE
Give each device a stored ESPHome identity, fixing MAC collisions

### DIFF
--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -221,6 +221,38 @@ record; they appear as pending and are approved onto fresh config.
 
 The controller impersonates ESPHome voice satellites: one asyncio TCP listener per device on ports 16001+ (persisted in the device registry, never reused). Home Assistant's built-in ESPHome integration dials in and drives voice turns via Assist. Implemented in `em_esphome.py` on top of the protocol layer in `controller/esphome/` (`frame_protocol.py`, `satellite_server.py`, vendored aioesphomeapi protobufs in `esphome/vendor/`). Servers are created at startup for every approved device **and on demand** when a device approved after boot first connects (`_register_device_server` — idempotent on purpose: the startup loop and `device_connected()` race, first creation wins). HA naming: friendly name is `<label> Voice Assistant` (BT proxy: `<label> BT Proxy`); `project_name` carries `ESPHOME_DEVICE_MODEL` after the dot because HA displays that segment as the device Model, overriding DeviceInfo's `model` field. (A legacy `claracore` WebSocket backend was removed 2026-07-12 — ESPHome/HA is the only voice path.)
 
+**The ESPHome `mac_address` is a stored IDENTITY, not a derivation and not a
+network address.** Nothing routes to it and no packet carries it; HA keys its
+device registry on it, and its config flow aborts the zeroconf step with
+`mdns_missing_mac` when the TXT record lacks one — so a device advertised
+without it never produces a discovery card, silently. The mDNS TXT value and
+the `DeviceInfoResponse` value must agree, so the mac is resolved once and
+**passed** to `_make_device_mdns_info` rather than derived twice.
+
+It used to be computed from the serial on every call, and that was two bugs in
+one. The derivation stripped non-hex characters from an alphanumeric serial, so
+devices from one batch differing only in the trailing letters collapsed onto
+one address and HA treated two Echoes as one, overwriting the first (#212,
+found by @lennart24 in #217). And because identity was a *function*, fixing the
+derivation would have moved EVERY device, orphaning every HA device row and the
+automations referencing their entities.
+
+`db.get_esphome_mac` assigns once and stores (schema v19), the same
+assign-once discipline `get_esphome_port` already uses. The v19 fixup seeds
+existing rows with their **current** address wherever it is unique, so nothing
+that works today moves; within a colliding group the oldest keeps it and the
+rest take the new derivation, since they are the ones being overwritten now.
+
+The new derivation is a **fixed prefix** `02:EC` plus 4 bytes of md5, not a
+masked hash. `0x02` is the locally-administered bit — the private-address
+equivalent for MACs — and bit 0 is a *different* flag (unicast vs multicast)
+that must stay clear; a raw hash sets it half the time and produces something
+that is not a valid unicast address. A fixed prefix satisfies both by
+construction, so there is no bit for a later change to forget, which is what
+Docker (`02:42`) and QEMU (`52:54:00`) do. The cost is 32 bits of hash rather
+than 48, affordable because uniqueness is only ever needed within ONE HA
+registry — 1.15e-6 at 100 devices.
+
 **Entity names must NOT repeat the device label.** HA sets
 `_attr_has_entity_name = True` for every esphome entity and composes
 `<device name> <entity name>` itself, and our device name is already

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -20,6 +20,7 @@ Usage:
     db.log_device(device_id, "info", "device", "Connected")
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -764,6 +765,37 @@ MIGRATIONS: list[str] = [
 
     UPDATE system_config SET value = '18' WHERE key = 'schema_version';
     """,
+
+    # ── v19 — the ESPHome identity becomes a stored fact ────────────────────
+    #
+    # Home Assistant keys its device registry on the mac_address an ESPHome
+    # device reports, so this value IS the device's identity in HA — nothing
+    # routes to it and no packet carries it. It was DERIVED from the serial
+    # on every use, which made identity a function, with two consequences.
+    #
+    # The derivation stripped non-hex characters from an alphanumeric serial,
+    # so devices from one batch differing only in the trailing characters
+    # collapsed to the same address and Home Assistant treated two Echoes as
+    # one, overwriting the first (#212, found by @lennart24 in #217):
+    #
+    #     G090LF1180440C9K -> 090F1180440C9 -> 90:F1:18:04:40:C9
+    #     G090LF1180440C9R -> 090F1180440C9 -> 90:F1:18:04:40:C9
+    #
+    # And because it was a function, changing it to fix that would have
+    # changed EVERY device's identity, orphaning every HA device row and the
+    # automations referencing their entities. Storing it is what separates
+    # the two: the fix reaches the devices that need it and nobody else.
+    #
+    # The seeding rule is the whole point of the fixup below. A device whose
+    # current address is unique keeps it, so nothing that works today moves.
+    # Within a colliding group the oldest keeps it — it is the one HA
+    # actually has registered — and the others take the new derivation, since
+    # they are the ones being overwritten right now and cannot get worse.
+    """
+    ALTER TABLE devices ADD COLUMN esphome_mac TEXT;
+
+    UPDATE system_config SET value = '19' WHERE key = 'schema_version';
+    """,
 ]
 
 # Post-migration fixups that need Python rather than SQL. Keyed by the schema
@@ -789,7 +821,45 @@ def _fixup_v11(conn) -> None:
             )
 
 
-_MIGRATION_FIXUPS = {11: _fixup_v11}
+def _fixup_v19(conn) -> None:
+    """
+    Seed devices.esphome_mac so no working device changes identity.
+
+    Preserving the CURRENT address wherever it is unique is the entire
+    reason this is a fixup rather than a plain DEFAULT: Home Assistant has
+    already registered these devices under those values, and a new one
+    orphans the device row along with every automation referencing its
+    entities.
+
+    Ordering inside a colliding group is by first_seen then device_id —
+    deterministic, so a re-run after a failed migration reaches the same
+    answer rather than reshuffling which device keeps its identity.
+    """
+    rows = conn.execute(
+        "SELECT device_id, first_seen FROM devices ORDER BY first_seen, device_id"
+    ).fetchall()
+
+    by_legacy: dict[str, list[str]] = {}
+    for row in rows:
+        by_legacy.setdefault(_legacy_serialno_to_mac(row["device_id"]), []).append(
+            row["device_id"])
+
+    for legacy, ids in by_legacy.items():
+        # First in the group keeps what HA already knows; the rest were being
+        # overwritten by it, so they take the new derivation.
+        conn.execute("UPDATE devices SET esphome_mac = ? WHERE device_id = ?",
+                     (legacy, ids[0]))
+        for device_id in ids[1:]:
+            conn.execute("UPDATE devices SET esphome_mac = ? WHERE device_id = ?",
+                         (esphome_mac_for(device_id), device_id))
+            log.warning(
+                f"[db] {device_id} shared an ESPHome identity with {ids[0]} "
+                f"({legacy}) — assigned {esphome_mac_for(device_id)}. Home "
+                f"Assistant will discover it as a new device; the other keeps "
+                f"its entities."
+            )
+
+_MIGRATION_FIXUPS = {11: _fixup_v11, 19: _fixup_v19}
 
 # ─── Connection management ────────────────────────────────────────────────────
 
@@ -967,6 +1037,81 @@ def _migrate(conn: sqlite3.Connection) -> None:
 
     new_version = current + len(pending)
     log.info(f"Schema migrated to v{new_version}")
+
+
+# ─── ESPHome identity ─────────────────────────────────────────────────────────
+#
+# Home Assistant keys its device registry on the mac_address an ESPHome device
+# reports, so this value IS a device's identity in HA. It is not a network
+# address in any functional sense: nothing routes to it and no packet carries
+# it. We supply one because the protocol requires it — HA's config flow aborts
+# its zeroconf step with "mdns_missing_mac" when the TXT record lacks it, and
+# never produces a discovery card at all.
+#
+# The prefix is fixed and the rest is a hash of the serial.
+#
+# 0x02 in the first octet is the LOCALLY ADMINISTERED bit — the MAC equivalent
+# of a private address range, declaring "not from an IEEE OUI, do not expect
+# global uniqueness". Bit 0 is a different flag entirely (unicast vs
+# multicast) and must stay clear; a raw hash sets it half the time, producing
+# an address that is not a valid unicast MAC. Choosing a fixed prefix that
+# satisfies both by CONSTRUCTION is why this is not a mask applied to a hash:
+# there is no bit for a later change to forget. Docker (02:42) and QEMU
+# (52:54:00) do the same thing for the same reason.
+#
+# 32 bits of hash rather than 48 is the cost, and it is affordable because
+# uniqueness is only ever needed within ONE Home Assistant registry — a
+# household fleet. At 100 devices the collision probability is 1.15e-6.
+ESPHOME_MAC_PREFIX = (0x02, 0xEC)
+
+
+def esphome_mac_for(device_id: str) -> str:
+    """The address a device WOULD be given. Deterministic; see the note above."""
+    digest = hashlib.md5(device_id.encode("utf-8")).digest()
+    octets = list(ESPHOME_MAC_PREFIX) + list(digest[:4])
+    return ":".join(f"{b:02X}" for b in octets)
+
+
+def _legacy_serialno_to_mac(device_id: str) -> str:
+    """
+    The pre-v19 derivation, kept ONLY so the migration can recognise the
+    identity Home Assistant already holds for a device.
+
+    It stripped non-hex characters from an alphanumeric serial, which is the
+    bug: devices differing only in the discarded characters collide. Never
+    call this for a new device.
+    """
+    hex_chars = "".join(c for c in device_id if c in "0123456789ABCDEFabcdef")
+    hex_chars = hex_chars[-12:].upper().zfill(12)
+    return ":".join(hex_chars[i:i + 2] for i in range(0, 12, 2))
+
+
+def get_esphome_mac(device_id: str) -> str:
+    """
+    The stored ESPHome identity for a device, assigning one if it has none.
+
+    Assign-once, like get_esphome_port/assign_esphome_port beside it, and for
+    the same reason: Home Assistant keys its registry on the value, so it must
+    never change under a device that is already registered. A device row that
+    predates v19 was seeded by that migration; one created afterwards is
+    assigned here on first use.
+    """
+    row = _q1("SELECT esphome_mac FROM devices WHERE device_id = ?", (device_id,))
+    if row is not None and row["esphome_mac"]:
+        return row["esphome_mac"]
+    mac = esphome_mac_for(device_id)
+    with _tx() as conn:
+        # Only where it is still unset: a concurrent caller may have won, and
+        # the first answer must stand.
+        conn.execute(
+            "UPDATE devices SET esphome_mac = ? "
+            "WHERE device_id = ? AND (esphome_mac IS NULL OR esphome_mac = '')",
+            (mac, device_id),
+        )
+    row = _q1("SELECT esphome_mac FROM devices WHERE device_id = ?", (device_id,))
+    # No device row yet (servers can be built before registration) — the value
+    # is still correct and will be stored the first time there is a row.
+    return (row["esphome_mac"] if row and row["esphome_mac"] else mac)
 
 
 # ─── Device registry ──────────────────────────────────────────────────────────

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -1958,7 +1958,7 @@ async def _register_device_server(device_id: str, label: str | None) -> DeviceES
 
     # mDNS registration — _esphomelib._tcp, one per device port,
     # same pattern as the controller's own _emcontroller._tcp service.
-    mdns_info = _make_device_mdns_info(device_id, label, port)
+    mdns_info = _make_device_mdns_info(device_id, label, port, mac)
     try:
         await _azc.async_register_service(mdns_info, allow_name_change=True)
         server.set_mdns_info(mdns_info)
@@ -2528,7 +2528,8 @@ def _mdns_service_name(device_id: str) -> str:
     return f"echomuse-{device_id[-12:].lower()}"
 
 
-def _make_device_mdns_info(device_id: str, label: str, port: int) -> ServiceInfo:
+def _make_device_mdns_info(device_id: str, label: str, port: int,
+                           mac: str) -> ServiceInfo:
     svc_name = _mdns_service_name(device_id)
     return ServiceInfo(
         "_esphomelib._tcp.local.",
@@ -2543,9 +2544,10 @@ def _make_device_mdns_info(device_id: str, label: str, port: int) -> ServiceInfo
             # record lacks it — devices advertised without it never produce
             # a discovery card, silently. Real ESPHome firmware advertises
             # bare lowercase hex; HA normalises it (format_mac) and matches
-            # it against the mac the satellite reports in DeviceInfo (same
-            # _serialno_to_mac derivation, so they agree).
-            "mac": _serialno_to_mac(device_id).replace(":", "").lower(),
+            # it against the mac the satellite reports in DeviceInfo. Passed
+            # in rather than re-derived so the two cannot drift — they are
+            # required to agree, and nothing reports it if they stop.
+            "mac": mac.replace(":", "").lower(),
             "network": "ethwifi",
             "project_name": f"EchoMuse.{ESPHOME_DEVICE_MODEL}",
             "project_version": ESPHOME_PROJECT_VERSION,
@@ -2556,15 +2558,13 @@ def _make_device_mdns_info(device_id: str, label: str, port: int) -> ServiceInfo
 
 def _serialno_to_mac(device_id: str) -> str:
     """
-    Derive a stable MAC-format string from a device's ro.serialno.
+    The device's ESPHome identity — a stored fact now, not a derivation.
 
-    ro.serialno on the biscuit is a 12-char uppercase hex string
-    (e.g. G0K0XXXXXXXX). We take the last 12 hex chars (or pad/truncate)
-    to build a MAC-style address for ESPHome's mac_address field.
-    This is cosmetic only — ESPHome's protocol uses it as a stable
-    device identifier in HA's device registry.
+    Home Assistant keys its device registry on this value, so it must never
+    change under a device it has already registered. It used to be computed
+    from the serial on every call, which made identity a FUNCTION: fixing the
+    derivation would have moved every device at once. em_db.get_esphome_mac
+    assigns once and stores; see the note there for the prefix and why it is
+    fixed rather than masked.
     """
-    # Extract hex chars only, take last 12, pad with zeros if short
-    hex_chars = "".join(c for c in device_id if c in "0123456789ABCDEFabcdef")
-    hex_chars = hex_chars[-12:].upper().zfill(12)
-    return ":".join(hex_chars[i:i+2] for i in range(0, 12, 2))
+    return db.get_esphome_mac(device_id)

--- a/controller/tests/test_esphome_mac.py
+++ b/controller/tests/test_esphome_mac.py
@@ -1,0 +1,164 @@
+"""
+The ESPHome identity: what Home Assistant keys its device registry on.
+
+Two things are being pinned. The derivation must produce a valid, unique,
+locally-administered address — the bug @lennart24 found in #212/#217 is that
+it did not. And the value must be a stored FACT rather than a function, so
+that fixing the derivation does not move every device that already works.
+"""
+
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+
+import em_db as db
+
+
+@pytest.fixture()
+def fresh_db(tmp_path):
+    path = tmp_path / "test.db"
+    db.init(str(path))
+    yield db
+    if db._conn is not None:
+        db._conn.close()
+        db._conn = None
+
+
+# ── The derivation ────────────────────────────────────────────────────────────
+
+def test_serials_differing_only_in_stripped_characters_no_longer_collide():
+    """
+    The bug. The old derivation kept hex characters only, so devices from one
+    batch differing in the trailing letters became the same address and Home
+    Assistant treated two Echoes as one.
+    """
+    a = db.esphome_mac_for("G090LF1180440C9K")
+    b = db.esphome_mac_for("G090LF1180440C9R")
+    assert db._legacy_serialno_to_mac("G090LF1180440C9K") == \
+           db._legacy_serialno_to_mac("G090LF1180440C9R")   # the old bug
+    assert a != b
+
+
+def test_every_address_is_a_valid_locally_administered_unicast_mac():
+    """
+    Two different bits. 0x02 is locally administered — the private-address
+    equivalent. Bit 0 is unicast/multicast and must stay CLEAR: a raw hash
+    sets it half the time, which is not a valid unicast address at all.
+
+    Guaranteed by the fixed prefix rather than by masking, so there is no bit
+    for a later change to forget.
+    """
+    for serial in ("G090LF1180440C95", "G0K0XY1180440C9K", "x", "", "ZZZZ"):
+        mac = db.esphome_mac_for(serial)
+        first = int(mac.split(":")[0], 16)
+        assert first & 0x02, f"{mac} is not locally administered"
+        assert not first & 0x01, f"{mac} has the multicast bit set"
+        assert len(mac.split(":")) == 6
+
+
+def test_the_derivation_is_stable():
+    """It has to survive restarts and rebuilds, or HA loses the device."""
+    assert db.esphome_mac_for("G090LF1180440C95") == \
+           db.esphome_mac_for("G090LF1180440C95")
+
+
+# ── Assign once, then never move ──────────────────────────────────────────────
+
+def test_a_mac_is_assigned_once_and_kept(fresh_db):
+    db.register_new_device("G090LF1180440C95", "10.0.0.9", "v2.12.0")
+    first = db.get_esphome_mac("G090LF1180440C95")
+    assert first == db.get_esphome_mac("G090LF1180440C95")
+    row = db.get_device("G090LF1180440C95")
+    assert row["esphome_mac"] == first
+
+
+def test_a_stored_mac_wins_over_the_derivation(fresh_db):
+    """
+    The whole point of storing it. A device registered under an older scheme
+    keeps the identity Home Assistant already holds, whatever the current
+    derivation would say.
+    """
+    db.register_new_device("G090LF1180440C95", "10.0.0.9", "v2.12.0")
+    with db._tx() as conn:
+        conn.execute("UPDATE devices SET esphome_mac = ? WHERE device_id = ?",
+                     ("DE:AD:BE:EF:00:01", "G090LF1180440C95"))
+    assert db.get_esphome_mac("G090LF1180440C95") == "DE:AD:BE:EF:00:01"
+    assert db.get_esphome_mac("G090LF1180440C95") != \
+           db.esphome_mac_for("G090LF1180440C95")
+
+
+def test_an_unregistered_device_still_gets_an_answer(fresh_db):
+    """
+    ESPHome servers can be built before the device row exists, so this must
+    not raise — it returns the value it would store.
+    """
+    assert db.get_esphome_mac("NEVERSEEN") == db.esphome_mac_for("NEVERSEEN")
+
+
+# ── The v19 migration ─────────────────────────────────────────────────────────
+#
+# Built by reintroducing the situation: devices already in the database under
+# the old derivation, including a colliding pair. The migration's job is that
+# nothing which works today moves.
+
+def _legacy_fleet(tmp_path, serials):
+    """A v18 database holding devices, then migrated to current."""
+    import sqlite3
+    path = tmp_path / "legacy.db"
+    db.init(str(path))
+    for i, s in enumerate(serials):
+        db.register_new_device(s, f"10.0.0.{i+2}", "v2.12.0")
+    # Rewind to v18 with the column dropped, as a real pre-v19 database is.
+    with db._tx() as conn:
+        conn.execute("UPDATE devices SET esphome_mac = NULL")
+        conn.execute("ALTER TABLE devices DROP COLUMN esphome_mac")
+        conn.execute("UPDATE system_config SET value = '18' WHERE key = 'schema_version'")
+    db._conn.close(); db._conn = None
+    db.init(str(path))            # runs v19 + its fixup
+    return {s: db.get_device(s)["esphome_mac"] for s in serials}
+
+
+def test_a_device_with_a_unique_identity_keeps_it(tmp_path):
+    """
+    The reason this is a fixup and not a DEFAULT. Home Assistant has already
+    registered these devices under the old value; a new one orphans the device
+    row and every automation referencing its entities.
+    """
+    serials = ["G090LF1180440C95", "G0K0XY1180440C11"]
+    macs = _legacy_fleet(tmp_path, serials)
+    for s in serials:
+        assert macs[s] == db._legacy_serialno_to_mac(s)
+
+
+def test_a_colliding_pair_is_split_and_the_oldest_keeps_its_identity(tmp_path):
+    """
+    The bug being fixed. Both devices derived the same address, so HA had one
+    device row for two Echoes. The first-seen one keeps it — it is the one HA
+    actually holds — and the other, which was being overwritten, gets a new
+    identity and appears properly for the first time.
+    """
+    a, b = "G090LF1180440C9K", "G090LF1180440C9R"
+    assert db._legacy_serialno_to_mac(a) == db._legacy_serialno_to_mac(b)
+    macs = _legacy_fleet(tmp_path, [a, b])
+    assert macs[a] == db._legacy_serialno_to_mac(a)      # oldest keeps it
+    assert macs[b] == db.esphome_mac_for(b)              # the overwritten one moves
+    assert macs[a] != macs[b]
+
+
+def test_the_migration_leaves_every_device_with_a_distinct_identity(tmp_path):
+    serials = ["G090LF1180440C95", "G090LF1180440C9K", "G090LF1180440C9R",
+               "G090LF1180440FRK", "G090LF1180440FRR"]
+    macs = _legacy_fleet(tmp_path, serials)
+    assert len(set(macs.values())) == len(serials)
+
+
+def test_migrations_are_append_only():
+    """
+    The stored schema_version is an index into MIGRATIONS, so appending to a
+    deployed entry corrupts every database that already ran it. v19 must be a
+    new entry, and v18 must be untouched.
+    """
+    assert len(db.MIGRATIONS) == 19
+    assert "esphome_mac" in db.MIGRATIONS[18]
+    assert "esphome_mac" not in db.MIGRATIONS[17]


### PR DESCRIPTION
**Builds on @lennart24's diagnosis and fix in #217** — the bug, the root cause and the decision to hash the serial are all theirs, and they're credited as co-author. This adds the persistence layer so the fix doesn't cost every existing user their Home Assistant devices.

Closes #212. Supersedes #217.

## The bug

`_serialno_to_mac` stripped non-hex characters from an alphanumeric Amazon serial, so devices from one batch differing only in trailing letters collapsed onto one address:

```
G090LF1180440C9K -> 090F1180440C9 -> 90:F1:18:04:40:C9
G090LF1180440C9R -> 090F1180440C9 -> 90:F1:18:04:40:C9   ← same
```

HA keys its device registry on that value, so it concluded two Echoes were one device and the second overwrote the first.

## Why this isn't just #217

Identity was a **function**, so any change to the derivation moved *every* device at once — orphaning every HA device row and the automations referencing its entities. That's why #217 correctly warned users they'd have to re-add their devices.

Storing it separates the two concerns, so **the fix reaches the devices that need it and nobody else**:

| | before | after |
|---|---|---|
| unique serial, works today | breaks, must re-add | **keeps its identity** |
| colliding pair, oldest | breaks | **keeps its identity** |
| colliding pair, the overwritten one | breaks | gets a new identity, appears properly for the first time |
| new device | — | assigned on first use |

`db.get_esphome_mac` assigns once and stores — the same discipline `get_esphome_port` already uses beside it. The v19 fixup seeds existing rows from their *current* address; within a colliding group the oldest keeps it, ordered by `first_seen` then `device_id` so a re-run after a failed migration reaches the same answer rather than reshuffling who keeps their entities.

## Fixed prefix rather than a masked hash

`02:EC` + 4 bytes of md5. **Two different bits matter and only one is about privacy:** `0x02` is locally-administered — the MAC equivalent of a private range — while bit 0 is unicast vs multicast and must stay *clear*. A raw hash sets it half the time and produces something that is not a valid unicast address; that's true of #217 as sent (5 of 6 sample serials) and of the old code (3 of 6).

A fixed prefix satisfies both **by construction**, so there's no bit for a later change to forget — what Docker (`02:42`) and QEMU (`52:54:00`) do. Cost is 32 bits of hash rather than 48, affordable because uniqueness is only needed within one HA registry: 1.15e-6 at 100 devices.

## Also

The mac is now resolved once and passed to `_make_device_mdns_info` rather than derived twice. The mDNS TXT value and the `DeviceInfoResponse` value are *required* to agree — HA matches them — and nothing reports it if they stop.

## Testing

By reintroducing the situation: a v18 database holding real devices including a colliding pair, migrated forward, asserting unique devices keep their address, the oldest of a colliding pair keeps theirs while the overwritten one moves, and every device ends distinct. Plus that `MIGRATIONS` stayed append-only, since the stored `schema_version` is an index into it.

629 tests pass, 10 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)