### PR TITLE
Check the controller imports and boots, and name the owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,67 @@
+# Who must review what.
+#
+# This repo takes contributions from people who cannot test on the hardware
+# and cannot see the fleet, which is most of its contributors and is fine —
+# the code below is not harder than the rest, it is the code where a mistake
+# is EXPENSIVE OR UNRECOVERABLE rather than merely wrong. Everything here
+# either writes to a user's device, decides who is allowed in, or produces an
+# artifact that a stranger's Supervisor will pull and install unattended.
+#
+# The default is deliberately broad. A single maintainer reviewing everything
+# is the current reality; this file is what makes the review REQUIRED on the
+# paths where "the tests were green" is not sufficient evidence.
+
+*                                   @wilbowes
+
+# ── Anything that writes to somebody's device ───────────────────────────────
+# The OTA path, the shell proxy and the provisioning wizard are the three
+# places the controller can brick hardware it does not own. `patch_boot` is
+# the only partition write in the project, and a rule written against the
+# wrong by-name map is inverted rather than merely broken (see
+# controller/CLAUDE.md on TWRP vs Android).
+/controller/em_firmware.py          @wilbowes
+/controller/device_payloads/        @wilbowes
+/device/scripts/                    @wilbowes
+
+# ── Schema migrations: append-only and unrecoverable ────────────────────────
+# `em_db.MIGRATIONS` is indexed by the stored schema_version, so editing a
+# deployed entry corrupts every database that already ran it. This has
+# happened once and it disconnect-looped the fleet. There is no fix-forward
+# for a user whose database ran the edited version.
+/controller/em_db.py                @wilbowes
+
+# ── Who is allowed in ───────────────────────────────────────────────────────
+# Three pure decision modules plus the PKI. em_linkauth was security logic
+# with NO coverage until it orphaned a device; em_ingressauth honours a
+# header that is proof under the add-on and attacker-supplied on the
+# standalone container, and getting that condition wrong is an
+# unauthenticated admin session on a dashboard that proxies a root shell.
+/controller/em_auth.py              @wilbowes
+/controller/em_linkauth.py          @wilbowes
+/controller/em_ingressauth.py       @wilbowes
+/controller/em_pki.py               @wilbowes
+
+# ── What leaves the building ────────────────────────────────────────────────
+# Support bundles are attached to PUBLIC issues. em_support is an allowlist
+# and must stay one: the failure mode of a denylist is recognisable speech
+# or a geolocatable SSID in a stranger's browser, and it is unrecoverable
+# once posted.
+/controller/em_support.py           @wilbowes
+
+# ── Anything a stranger's machine installs unattended ───────────────────────
+# The release workflows publish images that Supervisor pulls on its own, and
+# config.yaml's `version:` pins which one. A wrong pin here shipped a
+# controller with no ingress support at all. controller-ea/ is GENERATED —
+# a hand-edit is reverted by the next sync and fails CI in between.
+/.github/workflows/                 @wilbowes
+/controller/config.yaml             @wilbowes
+/controller-ea/                     @wilbowes
+/repository.yaml                    @wilbowes
+
+# ── The reasoning, which is the thing that keeps fixes fixed ────────────────
+# These files are the record. Most of what is in them was learned the
+# expensive way, and a change that quietly drops a "why" costs the next
+# person the same debugging session.
+/CLAUDE.md                          @wilbowes
+/controller/CLAUDE.md               @wilbowes
+/device/CLAUDE.md                   @wilbowes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -103,6 +103,35 @@ updates:
     groups:
       go-dependencies:
         patterns: ["*"]
+    # golang.org/x/sys is pinned BELOW its latest on purpose, and the reason
+    # is the compiler rather than the library. The device image carries Go
+    # 1.24 with GOTOOLCHAIN=local baked in — deliberately, since that pin is
+    # what stops a third party's floating tag changing the compiler under
+    # us — and x/sys v0.42.0 declares `go 1.25.0` in its own go.mod, so the
+    # toolchain refuses it whatever directive device/go.mod carries.
+    #
+    # Verified against the module proxy 2026-08-23 rather than asserted:
+    #   v0.40.0 -> go 1.24.0
+    #   v0.41.0 -> go 1.24.0   <- the newest usable version, currently pinned
+    #   v0.42.0 -> go 1.25.0
+    #
+    # #128 raised the module graph past that line and the FIRMWARE WAS
+    # UNBUILDABLE FOR FOUR DAYS with every check green, because at the time
+    # nothing in CI used the pinned image — the other Go jobs run on
+    # GitHub's own toolchain, which silently resolves a newer Go. The
+    # device-firmware-build job in ci.yml now catches it, so this ignore is
+    # not what makes it safe; it is what stops a PR arriving every week that
+    # can only ever be closed.
+    #
+    # LIFT THIS WHEN THE COMPILER PIN MOVES, not before, and note that
+    # moving the compiler needs hardware in the loop: the failure mode is a
+    # binary the Dot refuses to run, which is the one thing not recoverable
+    # from the dashboard.
+    ignore:
+      - dependency-name: golang.org/x/sys
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
 
   # ── GitHub Actions ──────────────────────────────────────────────────────
   # Workflow actions run with repository credentials, so a stale pinned

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,125 @@ jobs:
           cache-to: type=gha,mode=max
 
 
+  controller-imports:
+    name: Controller modules import and the controller boots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # WHY THIS EXISTS: the two largest files in the controller have no
+      # test that so much as imports them. controller/CLAUDE.md records the
+      # constraint honestly — the suite cannot import em_controller or
+      # em_esphome, which is why em_linkauth, em_runbarrier, em_barge and
+      # em_turnclock were split out as pure modules with real coverage.
+      # That split is right and should continue. What it leaves behind is a
+      # blind spot: em_controller.py is ~4000 lines that nothing in CI ever
+      # parses beyond `pyflakes`, and em_api.py is not far behind.
+      #
+      # PR #280 walked straight into it — the control-plane dispatch chain
+      # re-indented inside a try/except, +498/-389, in exactly that file.
+      # A misplaced `except` would have been syntactically valid Python
+      # with the wrong control flow, every test still green, and the first
+      # symptom a device dropping its connection in the field. It was
+      # smoke-tested by hand instead, which is not a control.
+      #
+      # NO BUILD. The published image already carries aiohttp, onnxruntime,
+      # numpy and the rest, so the PR's source is mounted OVER it and the
+      # imports run against real dependencies. A pull is seconds where a
+      # build is minutes, and this has to run on every PR to be worth
+      # anything — application code is precisely what it catches.
+      #
+      # The tradeoff, stated so a later failure is not mysterious: a PR that
+      # ADDS a dependency fails here until the image is rebuilt, because
+      # :latest predates it. That is a true signal (a new dependency IS a
+      # deployment change) and the controller-image job above is what
+      # actually verifies such a PR builds. If it becomes noisy, gate this
+      # on requirements.txt being unchanged rather than deleting the job.
+      # The PR's Python is layered ONTO the published image rather than
+      # bind-mounted over /app. static/dashboard.js is gitignored and built
+      # during the image build, so mounting the source tree over /app hides
+      # the compiled bundle — the controller would still boot and serve a
+      # dashboard that 404s its own JavaScript, which is a worse check than
+      # no check. Overlaying only *.py keeps everything the build produced.
+      - name: Layer this PR's controller source onto the published image
+        run: |
+          docker pull ghcr.io/wilbowes/echomuse-controller:latest
+          printf '%s\n' \
+            'FROM ghcr.io/wilbowes/echomuse-controller:latest' \
+            'COPY controller/*.py /app/' \
+            > /tmp/ci-overlay.Dockerfile
+          docker build -f /tmp/ci-overlay.Dockerfile -t echomuse-controller:ci .
+      # Every module, not a hand-picked list: a new file added to the
+      # controller must import cleanly on the day it lands, and naming them
+      # individually means the next em_*.py is silently exempt.
+      #
+      # em_start is excluded because it is the add-on entrypoint — it reads
+      # /data/options.json and execs the controller, so importing it does
+      # not mean what importing the others means.
+      - name: Import every controller module
+        run: |
+          docker run --rm -w /app --entrypoint python3 \
+            echomuse-controller:ci -c '
+          import importlib, pathlib, sys, traceback
+          mods = sorted(p.stem for p in pathlib.Path(".").glob("*.py"))
+          mods = [m for m in mods if m not in ("em_start",)]
+          print(f"importing {len(mods)} modules")
+          failed = []
+          for m in mods:
+              try:
+                  importlib.import_module(m)
+              except BaseException:
+                  failed.append(m)
+                  print(f"--- {m} ---", file=sys.stderr)
+                  traceback.print_exc()
+          if failed:
+              print("\nFAILED: " + ", ".join(failed), file=sys.stderr)
+              sys.exit(1)
+          print("all modules imported")
+          '
+      # Importing proves the file parses and its module-level code runs.
+      # It does NOT prove the thing starts: the asyncio setup, the mDNS
+      # advertisement, the PKI generation and the ESPHome listeners all
+      # happen after that. Booting to "ready" covers the rest of the path a
+      # user meets first, and a controller that cannot start is the one
+      # failure nobody can work around.
+      - name: Boot the controller and wait for ready
+        run: |
+          mkdir -p /tmp/em-ci-data
+          docker run -d --name em-ci \
+            -e SERVER_IP=127.0.0.1 \
+            -e DB_PATH=/app/data/echomuse.db \
+            -e DEVICE_APPROVAL=strict \
+            -v /tmp/em-ci-data:/app/data \
+            echomuse-controller:ci
+          # 90s: a first start generates the CA and runs every migration on
+          # an empty database, which is the slowest legitimate boot there is.
+          for i in $(seq 1 90); do
+            if docker logs em-ci 2>&1 | grep -q "Controller ready"; then
+              echo "booted in ${i}s"
+              docker logs em-ci
+              # A traceback ANYWHERE in a clean first boot is a fault, even
+              # one something caught — nothing should be recovering from an
+              # error on an empty database with no devices attached.
+              if docker logs em-ci 2>&1 | grep -q "Traceback"; then
+                echo "::error::traceback during a clean first boot"
+                exit 1
+              fi
+              exit 0
+            fi
+            if [ "$(docker inspect -f '{{.State.Status}}' em-ci)" != "running" ]; then
+              echo "::error::controller exited before becoming ready"
+              docker logs em-ci
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "::error::controller did not report ready within 90s"
+          docker logs em-ci
+          exit 1
+      - name: Stop the controller
+        if: always()
+        run: docker rm -f em-ci 2>/dev/null || true
+
   device-firmware-build:
     name: Device firmware builds (pinned compiler)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Three guards against the gap today exposed: eleven commits reached main without a PR, and the largest re-indented 834 lines in a file nothing in CI parses.

- **The controller imports and boots on every PR.** The suite deliberately cannot import `em_controller` or `em_esphome`, which leaves the two largest files in the project with no check that they even load. #280's dispatch re-indent walked straight into it — a misplaced `except` is valid Python with the wrong control flow and every test still green. The job layers this PR's `*.py` onto the published image (a pull, not a build), imports all 34 modules, then boots against an empty database and waits for `Controller ready`. Verified locally: 34 imported, booted in 4s, zero tracebacks.
- **CODEOWNERS** on the paths where a mistake is unrecoverable rather than merely wrong — device writes, `MIGRATIONS`, the auth and PKI modules, `em_support` (its output goes on public issues), and anything Supervisor installs unattended.
- **Dependabot leash on `golang.org/x/sys`**, pinned below latest because of the compiler, not the library. Checked against the module proxy: v0.41.0 is the newest declaring `go 1.24.0`. #128 crossed that line and left the firmware unbuildable for four days with every check green.

Lift the x/sys ignore when the compiler pin moves — that needs hardware, since the failure mode is a binary the Dot refuses to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)