### PR TITLE
Fix #150: a dead media source ends the stream and reports idle

### DIFF
--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -137,6 +137,16 @@ SEEK_STALL_S    = 5.0
 # which is the point of catching it here.
 SOURCE_STALL_MS = 500.0
 
+# A source that has produced nothing for this long is not STALLING, it is
+# DEAD (#150): a starving Music Assistant flow stream never recovers its
+# position (a flow cannot be seeked back to where it stopped), so waiting
+# longer only leaves HA reporting `playing` against silence while the
+# session holds the decoder and the intent state. The stream is ended and
+# reported idle. Generous enough that a slow upstream failover — tens of
+# seconds of SOURCE-stall warnings — still resumes; any successful read
+# resets the clock.
+SOURCE_DEAD_S = 30.0
+
 
 IDLE, PLAYING, PAUSED = "idle", "playing", "paused"
 
@@ -558,6 +568,7 @@ class MediaSession:
         eos_sent = False
         src_max_ms = 0.0
         src_stalls = 0
+        src_dead = False
 
         # Arm the data-plane reconnect grace for this feed: a Wi-Fi blip
         # mid-song should cost a pause, not the rest of the track.
@@ -641,7 +652,20 @@ class MediaSession:
                         # Only the READ is timed. The pacing sleep below is
                         # deliberate and must not read as a stall.
                         _t0 = loop.time()
-                        chunk = await proc.stdout.readexactly(SPEAKER_BYTES)
+                        try:
+                            chunk = await asyncio.wait_for(
+                                proc.stdout.readexactly(SPEAKER_BYTES),
+                                SOURCE_DEAD_S)
+                        except asyncio.TimeoutError:
+                            # #150: the read used to have no deadline at all,
+                            # so a source that stopped producing left the feed
+                            # parked forever — silent player log, HA showing
+                            # `playing` indefinitely, decoder held. A stalled
+                            # source is logged upstream; a dead one ends the
+                            # stream here and reports honestly.
+                            src_dead = True
+                            await self._kill_decoder(proc)
+                            break
                         _read_ms = (loop.time() - _t0) * 1000.0
                         if t_first_pcm is None:
                             t_first_pcm = loop.time()
@@ -699,8 +723,15 @@ class MediaSession:
             self.state = IDLE
             self.url = None
             self._pos = 0.0
-            log.info(f"[{self.device_id}] Media finished "
-                     f"({sent // SPEAKER_BYTES} periods)")
+            if src_dead:
+                log.error(
+                    f"[{self.device_id}] Media source produced nothing for "
+                    f"{SOURCE_DEAD_S:.0f}s — ending stream after "
+                    f"{sent // SPEAKER_BYTES} periods. HA reports idle; a "
+                    f"flow stream cannot resume where it died (#150).")
+            else:
+                log.info(f"[{self.device_id}] Media finished "
+                         f"({sent // SPEAKER_BYTES} periods)")
             await self._push_state()
         except asyncio.CancelledError:
             # pause()/stop() tearing us down. Bookmark ≈ what has audibly

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -887,3 +887,105 @@ def test_a_pausing_device_does_not_change_its_lead():
         await s.stop()
         return during
     assert asyncio.run(main()) == em_player.LEAD_S
+
+
+# ── #150: a source that stops producing ends the stream and reports idle ────
+
+
+class DeadSourceProc(FakeProc):
+    """Delivers a few periods, then hangs forever: no EOF (the decoder is
+    still alive, parked on a dead upstream), no audio. The shape of a
+    starving Music Assistant flow."""
+
+    def __init__(self, periods):
+        super().__init__(periods, endless=True)
+        real_readexactly = self.stdout.readexactly
+
+        served = {"n": 0}
+        total = periods
+
+        async def hang_eventually(n):
+            if served["n"] >= total:
+                await asyncio.sleep(3600)     # never returns
+            served["n"] += 1
+            return await real_readexactly(n)
+
+        self.stdout.readexactly = hang_eventually
+
+
+def test_a_dead_source_ends_the_stream_and_reports_idle(caplog, monkeypatch):
+    """
+    #150: the read had no deadline, so a source that stopped producing left
+    the feed parked forever - player log silent, HA showing `playing`
+    indefinitely, decoder held. A source that produces nothing for
+    SOURCE_DEAD_S must end the stream, send EOS so the device settles, and
+    let HA report idle.
+    """
+    import logging
+    monkeypatch.setattr(em_player, "SOURCE_DEAD_S", 0.2)
+
+    async def main():
+        device = FakeDevice()
+        _wire(device)
+        s = StubSession("office", periods=2)
+        s._spawn_decoder = lambda url, pos: _spawn(url, pos, s)
+
+        async def _spawn(url, pos, s):
+            proc = DeadSourceProc(2)
+            s.procs.append(proc)
+            return proc
+
+        with caplog.at_level(logging.ERROR, logger="player"):
+            await s.play("http://ma/flow/stream")
+            await asyncio.wait_for(s._task, 10)
+        return device, s
+
+    device, s = asyncio.run(main())
+    assert s.state == IDLE, "a dead source must not leave the session playing"
+    assert device.data_frames[-1][0] == 0x03, \
+        "EOS must reach the device so its ring and buffer settle"
+    text = "\n".join(r.message for r in caplog.records)
+    assert "produced nothing" in text, \
+        "the log must say the source died, not that the media finished"
+
+
+def test_a_slow_but_recovering_source_is_not_killed(monkeypatch):
+    """
+    The deadline exists for DEAD sources. One that stalls past the stall
+    warning but returns inside the deadline keeps streaming.
+    """
+    monkeypatch.setattr(em_player, "SOURCE_DEAD_S", 0.5)
+
+    async def main():
+        device = FakeDevice()
+        _wire(device)
+        s = StubSession("office", periods=3)
+
+        class SlowThenFineProc(FakeProc):
+            def __init__(self):
+                super().__init__(3, endless=False)
+                real = self.stdout.readexactly
+                calls = {"n": 0}
+
+                async def slow(n):
+                    calls["n"] += 1
+                    if calls["n"] == 2:
+                        await asyncio.sleep(0.2)   # over SOURCE_STALL_MS,
+                    return await real(n)           # under SOURCE_DEAD_S
+                self.stdout.readexactly = slow
+
+        async def spawn(url, pos):
+            p = SlowThenFineProc()
+            s.procs.append(p)
+            return p
+        s._spawn_decoder = spawn
+
+        await s.play("http://ma/flow/stream")
+        await asyncio.wait_for(s._task, 10)
+        return device, s
+
+    device, s = asyncio.run(main())
+    assert s.state == IDLE
+    types = [f[0] for f in device.data_frames]
+    assert types.count(0x02) == 3 and types[-1] == 0x03, \
+        "every period must have made it out before EOS"


### PR DESCRIPTION
A Music Assistant flow stream that stops producing used to park the feed forever: silent player log, HA showing `playing` indefinitely, decoder held. Reproduced on all three music sessions during the #117 investigation.

- The stdout read now carries a SOURCE_DEAD_S deadline (30s; any successful read resets it, so slow upstream failovers still resume).
- On expiry the decoder is killed, EOS reaches the device, HA gets idle, and the log says the source died instead of looking like a normal finish.
- Ending beats retrying here: a flow stream cannot seek back to where it died.

Fixes #150
