### PR TITLE
Record a playback barge as barged, which #251 missed

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -326,6 +326,13 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         # controller; only one turn active at a time.
         self._turn_active       = False
         self._turn_cancelled    = False
+        # A barge during PLAYBACK, which deliberately does NOT set
+        # _turn_cancelled — see abort_ha_run. Kept separate because that flag
+        # gates control flow (on_thinking, on_stt_end, the intent-ended
+        # check) and marking a delivered response cancelled would change what
+        # the turn DOES, not just what it is recorded as. This one is read by
+        # the outcome logic and nothing else.
+        self._turn_barged       = False
         self._tts_audio_url:    Optional[str] = None
         self._tts_audio_data:   Optional[bytes] = None
         self._tts_event         = asyncio.Event()
@@ -955,6 +962,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
 
         self._turn_active           = True
         self._turn_cancelled        = False
+        self._turn_barged           = False
         self._tts_event.clear()
         self._tts_audio_url         = None
         self._tts_audio_data        = None
@@ -1106,7 +1114,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 if trace:
                     trace.tts_bytes = pcm_bytes or 0
 
-                if self._turn_cancelled:
+                if self._turn_cancelled or self._turn_barged:
                     # #251: cut off mid-response. This used to fall through to
                     # the finally-default "ok", so a turn cancelled during
                     # playback was indistinguishable from an answered one —
@@ -1118,7 +1126,19 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     # immediately followed by a turn whose trigger is
                     # "barge-in" — the interrupting wake is recorded as that
                     # turn's trigger.
-                    log.info(f"[{self._log_name}] Turn cancelled during playback")
+                    #
+                    # BOTH FLAGS, because the two barge paths set different
+                    # ones and the first fix read only the first. A barge
+                    # during THINKING goes through cancel_voice_turn and sets
+                    # _turn_cancelled; a barge during PLAYBACK goes through
+                    # abort_ha_run, which deliberately does not — marking a
+                    # delivered response cancelled would change control flow,
+                    # not just the record. So the fix for #251 covered the
+                    # case where nothing had been said and missed the one it
+                    # was written for. Measured 2026-08-23: "Sing a song."
+                    # cut off mid-song, logged `Cancelled during streamed
+                    # buffer drain`, and persisted outcome=ok.
+                    log.info(f"[{self._log_name}] Turn cut off mid-response")
                     if trace: trace.outcome = "barged"
                 elif pcm_bytes:
                     if trace: trace.outcome = "ok"
@@ -1558,6 +1578,15 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         cancels a completed task (a no-op) and queues a sentinel into a queue
         that handle_pipeline_start drains before the next run.
         """
+        # #251 follow-up: record that this turn was cut off, WITHOUT marking
+        # it cancelled. The two are different questions and only the second
+        # changes behaviour. A playback barge reaching the outcome logic with
+        # neither flag set is what made "Sing a song." record `ok` after
+        # being cut off mid-song (measured 2026-08-23) — the fix for #251
+        # keyed on _turn_cancelled, which this path deliberately never sets,
+        # so it covered the thinking barge and missed the playback one it was
+        # actually written for.
+        self._turn_barged = True
         if self._transport and not self._transport.is_closing():
             self._send_one(api_pb2.VoiceAssistantRequest(start=False))
         # Armed even if the transport is gone: the barrier is cheap, and a

--- a/controller/tests/test_turn_outcomes.py
+++ b/controller/tests/test_turn_outcomes.py
@@ -61,3 +61,63 @@ def test_self_interruption_is_detectable_from_the_persisted_fields():
     rec = rec[:rec.index("}")]
     assert '"outcome"' in rec and '"trigger"' in rec, \
         "outcome and trigger must both reach the turns table"
+
+
+# ─── Both barge paths, because covering one is what caused the bug ───────────
+
+def test_the_playback_barge_path_also_marks_the_outcome():
+    """
+    #251's fix keyed on `_turn_cancelled` and therefore covered the barge it
+    was NOT written for.
+
+    There are two paths and they set different flags:
+
+        barge during THINKING  -> cancel_voice_turn()  -> _turn_cancelled
+        barge during PLAYBACK  -> abort_ha_run()       -> (nothing, by design)
+
+    abort_ha_run deliberately does not mark the turn cancelled — that flag
+    gates on_thinking, on_stt_end and the intent-ended check, so marking a
+    delivered response cancelled would change what the turn DOES. Its
+    docstring says so.
+
+    The consequence, measured on hardware 2026-08-23: "Sing a song." was cut
+    off mid-song by a real barge, logged `Cancelled during streamed buffer
+    drain`, and persisted `outcome=ok`. The exact reading #251 existed to
+    prevent, on the exact case its description describes.
+
+    So abort_ha_run must record something, and the outcome must read both.
+    """
+    src = (CONTROLLER / "em_esphome.py").read_text()
+
+    abort = src[src.index("def abort_ha_run"):]
+    abort = abort[:abort.index("\n\n\n")] if "\n\n\n" in abort else abort[:2000]
+    assert "_turn_barged" in abort, (
+        "abort_ha_run is the PLAYBACK barge path and must record that the "
+        "turn was cut off, even though it must not mark it cancelled"
+    )
+    assert "_turn_cancelled = True" not in abort, (
+        "abort_ha_run must NOT set _turn_cancelled — that flag changes "
+        "control flow, and its docstring explains why this path avoids it"
+    )
+
+    branch = src[src.index("# #251: cut off mid-response") - 200:]
+    branch = branch[:branch.index('trace.outcome = "barged"')]
+    assert "_turn_barged" in branch and "_turn_cancelled" in branch, (
+        "the outcome must read BOTH flags — one per barge path"
+    )
+
+
+def test_the_barged_flag_is_reset_per_turn():
+    """
+    A sticky flag would mark every later turn on the same satellite as
+    barged, which is the same class of wrong answer in the other direction.
+    Reset alongside _turn_cancelled at turn start, not only at construction.
+    """
+    src = (CONTROLLER / "em_esphome.py").read_text()
+    start = src.index("self._turn_active           = True")
+    window = src[start:start + 400]
+    assert "_turn_barged" in window, (
+        "_turn_barged must be cleared where _turn_cancelled is, at turn "
+        "start — clearing it only in __init__ leaves it set for the life "
+        "of the connection"
+    )


### PR DESCRIPTION
#251 keyed on `_turn_cancelled` and therefore covered the barge it was **not** written for.

| barge during | calls | sets `_turn_cancelled` |
|---|---|---|
| thinking | `cancel_voice_turn()` | yes |
| **playback** | `abort_ha_run()` | **no — by design** |

`abort_ha_run` deliberately avoids that flag, and its docstring explains why: it gates `on_thinking`, `on_stt_end` and the intent-ended check, so marking a delivered response cancelled would change what the turn *does*, not just what it's recorded as. That reasoning is correct and is kept.

## Measured on hardware today

A real barge cut "Sing a song." off mid-song. The controller logged `Cancelled during streamed buffer drain`, and the turn persisted as:

```
[TURN] trigger=barge-in outcome=ok text='Sing a song.'
```

Exactly the reading #251 exists to prevent, on exactly the case its description describes — *"there nothing had been said yet, here a response had begun."*

The signal was present throughout: `device.cancel_event` was set, which is what produced the drain log. The fix read the other flag.

## The change

`abort_ha_run` records `_turn_barged`, kept separate so it carries no control-flow meaning, and the outcome reads both flags.

**The test covers both paths**, since covering one is what caused this. Verified by reintroducing each half independently:

- outcome check reverted to `_turn_cancelled` only → fails
- flag removed from `abort_ha_run` → fails
- per-turn reset dropped (a sticky flag would mark every later turn as barged) → fails

720 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)