### PR TITLE
Fix #251: a turn cancelled during playback records barged, not ok

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -959,8 +959,8 @@ async def leds_off(device: Device):
 
 
 # Turn outcomes that get a distinguishing ring cue at turn end. Everything
-# else ("ok", "cancelled") ends silently: the user either heard a reply or
-# pressed the button themselves, so a cue would be noise.
+# else ("ok", "cancelled", "barged") ends silently: the user either heard a
+# reply or cut it off themselves, so a cue would be noise.
 #
 # Rhythm carries the meaning, not colour — a new colour would collide with
 # red (mute), orange (link down) or cyan (volume), and the point of the

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -134,7 +134,7 @@ class TurnTrace:
     ha_think_ms:      int   = -1
     tts_gen_ms:       int   = -1
     fetch_ms:         int   = -1
-    outcome:          str   = ""      # "ok", "no_speech", "cancelled", "tts_error", "timeout"
+    outcome:          str   = ""      # "ok", "no_speech", "cancelled", "barged", "tts_error", "timeout"
     # Wake detection detail (model, score, threshold, noise_floor) popped
     # from device.last_wake at turn start — None for button/continuation
     # turns. Persisted with the turn for threshold tuning and model A/Bs.
@@ -1106,8 +1106,22 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 if trace:
                     trace.tts_bytes = pcm_bytes or 0
 
-                if pcm_bytes and not self._turn_cancelled:
-                    if trace: trace.outcome = "ok"
+                if self._turn_cancelled:
+                    # #251: cut off mid-response. This used to fall through to
+                    # the finally-default "ok", so a turn cancelled during
+                    # playback was indistinguishable from an answered one —
+                    # which is how #250 (the device barging on its own
+                    # narration) hid from the activity stats for two days.
+                    # "barged" is deliberately distinct from the earlier
+                    # "cancelled" outcomes: there, nothing had been said yet.
+                    # Signature for self-interruption: a "barged" turn
+                    # immediately followed by a turn whose trigger is
+                    # "barge-in" — the interrupting wake is recorded as that
+                    # turn's trigger.
+                    log.info(f"[{self._log_name}] Turn cancelled during playback")
+                    trace.outcome = "barged"
+                elif pcm_bytes:
+                    trace.outcome = "ok"
             else:
                 log.info(f"[{self._log_name}] No TTS audio URL received — turn ended without response")
                 if trace: trace.outcome = "no_tts"

--- a/controller/tests/test_turn_outcomes.py
+++ b/controller/tests/test_turn_outcomes.py
@@ -1,0 +1,63 @@
+"""
+#251: a turn cancelled during playback must not record outcome=ok.
+
+A barge-in that cut a response off mid-sentence was persisted as
+outcome=ok with tts_bytes=0 — indistinguishable in the activity stats
+from a turn that answered. An outcome that flatters the system is the
+worst kind to get wrong: the rollup is what you consult when deciding
+whether something is broken, and this one hid #250 (self-interruption)
+for two days of false-barge investigation.
+
+em_esphome imports openwakeword/aiohttp and is deliberately not
+importable here (see conftest), so these are shape guards on the shipped
+source.
+"""
+
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _turn_src() -> str:
+    src = (CONTROLLER / "em_esphome.py").read_text()
+    start = src.index("if self._tts_audio_url:")
+    return src[start:start + 6000]
+
+
+def test_a_cancel_during_playback_records_barged_not_ok():
+    src = _turn_src()
+    assert 'trace.outcome = "barged"' in src, \
+        "a turn cut off mid-response must be distinguishable from an answer"
+    assert "_turn_cancelled" in src.split('trace.outcome = "barged"')[0], \
+        "the barged outcome must be gated on the cancel flag"
+    # The finally-block default must not be able to overwrite it back to ok:
+    # the barged branch has to sit BEFORE the unconditional default runs.
+    default = src.index("if not trace.outcome:")
+    assert src.index('"barged"') < default
+
+
+def test_barged_is_distinct_from_the_pre_playback_cancel():
+    """
+    "cancelled" already covers cuts during mic streaming and the TTS wait -
+    nothing had been said yet. "barged" means a response had begun. Both
+    must exist; collapsing them would blur 'user pressed the button early'
+    into 'something interrupted the answer'.
+    """
+    src = (CONTROLLER / "em_esphome.py").read_text()
+    assert src.count('trace.outcome = "cancelled"') >= 2, \
+        "the pre-playback cancel outcomes must stay"
+    assert 'trace.outcome = "barged"' in src
+
+
+def test_self_interruption_is_detectable_from_the_persisted_fields():
+    """
+    The motivating case (#250): the device triggering on its own narration.
+    Neither row alone says why - but a barged turn immediately followed by a
+    turn whose trigger is "barge-in" is the signature, which requires both
+    fields persisted as-is.
+    """
+    src = (CONTROLLER / "em_esphome.py").read_text()
+    rec = src[src.index("turn_record = {"):]
+    rec = rec[:rec.index("}")]
+    assert '"outcome"' in rec and '"trigger"' in rec, \
+        "outcome and trigger must both reach the turns table"


### PR DESCRIPTION
A turn cancelled during playback is recorded as `barged`, not `ok`.

Cutting a response off mid-sentence used to fall through to the finally-default `ok`, so from the activity stats a fleet cancelling a third of its answers read as a fleet answering everything — which is how #250 hid for two days. "Barged" stays distinct from the earlier "cancelled" outcomes: there nothing had been said yet, here a response had begun.

Cause split (button vs self-barge) stayed out deliberately: it needs threading a reason through three call sites, and the persisted data already carries the signature — barged followed by trigger=barge-in IS the self-interruption case, pinned by test.

Fixes #251
