### PR TITLE
Trust a private CA, for a Home Assistant served over HTTPS with one

### DIFF
--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -64,6 +64,12 @@ environment:
   # Supervisor — fixed rather than a user option so the database can't be
   # pointed somewhere that doesn't survive a restart.
   DB_PATH: "/data/echomuse.db"
+# Read-only access to Home Assistant's /ssl folder, so a private CA
+# certificate can be pointed at with extra_ca_cert. Read-only by default,
+# which is all this needs — we copy the file, never write it.
+map:
+  - type: ssl
+
 options:
   server_host: "0.0.0.0"
   server_ip: ""
@@ -81,6 +87,10 @@ options:
   require_device_tls: false
   device_approval: "strict"
   debug: false
+  # Path to a PEM CA certificate to trust, for a Home Assistant served
+  # over HTTPS with a private CA. Put the file in Home Assistant's /ssl
+  # folder and give the path as /ssl/<filename>.
+  extra_ca_cert: ""
 schema:
   server_host: "str"
   server_ip: "str"
@@ -92,3 +102,4 @@ schema:
   require_device_tls: "bool"
   device_approval: "list(strict|auto)"
   debug: "bool"
+  extra_ca_cert: "str?"

--- a/controller-ea/translations/en.yaml
+++ b/controller-ea/translations/en.yaml
@@ -60,3 +60,11 @@ configuration:
       Log protocol-level detail for devices and the Home Assistant
       connection. Verbose — turn it on to diagnose something, then off
       again.
+  extra_ca_cert:
+    name: Private CA certificate
+    description: >-
+      Only needed if Home Assistant is served over HTTPS using your own
+      internal certificate authority. Put the CA certificate (PEM format)
+      in Home Assistant's ssl folder and enter /ssl/<filename> here.
+      Without it, fetching the spoken response fails certificate
+      verification and turns end with no audio.

--- a/controller/.env.example
+++ b/controller/.env.example
@@ -56,3 +56,23 @@ DEVICE_APPROVAL=strict
 # diagnostic setting rather than a default. Read once at startup, so a change
 # needs a restart.
 DEBUG=0
+
+# Path to a PEM CA certificate to trust, for a Home Assistant served over
+# HTTPS with your own internal certificate authority. Without it the fetch of
+# a turn's spoken response fails certificate verification and the turn ends
+# with no audio.
+#
+# Installed into the container's system trust store at startup rather than set
+# as SSL_CERT_FILE, because that is the one location BOTH TLS stacks read:
+# Python for the response fetch, and GnuTLS-linked ffmpeg, which ignores
+# SSL_CERT_FILE. Mount the certificate into the container and give the path
+# inside it.
+#
+#   volumes:
+#     - /path/to/internal-ca.crt:/certs/internal-ca.crt:ro
+#   environment:
+#     - EM_EXTRA_CA_CERT=/certs/internal-ca.crt
+#
+# Startup FAILS if the file is missing or is not PEM, rather than carrying on
+# and dying on every voice turn with an error nobody connects to this setting.
+EM_EXTRA_CA_CERT=

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -126,6 +126,7 @@ RUN EARCH="$(dpkg --print-architecture)" && case "$EARCH" in amd64) EPKG=linux-x
 # Database persisted via volume mount
 # docker run -v ~/EchoMuse/controller/data:/app/data ...
 # Set DB_PATH=/app/data/echomuse.db in environment
+COPY em_cacerts.py .
 COPY em_start.py .
 # em_start.py bridges /data/options.json (Home Assistant add-on config) into
 # the env vars em_controller.py already reads, then execs into it — a no-op

--- a/controller/config.yaml
+++ b/controller/config.yaml
@@ -50,6 +50,12 @@ environment:
   # Supervisor — fixed rather than a user option so the database can't be
   # pointed somewhere that doesn't survive a restart.
   DB_PATH: "/data/echomuse.db"
+# Read-only access to Home Assistant's /ssl folder, so a private CA
+# certificate can be pointed at with extra_ca_cert. Read-only by default,
+# which is all this needs — we copy the file, never write it.
+map:
+  - type: ssl
+
 options:
   server_host: "0.0.0.0"
   server_ip: ""
@@ -67,6 +73,10 @@ options:
   require_device_tls: false
   device_approval: "strict"
   debug: false
+  # Path to a PEM CA certificate to trust, for a Home Assistant served
+  # over HTTPS with a private CA. Put the file in Home Assistant's /ssl
+  # folder and give the path as /ssl/<filename>.
+  extra_ca_cert: ""
 schema:
   server_host: "str"
   server_ip: "str"
@@ -78,3 +88,4 @@ schema:
   require_device_tls: "bool"
   device_approval: "list(strict|auto)"
   debug: "bool"
+  extra_ca_cert: "str?"

--- a/controller/em_cacerts.py
+++ b/controller/em_cacerts.py
@@ -1,0 +1,128 @@
+"""
+em_cacerts.py — trusting a private certificate authority.
+
+Home Assistant hands us an absolute URL for a turn's TTS audio. When Home
+Assistant is served over HTTPS with a certificate from the user's own internal
+CA, that fetch fails certificate verification and the turn dies as
+`tts_error` with zero bytes — a controller that starts cleanly, wakes, and
+then answers nothing.
+
+WHY THE SYSTEM TRUST STORE, AND NOT SSL_CERT_FILE
+-------------------------------------------------
+Measured in the built image rather than assumed, because the first version of
+this reasoning was wrong.
+
+The failure is Python's. aiohttp uses `ssl.create_default_context()`, which
+reads the system bundle, so a private CA is not trusted and the fetch raises
+SSLCertVerificationError. Verified end to end against a locally-signed HTTPS
+server in the image: aiohttp fails before installing the CA and returns 200
+after.
+
+ffmpeg, which fetches MEDIA urls directly (`-i <url>` in em_player), is NOT
+currently affected — this image's build defaults `-tls_verify` to **0**, so it
+does not check peer certificates at all. That is worth knowing for two
+reasons: it means media playback was never broken by a private CA, and it
+means media is fetched over HTTPS without verification (filed separately).
+
+The system store is still the right place, for a reason that survives both
+facts: it is what BOTH stacks read. Python reads it today, and ffmpeg is
+built --enable-gnutls, which **ignores SSL_CERT_FILE entirely** and reads only
+the system bundle — confirmed by installing a CA here and watching GnuTLS
+accept a server it had just rejected. So if `-tls_verify 1` is ever turned on,
+this keeps working with no second mechanism; SSL_CERT_FILE would quietly
+not.
+
+WHY NOT ROUTE THROUGH THE SUPERVISOR PROXY
+------------------------------------------
+Add-ons can reach Home Assistant at `http://supervisor/core/api/` with
+SUPERVISOR_TOKEN, avoiding TLS altogether. It requires `homeassistant_api:
+true`, which this project deliberately declined when it would have been
+convenient for mirroring user roles (see the add-on notes in CLAUDE.md, and
+issue #171): it grants the ENTIRE Home Assistant API. Taking it to avoid
+reading one file would be a much larger permission for a smaller benefit, and
+it would not help the standalone container at all.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+# Where update-ca-certificates looks for locally-added anchors on Debian.
+ANCHOR_DIR = Path("/usr/local/share/ca-certificates")
+
+_PEM_HEADER = "-----BEGIN CERTIFICATE-----"
+
+
+def looks_like_pem(text: str) -> bool:
+    """
+    Whether this is a PEM certificate.
+
+    Checked because update-ca-certificates accepts a DER file, a private key
+    or a text file without complaint and simply produces a bundle that does
+    not contain the CA — leaving exactly the failure the user was trying to
+    fix, with a successful-looking startup in front of it. Better to say so.
+    """
+    return _PEM_HEADER in text
+
+
+def anchor_name(src: str | Path) -> str:
+    """
+    The filename to install as, always ending `.crt`.
+
+    update-ca-certificates processes ONLY files matching `*.crt` in its
+    anchor directory. A user pointing at `internal-ca.pem` — the more common
+    extension by far — would otherwise have it copied in, skipped silently,
+    and nothing would change.
+    """
+    stem = Path(src).name
+    if stem.lower().endswith(".crt"):
+        return stem
+    return f"{Path(stem).stem}.crt"
+
+
+class CATrustError(RuntimeError):
+    """The certificate could not be trusted, with a reason to show the user."""
+
+
+def install(src: str, anchor_dir: Path = ANCHOR_DIR, runner=subprocess.run) -> str:
+    """
+    Install a PEM CA certificate into the system trust store.
+
+    Returns a one-line description of what happened. Raises CATrustError with
+    a usable message on anything that would leave the store unchanged —
+    startup should fail loudly here rather than run on and produce voice turns
+    that die with a TLS error nobody connects to this setting.
+    """
+    path = Path(src)
+    if not path.is_file():
+        raise CATrustError(
+            f"{src} does not exist or is not a file. On the add-on, put the "
+            f"certificate in Home Assistant's /ssl directory and set the "
+            f"option to /ssl/<filename>; on the container, mount it and give "
+            f"the path inside the container."
+        )
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as err:
+        raise CATrustError(f"{src} could not be read: {err}") from err
+
+    if not looks_like_pem(text):
+        raise CATrustError(
+            f"{src} is not a PEM certificate (no {_PEM_HEADER!r} line). A DER "
+            f"or PKCS#12 file has to be converted first: "
+            f"openssl x509 -inform der -in ca.der -out ca.crt"
+        )
+
+    anchor_dir.mkdir(parents=True, exist_ok=True)
+    dest = anchor_dir / anchor_name(src)
+    shutil.copyfile(path, dest)
+
+    result = runner(["update-ca-certificates"], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise CATrustError(
+            f"update-ca-certificates failed ({result.returncode}): "
+            f"{(result.stderr or '').strip()}"
+        )
+    return f"trusting {src} as {dest.name}"

--- a/controller/em_start.py
+++ b/controller/em_start.py
@@ -15,7 +15,10 @@ missing.
 
 import json
 import os
+import sys
 from pathlib import Path
+
+import em_cacerts
 
 OPTIONS_PATH = Path("/data/options.json")
 
@@ -37,6 +40,7 @@ OPTION_ENV_VARS = {
     "require_device_tls": "REQUIRE_DEVICE_TLS",
     "device_approval": "DEVICE_APPROVAL",
     "debug": "DEBUG",
+    "extra_ca_cert": "EM_EXTRA_CA_CERT",
 }
 
 if OPTIONS_PATH.is_file():
@@ -64,5 +68,23 @@ if OPTIONS_PATH.is_file():
         else:
             env_value = str(value)
         os.environ.setdefault(env_key, env_value)
+
+# Trust a private CA before starting, so BOTH TLS stacks see it — Python for
+# the TTS fetch and GnuTLS-linked ffmpeg for media URLs. Done here rather than
+# in em_controller because it is a property of the container, has to happen
+# before anything opens a connection, and needs the root privileges this
+# process still has.
+#
+# Failing hard is deliberate. The alternative is a controller that starts
+# cleanly and then dies on every voice turn with a certificate error nobody
+# connects back to this setting — the user set an option and it silently did
+# not take.
+_ca = os.environ.get("EM_EXTRA_CA_CERT", "").strip()
+if _ca:
+    try:
+        print(f"em_start: {em_cacerts.install(_ca)}", flush=True)
+    except em_cacerts.CATrustError as err:
+        print(f"em_start: EM_EXTRA_CA_CERT — {err}", flush=True)
+        sys.exit(1)
 
 os.execvp("python3", ["python3", "-u", "em_controller.py"])

--- a/controller/tests/test_cacerts.py
+++ b/controller/tests/test_cacerts.py
@@ -1,0 +1,121 @@
+"""
+Trusting a private CA, for a Home Assistant served over HTTPS with one.
+
+The failure this fixes is quiet from the user's side: the controller starts
+cleanly, the device wakes, and then every turn ends with no audio because the
+TTS fetch could not verify the certificate. So the tests here are mostly about
+refusing to look like it worked.
+"""
+
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+
+import em_cacerts
+
+PEM = ("-----BEGIN CERTIFICATE-----\n"
+       "MIIByjCCATOgAwIBAgIUFakeFakeFake\n"
+       "-----END CERTIFICATE-----\n")
+
+
+def _ok(*args, **kwargs):
+    class R:
+        returncode = 0
+        stdout = "1 added"
+        stderr = ""
+    return R()
+
+
+def _fails(*args, **kwargs):
+    class R:
+        returncode = 1
+        stdout = ""
+        stderr = "update-ca-certificates: broken"
+    return R()
+
+
+def test_a_pem_certificate_is_installed_and_the_store_rebuilt(tmp_path):
+    src = tmp_path / "internal-ca.crt"
+    src.write_text(PEM)
+    anchors = tmp_path / "anchors"
+    calls = []
+
+    def runner(cmd, **kw):
+        calls.append(cmd)
+        return _ok()
+
+    msg = em_cacerts.install(str(src), anchor_dir=anchors, runner=runner)
+    assert (anchors / "internal-ca.crt").read_text() == PEM
+    assert calls == [["update-ca-certificates"]]
+    assert "internal-ca.crt" in msg
+
+
+def test_a_pem_extension_is_renamed_to_crt(tmp_path):
+    """
+    update-ca-certificates processes ONLY *.crt in its anchor directory, and
+    .pem is the more common extension by far. Copying the file under its own
+    name would have it silently skipped — the store rebuilds, the command
+    succeeds, and nothing is trusted.
+    """
+    src = tmp_path / "internal-ca.pem"
+    src.write_text(PEM)
+    anchors = tmp_path / "anchors"
+    em_cacerts.install(str(src), anchor_dir=anchors, runner=_ok)
+    assert (anchors / "internal-ca.crt").is_file()
+    assert not (anchors / "internal-ca.pem").exists()
+
+
+def test_anchor_name_always_ends_crt():
+    assert em_cacerts.anchor_name("/ssl/ca.pem") == "ca.crt"
+    assert em_cacerts.anchor_name("/ssl/ca.crt") == "ca.crt"
+    assert em_cacerts.anchor_name("/ssl/ca.CRT") == "ca.CRT"
+    assert em_cacerts.anchor_name("/ssl/internal") == "internal.crt"
+
+
+def test_a_missing_file_is_refused_with_somewhere_to_look(tmp_path):
+    with pytest.raises(em_cacerts.CATrustError) as e:
+        em_cacerts.install(str(tmp_path / "nope.crt"),
+                           anchor_dir=tmp_path / "a", runner=_ok)
+    # The message has to say where to put it, or the user is left guessing
+    # between the host path and the path inside the container.
+    assert "/ssl" in str(e.value)
+
+
+def test_a_non_pem_file_is_refused_with_the_conversion_command(tmp_path):
+    """
+    update-ca-certificates accepts a DER file without complaint and produces
+    a bundle that does not contain the CA — the original failure, with a
+    successful-looking startup in front of it.
+    """
+    src = tmp_path / "ca.crt"
+    src.write_bytes(b"\x30\x82\x01\x0a\x02\x82")      # DER, not PEM
+    with pytest.raises(em_cacerts.CATrustError) as e:
+        em_cacerts.install(str(src), anchor_dir=tmp_path / "a", runner=_ok)
+    assert "openssl" in str(e.value)
+
+
+def test_a_failing_update_is_reported_not_swallowed(tmp_path):
+    src = tmp_path / "ca.crt"
+    src.write_text(PEM)
+    with pytest.raises(em_cacerts.CATrustError) as e:
+        em_cacerts.install(str(src), anchor_dir=tmp_path / "a", runner=_fails)
+    assert "broken" in str(e.value)
+
+
+def test_looks_like_pem():
+    assert em_cacerts.looks_like_pem(PEM)
+    assert not em_cacerts.looks_like_pem("-----BEGIN PRIVATE KEY-----\n")
+    assert not em_cacerts.looks_like_pem("")
+
+
+def test_startup_refuses_rather_than_starting_untrusted():
+    """
+    em_start exits non-zero on a bad certificate. Starting anyway would give a
+    controller that looks healthy and fails every voice turn on a TLS error
+    nobody connects back to this option.
+    """
+    src = (pathlib.Path(__file__).resolve().parents[1] / "em_start.py").read_text()
+    ca = src[src.index("EM_EXTRA_CA_CERT"):]
+    assert "sys.exit(1)" in ca
+    assert "em_cacerts.install" in ca

--- a/controller/translations/en.yaml
+++ b/controller/translations/en.yaml
@@ -60,3 +60,11 @@ configuration:
       Log protocol-level detail for devices and the Home Assistant
       connection. Verbose — turn it on to diagnose something, then off
       again.
+  extra_ca_cert:
+    name: Private CA certificate
+    description: >-
+      Only needed if Home Assistant is served over HTTPS using your own
+      internal certificate authority. Put the CA certificate (PEM format)
+      in Home Assistant's ssl folder and enter /ssl/<filename> here.
+      Without it, fetching the spoken response fails certificate
+      verification and turns end with no audio.


### PR DESCRIPTION
**Reported on Discord:** Home Assistant behind a private internal CA gives no audio. HA hands us an absolute TTS URL, aiohttp uses `ssl.create_default_context()` which reads the system bundle, the private CA isn't in it, and the fetch dies with `SSLCertVerificationError`. The controller starts cleanly, the device wakes, and **every turn ends as `tts_error` with zero bytes.**

`EM_EXTRA_CA_CERT` names a PEM certificate; `em_start` installs it into `/usr/local/share/ca-certificates` and runs `update-ca-certificates` before exec'ing the controller. `em_start` is the image's `CMD` for **both** deployments, so this covers the add-on and the standalone container from one place, and still has the root privileges the install needs.

## Two design points, both checked rather than assumed

**The system store rather than `SSL_CERT_FILE`** — and my first reasoning for this was wrong, so it's worth stating plainly. Measured in the built image: ffmpeg, which fetches media URLs directly, is **not** affected by this at all. Its build defaults `-tls_verify` to `0` and doesn't check peer certificates. So media was never broken by a private CA, and my claim that `SSL_CERT_FILE` would be a half-fix was false.

The system store is still right, for a reason that survives that: **it's what both stacks read.** Python reads it today, and ffmpeg is built `--enable-gnutls`, which ignores `SSL_CERT_FILE` entirely. If `-tls_verify` is ever turned on — and it should be, filed as #258 — this keeps working with no second mechanism.

**Not the Supervisor proxy.** Add-ons can reach HA over plain HTTP at `http://supervisor/core/api/`, avoiding TLS altogether. The Supervisor docs are explicit that it requires **`homeassistant_api: true`** — the permission this project deliberately declined when it would have been convenient for mirroring user roles, because it grants the entire HA API. A much larger permission to avoid reading one file, and it wouldn't help the standalone container at all.

## Add-on wiring

`map: - type: ssl` gives read-only access to HA's own `/ssl` folder, where users already keep certificates — so the option takes `/ssl/<filename>` and needs no new mount. Confirmed against the [add-on configuration docs](https://developers.home-assistant.io/docs/add-ons/configuration): `ssl` is a documented map type and defaults to read-only.

## Three refusals rather than a quiet half-success

Each otherwise ends where the user started — no audio, now with a setting they believe is applied:

- **Missing file** — message names where to put it on each deployment; host path vs in-container path is the easy confusion.
- **Non-PEM file** — with the `openssl` conversion command. `update-ca-certificates` accepts DER without complaint and produces a bundle that doesn't contain the CA.
- **Not named `*.crt`** — renamed, because `update-ca-certificates` processes only that glob and `.pem` is the commoner extension. Copying verbatim would rebuild the store successfully and trust nothing.

Startup exits non-zero on any of them.

## Verified end to end

In the built image, against a locally-signed HTTPS server:

```
BEFORE trusting the CA:
  aiohttp: FAILED — ClientConnectorCertificateError ... SSLCertVerificationError
trusting /tmp/ca.crt as ca.crt
AFTER:
  aiohttp: OK 200
```

672 tests pass, 8 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)