### PR TITLE
Fix #159: update_check_interval=0 means OFF, not a busy loop

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -3162,6 +3162,26 @@ async def _push_log_event(
 
 # ─── GitHub release fetching ──────────────────────────────────────────────────
 
+def _update_check_interval() -> int:
+    """
+    The parsed update_check_interval; <= 0 means DISABLED (#159).
+
+    db.get_config returns a STRING, so a stored "0" is truthy and survived
+    the old `or 3600` fallback into asyncio.sleep(0) — turning the obvious
+    way to stop the controller contacting GitHub (#158 documents this poll
+    as its only outbound connection) into a busy loop against api.github.com
+    until it rate-limits. The worst available outcome for exactly the reader
+    who set it carefully. A non-numeric value used to raise out of the poll
+    loop and kill the task outright; it now falls back to the default with
+    a line in the log.
+    """
+    raw = (db.get_config("update_check_interval", "3600") or "3600").strip()
+    try:
+        return int(raw)
+    except ValueError:
+        log.warning(f"[api] update_check_interval {raw!r} is not a number — using 3600")
+        return 3600
+
 async def _get_cached_release() -> Optional[dict]:
     """
     Return the latest release info, using the in-memory cache if fresh.
@@ -3204,8 +3224,14 @@ async def _get_cached_release() -> Optional[dict]:
         # interval lapses — release_poll_loop normally refreshes ahead of any
         # caller. A failed refresh falls through to the stale cache, which is
         # better than no answer.
-        interval = int(db.get_config("update_check_interval", "3600") or 3600)
-        if not last_check or (time.time() - float(last_check)) > interval:
+        # 0 (any non-positive value) means updates are DISABLED (#159):
+        # serve the cache whatever its age and make no outbound call. The
+        # poll loop reads this the same way, so the knob does what the
+        # privacy section implies it does.
+        interval = _update_check_interval()
+        if (interval > 0
+                and (not last_check
+                     or (time.time() - float(last_check)) > interval)):
             fresh = await _fetch_latest_release()
             if fresh:
                 return fresh
@@ -4211,6 +4237,14 @@ async def release_poll_loop() -> None:
     await asyncio.sleep(30)
 
     while True:
+        interval = _update_check_interval()
+        if interval <= 0:
+            # Disabled (#159): no fetch, no outbound connection. Re-read
+            # after a fixed park so re-enabling from the dashboard takes
+            # effect without a restart.
+            await asyncio.sleep(60)
+            continue
+
         try:
             await _fetch_latest_release()
         except Exception as e:
@@ -4223,8 +4257,9 @@ async def release_poll_loop() -> None:
         except Exception as e:
             log.error(f"[api] Controller release poll error: {e}")
 
-        interval = int(db.get_config("update_check_interval", "3600") or 3600)
-        await asyncio.sleep(interval)
+        # Floor of 1s so even an absurd tiny positive interval cannot spin
+        # the loop faster than the event loop allows.
+        await asyncio.sleep(max(interval, 1))
 
 
 async def session_prune_loop() -> None:

--- a/controller/tests/test_update_interval.py
+++ b/controller/tests/test_update_interval.py
@@ -1,0 +1,137 @@
+"""
+#159: update_check_interval=0 must mean OFF, not "as fast as possible".
+
+db.get_config returns a STRING, so a stored "0" is truthy and survived the
+old `or 3600` fallback into asyncio.sleep(0) — spinning the release poll
+loop against api.github.com until it rate-limited, for exactly the user who
+set it to stop the controller's only outbound connection (#158). A
+non-numeric value raised out of the poll loop and killed the task outright.
+
+The functions under test live in em_api.py, which imports aiohttp and the
+whole controller stack — deliberately not importable here (see conftest).
+Each function's source is extracted and executed in a stub namespace
+instead, so what runs is the code that actually ships.
+"""
+
+import asyncio
+import logging
+import types
+from pathlib import Path
+
+import pytest
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _extract(name: str) -> str:
+    """The source of one top-level function in em_api.py."""
+    src = (CONTROLLER / "em_api.py").read_text()
+    start = src.index(f"def {name}")
+    if src[max(0, start - 6):start] == "async ":
+        start -= 6                       # keep the async keyword
+    body = src[start:]
+    ends = [i for i in (body.find("\ndef "), body.find("\nasync def "))
+            if i != -1]
+    return body[:min(ends)]
+
+
+def _ns(interval_value: str) -> dict:
+    """A namespace with db/log stubbed to one stored config value."""
+    return {
+        "db": types.SimpleNamespace(get_config=(
+            lambda k, d=None: {"update_check_interval": interval_value}
+            .get(k, d))),
+        "log": logging.getLogger("test-update-interval"),
+        "asyncio": asyncio,
+    }
+
+
+@pytest.mark.parametrize("stored,expected", [
+    ("0", 0),          # the case that used to busy-loop
+    ("", 3600),        # empty falls back
+    ("abc", 3600),     # garbage falls back instead of killing the task
+    ("-5", -5),        # negative reads as disabled too
+    ("1800", 1800),
+    (" 900 ", 900),    # whitespace tolerated
+])
+def test_interval_parsing_treats_non_positive_as_disabled(stored, expected):
+    ns = _ns(stored)
+    exec(_extract("_update_check_interval"), ns)
+    assert ns["_update_check_interval"]() == expected
+
+
+def test_poll_loop_disabled_never_fetches_and_parks():
+    fetched, sleeps = [], []
+
+    async def fake_fetch(force=False):
+        fetched.append("release")
+
+    async def fake_ctrl(force=True):
+        fetched.append("controller")
+
+    async def fake_sleep(s):
+        sleeps.append(s)
+        if len(sleeps) >= 3:            # startup delay + two park cycles
+            raise asyncio.CancelledError
+
+    ns = _ns("0")
+    ns.update({
+        "_fetch_latest_release": fake_fetch,
+        "_fetch_controller_release": fake_ctrl,
+        "asyncio": types.SimpleNamespace(sleep=fake_sleep),
+    })
+    exec(_extract("_update_check_interval"), ns)
+    exec(_extract("release_poll_loop"), ns)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(ns["release_poll_loop"]())
+
+    assert fetched == [], \
+        "a disabled poll loop must make NO outbound call"
+    assert sleeps[0] == 30              # unchanged startup grace
+    assert all(s == 60 for s in sleeps[1:]), \
+        "disabled must re-read the config periodically, not spin"
+
+
+def test_poll_loop_enabled_fetches_then_sleeps_the_interval():
+    fetched, sleeps = [], []
+
+    async def fake_fetch(force=False):
+        fetched.append("release")
+
+    async def fake_ctrl(force=True):
+        fetched.append("controller")
+
+    async def fake_sleep(s):
+        sleeps.append(s)
+        if len(sleeps) >= 2:            # startup delay + first interval
+            raise asyncio.CancelledError
+
+    ns = _ns("1800")
+    ns.update({
+        "_fetch_latest_release": fake_fetch,
+        "_fetch_controller_release": fake_ctrl,
+        "asyncio": types.SimpleNamespace(sleep=fake_sleep),
+    })
+    exec(_extract("_update_check_interval"), ns)
+    exec(_extract("release_poll_loop"), ns)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(ns["release_poll_loop"]())
+
+    assert sleeps[0] == 30 and sleeps[1] == 1800
+    assert len(fetched) == 2            # both planes polled once per cycle
+
+
+def test_on_demand_refresh_is_gated_when_disabled():
+    """
+    The dashboard read path (_get_cached_release) awaits a refresh when its
+    cache has aged out — which, with updates disabled, would be an outbound
+    GitHub call on every dashboard visit. The fetch must sit behind the
+    same `interval > 0` reading as the poll loop.
+    """
+    fn = _extract("_get_cached_release")
+    assert "_update_check_interval()" in fn, \
+        "the freshness check must use the shared parser, not raw int()"
+    assert "interval > 0" in fn, \
+        "a disabled interval must serve the cache without fetching"


### PR DESCRIPTION
Setting `update_check_interval` to `0` now stops the GitHub poll instead of turning it into a busy loop against api.github.com.

- `db.get_config` returns a string, so `"0"` was truthy and survived the `or 3600` fallback into `asyncio.sleep(0)` — the worst outcome for exactly the reader who set it to stop the controller's only outbound connection (#158).
- Both call sites read through one parser: `<= 0` means disabled (poll parks at 60s so re-enabling needs no restart), non-numeric values fall back to 3600 instead of killing the poll task, positive intervals get a 1s floor.
- Tests run the shipped function sources in a stub namespace, since em_api is deliberately not importable in the minimal test env.

Fixes #159
