### PR TITLE
Fix #270 (half): dev tools resolve the add-on database path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,57 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  device-firmware-build:
+    name: Device firmware builds in pinned compiler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true  # GoTinyAlsa replace directive in device/go.mod
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      # Why this job exists: #276. Dependabot #128 raised device/go.mod to
+      # Go 1.25 while the pinned compiler image carries 1.24, and NOTHING
+      # noticed for weeks -- every other device job (tests, vet, vulncheck)
+      # runs on the host toolchain, which resolves a newer Go silently.
+      # The pinned image is exercised by compile.sh (local, manual) and
+      # release.yml (tags only, a handful of times a month), so the first
+      # symptom of a broken pin was a release tag failing at the build step.
+      # A module graph that needs a newer Go than the image ships is caught
+      # here, on the PR that causes it, minutes rather than at tag time.
+      #
+      # No path filter, unlike the controller-image job below: that one is
+      # covered on main by controller-build.yml, but the firmware has NO
+      # build between "merged to main" and "release tag", so this job is
+      # also the only continuous check on direct pushes to main. It runs
+      # unconditionally; the GHA cache keeps the compiler image layers warm,
+      # so the steady-state cost is the go build itself.
+      - name: Build the pinned compiler image
+        uses: docker/build-push-action@v7
+        with:
+          context: device/compiler
+          push: false
+          load: true
+          tags: echomuse-compiler:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      # Same invocation as release.yml, minus the version ldflags: a CI run
+      # has no v* ref_name to embed, and BuildUnix is only meaningful for a
+      # binary a device will boot. Everything else must stay identical --
+      # this job exists to fail exactly where the release would.
+      - name: Compile the firmware
+        run: |
+          mkdir -p device/build
+          docker run --rm \
+            --entrypoint bash \
+            -e CGO_LDFLAGS="-Wl,--hash-style=both" \
+            -v "${{ github.workspace }}/device":/sdk \
+            -v "${{ github.workspace }}/GoTinyAlsa":/GoTinyAlsa \
+            echomuse-compiler:ci \
+            -c "cd /sdk && mkdir -p build && go build \
+              -tags server \
+              -o build/server ./cmd/"
+
   device-vet:
     name: Device go vet
     runs-on: ubuntu-latest

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -1027,6 +1027,16 @@ async def _apply_live_config(device_id: str, live, effective: dict) -> None:
     if "bassGuardDb" in effective:
         live.bass_guard_db = float(effective["bassGuardDb"])
     live.led_scene = em_scenes.resolve(effective)
+    # #263: keep the device's cached listening animation in step when the
+    # scene changes live, same push as at registration. Without it the ring
+    # lit locally in the OLD scene's colours until the next reconnect.
+    if live.led_anim_capable and live.led_scene.get("listening_anim"):
+        try:
+            await live.send_control(
+                {"type": "config",
+                 "listeningAnim": live.led_scene["listening_anim"]})
+        except Exception:
+            pass  # device offline — next connect re-sends it
 
 
 @auth.require_auth

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -2732,6 +2732,16 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
         device.limiter_release   = float(config.get(
             "limiterRelease", em_limiter.DEFAULT_RELEASE_MS))
         device.led_scene     = em_scenes.resolve(config)
+        # #263: hand the device its current listening animation so a wake it
+        # detected ITSELF can light the ring immediately, instead of waiting
+        # for leds_listening to make the round trip (measured +522ms before
+        # the ring moved; control-plane tail reaches 2s, #139). The
+        # controller's frame still lands within an RTT and takes over — the
+        # device just stops being two hops behind its own event.
+        if device.led_anim_capable and device.led_scene.get("listening_anim"):
+            await device.send_control(
+                {"type": "config",
+                 "listeningAnim": device.led_scene["listening_anim"]})
         # Initialise volume from stored config — device will report its real
         # value via volume_state on connect, but this seeds a sane default
         # in the window before that first message arrives.

--- a/controller/tests/test_local_wake_ring.py
+++ b/controller/tests/test_local_wake_ring.py
@@ -1,0 +1,61 @@
+"""
+#263: the device lights the listening ring locally at its own wake crossing.
+
+The crossing used to travel to the controller and wait for leds_listening
+to come back — measured at +522ms before the ring moved, on a link whose
+control-plane tail reaches 2s (#139). The fix has two halves that must both
+exist: the controller hands the device its current listening animation in
+the config push, and the device draws it before reporting the crossing.
+"""
+
+import re
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+ROOT = CONTROLLER.parent
+
+
+def test_the_controller_pushes_the_listening_anim_at_registration():
+    src = (CONTROLLER / "em_controller.py").read_text()
+    block = src[src.index("device.led_scene     = em_scenes.resolve(config)"):]
+    block = block[:2000]
+    assert '"listeningAnim"' in block, \
+        "registration must hand the device its listening animation"
+    assert "led_anim_capable" in block, \
+        "firmware without local animation must keep the old behaviour"
+
+
+def test_the_controller_updates_it_on_a_live_scene_change():
+    """
+    Without this, a scene changed on the dashboard lights the ring locally
+    in the OLD colours until the device happens to reconnect — the same
+    'mirrored at registration but not live' shape test_config_mirrors
+    exists for.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+    body = src[src.index("live.led_scene = em_scenes.resolve(effective)"):]
+    body = body[:1200]
+    assert '"listeningAnim"' in body, \
+        "a live scene change must refresh the device's cached animation"
+
+
+def test_the_device_draws_locally_before_reporting_the_crossing():
+    src = (ROOT / "device" / "cmd" / "server.go").read_text()
+    fn = src[src.index("func onWakeCrossing"):]
+    fn = fn[:fn.index("\nfunc ", 1)]
+    draw = fn.index("srv.StartAnim(spec)")
+    send = fn.index("cc.SendOwwWake(")
+    assert draw < send, \
+        "the local draw must precede the report - drawing after is the bug"
+    # Only devices that actually trigger locally may do this; shadow mode
+    # and muted crossings keep their existing paths.
+    assert fn.index("OnDeviceOn") < draw, \
+        "shadow-mode crossings must not light the turn ring"
+    assert "IsMuted()" in fn[:fn.index("srv.StartAnim(spec)")], \
+        "a muted crossing is suppressed, not announced"
+
+
+def test_the_go_config_message_carries_the_field():
+    src = (ROOT / "device" / "internal" / "config" / "config.go").read_text()
+    assert re.search(r'ListeningAnim\s+json\.RawMessage\s+`json:"listeningAnim,omitempty"`', src), \
+        "the wire field must exist with the exact tag the controller sends"

--- a/controller/tools/devshell.py
+++ b/controller/tools/devshell.py
@@ -17,7 +17,24 @@ import websockets
 # Default when neither -d nor --all is given — kept so existing invocations
 # and the README's one-liner behave exactly as before.
 DEVICE = "G090LF11803611NF"
-DB = "/app/data/echomuse.db"
+
+def _resolve_db() -> str:
+    # #270: the container keeps its database at /app/data, the HA add-on at
+    # /data. EM_DB overrides both. Inlined rather than shared: these tools
+    # are docker-cp'd into the container one file at a time and must stay
+    # standalone.
+    import os
+    env = os.environ.get("EM_DB", "").strip()
+    if env:
+        return env
+    for c in ("/data/echomuse.db", "/app/data/echomuse.db"):
+        if os.path.exists(c):
+            return c
+    return "/app/data/echomuse.db"
+
+
+DB = _resolve_db()
+
 
 
 def all_devices(max_age_s=300):

--- a/controller/tools/ota.py
+++ b/controller/tools/ota.py
@@ -4,7 +4,22 @@ import aiohttp
 
 DEVICE = sys.argv[1]
 BINARY = "/tmp/server-new"
-DB = "/app/data/echomuse.db"
+def _resolve_db() -> str:
+    # #270: the container keeps its database at /app/data, the HA add-on at
+    # /data. EM_DB overrides both. Inlined rather than shared: these tools
+    # are docker-cp'd into the container one file at a time and must stay
+    # standalone.
+    import os
+    env = os.environ.get("EM_DB", "").strip()
+    if env:
+        return env
+    for c in ("/data/echomuse.db", "/app/data/echomuse.db"):
+        if os.path.exists(c):
+            return c
+    return "/app/data/echomuse.db"
+
+
+DB = _resolve_db()
 
 def make_token():
     tok = secrets.token_hex(32)

--- a/controller/tools/pull_so.py
+++ b/controller/tools/pull_so.py
@@ -1,7 +1,25 @@
 import asyncio, secrets, sqlite3, sys, time, base64, re
 import websockets
 
-DEVICE = "G090LF11803611NF"; DB = "/app/data/echomuse.db"
+DEVICE = "G090LF11803611NF"
+
+def _resolve_db() -> str:
+    # #270: the container keeps its database at /app/data, the HA add-on at
+    # /data. EM_DB overrides both. Inlined rather than shared: these tools
+    # are docker-cp'd into the container one file at a time and must stay
+    # standalone.
+    import os
+    env = os.environ.get("EM_DB", "").strip()
+    if env:
+        return env
+    for c in ("/data/echomuse.db", "/app/data/echomuse.db"):
+        if os.path.exists(c):
+            return c
+    return "/app/data/echomuse.db"
+
+
+DB = _resolve_db()
+
 SRC = sys.argv[1]
 
 def tok_add():

--- a/controller/tools/push_file.py
+++ b/controller/tools/push_file.py
@@ -44,7 +44,22 @@ Success is md5 agreement, not "no errors". Exit status is non-zero otherwise.
 import asyncio, base64, hashlib, os, secrets, sqlite3, sys, time
 import websockets
 
-DB = "/app/data/echomuse.db"
+def _resolve_db() -> str:
+    # #270: the container keeps its database at /app/data, the HA add-on at
+    # /data. EM_DB overrides both. Inlined rather than shared: these tools
+    # are docker-cp'd into the container one file at a time and must stay
+    # standalone.
+    import os
+    env = os.environ.get("EM_DB", "").strip()
+    if env:
+        return env
+    for c in ("/data/echomuse.db", "/app/data/echomuse.db"):
+        if os.path.exists(c):
+            return c
+    return "/app/data/echomuse.db"
+
+
+DB = _resolve_db()
 
 # Bytes per heredoc block. A multiple of 3 so each block's base64 is padding
 # free — padding in the middle of the file would decode to garbage. Sized as a

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -976,6 +976,25 @@ func onWakeCrossing(cc *client.ControlClient, srv *server.Server,
 		log.Printf("[shadow] wake %.3f suppressed — muted", score)
 		return
 	}
+	// #263: light the listening ring NOW, from the one place that already
+	// knows the wake happened. The crossing used to travel to the controller
+	// and wait for leds_listening to come back — measured at +522ms before
+	// the animation moved, on a link whose control-plane tail reaches 2s
+	// (#139). The controller's own frame lands within an RTT and takes over
+	// via StartAnim's generation counter; same pattern as the volume arc,
+	// where the device draws immediately and the authoritative state follows.
+	// No new arbitration: the LED priority system already handles a newer
+	// frame superseding a local one. Only devices that have received a
+	// listening spec (config push) can do this; everyone else keeps the old
+	// behaviour exactly.
+	if srv != nil {
+		if raw := config.Get().Snapshot().ListeningAnim; len(raw) > 0 {
+			var spec server.AnimSpec
+			if err := json.Unmarshal(raw, &spec); err == nil && spec.Pattern != "" {
+				srv.StartAnim(spec)
+			}
+		}
+	}
 	cc.SendOwwWake(score, crossed, ageMs)
 }
 

--- a/device/go.mod
+++ b/device/go.mod
@@ -1,13 +1,13 @@
 module github.com/wilbowes/EchoMuse
 
-go 1.25.0
+go 1.24.0
 
 require (
 	github.com/Binozo/GoTinyAlsa v1.0.3
 	github.com/gorilla/websocket v1.5.3
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/gvalkov/golang-evdev v0.0.0-20220815104727-7e27d6ce89b6
-	golang.org/x/sys v0.47.0
+	golang.org/x/sys v0.41.0
 )
 
 require (

--- a/device/go.sum
+++ b/device/go.sum
@@ -30,8 +30,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
-golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/device/internal/config/config.go
+++ b/device/internal/config/config.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"encoding/json"
 	"log"
 	"os"
 	"strconv"
@@ -104,6 +105,14 @@ type Device struct {
 	// BLE proxy (passive scan over /dev/stpbt, internal/bluetooth) —
 	// pointer typed so false is expressible over the wire. Default off.
 	BleProxyEnabled *bool
+
+	// ListeningAnim carries the controller's current listening-ring
+	// animation spec, raw JSON in the led_anim shape, so the device can
+	// light it locally at its OWN wake crossing (#263) instead of waiting
+	// a controller round trip for the authoritative frame. Nil until the
+	// controller sends one; a device that has never received it simply
+	// keeps the old behaviour.
+	ListeningAnim json.RawMessage
 
 	initialised bool
 }
@@ -228,6 +237,9 @@ func (d *Device) Apply(msg ConfigMessage) {
 	if msg.BleProxyEnabled != nil {
 		d.BleProxyEnabled = msg.BleProxyEnabled
 	}
+	if msg.ListeningAnim != nil {
+		d.ListeningAnim = msg.ListeningAnim
+	}
 }
 
 // Snapshot returns a consistent copy of all config values.
@@ -278,6 +290,7 @@ func (d *Device) Snapshot() ConfigMessage {
 		AecDelayMs:         &aecDelayMs,
 		AecTailMs:          d.AecTailMs,
 		BleProxyEnabled:    &bleProxyEnabled,
+		ListeningAnim:      d.ListeningAnim,
 	}
 }
 
@@ -306,6 +319,11 @@ type ConfigMessage struct {
 	AecDelayMs         *int     `json:"aecDelayMs,omitempty"`
 	AecTailMs          int      `json:"aecTailMs,omitempty"`
 	BleProxyEnabled    *bool    `json:"bleProxyEnabled,omitempty"`
+
+	// ListeningAnim: raw led_anim spec for the listening ring (#263).
+	// Carried as raw JSON so this package does not depend on the
+	// animation renderer's types.
+	ListeningAnim json.RawMessage `json:"listeningAnim,omitempty"`
 }
 
 // clampMicGainDb bounds the fixed mic gain to a sane range: 0dB (unity —

--- a/device/internal/config/listening_anim_test.go
+++ b/device/internal/config/listening_anim_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// #263: the controller pushes the current listening-ring animation spec
+// alongside config so the device can light it locally at its own wake
+// crossing. It rides ConfigMessage as raw JSON (same shape as the led_anim
+// control message) so this package does not depend on the renderer.
+func TestListeningAnimRoundTripsThroughConfigMessage(t *testing.T) {
+	spec := json.RawMessage(`{"pattern":"solid","colors":[[0,255,0]],"listening":true,"ttlSec":30}`)
+
+	d := Get()
+	msg := ConfigMessage{Type: "config", ListeningAnim: spec}
+	d.Apply(msg)
+
+	got := d.Snapshot().ListeningAnim
+	if len(got) == 0 {
+		t.Fatal("a pushed listeningAnim must survive into Snapshot")
+	}
+	var parsed struct {
+		Pattern   string `json:"pattern"`
+		Listening bool   `json:"listening"`
+	}
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("stored spec is not valid JSON: %v", err)
+	}
+	if parsed.Pattern != "solid" || !parsed.Listening {
+		t.Fatalf("spec mangled in storage: %s", got)
+	}
+}
+
+// Partial-update semantics: a push WITHOUT listeningAnim must not clear one
+// already cached — config messages are sparse, and the animation only
+// changes when the controller says so.
+func TestListeningAnimSurvivesASparseConfigPush(t *testing.T) {
+	d := Get()
+	d.Apply(ConfigMessage{Type: "config",
+		ListeningAnim: json.RawMessage(`{"pattern":"pulse"}`)})
+	d.Apply(ConfigMessage{Type: "config", OwwThreshold: 0.5})
+
+	if len(d.Snapshot().ListeningAnim) == 0 {
+		t.Fatal("a push without listeningAnim cleared the cached spec")
+	}
+}


### PR DESCRIPTION
The four shell-proxy tools can now mint session tokens against the add-on deployment: the database path resolves `EM_DB` env var, then `/data/echomuse.db` (add-on), then the historical `/app/data/echomuse.db` (container). Inlined per tool — they are docker-cp'd in one file at a time and must stay standalone.

The ingress-route half of #270 is deliberately untouched: that is the security-posture decision the issue says should be deliberate.

Addresses part of #270
