### PR TITLE
Fix #275: bypassed clipping gets its own counter

### DIFF
--- a/controller/em_limiter.py
+++ b/controller/em_limiter.py
@@ -46,8 +46,13 @@ per-sample Python loop is not available to us.
    across a long stream.
 
 3. **A final clip that must never engage.** Kept as a backstop, and it is
-   counted: if `clipped` is ever non-zero the limiter has a bug, and a
-   silent backstop is how the original problem survived.
+   counted: if `clipped` is ever non-zero while the limiter is LIMITING,
+   the limiter has a bug, and a silent backstop is how the original
+   problem survived. While the limiter is BYPASSED the same backstop
+   legitimately catches a boosted EQ's output — that goes to
+   `clipped_bypassed`, so the two readings cannot be confused (#275):
+   identical counts in both states would send someone hunting a bug in a
+   limiter that is behaving correctly.
 
 STATE
 -----
@@ -140,9 +145,11 @@ class Limiter:
         self._tail = np.zeros(max(0, self.lookahead - 1), dtype=np.float64)
         self._gain_db = 0.0                          # last gain, dB (≤ 0)
 
-        # Instrumentation. `clipped` must stay zero; see the module docstring.
+        # Instrumentation. `clipped` must stay zero while limiting; see the
+        # module docstring for the bypassed sibling.
         self.max_reduction_db = 0.0
         self.clipped = 0
+        self.clipped_bypassed = 0
 
     def set_params(self,
                    threshold_db: float | None = None,
@@ -250,7 +257,14 @@ class Limiter:
         if emit.size:
             self.max_reduction_db = max(self.max_reduction_db,
                                         float(-gain_db[:emit.size].min()))
-            self.clipped += int(np.count_nonzero(np.abs(emit) > _CEILING))
+            # #275: one number, two states, opposite investigations. While
+            # limiting, a backstop clip is a bug; while bypassed it is the
+            # backstop doing exactly its job on a boosted EQ's output.
+            n_clipped = int(np.count_nonzero(np.abs(emit) > _CEILING))
+            if self.enabled:
+                self.clipped += n_clipped
+            else:
+                self.clipped_bypassed += n_clipped
 
         # The first call emits `lookahead-1` fewer samples than it was given
         # (they are in the tail) and every later call emits that many more.
@@ -273,7 +287,11 @@ class Limiter:
         # No further look-ahead is possible, so hold the last gain rather than
         # springing back to unity, which would be an audible step.
         out = tail * (10.0 ** (self._gain_db / 20.0))
-        self.clipped += int(np.count_nonzero(np.abs(out) > _CEILING))
+        n_clipped = int(np.count_nonzero(np.abs(out) > _CEILING))
+        if self.enabled:
+            self.clipped += n_clipped
+        else:
+            self.clipped_bypassed += n_clipped
         return out
 
 

--- a/controller/tests/test_limiter.py
+++ b/controller/tests/test_limiter.py
@@ -239,3 +239,53 @@ def test_reduction_is_reported():
     lim = L.Limiter(FS)
     _run(lim, _sine(amp=2.0))
     assert lim.max_reduction_db == pytest.approx(6.0 + 1.0, abs=0.3)
+
+
+# ─── #275: bypassed clipping is the backstop working, not a bug ──────────────
+
+def test_bypassed_limiter_counts_its_clips_separately():
+    """
+    While limiterEnabled is off, a boosted EQ ahead legitimately pushes
+    samples past the ceiling for the backstop np.clip to catch — measured
+    in #275: 86 clipped samples across the sweep_params fixture. Counting
+    those into `clipped` made "non-zero means the limiter has a bug" send
+    someone hunting a bug in a limiter that was behaving correctly. The
+    two states want opposite investigations, so they get two counters.
+    """
+    lim = L.Limiter(FS, enabled=False)
+    hot = _sine(amp=4.0)                     # far past the ceiling
+    out = _run(lim, hot)
+    assert lim.clipped == 0, \
+        "a bypassed limiter must not read as a buggy limiting one"
+    assert lim.clipped_bypassed > 0, \
+        "over-ceiling samples while bypassed must be counted - visibly"
+    # And they pass through hot: nobody is limiting this signal.
+    assert np.abs(out).max() > L._CEILING
+
+
+def test_enabling_moves_the_count_back_to_clipped():
+    """
+    The same material through an ENABLED limiter must land in `clipped`
+    if the backstop ever engages - and never in clipped_bypassed.
+    """
+    lim = L.Limiter(FS)
+    _run(lim, _sine(amp=3.0))
+    assert lim.clipped_bypassed == 0
+
+
+def test_toggle_midstream_splits_the_two_counters():
+    """
+    set_params(enabled=False) mid-stream is supported (the music path
+    re-reads config per chunk). Clips after the toggle belong to the
+    bypassed counter alone; the enabled half never leaks into it.
+    """
+    lim = L.Limiter(FS)
+    x = _sine(amp=3.0)
+    lim.process(x[: len(x) // 2])            # enabled: limited, nothing clipped
+    lim.set_params(enabled=False)
+    lim.process(x[len(x) // 2:])
+    lim.flush()
+    assert lim.clipped_bypassed > 0, \
+        "hot material after the toggle must be visible as bypassed clipping"
+    assert lim.clipped == 0, \
+        "post-toggle clips must not read as a buggy limiting limiter"


### PR DESCRIPTION
The limiter's clip counter can no longer read as a bug while the limiter is simply off.

`clipped` is documented as "non-zero means a bug" — true while limiting, wrong while bypassed, where a boosted EQ legitimately pushes samples past the ceiling (#275 measured 86 across one fixture). Two counters now: `clipped` counts only while limiting, `clipped_bypassed` keeps the EQ-running-hot signal without the false alarm.

Note for #243's Go port: `device/internal/outchain/limiter.go` is not on main yet; when it lands it should follow this split rather than the faithful single counter.

Fixes #275
