### PR TITLE
Let the firmware upload through again after the aiohttp bump

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -180,6 +180,13 @@ _update_errors: dict[str, str] = {}
 # Pending local binary uploads — keyed by UUID token, expire after 10 minutes.
 _pending_uploads: dict[str, bytes] = {}
 
+# Largest firmware binary /api/releases/upload will accept. Roughly 5x the
+# current ~10.7 MB build, so it bounds memory (the upload is held in RAM until
+# deployed or expired) without needing revision every release. The aiohttp
+# transport limit is set ABOVE this in create_app so this is the ceiling a
+# user actually meets, with a message that names it.
+UPLOAD_MAX_BYTES = 50 * 1024 * 1024
+
 # WiFi change state per device_id — {"pending": {...}|None, "last_result":
 # {...}|None}. Deliberately NOT on the live Device object: the connection
 # (and with it the Device) dies when the network switches, and the outcome
@@ -253,7 +260,33 @@ async def create_app() -> web.Application:
     Routes are registered here. The app is not started — the caller
     creates an AppRunner and TCPSite.
     """
-    app = web.Application(middlewares=[_ingress_only_middleware, _error_middleware])
+    # client_max_size defaults to 1 MB in aiohttp and the firmware is ~10.7 MB,
+    # so /api/releases/upload rejects every real binary without this. Both
+    # callers post there: the dashboard's Local Build panel and
+    # controller/tools/ota.py.
+    #
+    # THIS IS A REGRESSION FROM AN AIOHTTP BUMP, NOT AN OLD BUG, and the
+    # difference matters for what else to distrust. Measured across the two
+    # pinned versions with a 3 MB multipart POST at a default Application:
+    #
+    #   aiohttp 3.13.5  -> 200   (streaming multipart bypassed the limit)
+    #   aiohttp 3.14.3  -> 413   HTTPRequestEntityTooLarge
+    #
+    # 3.13.5 held from May until 2026-08-18, when #129's routine half moved to
+    # 3.14.3 and broke local deploys silently — no CI job posts a real-sized
+    # body at this endpoint, and the ordinary release path never touches it
+    # (em_firmware fetches controller-side and pushes from there), so only a
+    # developer deploying a local build ever met it.
+    #
+    # Set ABOVE the handler's limit on purpose: the handler's 413 names the
+    # actual ceiling ("Binary exceeds 50 MB limit"), and it can only be the
+    # error a user sees if the transport lets the body through first. A
+    # transport limit equal to the application limit means the useful message
+    # is unreachable by construction.
+    app = web.Application(
+        middlewares=[_ingress_only_middleware, _error_middleware],
+        client_max_size=UPLOAD_MAX_BYTES + 8 * 1024 * 1024,
+    )
 
     # Static / setup
     app.router.add_get("/",           _serve_spa)
@@ -1398,8 +1431,13 @@ async def _post_upload_binary(request: web.Request) -> web.Response:
         binary = await field.read()
         if not binary:
             return _error("empty_upload", "Uploaded binary is empty", 400)
-        if len(binary) > 50 * 1024 * 1024:
-            return _error("too_large", "Binary exceeds 50 MB limit", 413)
+        if len(binary) > UPLOAD_MAX_BYTES:
+            return _error(
+                "too_large",
+                f"Binary is {len(binary) / 1024 / 1024:.1f} MB, over the "
+                f"{UPLOAD_MAX_BYTES // 1024 // 1024} MB limit",
+                413,
+            )
 
         token = str(_uuid.uuid4())
         _pending_uploads[token] = binary
@@ -1411,6 +1449,13 @@ async def _post_upload_binary(request: web.Request) -> web.Response:
         asyncio.create_task(_expire())
 
         return _ok({"upload_token": token, "size": len(binary)})
+    except web.HTTPException:
+        # aiohttp's own — HTTPRequestEntityTooLarge above all, raised by the
+        # transport before this handler sees a byte. Swallowing it into a 500
+        # is how a 1 MB transport limit presented as "an internal error
+        # occurred" instead of naming a size, and the middleware already
+        # re-raises these deliberately.
+        raise
     except Exception as e:
         log.error(f"[api] Upload error: {e}")
         return _error("upload_failed", str(e), 500)

--- a/controller/tests/test_upload_limit.py
+++ b/controller/tests/test_upload_limit.py
@@ -1,0 +1,97 @@
+"""
+The firmware upload must not be capped below a firmware.
+
+aiohttp's `client_max_size` defaults to 1 MB and `create_app` never set it,
+so /api/releases/upload rejected every real binary — the build is ~10.7 MB.
+Both callers post there: the dashboard's Local Build panel and
+controller/tools/ota.py. The failure arrived as a 500 reading "An internal
+error occurred", because the transport raises before the handler runs and the
+handler's own `except Exception` turned aiohttp's 413 into a 500.
+
+A REGRESSION, NOT AN OLD BUG. Measured across the two pinned versions with a
+3 MB multipart POST at a default Application:
+
+    aiohttp 3.13.5  -> 200   (streaming multipart bypassed the limit)
+    aiohttp 3.14.3  -> 413   HTTPRequestEntityTooLarge
+
+3.13.5 held from May until 2026-08-18, when #129's routine half moved to
+3.14.3. Local deploys worked for the life of the project until that day.
+
+Nothing caught it for three reasons worth keeping in mind. The handler DOES
+carry a 50 MB check, so reading the code suggests large uploads were
+considered — that check sits after the transport limit and never ran. The
+ordinary release path never touches this endpoint, because em_firmware
+fetches the binary controller-side and pushes from there, so only a developer
+deploying a local build meets it. And a dependency bump changed BEHAVIOUR
+rather than an interface, which no import, no type and no green check can
+see — the same class of gap as #224 (numpy/onnxruntime bumps needing a wake
+word comparison behind them).
+
+em_api imports aiohttp and the whole controller stack, so these assert on the
+shipped source in the established style (see test_update_interval.py).
+"""
+
+import re
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _src() -> str:
+    return (CONTROLLER / "em_api.py").read_text()
+
+
+def test_the_app_raises_the_transport_limit_above_a_firmware():
+    """
+    A default aiohttp Application caps bodies at 1 MB. The firmware is an
+    order of magnitude larger, so create_app must set client_max_size or the
+    upload endpoint cannot work at all.
+    """
+    src = _src()
+    m = re.search(r"web\.Application\((.*?)\)\n", src, re.S)
+    assert m, "create_app's web.Application call not found"
+    assert "client_max_size" in m.group(1), (
+        "web.Application must set client_max_size — the 1 MB default is "
+        "below the ~10.7 MB firmware and rejects every upload"
+    )
+
+
+def test_the_transport_limit_is_looser_than_the_handler_limit():
+    """
+    The handler's 413 names the real ceiling. It can only ever be the error a
+    user sees if the transport lets the body arrive first — set them equal and
+    the useful message becomes unreachable, with aiohttp's terse version
+    winning every time.
+    """
+    src = _src()
+    assert "UPLOAD_MAX_BYTES" in src, "the limit should be a named constant"
+
+    m = re.search(r"client_max_size\s*=\s*([^,\n]+)", src)
+    assert m, "client_max_size assignment not found"
+    expr = m.group(1)
+    assert "UPLOAD_MAX_BYTES" in expr and "+" in expr, (
+        "the transport limit must be derived from UPLOAD_MAX_BYTES plus "
+        f"headroom so the handler's message wins; found: {expr!r}"
+    )
+
+
+def test_the_handler_does_not_swallow_aiohttp_http_exceptions():
+    """
+    HTTPRequestEntityTooLarge is raised by the transport, not by us. The
+    upload handler's blanket `except Exception` caught it and returned a 500
+    with no size in the message, which is how a size limit presented as an
+    internal error. The middleware re-raises HTTPException deliberately; the
+    handler has to as well, and BEFORE the general clause.
+    """
+    src = _src()
+    start = src.index("async def _post_upload_binary")
+    body = src[start:start + 4000]
+
+    assert "except web.HTTPException" in body, (
+        "the upload handler must re-raise aiohttp's own HTTP exceptions "
+        "rather than turning a 413 into a 500"
+    )
+    assert body.index("except web.HTTPException") < body.index("except Exception"), (
+        "the HTTPException clause must come first, or the general clause "
+        "catches it and the fix does nothing"
+    )


### PR DESCRIPTION
`/api/releases/upload` rejects every real binary: aiohttp's `client_max_size` defaults to **1 MB** and `create_app` never set it, while the firmware is **~10.7 MB**. Both callers post there — the dashboard's Local Build panel and `controller/tools/ota.py`.

## A regression, not an old bug

Measured across the two pinned versions with a 3 MB multipart POST at a default `Application`:

| aiohttp | result |
|---|---|
| **3.13.5** | `200` — streaming multipart bypassed the limit |
| **3.14.3** | `413` `HTTPRequestEntityTooLarge` |

3.13.5 held from May until **2026-08-18**, when #129's routine half moved to 3.14.3. Local deploys worked for the life of the project until that day, and the bump reported nothing.

## Why nothing caught it

- The handler carries its **own 50 MB check**, so the code reads as though large uploads were handled. That check sits *after* the transport limit and never ran.
- **The ordinary release path never touches this endpoint** — `em_firmware` fetches the binary controller-side and pushes from there. Only a developer deploying a local build meets it.
- A dependency bump changed **behaviour rather than an interface**, which no import, no type and no green check can see. Same class of gap as #224.

## The fix

- `client_max_size = UPLOAD_MAX_BYTES + 8 MB` — **above** the application limit on purpose, so the handler's 413 (which names the real ceiling *and* the size sent) is reachable. Equal limits make the useful message unreachable by construction.
- The handler re-raises `web.HTTPException` before its general clause. That blanket `except Exception` is why a size limit presented as *"An internal error occurred"* with a 500 instead of a number.

## Verified by running it

| | |
|---|---|
| the real 10.7 MB firmware | `200`, `size: 10708001` |
| a 60 MB file | `413`, `Binary is 57.2 MB, over the 50 MB limit` |

718 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)