### PR TITLE
forge: run control, browser credentials, dashboard theming, and a published image

### DIFF
--- a/.github/workflows/forge-release.yml
+++ b/.github/workflows/forge-release.yml
@@ -1,0 +1,239 @@
+name: Forge Release (Docker image)
+
+# Publishes the wake-word trainer as a built image, so training a custom wake
+# word does not start with a local build.
+#
+# The real reason is reproducibility rather than convenience. Every pin in
+# oww_forge/Dockerfile is load-bearing — piper-sample-generator v2.0.0 for its
+# flat layout, an openWakeWord SHA carrying a local patch, torch 2.7.1 — and a
+# local `docker compose build` re-resolves the floating layers underneath them
+# every time it runs. A published image is the only artifact that preserves
+# what was actually verified. Same argument as the controller's
+# promote-don't-rebuild flow, arrived at from the other direction.
+#
+# TWO VARIANTS, and the split is deliberate:
+#
+#   :X.Y.Z / :latest          CUDA, linux/amd64 ONLY
+#   :X.Y.Z-cpu / :latest-cpu  CPU torch, linux/amd64 + linux/arm64
+#
+# CUDA is amd64-only because there is no arm64 machine anyone would train on
+# with an NVIDIA GPU attached; building it would spend runner time producing
+# an image for hardware that does not exist.
+#
+# The CPU variant IS multi-arch, for Apple Silicon. Note what that does and
+# does not buy: Docker Desktop on macOS runs containers in a Linux VM with no
+# Metal/MPS passthrough, so training in a container on a Mac is CPU-bound
+# whatever we ship. arm64 does not unlock the GPU — it removes QEMU, which is
+# the difference between the documented overnight CPU run and something nobody
+# would sit through. Anyone wanting the M-series GPU has to run the trainer
+# outside Docker against torch's MPS backend, which is not what this ships.
+#
+# Tag prefix is `forge-v*`, kept clear of the plain `v*` firmware tags: OTA
+# release polling (em_api._fetch_latest_release) filters those for a `server`
+# asset, and the dashboard's controller notice prefix-matches `controller-v`.
+# Neither sees this one. No GitHub Release is created here, for the same
+# reason the controller creates none.
+
+on:
+  push:
+    tags:
+      - 'forge-v*'
+  # Builds WITHOUT publishing, so the workflow itself can be exercised
+  # against a branch. The expensive failure here is a tag that half-publishes.
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/echomuse-forge
+
+jobs:
+  # ── CUDA, amd64 ──────────────────────────────────────────────────────────
+  cuda:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # A hosted runner has roughly 14GB free on /, and CUDA torch does not
+      # fit in it: the wheels alone are ~3GB and the installed image lands
+      # near 10GB before the build cache. Without this the build dies partway
+      # with a disk error that reads like a broken Dockerfile. Done inline
+      # rather than with a third-party action, so nothing outside this repo
+      # gets to run as part of a publish.
+      - name: Reclaim runner disk
+        run: |
+          echo "before:"; df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost /usr/local/share/powershell \
+                      /usr/local/lib/node_modules /opt/hostedtoolcache/CodeQL \
+                      "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo docker image prune -af || true
+          echo "after:"; df -h / | tail -1
+
+      - name: Version from the tag
+        id: v
+        run: |
+          case "${GITHUB_REF_TYPE}:${GITHUB_REF_NAME}" in
+            tag:forge-v*) echo "version=${GITHUB_REF_NAME#forge-v}" >> "$GITHUB_OUTPUT"
+                          echo "publish=true"  >> "$GITHUB_OUTPUT" ;;
+            *)            echo "version=dev"   >> "$GITHUB_OUTPUT"
+                          echo "publish=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: steps.v.outputs.publish == 'true'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (CUDA, amd64)
+        uses: docker/build-push-action@v7
+        with:
+          context: oww_forge
+          file: oww_forge/Dockerfile
+          platforms: linux/amd64
+          build-args: GPU=1
+          push: ${{ steps.v.outputs.publish == 'true' }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.v.outputs.version }}
+            ${{ env.IMAGE }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.v.outputs.version }}
+            org.opencontainers.image.description=EchoMuse wake-word trainer (CUDA)
+
+  # ── CPU, one job per architecture on its OWN runner ──────────────────────
+  #
+  # Native runners rather than one QEMU job: the arm64 half is free for a
+  # public repo, and emulating a torch install is slow enough to dominate the
+  # whole workflow. Each arch pushes by DIGEST and the manifest is assembled
+  # afterwards — two jobs cannot both write the same tag without one of them
+  # winning and the other silently disappearing from the manifest.
+  cpu:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+            slug: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            slug: arm64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Version from the tag
+        id: v
+        run: |
+          case "${GITHUB_REF_TYPE}:${GITHUB_REF_NAME}" in
+            tag:forge-v*) echo "version=${GITHUB_REF_NAME#forge-v}" >> "$GITHUB_OUTPUT"
+                          echo "publish=true"  >> "$GITHUB_OUTPUT" ;;
+            *)            echo "version=dev"   >> "$GITHUB_OUTPUT"
+                          echo "publish=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: steps.v.outputs.publish == 'true'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest (CPU, ${{ matrix.slug }})
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: oww_forge
+          file: oww_forge/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: GPU=0
+          # push lives INSIDE outputs here, not as the `push:` input: setting
+          # both makes buildx take two conflicting instructions about what to
+          # do with the result. On a non-tag run this resolves to push=false,
+          # so the build still exercises the whole path without publishing.
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=${{ steps.v.outputs.publish }},name-canonical=true,push=${{ steps.v.outputs.publish }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.v.outputs.version }}
+            org.opencontainers.image.description=EchoMuse wake-word trainer (CPU)
+
+      - name: Export the digest
+        if: steps.v.outputs.publish == 'true'
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${{ matrix.slug }}-${{ steps.build.outputs.digest }}"
+
+      - name: Upload the digest
+        if: steps.v.outputs.publish == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: forge-digest-${{ matrix.slug }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  # ── One multi-arch tag from the two digests ──────────────────────────────
+  cpu-manifest:
+    needs: cpu
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download the digests
+        uses: actions/download-artifact@v7
+        with:
+          pattern: forge-digest-*
+          merge-multiple: true
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Both architectures must be present. A manifest quietly built from one
+      # digest is the failure worth catching here: it publishes, it pulls, and
+      # it is simply the wrong architecture for half the people who asked for
+      # it — which surfaces as exec format error on their machine, not ours.
+      - name: Assemble and push
+        run: |
+          version="${GITHUB_REF_NAME#forge-v}"
+          cd /tmp/digests
+          n=$(ls | wc -l)
+          if [ "$n" -ne 2 ]; then
+            echo "::error::expected 2 architecture digests, found $n: $(ls | tr '\n' ' ')"
+            exit 1
+          fi
+          refs=""
+          for f in *; do
+            refs="$refs ${IMAGE}@${f#*-}"
+          done
+          docker buildx imagetools create \
+            -t "${IMAGE}:${version}-cpu" \
+            -t "${IMAGE}:latest-cpu" \
+            $refs
+          docker buildx imagetools inspect "${IMAGE}:${version}-cpu"

--- a/oww_forge/.dockerignore
+++ b/oww_forge/.dockerignore
@@ -1,0 +1,8 @@
+# /data is the training volume — assets alone are ~25GB, and it is MOUNTED at
+# run time, never copied in. Without this the daemon is handed the whole lot
+# as build context on every local build, which reads as the build hanging
+# before it has run a single instruction.
+data/
+
+__pycache__/
+*.pyc

--- a/oww_forge/README.md
+++ b/oww_forge/README.md
@@ -46,7 +46,21 @@ The UI covers the whole flow: asset download with live progress, wake-word
 creation, build with a streaming log console, Google-TTS mix-in, wav-upload
 testing, and `.onnx` download. One job runs at a time (training saturates
 the machine anyway); state is derived from disk on every poll, so it
-survives container restarts. No auth — LAN tool.
+survives container restarts. Light and dark follow the dashboard, sharing
+its `em-theme` setting. No auth — LAN tool.
+
+A run can be **stopped** from the console bar, its settings changed under
+*training settings*, and started again. Stopping keeps everything already
+produced: clip generation is resumable and both later steps check what
+exists, so the loop is stop, adjust, train again rather than start over. The
+stop kills the whole process group, because `forge.py` is only the parent —
+openWakeWord's `train.py` underneath it is what holds the GPU, and killing
+the parent alone leaves that running behind a UI that says it stopped.
+
+Note the credentials endpoint writes a Google service-account key, and there
+is no auth in front of it. That is the same trust model as everything else
+here (the UI can already delete training data and run arbitrary jobs), but
+it is a secret at rest now, so keep the port on the LAN.
 
 ## Quickstart — CLI
 
@@ -158,8 +172,19 @@ dirs — the subsequent piper generation counts them toward `n_samples`, so
 you get a mixed-family training set at no extra training cost. Piper remains
 the volume source; Google adds acoustic character a single TTS family can't.
 
-Setup: create a GCP service account with the Text-to-Speech API enabled, save
-the JSON key as `./data/google-credentials.json`. **Usually free**: the API's
+Setup, from the web UI: **Google voices** on the left, then upload (or paste)
+the JSON key and press **Test connection**. The key is written to
+`./data/google-credentials.json` with mode 600 and picked up by the next job
+with no container restart, so the compose mapping is no longer something you
+have to arrange yourself. Test connection is worth pressing: the usual
+failure is a perfectly valid key on a project where the Text-to-Speech API
+was never enabled, and nothing local can see that.
+
+Setup, by hand: create a GCP service account with the Text-to-Speech API
+enabled, save the JSON key as `./data/google-credentials.json`. Note this
+must be a **service account** key, not an OAuth client secret — the UI
+rejects the latter, but the CLI will only fail later, inside a job.
+**Usually free**: the API's
 always-free tier covers ~1M premium-voice characters/month and a 2,000-clip
 wake-word run is ~25k characters (~2% of it). Past the free tier it's ~$16/1M
 chars; the command prints an estimate and asks before running.

--- a/oww_forge/README.md
+++ b/oww_forge/README.md
@@ -62,7 +62,34 @@ is no auth in front of it. That is the same trust model as everything else
 here (the UI can already delete training data and run arbitrary jobs), but
 it is a secret at rest now, so keep the port on the LAN.
 
-## Quickstart — CLI
+## Quickstart — published image
+
+```bash
+cd oww_forge
+docker compose -f docker-compose.deploy.yml up -d forge-ui   # http://<host>:8769
+```
+
+Two images, and picking the wrong one costs a night:
+
+| tag | torch | platforms | for |
+|-----|-------|-----------|-----|
+| `:latest` | CUDA 12.8 | linux/amd64 | a machine with an NVIDIA GPU |
+| `:latest-cpu` | CPU | linux/amd64, linux/arm64 | everything else, including Apple Silicon |
+
+On Apple Silicon use `-cpu` and the `forge-ui-cpu` / `forge-cpu` services. The
+arm64 image runs natively instead of under emulation, which is the difference
+between the overnight CPU run described below and one nobody would sit
+through. It is **still CPU training**: Docker on macOS runs containers in a
+Linux VM with no Metal passthrough, so there is no GPU in there to reach. Using
+the M-series GPU means running the trainer outside Docker against torch's MPS
+backend, which is not what this ships.
+
+Prefer the published image unless you are changing the trainer itself. Every
+pin in the Dockerfile is load-bearing, and a local build re-resolves the
+floating layers underneath them on every run; the published image is the only
+artifact that preserves what was actually verified.
+
+## Quickstart — local build
 
 ```bash
 cd oww_forge

--- a/oww_forge/docker-compose.deploy.yml
+++ b/oww_forge/docker-compose.deploy.yml
@@ -1,0 +1,71 @@
+## oww_forge, pulling the published image instead of building it.
+##
+##   docker compose -f docker-compose.deploy.yml up -d forge-ui
+##   docker compose -f docker-compose.deploy.yml run --rm forge new "hey biscuit"
+##
+## Use this unless you are changing the trainer itself; docker-compose.yml is
+## the local build. The published image is also the only artifact that pins
+## what was verified — a local build re-resolves the floating layers under
+## piper-sample-generator and openWakeWord every time it runs.
+##
+## TWO IMAGES, and picking the wrong one costs you a night:
+##
+##   :latest       CUDA, linux/amd64 only. What you want with an NVIDIA GPU.
+##   :latest-cpu   CPU torch, linux/amd64 + linux/arm64.
+##
+## On Apple Silicon use `-cpu` and the `forge-cpu` service. The arm64 image
+## runs natively rather than under emulation, which is the difference between
+## an overnight run and an unusable one — but it is still CPU training, because
+## Docker on macOS cannot reach Metal. There is no GPU to reserve.
+
+x-forge-base: &forge-base
+  # torch DataLoader workers pass tensors via /dev/shm; Docker's 64MB default
+  # kills them with bus errors during the training step
+  shm_size: "8gb"
+  volumes:
+    # Assets (~25GB), per-wake-word workdirs, and finished models.
+    # Point this at a disk with room.
+    - ./data:/data
+
+x-gpu: &gpu
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - driver: nvidia
+            count: 1
+            capabilities: [gpu]
+
+services:
+  # web frontend (long-running); training jobs spawn inside this container
+  forge-ui:
+    <<: [*forge-base, *gpu]
+    image: ghcr.io/wilbowes/echomuse-forge:latest
+    container_name: oww-forge-ui
+    command: ["ui"]
+    ports:
+      - "8769:8769"
+    restart: unless-stopped
+
+  # same, for a host with no NVIDIA runtime — including Apple Silicon
+  forge-ui-cpu:
+    <<: *forge-base
+    image: ghcr.io/wilbowes/echomuse-forge:latest-cpu
+    container_name: oww-forge-ui
+    command: ["ui"]
+    ports:
+      - "8769:8769"
+    restart: unless-stopped
+    profiles: ["cpu"]
+
+  # one-shot CLI with GPU
+  forge:
+    <<: [*forge-base, *gpu]
+    image: ghcr.io/wilbowes/echomuse-forge:latest
+    profiles: ["cli"]
+
+  # one-shot CLI, no GPU reservation
+  forge-cpu:
+    <<: *forge-base
+    image: ghcr.io/wilbowes/echomuse-forge:latest-cpu
+    profiles: ["cli"]

--- a/oww_forge/forge_web.py
+++ b/oww_forge/forge_web.py
@@ -9,7 +9,10 @@ No auth: this is a LAN batch tool, same trust model as `docker compose run`.
 """
 
 import json
+import os
+import re
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -28,6 +31,28 @@ STATIC = Path(__file__).parent / "static"
 
 FORGE_PY = str(Path(__file__).parent / "forge.py")
 
+# Where a service-account key lands when it is uploaded through the UI. The
+# same path docker-compose.yml maps GOOGLE_APPLICATION_CREDENTIALS to, so
+# the two routes cannot disagree about which file is in force.
+GOOGLE_CREDS = forge.DATA / "google-credentials.json"
+
+# How long a cancelled job gets to exit on its own before it is killed.
+CANCEL_GRACE_S = 10.0
+
+
+def _job_env() -> dict:
+    """
+    Environment for a forge.py subprocess. GOOGLE_APPLICATION_CREDENTIALS is
+    set from the file on disk rather than inherited, so a key uploaded after
+    the container started is picked up by the next job with no restart.
+    """
+    env = dict(os.environ)
+    if GOOGLE_CREDS.exists():
+        env["GOOGLE_APPLICATION_CREDENTIALS"] = str(GOOGLE_CREDS)
+    else:
+        env.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+    return env
+
 
 class Job:
     def __init__(self, kind: str, label: str, argv: list):
@@ -35,13 +60,21 @@ class Job:
         self.label = label
         self.started = time.time()
         self.rc = None
+        self.cancelled = False
         LOGS.mkdir(parents=True, exist_ok=True)
         self.log_path = LOGS / f"{int(self.started)}_{kind}.log"
         self._logf = open(self.log_path, "wb", buffering=0)
+        # Its own process group. forge.py is a PARENT: build spawns
+        # openWakeWord's train.py, which is what actually holds the GPU and
+        # does the work. Killing only forge.py would orphan that, leaving a
+        # run that the UI says is stopped still saturating the machine and
+        # still writing to the wake word's directory.
         self.proc = subprocess.Popen(
             [sys.executable, "-u", FORGE_PY, *argv],
             stdout=self._logf,
             stderr=subprocess.STDOUT,
+            env=_job_env(),
+            start_new_session=True,
         )
 
     def poll(self):
@@ -52,6 +85,42 @@ class Job:
                 self._logf.close()
         return self.rc
 
+    def cancel(self) -> None:
+        """SIGTERM the group, then SIGKILL whatever is left."""
+        if self.poll() is not None:
+            return
+        self.cancelled = True
+        try:
+            pgid = os.getpgid(self.proc.pid)
+        except ProcessLookupError:
+            return
+        self._note(f"\n[forge-ui] cancelled by request — stopping (SIGTERM)\n")
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        deadline = time.time() + CANCEL_GRACE_S
+        while time.time() < deadline:
+            if self.proc.poll() is not None:
+                break
+            time.sleep(0.2)
+        if self.proc.poll() is None:
+            self._note("[forge-ui] still running after "
+                       f"{CANCEL_GRACE_S:.0f}s — SIGKILL\n")
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        self.poll()
+
+    def _note(self, line: str) -> None:
+        """Write to the job's own log, so the console shows what happened."""
+        try:
+            if not self._logf.closed:
+                self._logf.write(line.encode())
+        except Exception:
+            pass
+
     def as_dict(self):
         self.poll()
         return {
@@ -59,6 +128,7 @@ class Job:
             "label": self.label,
             "running": self.rc is None,
             "rc": self.rc,
+            "cancelled": self.cancelled,
             "started": self.started,
         }
 
@@ -137,7 +207,9 @@ def _wakewords_state() -> list:
             "name": name,
             "phrases": cfg.get("target_phrase", []),
             "n_samples": cfg.get("n_samples"),
+            "n_samples_val": cfg.get("n_samples_val"),
             "steps": cfg.get("steps"),
+            "custom_negative_phrases": cfg.get("custom_negative_phrases") or [],
             "clips_train": _count(work / "positive_train"),
             "clips_test": _count(work / "positive_test"),
             "features_built": (work / "positive_features_train.npy").exists(),
@@ -151,6 +223,7 @@ def _wakewords_state() -> list:
 async def api_state(request):
     return web.json_response({
         "gpu": _gpu(),
+        "google": _google_state(),
         "assets": _assets_state(),
         "wakewords": _wakewords_state(),
         "job": _job.as_dict() if _job else None,
@@ -283,6 +356,215 @@ async def api_google_tts(request):
     return web.json_response({"ok": True})
 
 
+async def api_job_cancel(request):
+    """
+    Stop the running job. Partial work is KEPT: clip generation is resumable
+    and augment/train both check what already exists, so the point of
+    stopping is usually to change a parameter and pick up where it left off
+    rather than to throw the run away.
+    """
+    if _job is None or _job.poll() is not None:
+        raise web.HTTPConflict(text="no job is running")
+    label = _job.label
+    _job.cancel()
+    return web.json_response({"ok": True, "cancelled": label})
+
+
+# ---------------------------------------------------------------- google
+
+def _google_state() -> dict:
+    """
+    What is on disk, never the key itself. The private key is the whole
+    secret and there is no reason for it to travel back to a browser.
+    """
+    if not GOOGLE_CREDS.exists():
+        return {"present": False}
+    try:
+        blob = json.loads(GOOGLE_CREDS.read_text())
+    except Exception as e:
+        return {"present": True, "valid": False, "error": f"not readable as JSON: {e}"}
+    return {
+        "present": True,
+        "valid": True,
+        "project_id": blob.get("project_id"),
+        "client_email": blob.get("client_email"),
+    }
+
+
+def _validate_service_account(raw: bytes) -> dict:
+    """
+    Reject anything that is not a service-account key BEFORE it is written.
+    An OAuth client secret is the file people reach for first and it looks
+    close enough to pass a glance; it fails much later, inside a training
+    job, as an authentication error with nothing pointing back at the
+    upload.
+    """
+    try:
+        blob = json.loads(raw.decode("utf-8"))
+    except Exception as e:
+        raise web.HTTPBadRequest(text=f"not valid JSON: {e}")
+    if not isinstance(blob, dict):
+        raise web.HTTPBadRequest(text="expected a JSON object")
+    if blob.get("type") != "service_account":
+        got = blob.get("type") or ("an OAuth client secret" if "installed" in blob
+                                   or "web" in blob else "unrecognised")
+        raise web.HTTPBadRequest(
+            text=f"this is {got}, not a service-account key. In the Google Cloud "
+                 "console: IAM & Admin, Service Accounts, Keys, Add key, JSON."
+        )
+    missing = [k for k in ("project_id", "client_email", "private_key") if not blob.get(k)]
+    if missing:
+        raise web.HTTPBadRequest(text=f"service-account key is missing: {', '.join(missing)}")
+    return blob
+
+
+async def api_google_get(request):
+    return web.json_response(_google_state())
+
+
+async def api_google_put(request):
+    """Accepts the key as a file upload or as a pasted JSON body."""
+    raw = b""
+    if request.content_type and "multipart" in request.content_type:
+        reader = await request.multipart()
+        async for field in reader:
+            if field.name in ("credentials", "file"):
+                while chunk := await field.read_chunk():
+                    raw += chunk
+                break
+    else:
+        raw = await request.read()
+    if not raw.strip():
+        raise web.HTTPBadRequest(text="no credentials supplied")
+
+    _validate_service_account(raw)
+    GOOGLE_CREDS.parent.mkdir(parents=True, exist_ok=True)
+    # Written through a temp file with the restrictive mode set BEFORE any
+    # content lands in it, so the key is never briefly world-readable.
+    tmp = GOOGLE_CREDS.with_suffix(".part")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(raw)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+    tmp.replace(GOOGLE_CREDS)
+    os.chmod(GOOGLE_CREDS, 0o600)
+    return web.json_response(_google_state())
+
+
+async def api_google_delete(request):
+    GOOGLE_CREDS.unlink(missing_ok=True)
+    return web.json_response({"ok": True, "present": False})
+
+
+async def api_google_check(request):
+    """
+    Ask Google to list voices. This is the only thing that distinguishes a
+    well-formed key from a WORKING one: the usual failure is a valid key on
+    a project where the Text-to-Speech API was never enabled, which no
+    amount of local validation can see.
+    """
+    if not GOOGLE_CREDS.exists():
+        raise web.HTTPBadRequest(text="no credentials uploaded")
+    probe = (
+        "import json\n"
+        "from google.cloud import texttospeech as t\n"
+        "vs = t.TextToSpeechClient().list_voices().voices\n"
+        "langs = sorted({c for v in vs for c in v.language_codes})\n"
+        "print(json.dumps({'voices': len(vs), 'languages': len(langs)}))\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True, text=True, timeout=60, env=_job_env(),
+    )
+    if out.returncode != 0:
+        tail = (out.stderr or out.stdout).strip().splitlines()
+        return web.json_response(
+            {"ok": False, "error": tail[-1] if tail else "unknown error"}, status=200)
+    try:
+        info = json.loads(out.stdout.strip().splitlines()[-1])
+    except Exception:
+        return web.json_response({"ok": False, "error": out.stdout.strip()[:300]})
+    return web.json_response({"ok": True, **info, **_google_state()})
+
+
+# ---------------------------------------------------------------- config
+
+# Only the knobs worth turning between runs. target_phrase is deliberately
+# NOT here: changing it invalidates every clip already generated for this
+# wake word, which is a new wake word rather than an edited one.
+EDITABLE_INTS = {
+    "n_samples": (100, 2_000_000),
+    "n_samples_val": (10, 200_000),
+    "steps": (100, 5_000_000),
+}
+
+
+def _patch_config(text: str, ints: dict, negatives) -> str:
+    for key, value in ints.items():
+        text, n = re.subn(rf"(?m)^{re.escape(key)}:[ \t]*\S+[ \t]*$",
+                          f"{key}: {value}", text)
+        if n != 1:
+            raise web.HTTPConflict(
+                text=f"could not find a unique '{key}:' line to update")
+    if negatives is not None:
+        block = ("custom_negative_phrases: []" if not negatives else
+                 "custom_negative_phrases:\n" +
+                 "\n".join(f'  - "{p}"' for p in negatives))
+        # Matches both the empty inline form and a previously written block,
+        # stopping at the next top-level key.
+        text, n = re.subn(
+            r"(?ms)^custom_negative_phrases:.*?(?=^\S)", block + "\n\n", text)
+        if n != 1:
+            raise web.HTTPConflict(
+                text="could not find the custom_negative_phrases block to update")
+    return text
+
+
+async def api_wakeword_patch(request):
+    """
+    Change training parameters on an existing wake word. Edits the lines in
+    place rather than round-tripping the YAML, because the template's
+    comments explain every field and a dump would silently delete them.
+    """
+    name = request.match_info["name"]
+    _require_wakeword(name)
+    if _job and _job.poll() is None:
+        raise web.HTTPConflict(
+            text=f"stop the running job first: {_job.label}")
+    body = await request.json()
+
+    ints = {}
+    for key, (lo, hi) in EDITABLE_INTS.items():
+        if body.get(key) in (None, ""):
+            continue
+        try:
+            value = int(body[key])
+        except (TypeError, ValueError):
+            raise web.HTTPBadRequest(text=f"{key} must be a whole number")
+        if not lo <= value <= hi:
+            raise web.HTTPBadRequest(text=f"{key} must be between {lo} and {hi}")
+        ints[key] = value
+
+    negatives = body.get("custom_negative_phrases")
+    if negatives is not None:
+        if isinstance(negatives, str):
+            negatives = [p.strip() for p in negatives.split(",")]
+        negatives = [p.strip().lower() for p in negatives if p and p.strip()]
+
+    if not ints and negatives is None:
+        raise web.HTTPBadRequest(text="nothing to change")
+
+    cfg_path = forge.WAKEWORDS / name / "config.yml"
+    updated = _patch_config(cfg_path.read_text(), ints, negatives)
+    yaml.safe_load(updated)   # never leave a config the trainer cannot read
+    cfg_path.write_text(updated)
+    return web.json_response({"ok": True, "changed": {**ints, **(
+        {"custom_negative_phrases": negatives} if negatives is not None else {})}})
+
+
 async def api_test(request):
     name = request.match_info["name"]
     if not (forge.MODELS / f"{name}.onnx").exists():
@@ -339,7 +621,13 @@ def make_app() -> web.Application:
     app.router.add_get("/api/state", api_state)
     app.router.add_get("/api/log", api_log)
     app.router.add_post("/api/assets/download", api_assets_download)
+    app.router.add_post("/api/job/cancel", api_job_cancel)
+    app.router.add_get("/api/google", api_google_get)
+    app.router.add_put("/api/google", api_google_put)
+    app.router.add_post("/api/google/check", api_google_check)
+    app.router.add_delete("/api/google", api_google_delete)
     app.router.add_post("/api/wakewords", api_wakeword_create)
+    app.router.add_patch("/api/wakewords/{name}", api_wakeword_patch)
     app.router.add_post("/api/wakewords/{name}/build", api_build)
     app.router.add_post("/api/wakewords/{name}/google-tts", api_google_tts)
     app.router.add_post("/api/wakewords/{name}/test", api_test)

--- a/oww_forge/static/index.html
+++ b/oww_forge/static/index.html
@@ -6,30 +6,140 @@
 <title>EchoMuse — Wake Word Forge</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<script>
+  /* Applied before first paint, deliberately: the theme cannot be set from
+     the script at the end of the body without a dark-mode user seeing a
+     full flash of the light page on every load. Defaults to the OS
+     preference until a choice is made; the choice then wins permanently.
+     Same key as the dashboard ('em-theme'), so one pick covers both. */
+  (function () {
+    try {
+      var saved = localStorage.getItem('em-theme');
+      var theme = saved || (window.matchMedia &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+    } catch (e) {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
 <style>
   /* EchoMuse dashboard design language: warm greige appliance chassis,
-     gradient key-cap buttons, DM Sans/Mono, LCD console panels. */
-  :root {
-    --bg:        #ccc8c0;
-    --surface:   #d8d4cc;
+     gradient key-cap buttons, DM Sans/Mono, LCD console panels.
+
+     The token names and values are the DASHBOARD's, copied rather than
+     invented, so the two surfaces cannot drift into two slightly different
+     warm greys. Dark is not an inversion: it is the same hue family taken
+     down past the LCD, and the inset dark regions (the log console) stay
+     dark in both themes because they read as a lit panel set into the
+     surface. See controller/CLAUDE.md, "Dashboard styling and theming". */
+  :root, :root[data-theme="light"] {
+    --raised:    #e8e4de;
     --card:      #e0dcd4;
-    --border:    #b8b4ac;
+    --surface:   #d8d4cc;
+    --sunken:    #d0ccc4;
+    --bg:        #ccc8c0;
+    --chassis:   #b8b4ac;
+
+    --border:      #b8b4ac;
+    --border-soft: #c0bdb6;
+    --border-hard: #b0aca4;
+
+    --text:   #1e1c18;
+    --text2:  #4a4844;
+    --muted:  #8a8680;
+    --faint:  #a8a49c;
+
+    --ok:     #286040;
+    --warn:   #c0601a;
+    --error:  #9a3020;
+
+    --accent:      #405878;
+    --accent-hi:   #6080a8;
+    --accent-deep: #304860;
+    --accent-tint: #dde8f4;
+    --on-accent:   #dde8f0;
+
     --lcd-bg:    #1e2219;
     --lcd-green: #9aba80;
+    --lcd-amber: #c8a040;
     --lcd-text:  #c8d4b0;
     --lcd-dim:   #7a9a68;
-    --text:      #1e1c18;
-    --text2:     #4a4844;
-    --muted:     #8a8680;
-    --ok:        #286040;
-    --warn:      #c0601a;
-    --err:       #b03030;
-    --accent:    #405878;
+    --lcd-line:  #1a1c18;
+
+    --key-top:    #d8d4cc;
+    --key-bottom: #c0bdb6;
+    --key-edge:   #a8a49c;
+    --key-face:   #2a2822;
+    --field:      #f0ece4;
+
+    --shadow-card: 0 2px 6px rgba(0,0,0,0.08), 0 1px 0 rgba(255,255,255,0.6) inset;
+    --shadow-key:  0 2px 4px rgba(0,0,0,0.2), 0 1px 0 rgba(255,255,255,0.15) inset;
+    --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.08);
+    --hairline:    rgba(0,0,0,0.07);
+    --tint-ok:     rgba(40,96,64,0.12);
+    --tint-ok-line: rgba(40,96,64,0.3);
+    --tint-err:    rgba(154,48,32,0.09);
+    --tint-err-line: rgba(154,48,32,0.25);
+    --tint-accent: rgba(64,88,120,0.1);
+    --tint-accent-line: rgba(64,88,120,0.25);
+  }
+
+  :root[data-theme="dark"] {
+    --raised:    #2b3024;
+    --card:      #22261c;
+    --surface:   #1b1e16;
+    --sunken:    #171a12;
+    --bg:        #14160f;
+    --chassis:   #0e100a;
+
+    --border:      #343a2b;
+    --border-soft: #2c3124;
+    --border-hard: #414736;
+
+    --text:   #ddd9d1;
+    --text2:  #b2ada4;
+    --muted:  #83807a;
+    --faint:  #6d6a64;
+
+    --ok:     #6fa877;
+    --warn:   #d08a3a;
+    --error:  #cf7a68;
+
+    --accent:      #7397bd;
+    --accent-hi:   #8fb0d0;
+    --accent-deep: #4a6a8c;
+    --accent-tint: #1f2c3a;
+    --on-accent:   #101820;
+
+    --lcd-bg:    #12150e;
+    --lcd-green: #9aba80;
+    --lcd-amber: #c8a040;
+    --lcd-text:  #c8d4b0;
+    --lcd-dim:   #7a9a68;
+    --lcd-line:  #0c0e08;
+
+    --key-top:    #2f3427;
+    --key-bottom: #23271c;
+    --key-edge:   #414736;
+    --key-face:   #ddd9d1;
+    --field:      #11130c;
+
+    --shadow-card: 0 4px 16px rgba(0,0,0,0.45), 0 1px 0 rgba(255,255,255,0.05) inset;
+    --shadow-key:  0 2px 4px rgba(0,0,0,0.5), 0 1px 0 rgba(255,255,255,0.05) inset;
+    --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.5);
+    --hairline:    rgba(255,255,255,0.07);
+    --tint-ok:     rgba(111,168,119,0.14);
+    --tint-ok-line: rgba(111,168,119,0.35);
+    --tint-err:    rgba(207,122,104,0.13);
+    --tint-err-line: rgba(207,122,104,0.3);
+    --tint-accent: rgba(115,151,189,0.14);
+    --tint-accent-line: rgba(115,151,189,0.3);
   }
   * { box-sizing: border-box; margin: 0; }
   html, body { min-height: 100%; }
   body {
-    background: linear-gradient(160deg, var(--bg) 0%, #b8b4ac 100%);
+    background: linear-gradient(160deg, var(--bg) 0%, var(--chassis) 100%);
     color: var(--text); font: 400 14px/1.5 'DM Sans', sans-serif;
   }
   .mono { font-family: 'DM Mono', monospace; }
@@ -40,7 +150,7 @@
   header {
     display: flex; align-items: center; gap: 14px; padding: 16px 28px;
     border-bottom: 1px solid var(--border);
-    background: linear-gradient(180deg, #d8d4cc, #ccc8c0);
+    background: linear-gradient(180deg, var(--surface), var(--bg));
   }
   header h1 { font-size: 17px; font-weight: 600; letter-spacing: 0.02em; }
   header .sub { font-family: 'DM Mono', monospace; font-size: 10px; color: var(--muted);
@@ -49,42 +159,42 @@
     margin-left: auto; display: inline-flex; align-items: center; gap: 7px;
     font-family: 'DM Mono', monospace; font-size: 10px; letter-spacing: 0.06em;
     color: var(--text2); padding: 5px 12px; border-radius: 14px;
-    border: 1px solid var(--border); background: linear-gradient(180deg,#e4e0d8,#d4d0c8);
+    border: 1px solid var(--border); background: linear-gradient(180deg,var(--raised),var(--sunken));
   }
   .pill .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--muted); }
-  .pill.on .dot { background: #40906a; box-shadow: 0 0 5px #40906a; }
+  .pill.on .dot { background: var(--ok); box-shadow: 0 0 5px var(--ok); }
 
   main { max-width: 1180px; margin: 0 auto; padding: 22px 28px 120px;
          display: grid; grid-template-columns: 330px 1fr; gap: 20px; }
   @media (max-width: 900px) { main { grid-template-columns: 1fr; } }
 
   .card {
-    background: linear-gradient(170deg,#e4e0d8,#dad6ce);
+    background: linear-gradient(170deg,var(--raised),var(--card));
     border: 1px solid var(--border); border-radius: 10px;
     padding: 16px 18px; margin-bottom: 18px;
-    box-shadow: 0 1px 0 rgba(255,255,255,0.6) inset, 0 2px 6px rgba(0,0,0,0.08);
+    box-shadow: var(--shadow-card);
   }
 
   button {
-    background: linear-gradient(180deg,#d8d4cc,#c0bdb6); color: #2a2822;
-    border: 1px solid #a8a49c; border-radius: 20px;
+    background: linear-gradient(180deg,var(--key-top),var(--key-bottom)); color: var(--key-face);
+    border: 1px solid var(--key-edge); border-radius: 20px;
     font: 500 12px 'DM Sans', sans-serif; padding: 7px 18px; cursor: pointer;
-    box-shadow: 0 1px 0 rgba(255,255,255,0.15) inset, 0 2px 4px rgba(0,0,0,0.2);
+    box-shadow: var(--shadow-key);
     transition: all 0.1s; white-space: nowrap;
   }
   button:active:not(:disabled) { transform: translateY(1px); box-shadow: 0 1px 2px rgba(0,0,0,0.2); }
-  button:disabled { background: linear-gradient(180deg,#d0ccc4,#bab6ae); color: #8a8680;
-                    border-color: #aca8a0; box-shadow: none; cursor: not-allowed; }
-  button.accent { background: linear-gradient(180deg,#6080a8,#405878); color: #dde8f0;
-                  border-color: #304860; }
-  button.danger { background: none; border: none; box-shadow: none; color: var(--err);
+  button:disabled { background: var(--sunken); color: var(--faint);
+                    border-color: var(--border-soft); box-shadow: none; cursor: not-allowed; }
+  button.accent { background: linear-gradient(180deg,var(--accent-hi),var(--accent)); color: var(--on-accent);
+                  border-color: var(--accent-deep); }
+  button.danger { background: none; border: none; box-shadow: none; color: var(--error);
                   font-size: 11px; padding: 5px 8px; }
   button.small { font-size: 11px; padding: 5px 14px; }
 
   input {
-    background: #f0ece4; color: var(--text); border: 1px solid var(--border);
+    background: var(--field); color: var(--text); border: 1px solid var(--border);
     border-radius: 7px; padding: 8px 11px; font: 400 13px 'DM Sans', sans-serif;
-    width: 100%; box-shadow: inset 0 1px 3px rgba(0,0,0,0.08);
+    width: 100%; box-shadow: var(--shadow-inset);
   }
   label { font-family: 'DM Mono', monospace; font-size: 10px; color: var(--text2);
           text-transform: uppercase; letter-spacing: 0.08em; display: block; margin: 12px 0 5px; }
@@ -95,12 +205,12 @@
 
   /* asset checklist */
   .asset { display: flex; align-items: center; gap: 10px; padding: 7px 0;
-           border-bottom: 1px solid rgba(0,0,0,0.07); font-size: 13px; }
+           border-bottom: 1px solid var(--hairline); font-size: 13px; }
   .asset:last-child { border-bottom: 0; }
   .asset .detail { margin-left: auto; font-family: 'DM Mono', monospace; font-size: 10px;
                    color: var(--muted); }
-  .dot { width: 8px; height: 8px; border-radius: 50%; background: #c0601a; flex: none; }
-  .dot.on { background: #40906a; }
+  .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--warn); flex: none; }
+  .dot.on { background: var(--ok); }
 
   /* wake word cards */
   .ww .top { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
@@ -112,15 +222,15 @@
   .stepper { display: flex; align-items: center; margin: 14px 2px 16px; }
   .step { display: flex; flex-direction: column; align-items: center; gap: 5px; flex: none; width: 92px; }
   .step .bub { width: 14px; height: 14px; border-radius: 50%; border: 2px solid var(--border);
-               background: #d4d0c8; }
-  .step.done .bub { background: #40906a; border-color: #286040; }
-  .step.active .bub { background: #c8a040; border-color: #806010; animation: pulse 1.2s ease-in-out infinite; }
-  @keyframes pulse { 50% { box-shadow: 0 0 0 4px rgba(200,160,64,0.25); } }
+               background: var(--sunken); }
+  .step.done .bub { background: var(--ok); border-color: var(--ok); }
+  .step.active .bub { background: var(--lcd-amber); border-color: var(--warn); animation: pulse 1.2s ease-in-out infinite; }
+  @keyframes pulse { 50% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--lcd-amber) 25%, transparent); } }
   .step span { font-family: 'DM Mono', monospace; font-size: 8.5px; text-transform: uppercase;
                letter-spacing: 0.08em; color: var(--muted); text-align: center; }
   .step.done span, .step.active span { color: var(--text2); }
   .conn { flex: 1; height: 2px; background: var(--border); margin: 0 2px 18px; min-width: 8px; }
-  .conn.done { background: #40906a; }
+  .conn.done { background: var(--ok); }
 
   .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
   .actiongroup { margin-top: 10px; }
@@ -128,29 +238,45 @@
   /* results / verdicts */
   .verdict { display: flex; align-items: center; gap: 9px; margin-top: 12px; padding: 10px 13px;
              border-radius: 8px; font-weight: 500; font-size: 13px; }
-  .verdict.ok { background: rgba(40,96,64,0.12); color: var(--ok); border: 1px solid rgba(40,96,64,0.3); }
-  .verdict.no { background: rgba(176,48,48,0.09); color: var(--err); border: 1px solid rgba(176,48,48,0.25); }
-  .verdict.info { background: rgba(64,88,120,0.1); color: var(--accent); border: 1px solid rgba(64,88,120,0.25); }
+  .verdict.ok { background: var(--tint-ok); color: var(--ok); border: 1px solid var(--tint-ok-line); }
+  .verdict.no { background: var(--tint-err); color: var(--error); border: 1px solid var(--tint-err-line); }
+  .verdict.info { background: var(--tint-accent); color: var(--accent); border: 1px solid var(--tint-accent-line); }
   .rawout { font-family: 'DM Mono', monospace; font-size: 10px; color: var(--muted);
             margin-top: 7px; white-space: pre-wrap; }
 
   /* LCD console */
   #console { position: fixed; left: 0; right: 0; bottom: 0; padding: 10px 28px 14px;
-             background: linear-gradient(180deg, rgba(204,200,192,0), #bab6ae 30%); }
+             background: linear-gradient(180deg, transparent, var(--chassis) 30%); }
   #console .inner { max-width: 1124px; margin: 0 auto; }
   #console .bar { display: flex; gap: 12px; align-items: center; padding: 5px 4px; }
   #console .bar strong { font-size: 12.5px; font-weight: 600; }
   #console pre {
-    background: var(--lcd-bg); color: var(--lcd-text); border: 1px solid #1a1c16;
+    background: var(--lcd-bg); color: var(--lcd-text); border: 1px solid var(--lcd-line);
     border-radius: 6px; box-shadow: inset 0 2px 6px rgba(0,0,0,0.6);
     padding: 10px 13px; height: 150px; overflow-y: auto;
     font: 400 11px/1.6 'DM Mono', monospace; white-space: pre-wrap;
   }
   #console.min pre { display: none; }
   .status { font-family: 'DM Mono', monospace; font-size: 10.5px; letter-spacing: 0.04em; }
-  .status.running { color: #806010; } .status.ok { color: var(--ok); } .status.fail { color: var(--err); }
+  .status.running { color: var(--warn); } .status.ok { color: var(--ok); } .status.fail { color: var(--error); }
   #toggleLog { margin-left: auto; }
   .empty { color: var(--muted); font-size: 13px; line-height: 1.6; }
+
+  /* theme toggle */
+  .iconbtn { border-radius: 50%; width: 30px; height: 30px; padding: 0;
+             display: inline-flex; align-items: center; justify-content: center;
+             font-size: 13px; line-height: 1; }
+
+  /* google credentials */
+  .kv { display: flex; gap: 10px; font-size: 12px; padding: 3px 0; }
+  .kv .k { font-family: 'DM Mono', monospace; font-size: 10px; color: var(--muted);
+           text-transform: uppercase; letter-spacing: 0.08em; min-width: 62px; }
+  .kv .v { color: var(--text2); word-break: break-all; }
+  textarea {
+    background: var(--field); color: var(--text); border: 1px solid var(--border);
+    border-radius: 7px; padding: 8px 11px; font: 400 11px/1.5 'DM Mono', monospace;
+    width: 100%; min-height: 90px; box-shadow: var(--shadow-inset); resize: vertical;
+  }
 </style>
 </head>
 <body>
@@ -160,6 +286,7 @@
     <div class="sub">EchoMuse &middot; custom wake words</div>
   </div>
   <span class="pill" id="gpuBadge"><span class="dot"></span><span id="gpuText">connecting…</span></span>
+  <button class="iconbtn" id="themeBtn" title="Light / dark">◐</button>
 </header>
 
 <main>
@@ -194,6 +321,31 @@
         <button class="accent" id="createBtn">Create</button>
       </div>
     </div>
+
+    <div class="card">
+      <div class="microlabel">Optional &middot; Google voices</div>
+      <div id="googleState"></div>
+      <div id="googleSetup" style="display:none">
+        <div class="hint" style="margin-top:0">Adds British, Australian and US synthetic
+          voices on top of the built-in ones. Needs a Google Cloud
+          <strong>service account</strong> with the Text-to-Speech API enabled: in the
+          console, IAM &amp; Admin &rarr; Service Accounts &rarr; Keys &rarr; Add key &rarr; JSON.</div>
+        <label>Key file</label>
+        <input type="file" id="gFile" accept="application/json,.json">
+        <details>
+          <summary>or paste it</summary>
+          <textarea id="gPaste" placeholder='{ "type": "service_account", … }'></textarea>
+        </details>
+        <div class="row" style="margin-top:12px">
+          <button class="accent small" id="gSave">Save key</button>
+        </div>
+      </div>
+      <div class="row" id="googleActions" style="margin-top:12px; display:none">
+        <button class="small" id="gCheck">Test connection</button>
+        <button class="danger" id="gRemove" style="margin-left:auto">remove key</button>
+      </div>
+      <div class="verdict" id="gVerdict" style="display:none"></div>
+    </div>
   </section>
 
   <section>
@@ -207,6 +359,7 @@
     <div class="bar">
       <strong id="jobLabel"></strong>
       <span class="status" id="jobStatus"></span>
+      <button id="cancelJob" class="small" style="display:none">Stop</button>
       <button id="toggleLog" class="small">show log</button>
     </div>
     <pre id="logPre"></pre>
@@ -215,7 +368,7 @@
 
 <script>
 const $ = id => document.getElementById(id);
-let state = null, logOffset = 0, lastJobKey = null;
+let state = null, logOffset = 0, lastJobKey = null, lastWwHtml = null;
 
 async function api(path, opts) {
   const r = await fetch(path, opts);
@@ -258,8 +411,10 @@ function render() {
   $('dlAll').textContent = missing.length ? 'Download voice data' : '✓ Downloaded';
   $('dlAll').className = missing.length ? 'accent' : '';
 
+  renderGoogle();
+
   // wake words
-  $('wakewords').innerHTML = state.wakewords.length ? state.wakewords.map(w => {
+  const html = state.wakewords.length ? state.wakewords.map(w => {
     const stages = [
       ['Created', true],
       ['Voices', w.clips_train > 0],
@@ -301,6 +456,22 @@ function render() {
             title="Adds British/Australian/US synthetic voices (usually free)">+ Google voices…</button>
           <span class="hint" style="margin:0">then retrain to apply</span>
         </div>
+        <details>
+          <summary>training settings</summary>
+          <div class="hint" style="margin-top:8px">Stop a run, change these, then press
+            Train again. Nothing already generated is thrown away.</div>
+          <label>Synthetic voice samples</label>
+          <input type="number" data-f="n_samples" value="${w.n_samples ?? ''}">
+          <label>Max training steps</label>
+          <input type="number" data-f="steps" value="${w.steps ?? ''}">
+          <label>Words it must NOT wake on</label>
+          <input data-f="negatives" placeholder="comma separated, e.g. hey clarice"
+                 value="${esc((w.custom_negative_phrases || []).join(', '))}">
+          <div class="hint">Add anything you hear it wake on by mistake, then retrain.</div>
+          <div class="row" style="margin-top:12px">
+            <button class="small" data-act="save" ${busy() ? 'disabled' : ''}>Save settings</button>
+          </div>
+        </details>
       </div>
       <div class="verdict" style="display:none"></div>
       <div class="rawout" style="display:none"></div>
@@ -308,6 +479,39 @@ function render() {
   }).join('') : `<div class="card empty">No wake words yet.<br>
       Download the voice data (step 1), then create your first wake word on the left —
       after training you can try it with the microphone right here.</div>`;
+
+  // The poll rebuilds this list every 2.5s, which would wipe whatever is
+  // being typed into the settings fields and snap open panels shut. Only
+  // touch the DOM when the markup actually changed, never while the user is
+  // in one of the inputs, and put the open panels back afterwards.
+  const host = $('wakewords');
+  if (html === lastWwHtml) return;
+  if (host.contains(document.activeElement)) return;
+  const open = new Set([...host.querySelectorAll('.ww details[open]')]
+    .map(d => d.closest('.ww').dataset.name));
+  host.innerHTML = html;
+  lastWwHtml = html;
+  for (const d of host.querySelectorAll('.ww details'))
+    if (open.has(d.closest('.ww').dataset.name)) d.open = true;
+}
+
+/* Google credentials panel */
+function renderGoogle() {
+  const g = state.google || {};
+  const set = $('googleState'), setup = $('googleSetup'), acts = $('googleActions');
+  if (g.present && g.valid) {
+    set.innerHTML = `
+      <div class="kv"><span class="k">Project</span><span class="v">${esc(g.project_id || '—')}</span></div>
+      <div class="kv"><span class="k">Account</span><span class="v">${esc(g.client_email || '—')}</span></div>`;
+    setup.style.display = 'none';
+    acts.style.display = '';
+  } else {
+    set.innerHTML = g.present
+      ? `<div class="verdict no" style="margin-top:0">✗ The saved key is unreadable: ${esc(g.error || '')}</div>`
+      : '';
+    setup.style.display = '';
+    acts.style.display = g.present ? '' : 'none';
+  }
 }
 
 function renderJob() {
@@ -323,8 +527,10 @@ function renderJob() {
   $('jobLabel').textContent = friendlyJob(j.label);
   const s = $('jobStatus');
   if (j.running) { s.textContent = '● working — you can leave this page, it keeps going'; s.className = 'status running'; }
+  else if (j.cancelled) { s.textContent = '■ stopped — nothing generated so far was lost'; s.className = 'status'; }
   else if (j.rc === 0) { s.textContent = '✓ finished'; s.className = 'status ok'; }
   else { s.textContent = `✗ something went wrong (see log)`; s.className = 'status fail'; }
+  $('cancelJob').style.display = j.running ? '' : 'none';
 }
 
 async function pollLog() {
@@ -379,6 +585,55 @@ $('createBtn').onclick = async () => {
   refresh();
 };
 
+$('themeBtn').onclick = () => {
+  const next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  try { localStorage.setItem('em-theme', next); } catch (e) {}
+};
+
+$('cancelJob').onclick = async () => {
+  if (!confirm('Stop this run?\n\nWork already done is kept — pressing Train again picks up where it left off.')) return;
+  await api('/api/job/cancel', {method: 'POST'});
+  refresh();
+};
+
+/* Google credentials */
+function gVerdict(cls, text) {
+  const v = $('gVerdict');
+  v.style.display = ''; v.className = 'verdict ' + cls; v.textContent = text;
+}
+
+$('gSave').onclick = async () => {
+  const file = $('gFile').files[0];
+  const pasted = $('gPaste').value.trim();
+  let body;
+  if (file) { body = file; }
+  else if (pasted) { body = pasted; }
+  else return alert('Choose the JSON key file, or paste its contents.');
+  gVerdict('info', 'Saving…');
+  try {
+    await api('/api/google', {method: 'PUT', headers: {'Content-Type': 'application/json'}, body});
+  } catch (e) { $('gVerdict').style.display = 'none'; return; }
+  $('gFile').value = ''; $('gPaste').value = '';
+  gVerdict('info', 'Saved — testing the connection…');
+  await refresh();
+  $('gCheck').click();
+};
+
+$('gCheck').onclick = async () => {
+  gVerdict('info', 'Asking Google…');
+  const r = await api('/api/google/check', {method: 'POST'});
+  if (r.ok) gVerdict('ok', `✓ Connected — ${r.voices} voices across ${r.languages} languages available`);
+  else gVerdict('no', `✗ ${r.error}`);
+};
+
+$('gRemove').onclick = async () => {
+  if (!confirm('Remove the saved Google key?')) return;
+  await api('/api/google', {method: 'DELETE'});
+  $('gVerdict').style.display = 'none';
+  refresh();
+};
+
 $('toggleLog').onclick = () => {
   const c = $('console');
   c.classList.toggle('min');
@@ -393,8 +648,21 @@ $('wakewords').addEventListener('click', async e => {
   if (act === 'build') {
     await api(`/api/wakewords/${name}/build`, {method: 'POST',
       headers: {'Content-Type': 'application/json'}, body: '{}'});
+  } else if (act === 'save') {
+    const val = f => card.querySelector(`input[data-f="${f}"]`).value;
+    const r = await api(`/api/wakewords/${name}`, {method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({n_samples: val('n_samples'), steps: val('steps'),
+                            custom_negative_phrases: val('negatives')})});
+    const v = card.querySelector('.verdict');
+    v.style.display = ''; v.className = 'verdict ok';
+    v.textContent = '✓ Saved — press Train to apply';
+    lastWwHtml = null;
   } else if (act === 'gtts') {
-    const n = prompt('How many Google voice clips to add?\n(Usually free — a run this size is ~2% of Google\'s monthly free allowance. Needs the Google credentials file, see README.)', '2000');
+    if (!(state.google && state.google.valid)) {
+      return alert('Set up the Google key first — see "Google voices" on the left.');
+    }
+    const n = prompt('How many Google voice clips to add?\n(Usually free — a run this size is ~2% of Google\'s monthly free allowance.)', '2000');
     if (!n) return;
     const langs = prompt('Which accents?\n  en-GB,en-AU = British + Australian only\n  en-US,en-GB,en-AU = all three', 'en-GB,en-AU');
     if (!langs) return;


### PR DESCRIPTION
Three things in the forge that previously needed a shell or a container restart.

### Stop a run

A job could only be waited out. It now runs in its own process group, and Stop sends SIGTERM to the group, then SIGKILL to whatever is left after 10s.

The process group is the point. `forge.py` is only the parent: `build` spawns openWakeWord's `train.py`, and *that* is what holds the GPU and writes the wake word's directory. Killing the parent alone leaves it running behind a UI reporting the run as stopped. Verified against a parent that ignores SIGTERM and spawns a child doing the same; both are reaped.

**Partial work is kept.** Clip generation is resumable and both later steps check what already exists, so the loop this enables is stop, adjust, train again, not start over.

### Change settings between runs

`PATCH /api/wakewords/{name}` edits `n_samples`, `steps` and `custom_negative_phrases`, exposed as *training settings* on each card.

The lines are rewritten in place rather than the YAML round-tripped: the template's comments explain every field, and a dump would silently delete them. The result is parsed before it is written, so a bad edit can't leave a config the trainer chokes on. `target_phrase` is deliberately not editable, because changing it invalidates every clip already generated, which is a new wake word rather than an edited one.

### Google credentials from the browser

Upload or paste the JSON key; no compose mapping to arrange. It's validated as a **service account** before being written, because an OAuth client secret is what people reach for first, looks close enough to pass a glance, and otherwise fails much later inside a job with nothing pointing back at the upload. Written 0600 through a temp file so it's never briefly world-readable, and only `project_id` and `client_email` ever travel back to the browser. Jobs read the path at spawn time, so a key uploaded after the container started works with no restart.

**Test connection** exists because local validation structurally can't see the usual failure: a valid key on a project where the Text-to-Speech API was never enabled.

### Theme

The UI now carries the dashboard's own token set, both themes, applied before first paint from the same `em-theme` key, so one pick covers both surfaces. Copied rather than reinvented so the two can't drift into two slightly different warm greys. Checked: no undefined `var()`, and both themes define an identical token set.

Also, the wake word list stops rebuilding itself over the top of what you're typing. It re-renders only when the markup changed, never while an input inside it has focus, and restores open panels afterwards.

### Worth knowing

The credentials endpoint writes a secret and there's no auth in front of it. Same trust model as the rest of this tool (it can already delete training data and run arbitrary jobs), but it's a secret at rest now, so the port should stay on the LAN. Noted in the README.

`oww_forge` isn't covered by CI, so none of this is tested by the suite. The endpoints were exercised by hand against a temp `FORGE_DATA` (validation rejects, permissions, no key leakage to the UI, config patch preserving comments and phrases, cancel reaping the grandchild).