### PR TITLE
Close the other way update checks reach GitHub while disabled

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -3248,7 +3248,24 @@ async def _get_cached_release() -> Optional[dict]:
 
         return _release_cache
 
-    # No cache at all — fetch synchronously
+    # No cache at all. The disabled check has to be repeated HERE and not
+    # only on the branch above (#159): that one guards a controller which
+    # has successfully polled at least once, and this is the branch a fresh
+    # install takes — which is exactly the install belonging to someone who
+    # set the interval to 0 before the first poll ever ran. Gating only the
+    # refresh left them an outbound call on every dashboard visit that reads
+    # releases, forever, because a disabled poll loop never populates the
+    # cache that would have stopped it.
+    #
+    # None is the honest answer, and callers already handle it — this
+    # function returns None on any fetch failure. The dashboard shows no
+    # release information, which is what "I turned update checks off" should
+    # look like. "Check now" is unaffected: it calls _fetch_latest_release
+    # directly, and a button press is a deliberate request rather than
+    # background traffic.
+    if _update_check_interval() <= 0:
+        return None
+
     return await _fetch_latest_release()
 
 

--- a/controller/tests/test_update_interval.py
+++ b/controller/tests/test_update_interval.py
@@ -135,3 +135,43 @@ def test_on_demand_refresh_is_gated_when_disabled():
         "the freshness check must use the shared parser, not raw int()"
     assert "interval > 0" in fn, \
         "a disabled interval must serve the cache without fetching"
+
+
+def test_the_uncached_path_is_gated_too():
+    """
+    #159 follow-up: gating only the REFRESH leaves the no-cache branch open.
+
+    _get_cached_release has two exits that can reach GitHub. The first
+    guards a controller that has polled successfully at least once. The
+    second — "no cache at all — fetch synchronously" — is the branch a
+    FRESH INSTALL takes, and that is precisely the install belonging to
+    someone who set the interval to 0 before the first poll ever ran.
+
+    Leaving it ungated meant an outbound call on every dashboard visit that
+    reads releases, permanently: a disabled poll loop never populates the
+    cache whose presence would have taken the other branch.
+
+    Both exits must therefore be behind the same reading. Asserted on the
+    shipped source, like the test above, since em_api is deliberately not
+    importable here.
+    """
+    fn = _extract("_get_cached_release")
+
+    # The final fetch is the last statement in the function; everything
+    # after the cached-branch `return _release_cache` is the no-cache path.
+    tail = fn.rsplit("return _release_cache", 1)[-1]
+
+    # COMMENTS STRIPPED before the ordering check. The prose above the fix
+    # names _fetch_latest_release while explaining what "Check now" does, so
+    # matching raw source finds it before the code and the ordering assert
+    # fails on a correct implementation. A source-shape test has to look at
+    # the code, or it is testing the documentation.
+    code = "\n".join(l for l in tail.splitlines()
+                     if not l.lstrip().startswith("#"))
+
+    assert "_update_check_interval()" in code, \
+        "the no-cache path must consult the interval before fetching"
+    assert code.index("_update_check_interval()") < code.index("_fetch_latest_release"), \
+        "the disabled check must come BEFORE the fetch, not after it"
+    assert "return None" in code, \
+        "disabled with no cache must answer None, not fetch anyway"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -781,8 +781,19 @@ in a browser.
 
 Set `update_check_interval` (seconds, default `3600`) in the system config to
 change how often it runs. A long interval, say `86400`, reduces it to once a
-day. Note that `0` does **not** disable checking — it currently makes the
-poll loop spin without pausing, which is worse than leaving it alone.
+day, and `0` turns it off entirely — the controller then makes no outbound
+connection at all, and the dashboard shows whatever it last knew about
+releases rather than nothing.
+
+Re-enabling takes effect without a restart. Turning it off does not disable
+the **Check now** button on the Updates tab: that is a deliberate request, so
+it still asks GitHub when you press it.
+
+> **Before controller 2.21.0, `0` did the opposite** — it removed the pause
+> between checks instead of stopping them, so the controller polled
+> continuously until GitHub rate-limited it. If you set it to `0` on an
+> earlier version and left it there, updating fixes it; there is nothing to
+> undo.
 
 ### What never leaves
 


### PR DESCRIPTION
Follow-up to #279. It gated the refresh in `_get_cached_release` but not the fetch below it, and the two branches belong to different users.

```python
if version and url:                    # has polled before
    if interval > 0 and stale: ...     # gated ✓
    return _release_cache

return await _fetch_latest_release()   # fresh install — NOT gated ✗
```

The ungated branch is the one a **fresh install** takes — precisely the install belonging to someone who set the interval to `0` before the first poll ran. They got an outbound call on every dashboard visit that reads releases, permanently, because a disabled poll loop never populates the cache whose presence would have taken the other branch.

Narrow, but it is the exact claim the privacy section makes, and #158 documents this poll as the controller's only outbound connection.

- `None` is the honest answer; callers already handle it, since the function returns `None` on any fetch failure.
- **"Check now" is deliberately unaffected** — it calls `_fetch_latest_release` directly, and a button press is a request rather than background traffic. Verified, not assumed.
- **Docs corrected in the same change.** `configuration.md` still said `0` spins the poll loop — true when written, now exactly backwards, which is the worst state for a warning.

Test asserts on shipped source like its neighbour, stripping comments before the ordering check (the prose above the fix names `_fetch_latest_release`, which would fail a correct implementation). Verified by reintroducing the bug. 715 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)