### PR TITLE
Stop the denoiser gating speech to digital silence

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -1241,6 +1241,9 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     f"[{self._log_name}] nsAsr enabled but DTLN models missing "
                     f"({em_ns.MODEL_DIR}) — streaming raw audio"
                 )
+        # Survives `denoiser` being dropped on a mid-turn failure, so the
+        # turn still reports what the gate did before it gave up.
+        ns_reporter = denoiser
         ns_debug_raw = bytearray()
         ns_debug_out = bytearray()
 
@@ -1436,6 +1439,9 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                             f"[{self._log_name}] NS failed mid-turn ({e}) — "
                             f"raw audio for the rest of this turn"
                         )
+                        # Dropped from the loop, but the counters it collected
+                        # up to the failure still describe this turn.
+                        ns_reporter = denoiser
                         denoiser = None
                         payload = raw_payload
                     else:
@@ -1466,6 +1472,14 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     del pcm_buf[:AUDIO_CHUNK]
                     self._send_one(api_pb2.VoiceAssistantAudio(data=chunk))
         finally:
+            # What the gate actually did to this turn. Logged unconditionally
+            # when NS ran, because until now a denoiser chewing speech and a
+            # quiet room were indistinguishable from any log, on either side
+            # — which is why #137 spent nine days on two theories that a
+            # single number would have settled.
+            ns_reporter = denoiser if denoiser is not None else ns_reporter
+            if ns_reporter is not None:
+                log.info(f"[{self._log_name}] NS: {ns_reporter.zero_report()}")
             # Validation tooling: when NS_DEBUG_DIR is set, persist what
             # STT actually received next to what the mic actually sent.
             em_ns.dump_debug_pair(self._log_name, bytes(ns_debug_raw), bytes(ns_debug_out))

--- a/controller/em_ns.py
+++ b/controller/em_ns.py
@@ -36,6 +36,29 @@ BLOCK_LEN   = 512   # FFT window (samples at 16kHz)
 BLOCK_SHIFT = 128   # hop
 STATE_SHAPE = (1, 2, 128, 2)
 
+# Overlap-add latency: the block written out at step i is the OLDEST hop of
+# the accumulator, so it corresponds to input samples BLOCK_LEN - BLOCK_SHIFT
+# earlier. Anything mixed against the output has to be delayed by this or it
+# comb-filters — which is worse than the artefact being fixed here.
+OLA_DELAY = BLOCK_LEN - BLOCK_SHIFT   # 384 samples, 24ms
+
+# Suppression floor. DTLN is free to output digital silence, and on this
+# fleet it did: 8-15% of samples at EXACT zero at a healthy signal level,
+# against 0.3% with NS off (#154), heard as speech chopping in and out (#137).
+# That is the gate cutting into speech rather than shaving noise, and it
+# costs more transcription accuracy than the residual noise ever did.
+#
+# The output is therefore a convex blend of the model's estimate and the
+# (delayed) input, so suppression stops at NS_FLOOR_DB instead of infinity.
+# Convex, not additive: where the model passes speech through untouched
+# (enhanced == x) the blend is also x, so speech level is unchanged and only
+# the fully-suppressed regions move. ASR gains flatten well before 20dB of
+# noise reduction, so the ceiling this imposes is not a cost worth paying
+# attention to; the holes were.
+NS_FLOOR_DB = -20.0
+_DRY = float(10.0 ** (NS_FLOOR_DB / 20.0))   # 0.1
+_WET = 1.0 - _DRY
+
 MODEL_DIR = os.environ.get(
     "NS_MODEL_DIR",
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "models", "dtln"),
@@ -117,8 +140,11 @@ class StreamingDenoiser:
     so in practice output length == input length).
     """
 
-    def __init__(self):
-        sessions = _get_sessions()
+    def __init__(self, sessions=None):
+        # sessions is injectable so the frame maths — the OLA alignment in
+        # particular — is testable without onnxruntime or the model files,
+        # neither of which exists outside the built image.
+        sessions = sessions if sessions is not None else _get_sessions()
         if sessions is None:
             raise RuntimeError(f"DTLN models not loadable from {MODEL_DIR}")
         self._m1, self._m2 = sessions
@@ -127,6 +153,16 @@ class StreamingDenoiser:
         self._in_buf   = np.zeros(BLOCK_LEN, dtype=np.float32)
         self._out_buf  = np.zeros(BLOCK_LEN, dtype=np.float32)
         self._pending  = b""
+        # Input history for the floor blend, delayed to match OLA_DELAY.
+        self._dry_buf  = np.zeros(OLA_DELAY, dtype=np.float32)
+        # How much of the output the gate took to exact zero, and how much of
+        # the INPUT was already there. Both, because one without the other
+        # cannot separate "the denoiser chewed the speech" from "the room was
+        # silent" — which is the whole question #137 asks, and neither number
+        # was recorded anywhere when it was asked.
+        self.out_zeros = 0
+        self.in_zeros  = 0
+        self.samples   = 0
 
     def process(self, payload: bytes) -> bytes:
         data = self._pending + payload
@@ -161,9 +197,34 @@ class StreamingDenoiser:
             self._out_buf = np.roll(self._out_buf, -BLOCK_SHIFT)
             self._out_buf[-BLOCK_SHIFT:] = 0.0
             self._out_buf += enhanced.reshape(-1)
-            out[i:i + BLOCK_SHIFT] = self._out_buf[:BLOCK_SHIFT]
 
-        return (np.clip(out, -1.0, 0.999969) * 32768.0).astype(np.int16).tobytes()
+            # Blend against the input as it stood OLA_DELAY samples ago —
+            # the sample the model's output actually corresponds to.
+            dry = self._dry_buf[:BLOCK_SHIFT]
+            self._dry_buf = np.concatenate(
+                (self._dry_buf[BLOCK_SHIFT:], x[i:i + BLOCK_SHIFT])
+            )
+            out[i:i + BLOCK_SHIFT] = _WET * self._out_buf[:BLOCK_SHIFT] + _DRY * dry
+
+        pcm = (np.clip(out, -1.0, 0.999969) * 32768.0).astype(np.int16)
+        self.samples   += pcm.size
+        self.out_zeros += int(np.count_nonzero(pcm == 0))
+        self.in_zeros  += int(np.count_nonzero(
+            (x * 32768.0).astype(np.int16) == 0
+        ))
+        return pcm.tobytes()
+
+    def zero_report(self) -> str:
+        """
+        One line for the turn log: what fraction of the stream the gate took
+        to digital silence, against what arrived that way. Cheap enough to
+        run every turn — two counts per 80ms frame.
+        """
+        if not self.samples:
+            return "no samples"
+        return (f"zeros out={100.0 * self.out_zeros / self.samples:.1f}% "
+                f"in={100.0 * self.in_zeros / self.samples:.1f}% "
+                f"floor={NS_FLOOR_DB:.0f}dB")
 
 
 def dump_debug_pair(tag: str, raw: bytes, denoised: bytes) -> None:

--- a/controller/tests/test_ns.py
+++ b/controller/tests/test_ns.py
@@ -1,0 +1,147 @@
+"""
+DTLN framing and the suppression floor.
+
+The models are vendored into the image and are not in the tree, and
+onnxruntime is not in the test environment — so the sessions are stubbed and
+what is tested is the part that was actually wrong: the overlap-add
+alignment, and whether the output can still reach digital silence.
+"""
+
+import numpy as np
+import pytest
+
+import em_ns
+
+
+class _Stub:
+    """Stands in for one ONNX session. fn(data) -> data of the same shape."""
+
+    def __init__(self, fn):
+        self._fn = fn
+
+    def run(self, _outputs, feeds):
+        data  = next(v for k, v in feeds.items() if k == "data")
+        state = next(v for k, v in feeds.items() if k == "state")
+        return [self._fn(data), state]
+
+
+def _sessions(mask_fn, post_fn):
+    m1 = (_Stub(mask_fn), "data", "state", "data_out", "state_out")
+    m2 = (_Stub(post_fn), "data", "state", "data_out", "state_out")
+    return (m1, m2)
+
+
+def _passthrough():
+    """
+    A DTLN that suppresses nothing. The mask is all ones, and the post-net
+    returns the block scaled by 1/overlap so the overlap-add reconstructs
+    exactly — window 512 over hop 128 sums four copies of every sample.
+    """
+    overlap = em_ns.BLOCK_LEN // em_ns.BLOCK_SHIFT
+    return _sessions(
+        lambda mag: np.ones_like(mag),
+        lambda blk: (blk / overlap).astype(np.float32),
+    )
+
+
+def _silencer():
+    """A DTLN that gates everything away — the failure mode being floored."""
+    return _sessions(
+        lambda mag: np.zeros_like(mag),
+        lambda blk: np.zeros_like(blk),
+    )
+
+
+def _tone(n=4096, freq=440.0, amp=0.3):
+    t = np.arange(n, dtype=np.float32) / 16000.0
+    x = (amp * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+    return (x * 32768.0).astype(np.int16)
+
+
+def _pcm(b):
+    return np.frombuffer(b, dtype=np.int16)
+
+
+def test_passthrough_reconstructs_the_input_delayed_by_the_ola_latency():
+    """
+    The output sample written at index i is the OLDEST hop of the accumulator,
+    so it corresponds to input BLOCK_LEN - BLOCK_SHIFT earlier. If that is
+    wrong the floor blend mixes a signal against a shifted copy of itself and
+    comb-filters it, which is worse than the artefact being fixed.
+    """
+    src = _tone()
+    d = em_ns.StreamingDenoiser(sessions=_passthrough())
+    out = _pcm(d.process(src.tobytes()))
+
+    assert out.size == src.size
+    d_ = em_ns.OLA_DELAY
+    # Everything after the priming delay must be the input, sample for sample.
+    np.testing.assert_allclose(out[d_:], src[:-d_], atol=2)
+
+
+def test_a_total_gate_lands_on_the_floor_instead_of_silence():
+    src = _tone()
+    d = em_ns.StreamingDenoiser(sessions=_silencer())
+    out = _pcm(d.process(src.tobytes())).astype(np.float64)
+
+    expected = src[: -em_ns.OLA_DELAY].astype(np.float64) * (
+        10.0 ** (em_ns.NS_FLOOR_DB / 20.0)
+    )
+    got = out[em_ns.OLA_DELAY:]
+    np.testing.assert_allclose(got, expected, atol=2)
+
+    # The point of the floor: a fully-gated stream is attenuated, never
+    # zeroed. Exact zeros may only occur where the floored input rounds
+    # below one LSB.
+    audible = np.abs(expected) >= 1.0
+    assert np.count_nonzero(got[audible] == 0) == 0
+
+
+def test_the_floor_does_not_change_speech_that_the_model_passes():
+    """
+    The blend is convex, so where the model returns the input untouched the
+    output is the input — the floor must not add level to speech.
+    """
+    src = _tone()
+    d = em_ns.StreamingDenoiser(sessions=_passthrough())
+    out = _pcm(d.process(src.tobytes())).astype(np.float64)
+
+    ref = src[: -em_ns.OLA_DELAY].astype(np.float64)
+    got = out[em_ns.OLA_DELAY:]
+    rms_ref = float(np.sqrt(np.mean(ref**2)))
+    rms_got = float(np.sqrt(np.mean(got**2)))
+    assert rms_got == pytest.approx(rms_ref, rel=0.01)
+
+
+def test_frames_split_across_calls_are_carried_not_dropped():
+    """80ms frames are exactly ten hops, but nothing guarantees the caller."""
+    src = _tone(n=2048)
+    whole = em_ns.StreamingDenoiser(sessions=_passthrough())
+    ragged = em_ns.StreamingDenoiser(sessions=_passthrough())
+
+    a = _pcm(whole.process(src.tobytes()))
+    raw = src.tobytes()
+    b = b""
+    for cut in range(0, len(raw), 300):        # not a multiple of the hop
+        b += ragged.process(raw[cut:cut + 300])
+    b = _pcm(b)
+
+    n = min(a.size, b.size)
+    np.testing.assert_allclose(a[:n], b[:n], atol=2)
+
+
+def test_zero_report_separates_a_chewed_stream_from_a_silent_room():
+    src = _tone()
+
+    gated = em_ns.StreamingDenoiser(sessions=_silencer())
+    gated.process(src.tobytes())
+    assert gated.samples == src.size
+    assert gated.in_zeros / gated.samples < 0.02
+
+    silence = np.zeros(4096, dtype=np.int16)
+    quiet = em_ns.StreamingDenoiser(sessions=_passthrough())
+    quiet.process(silence.tobytes())
+    assert quiet.in_zeros == quiet.samples
+    assert "in=100.0%" in quiet.zero_report()
+
+    assert em_ns.StreamingDenoiser(sessions=_passthrough()).zero_report() == "no samples"


### PR DESCRIPTION
**The denoiser could output exact zero, and on this fleet it did** — 8–15% of samples at digital silence at a healthy level, against 0.3% with `nsAsr` off (measured in #154). That is the gate cutting into speech, not shaving noise.

Three changes.

**A suppression floor.** The output is now a convex blend of the model's estimate and the input, so suppression stops at −20dB instead of infinity. Convex is the part that matters: where the model passes speech through untouched, the blend returns the input unchanged, so speech level does not move and only fully-gated regions do. ASR accuracy flattens well before 20dB of noise reduction, so the ceiling costs nothing that was being collected.

**Delay alignment, or the fix is worse than the bug.** The hop written out at step `i` is the *oldest* hop of the overlap-add accumulator, so it corresponds to input 384 samples (24ms) earlier. Mixing against the live input would comb-filter every turn. A test reconstructs the input exactly through a pass-through stub, which can only pass if that alignment is right.

**The measurement that should have existed first.** Nothing recorded what the gate did, so "the denoiser chewed the speech" and "the room was quiet" were indistinguishable from any log — which is how #137 spent nine days on two theories one number settles. Every turn with NS active now logs output zeros *and* input zeros, and the counters survive a mid-turn NS failure.

Sessions are injectable, so this is testable without onnxruntime or the model files — neither exists outside the built image. 5 new tests, 677 pass.

### What this does not do

**It does not explain the original report in #137.** That user has `nsAsr` **off** and zero capture stalls, so their audio never reaches this code. Their case is still open and still unexplained, and the issue should not be closed on this.

**It does not touch any default.** The shipped default stays `false`. The contradiction #154 raises — stored fleet config says `true` — is a separate decision that wants the live DB read first.