### PR TITLE
Fix #276: firmware builds again under the pinned Go 1.24 compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,57 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  device-firmware-build:
+    name: Device firmware builds in pinned compiler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true  # GoTinyAlsa replace directive in device/go.mod
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      # Why this job exists: #276. Dependabot #128 raised device/go.mod to
+      # Go 1.25 while the pinned compiler image carries 1.24, and NOTHING
+      # noticed for weeks -- every other device job (tests, vet, vulncheck)
+      # runs on the host toolchain, which resolves a newer Go silently.
+      # The pinned image is exercised by compile.sh (local, manual) and
+      # release.yml (tags only, a handful of times a month), so the first
+      # symptom of a broken pin was a release tag failing at the build step.
+      # A module graph that needs a newer Go than the image ships is caught
+      # here, on the PR that causes it, minutes rather than at tag time.
+      #
+      # No path filter, unlike the controller-image job below: that one is
+      # covered on main by controller-build.yml, but the firmware has NO
+      # build between "merged to main" and "release tag", so this job is
+      # also the only continuous check on direct pushes to main. It runs
+      # unconditionally; the GHA cache keeps the compiler image layers warm,
+      # so the steady-state cost is the go build itself.
+      - name: Build the pinned compiler image
+        uses: docker/build-push-action@v7
+        with:
+          context: device/compiler
+          push: false
+          load: true
+          tags: echomuse-compiler:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      # Same invocation as release.yml, minus the version ldflags: a CI run
+      # has no v* ref_name to embed, and BuildUnix is only meaningful for a
+      # binary a device will boot. Everything else must stay identical --
+      # this job exists to fail exactly where the release would.
+      - name: Compile the firmware
+        run: |
+          mkdir -p device/build
+          docker run --rm \
+            --entrypoint bash \
+            -e CGO_LDFLAGS="-Wl,--hash-style=both" \
+            -v "${{ github.workspace }}/device":/sdk \
+            -v "${{ github.workspace }}/GoTinyAlsa":/GoTinyAlsa \
+            echomuse-compiler:ci \
+            -c "cd /sdk && mkdir -p build && go build \
+              -tags server \
+              -o build/server ./cmd/"
+
   device-vet:
     name: Device go vet
     runs-on: ubuntu-latest

--- a/device/go.mod
+++ b/device/go.mod
@@ -1,13 +1,13 @@
 module github.com/wilbowes/EchoMuse
 
-go 1.25.0
+go 1.24.0
 
 require (
 	github.com/Binozo/GoTinyAlsa v1.0.3
 	github.com/gorilla/websocket v1.5.3
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/gvalkov/golang-evdev v0.0.0-20220815104727-7e27d6ce89b6
-	golang.org/x/sys v0.47.0
+	golang.org/x/sys v0.41.0
 )
 
 require (

--- a/device/go.sum
+++ b/device/go.sum
@@ -30,8 +30,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
-golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
The firmware can be built with its pinned compiler again, and a change that breaks it now goes red in CI instead of failing at release time.

- Lowering only the `go` directive is not enough: x/sys v0.42.0+ declare `go 1.25.0` themselves, so both move back together (`go 1.24.0`, x/sys v0.41.0 — verified against the module proxy as the newest compatible version).
- Nothing in the tree needs 1.25 language or stdlib features.
- New `device-firmware-build` CI job builds the compiler image from its pinned Dockerfile and compiles `./cmd/` inside it, using release.yml's invocation. It runs unconditionally: between merge and release tag there is no other check that touches the pin.

Fixes #276
