### PR TITLE
Fix the barge-in disconnect: two initialisers stranded after a return

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -186,6 +186,20 @@ SPEAKER_PRIME_SECONDS = 1.1
 # the lock is ALSO free, which no running turn allows.
 OWW_PAUSE_STUCK_S = 180.0
 
+# Restarting the wake listener must never become a hot loop. A listener that
+# raises IMMEDIATELY on start would otherwise be recreated from its own done
+# callback as fast as the event loop can run it, which starves everything
+# else: control-plane pings stop, and the device drops the connection on its
+# own 10s ping timeout. Measured on 2026-08-20 as a device that disconnected
+# and reconnected on every barge-in — the supervision turned a silent death
+# into a visible one, and then into an outage.
+WAKE_RESTART_BACKOFF_S     = 1.0    # first retry
+WAKE_RESTART_MAX_BACKOFF_S = 60.0   # ceiling; never gives up entirely
+# Ran at least this long before dying = a fresh incident, not a loop. Without
+# it an occasional fault would inherit the backoff of an unrelated one from
+# hours earlier and take a minute to recover from something momentary.
+WAKE_RESTART_HEALTHY_S     = 60.0
+
 PING_INTERVAL_SEC = 5.0
 # A sample at or above this counts as an excursion. 200ms is well clear of a
 # healthy hop (Office measures 264ms median for a whole audio round trip
@@ -474,6 +488,16 @@ class Device:
         # playback_send_ms, which only times writing into the socket and
         # completes almost instantly however slow the link is.
         self.playback_send_t0: float | None = None
+        # Set on a COMPLETED playback and read when the device's
+        # playback_stats arrives. They lived after drain_rtt()'s `return` for
+        # months, so they were never initialised and only existed once a
+        # successful playback had assigned them. A barge-in cancel skips that
+        # assignment, so the next playback_stats raised AttributeError in the
+        # control handler and took the whole connection down with it —
+        # measured 2026-08-20 as a device disconnecting on every barge-in.
+        # -1 reads as "not measured", which is what the DB layer expects.
+        self.playback_send_ms: int = -1
+        self.playback_eq_ms:   int = -1
         # Set when the device reports playback_stats for the stream being
         # played. This is the authoritative "the audio has finished" signal
         # — the device emits it once its audio channel has drained after
@@ -556,8 +580,6 @@ class Device:
         self.rtt_excursions = self.rtt_excursions_idle = 0
         self.rtt_samples_idle = 0
         return out
-        self.playback_send_ms: int = -1
-        self.playback_eq_ms:   int = -1
 
     async def send_control(self, msg: dict):
         try:
@@ -1823,7 +1845,7 @@ async def _run_voice_locked(device: Device, trigger_label: str = "unknown", is_w
 
 # ─── Wake word listener ───────────────────────────────────────────────────────
 
-def _supervise_wake_listener(device: "Device") -> asyncio.Task:
+def _supervise_wake_listener(device: "Device", failures: int = 0) -> asyncio.Task:
     """
     Run wake_word_listener, and put it back if it ever falls over.
 
@@ -1849,18 +1871,20 @@ def _supervise_wake_listener(device: "Device") -> asyncio.Task:
     def _restart(task: asyncio.Task) -> None:
         if task.cancelled():
             return                      # ordinary teardown
+        ran_for = asyncio.get_event_loop().time() - started
         exc = task.exception()
         if exc is None:
             # Returned normally, which the loop never does — it is `while
             # True`. Still a death, so treat it as one.
             log.error(
                 f"[{device.device_id}] wake word listener returned "
-                f"unexpectedly — restarting. The device was deaf until now."
+                f"unexpectedly after {ran_for:.0f}s — restarting. The device "
+                f"was deaf until now."
             )
         else:
             log.error(
-                f"[{device.device_id}] wake word listener crashed — "
-                f"restarting. The device was deaf until now.",
+                f"[{device.device_id}] wake word listener crashed after "
+                f"{ran_for:.0f}s — restarting. The device was deaf until now.",
                 exc_info=exc,
             )
         if _devices.get(device.device_id) is not device:
@@ -1872,8 +1896,29 @@ def _supervise_wake_listener(device: "Device") -> asyncio.Task:
                 f"the device is no longer connected"
             )
             return
-        device.oww_task = _supervise_wake_listener(device)
 
+        # A listener that ran a while and then fell over is a fresh incident;
+        # one that dies instantly, every time, is a loop. Only the second
+        # needs slowing down, and conflating them would make an occasional
+        # fault take progressively longer to recover from.
+        n = 1 if ran_for >= WAKE_RESTART_HEALTHY_S else failures + 1
+        delay = min(WAKE_RESTART_BACKOFF_S * (2 ** (n - 1)),
+                    WAKE_RESTART_MAX_BACKOFF_S)
+
+        async def _later() -> None:
+            await asyncio.sleep(delay)
+            if _devices.get(device.device_id) is not device:
+                return
+            device.oww_task = _supervise_wake_listener(device, failures=n)
+
+        if n > 1:
+            log.error(
+                f"[{device.device_id}] wake word listener has now failed "
+                f"{n} times in a row — retrying in {delay:.0f}s"
+            )
+        asyncio.get_event_loop().create_task(_later())
+
+    started = asyncio.get_event_loop().time()
     t = asyncio.create_task(wake_word_listener(device))
     t.add_done_callback(_restart)
     return t

--- a/controller/tests/test_unreachable_code.py
+++ b/controller/tests/test_unreachable_code.py
@@ -1,0 +1,67 @@
+"""
+No statements after a return, anywhere in the controller.
+
+Written because two attribute initialisers sat after `return out` inside
+Device.drain_rtt() for months. They never ran, so Device.__init__ never
+defined playback_send_ms — the attribute existed only once a SUCCESSFUL
+playback had assigned it. A barge-in cancel skips that assignment, so the
+next playback_stats message raised AttributeError inside the control-plane
+handler and took the whole device connection down with it. Measured
+2026-08-20 as a device disconnecting and reconnecting on every barge-in.
+
+Nothing caught it. It is valid Python, pyflakes does not report unreachable
+code, and the test suite cannot import em_controller at all — which is
+precisely where it was hiding. An AST walk costs nothing and covers the
+whole class rather than the one instance.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+CONTROLLER = pathlib.Path(__file__).resolve().parent.parent
+
+# Every module, not just the ones the suite can import — the unimportable
+# ones are exactly where this hides.
+MODULES = sorted(p for p in CONTROLLER.glob("em_*.py"))
+
+
+def _unreachable(tree: ast.AST) -> list[tuple[str, int]]:
+    """(description, lineno) for any statement that can never execute."""
+    found = []
+    TERMINAL = (ast.Return, ast.Raise, ast.Continue, ast.Break)
+    for node in ast.walk(tree):
+        for field in ("body", "orelse", "finalbody"):
+            block = getattr(node, field, None)
+            if not isinstance(block, list):
+                continue
+            for i, stmt in enumerate(block[:-1]):
+                if isinstance(stmt, TERMINAL):
+                    nxt = block[i + 1]
+                    found.append(
+                        (f"{type(stmt).__name__.lower()} on line "
+                         f"{stmt.lineno} is followed by unreachable code",
+                         nxt.lineno)
+                    )
+    return found
+
+
+@pytest.mark.parametrize("path", MODULES, ids=lambda p: p.name)
+def test_no_unreachable_statements(path):
+    tree = ast.parse(path.read_text(), filename=str(path))
+    dead = _unreachable(tree)
+    assert not dead, (
+        f"{path.name} has code that can never run:\n"
+        + "\n".join(f"  line {ln}: {why}" for why, ln in dead)
+        + "\n\nIf it is an initialiser it is not initialising anything — that "
+          "is how Device.playback_send_ms came to be missing."
+    )
+
+
+def test_the_detector_actually_detects():
+    """A guard that cannot fail is not a guard."""
+    tree = ast.parse("def f():\n    return 1\n    x = 2\n")
+    assert _unreachable(tree)
+    tree = ast.parse("def f():\n    x = 2\n    return 1\n")
+    assert not _unreachable(tree)


### PR DESCRIPTION
**Barging in during a long response disconnected the device**, reproducibly, on consecutive turns:

```
[control] Handler error: 'Device' object has no attribute 'playback_send_ms'
[control] Device disconnected: G090LF1180440C95
```

`playback_send_ms` and `playback_eq_ms` were declared inside `Device.drain_rtt()` **after its `return out`**, so they never executed and `__init__` never defined them. The attributes existed only once a *successful* playback had assigned them — and a barge-in cancel skips that branch. The next `playback_stats` message then read a missing attribute inside the control-plane handler, which tears the connection down on any exception.

From `8c2eff6`, an old instrumentation commit — not from today's work.

## Nothing caught it, so the guard is a general one

It's valid Python, pyflakes doesn't report unreachable code, and the suite cannot import `em_controller` — which is exactly where it was hiding.

`tests/test_unreachable_code.py` walks the AST of every `em_*.py` and fails on any statement following a `return`, `raise`, `continue` or `break`. Verified by reintroducing the bug — it names line 558. It also tests its own detector, since a guard that cannot fail is not a guard.

## Separately, and *not* the cause

`_supervise_wake_listener` restarted from its own done callback with **no delay**, so a listener raising immediately on start would be recreated as fast as the event loop could run it — starving everything else until the device dropped the connection on its own 10s ping timeout.

That's a hazard this morning's supervision introduced and it had to be bounded regardless. **I misattributed tonight's disconnect to it before the log arrived**; the log shows no listener crash at all.

Restarts now back off 1s → 2s → 4s … to a 60s ceiling, and **never give up** — stopping would restore the silent deafness the supervision exists to end. A listener that ran at least 60s before dying counts as a fresh incident rather than a loop, so an occasional fault doesn't inherit an unrelated backoff.

Verified in the built image:

```
attempts in 1.5s: 6
gaps: [0.05, 0.1, 0.2, 0.401, 0.401]
event loop still servicing other tasks: 20/20 ticks
after a healthy run, retried promptly: 5 attempts
```

## Not fixed here

**One bad message should not cost the whole control connection** — filed as #255. A `playback_stats` report is telemetry; losing one should cost a data point, not the device's ESPHome server, BLE proxy and data plane. The dispatch chain is ~370 lines and wrapping it isn't a change to make mid-test.

653 tests pass, 35 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)