### PR TITLE
Say when automatic update checks are off

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -2902,6 +2902,16 @@ async def _get_system_status(request: web.Request) -> web.Response:
         "total_devices":  len(all_rows),
         "pending":        sum(1 for r in all_rows if not r["approved"]),
         "approval_mode":  db.get_config("device_approval", "strict"),
+        # Whether the BACKGROUND poll runs (#159). With it off, "No release
+        # info" and a GitHub outage are indistinguishable from the Updates
+        # tab, and the tab is where someone goes to find out — so the reason
+        # for the blank has to be visible there or it reads as a fault and
+        # sends them debugging their network.
+        #
+        # Deliberately not "are updates available": "Check now" still works
+        # when this is False, because a button press is a request rather than
+        # background traffic. The flag says the poll is off, nothing more.
+        "update_checks_enabled": _update_check_interval() > 0,
         "latest_release": release["version"] if release else None,
         # Controller update, surfaced alongside the firmware one so the header
         # can badge it without a second round trip. Read-only by design: the

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1151,6 +1151,11 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
   const [pushing, setPushing] = useState(false);
   const [release, setRelease] = useState(null);
   const [checkingRelease, setCheckingRelease] = useState(false);
+  // Whether the background release poll runs (#159). Defaults TRUE so a
+  // failed status fetch shows nothing rather than claiming checks are off —
+  // a wrong "disabled" notice sends someone to change a setting that is
+  // already correct.
+  const [autoChecks, setAutoChecks] = useState(true);
   const [approveLabel, setApproveLabel] = useState(device.label || '');
   const [approving, setApproving] = useState(false);
   const [localFile, setLocalFile] = useState(null);
@@ -1189,6 +1194,11 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
     }
     if (tab === 'updates') {
       API.get('/api/releases/latest').then(setRelease).catch(() => {});
+      // Same tab-entry pattern as the asset state below: this changes only
+      // when someone edits system config, so polling it would be waste.
+      API.get('/api/system/status')
+        .then(s => setAutoChecks(s.update_checks_enabled !== false))
+        .catch(() => {});
       // Asset state costs a device shell round trip, so it is fetched on tab
       // entry rather than polled — unlike a release, it only changes when
       // someone acts on it here.
@@ -1862,6 +1872,23 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                     <span style={{ fontFamily:"'DM Mono',monospace", fontSize:11, color: needsUpdate ? 'var(--warn)' : 'var(--ok)' }}>
                       {release?.version ? (needsUpdate ? `Update ${release.version} available` : 'Up to date') : 'No release info'}
                     </span>
+                    {/* #159: with the background poll off, "No release info"
+                        and a GitHub outage look identical from here — and
+                        this tab is where someone comes to find out, so the
+                        blank has to name its own cause or it reads as a
+                        fault. Shown whatever the release state, because the
+                        stale-by-design case ("Up to date", last checked in
+                        March) is the one that misleads hardest. Inline
+                        rather than a site-wide banner: it is a setting
+                        somebody chose on purpose, and a persistent warning
+                        for a deliberate choice trains people to ignore
+                        warnings. */}
+                    {!autoChecks && (
+                      <span style={{ fontFamily:"'DM Mono',monospace", fontSize:11, color:'var(--lcd-dim)' }}
+                            title="update_check_interval is 0 — the controller makes no background connection to GitHub. Check now still works.">
+                        Auto-checks off
+                      </span>
+                    )}
                     <Pill small onClick={doCheckRelease} disabled={checkingRelease}>
                       {checkingRelease ? 'Checking…' : 'Check now'}
                     </Pill>


### PR DESCRIPTION
Follow-up to #289. With the background poll disabled, `No release info` and a GitHub outage look identical from the Updates tab — and that tab is where someone goes to find out, so the blank has to name its own cause.

`update_checks_enabled` rides the status payload the dashboard already fetches; the Updates tab shows **Auto-checks off** beside the release line.

Three choices worth flagging for review:

- **Shown whatever the release state**, not only when blank. The stale-by-design case misleads hardest: "Up to date" against a release list last fetched in March is a confident wrong answer, where a blank is merely unhelpful.
- **Inline, not a site-wide banner.** It is a setting chosen deliberately, and a persistent warning for a deliberate choice trains people to ignore warnings.
- **Defaults `true` in the dashboard**, so a failed status fetch shows nothing rather than claiming checks are off — a wrong "disabled" notice sends someone to change a setting that is already correct.

The flag reports whether the **poll** runs, not whether updates can be found: "Check now" still works with it off.

Verified on a booted container: `True` by default, `False` after PATCHing the interval to `0`, no restart needed. The dashboard bundle is built during the image build, so it is not visible until the image is rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)