### PR TITLE
Read the version compile.sh actually embeds, and stop claiming rollbacks

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -1559,13 +1559,50 @@ async def _delete_oww_model(request: web.Request) -> web.Response:
 def _extract_binary_version(binary: bytes) -> str | None:
     """
     Scan a compiled Go binary for its embedded EchoMuse version string.
-    The version is compiled in via -ldflags "-X ...Version=YYYYMMDD-HHMM-suffix".
-    Pattern matches e.g. 20260614-1152-dev, 20260614-0513-release, etc.
-    Falls back to None if not found, caller generates a local-YYYYMMDD-HHMM label.
+
+    Two schemes, because compile.sh changed and this did not:
+
+      v2.12.0-63-g99628d3   `git describe --tags --match 'v*'` — CURRENT
+      20260614-1152-dev     date+suffix — used when the tree is DIRTY, and
+                            the only scheme this function knew until now
+
+    Matching only the second is why a clean-tree local build extracted
+    nothing, fell back to a `local-<timestamp>` label, and then never matched
+    the version the device reported on reboot — so a completely successful
+    deploy was announced as "auto-rolled back". A message that says the
+    opposite of what happened is worse than a plain failure, because the
+    natural response is to distrust the feature.
+
+    BARE `vX.Y.Z` IS DELIBERATELY NOT MATCHED, and that is the whole
+    subtlety. A Go binary embeds its dependencies' module versions, so the
+    shape is far from unique — measured on the v2.12.0-63-g99628d3 build:
+    102 occurrences, 9 distinct, including v0.41.0 (x/sys), v1.5.3
+    (gorilla/websocket), v1.0.3 (GoTinyAlsa) and v1.1.41 (miekg/dns). Our own
+    version happened to appear first in file order on that build, which is
+    luck and not a property to rely on: a dependency string landing earlier
+    would silently extract the wrong version and label the deploy with it.
+
+    The `-N-gSHA` suffix makes it unique — exactly one match on the same
+    binary — so only the suffixed form is accepted. A build made exactly ON a
+    tag has no suffix and extracts nothing, which is correct: that binary
+    belongs on the release path, and returning None gets an honest
+    `local-<timestamp>` label rather than a confident wrong one.
+
+    Returns None when nothing matches; the caller labels it
+    `local-YYYYMMDD-HHMM` and the reconnect check compares against the
+    version the device had BEFORE the push rather than against this.
     """
     import re as _re
-    match = _re.search(rb'20\d{6}-\d{4}-[a-z][a-z0-9]*', binary)
-    return match.group(0).decode("ascii") if match else None
+    for pattern in (
+        # git describe, suffixed form only — see above
+        rb'v\d+\.\d+\.\d+-\d+-g[0-9a-f]{7,40}',
+        # dirty-tree builds, and every binary predating the compile.sh change
+        rb'20\d{6}-\d{4}-[a-z][a-z0-9]*',
+    ):
+        match = _re.search(pattern, binary)
+        if match:
+            return match.group(0).decode("ascii")
+    return None
 
 
 async def _update_failed(device_id: str, reason: str) -> None:

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1370,7 +1370,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
     try {
       const res = await API.post(`/api/devices/${device.device_id}/update`, {});
       setPushLog(l => [...l, `Deploying ${res.version} — waiting for reconnect…`]);
-      _pollReconnect(res.version);
+      _pollReconnect(res.version, device.firmware_ver);
     } catch(e) {
       setPushLog([`Error: ${e.error || 'Update failed'}`]);
       setPushing(false);
@@ -1387,7 +1387,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
       setPushLog(l => [...l, '✓ Upload complete — deploying…']);
       const res = await API.post(`/api/devices/${device.device_id}/update`, { upload_token: up.upload_token });
       setPushLog(l => [...l, `Deploying ${res.version} — waiting for reconnect…`]);
-      _pollReconnect(res.version);
+      _pollReconnect(res.version, device.firmware_ver);
     } catch(e) {
       setUploading(false);
       setPushLog(l => [...l, `Error: ${e.error || 'Deploy failed'}`]);
@@ -1395,7 +1395,23 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
     }
   }
 
-  function _pollReconnect(targetVersion) {
+  // priorVersion is what the device was running BEFORE this push, and it is
+  // what makes "rolled back" a claim rather than a guess. The old code
+  // inferred a rollback from `firmware_ver !== targetVersion` alone, which is
+  // only sound when the target is known to be exactly what the device will
+  // report — true for a release, false for a local build.
+  //
+  // It was false in the way that matters: _extract_binary_version knew only
+  // the old date-based scheme, so a clean-tree local build got a synthetic
+  // `local-<timestamp>` label that the device could never report back. Every
+  // such deploy therefore succeeded and announced "auto-rolled back", which
+  // is worse than announcing nothing — the natural response to being told a
+  // deploy reverted is to stop using the feature.
+  //
+  // With the prior version in hand the three outcomes are distinguishable:
+  // back on the target is success, back on what it had before is a genuine
+  // rollback, anything else is unexpected and says so rather than guessing.
+  function _pollReconnect(targetVersion, priorVersion) {
     let attempts = 0;
     let wasDisconnected = false;
     const poll = setInterval(async () => {
@@ -1418,7 +1434,24 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
           setPushLog(l => [...l, `✗ ${d.update_error}`]);
           clearInterval(poll); setPushing(false);
         } else if (wasDisconnected && d?.connected && d?.firmware_ver && d.firmware_ver !== targetVersion) {
-          setPushLog(l => [...l, `⚠ Device reconnected on ${d.firmware_ver} — auto-rolled back`]);
+          // Back on what it was running before = the supervisor flipped the
+          // symlink after three fast exits. That is the only case that
+          // earns the word "rolled back".
+          const rolledBack = priorVersion && d.firmware_ver === priorVersion;
+          setPushLog(l => [...l, rolledBack
+            ? `⚠ Device reconnected on ${d.firmware_ver} — auto-rolled back`
+            // Not the target and not the old one either. Most often the
+            // deploy WORKED and the label was wrong: a binary whose version
+            // the controller could not read is labelled local-<timestamp>,
+            // which the device will never report. Say what was seen and what
+            // was expected, and let the reader judge — asserting a rollback
+            // here is what made a successful deploy look like a failure.
+            : `Device reconnected on ${d.firmware_ver} (expected ${targetVersion})`
+              + (String(targetVersion).startsWith('local-')
+                  ? ' — the label was generated because the binary carried no'
+                    + ' readable version; if the version above is the build you'
+                    + ' pushed, this succeeded'
+                  : '')]);
           clearInterval(poll); setPushing(false);
         } else if (attempts > 40) {
           setPushLog(l => [...l, 'Timed out — check device logs']);
@@ -1432,7 +1465,7 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
     setPushing(true); setPushLog([`Rolling back to ${device.firmware_previous}…`]);
     try {
       await API.post(`/api/devices/${device.device_id}/rollback`, {});
-      _pollReconnect(device.firmware_previous);
+      _pollReconnect(device.firmware_previous, device.firmware_ver);
     } catch(e) {
       setPushLog([`Error: ${e.error || 'Rollback failed'}`]);
       setPushing(false);

--- a/controller/tests/test_binary_version.py
+++ b/controller/tests/test_binary_version.py
@@ -1,0 +1,126 @@
+"""
+_extract_binary_version must know the scheme compile.sh actually produces.
+
+It knew only the old date-based one (`20260614-1152-dev`) while compile.sh
+moved to `git describe`. A clean-tree local build therefore extracted
+nothing, was labelled `local-<timestamp>`, and could never match the version
+the device reported on reboot — so the dashboard announced a completely
+successful deploy as "auto-rolled back". Measured on hardware 2026-08-23.
+
+A message that says the opposite of what happened is worse than a plain
+failure: the natural response to being told a deploy reverted is to stop
+using the feature.
+
+em_api imports aiohttp and the whole controller stack, so the function's
+source is executed in a stub namespace — the same approach as
+test_update_interval.py, and it runs the code that actually ships.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _extract():
+    """The shipped _extract_binary_version, executed standalone."""
+    src = (CONTROLLER / "em_api.py").read_text()
+    start = src.index("def _extract_binary_version")
+    end = src.index("async def _update_failed", start)
+    ns: dict = {}
+    exec(src[start:end], ns)
+    return ns["_extract_binary_version"]
+
+
+@pytest.mark.parametrize("embedded,expected", [
+    # git describe — what compile.sh produces from a clean tree today
+    (b"junk\x00v2.12.0-63-g99628d3\x00junk", "v2.12.0-63-g99628d3"),
+    (b"\x00v3.0.0-1-gabcdef0\x00",           "v3.0.0-1-gabcdef0"),
+    # date scheme — dirty tree, and every binary predating the change
+    (b"junk 20260614-1152-dev junk",         "20260614-1152-dev"),
+    (b"20260614-0513-release",               "20260614-0513-release"),
+])
+def test_both_version_schemes_are_recognised(embedded, expected):
+    assert _extract()(embedded) == expected
+
+
+def test_a_dependency_version_is_never_mistaken_for_ours():
+    """
+    THE REASON BARE vX.Y.Z IS NOT MATCHED.
+
+    A Go binary embeds its dependencies' module versions, so `vX.Y.Z` is
+    nowhere near unique. Measured on the real v2.12.0-63-g99628d3 firmware:
+    102 occurrences, 9 distinct, including v0.41.0 (x/sys), v1.5.3
+    (gorilla/websocket), v1.0.3 (GoTinyAlsa) and v1.1.41 (miekg/dns).
+
+    Our own version happened to sort first in file order on that build. That
+    is luck, not a property — a dependency string landing earlier would make
+    the controller label the deploy with somebody else's version number and
+    then report a rollback when the device disagreed.
+
+    None is the correct answer here: the caller falls back to a
+    `local-<timestamp>` label, which is honest about not knowing.
+    """
+    deps = b"v0.41.0\x00v1.5.3\x00v1.0.3\x00v1.1.41\x00v0.0.0\x00"
+    assert _extract()(deps) is None
+
+
+def test_a_bare_tag_build_extracts_nothing_rather_than_guessing():
+    """
+    A build made exactly ON a tag has no `-N-gSHA` suffix and is
+    indistinguishable from a dependency version. It belongs on the release
+    path anyway, where the version comes from the release rather than from
+    the bytes.
+    """
+    assert _extract()(b"v2.13.0 and v1.5.3 and v0.41.0") is None
+
+
+def test_the_suffixed_form_wins_over_a_stray_date_string():
+    """
+    Both patterns can be present — a Go binary contains plenty of digits.
+    The current scheme must be tried first, or a coincidental date-shaped
+    string earlier in the file would win.
+    """
+    both = b"20200101-0000-x\x00v2.12.0-63-g99628d3\x00"
+    assert _extract()(both) == "v2.12.0-63-g99628d3"
+
+
+def test_the_dashboard_only_claims_a_rollback_when_it_can_prove_one():
+    """
+    The other half of the same bug. `_pollReconnect` inferred "auto-rolled
+    back" from `firmware_ver !== targetVersion` alone, which is sound only
+    when the target is exactly what the device will report — true for a
+    release, false for a local build with an unreadable version.
+
+    It now takes the version the device was running BEFORE the push, so a
+    rollback is a device back on its previous binary rather than any
+    mismatch at all.
+    """
+    src = (CONTROLLER / "static" / "dashboard.jsx").read_text()
+
+    assert "function _pollReconnect(targetVersion, priorVersion)" in src, \
+        "the poll must know what the device was running before the push"
+
+    body = src[src.index("function _pollReconnect("):]
+    body = body[:body.index("\n  async function ")] if "\n  async function " in body \
+        else body[:4000]
+    assert "auto-rolled back" in body
+    claim = body[:body.index("auto-rolled back")]
+    # The COMPARISON, not merely the identifier. Asserting that
+    # "priorVersion" appears anywhere before the wording passes even when
+    # the gate is replaced by a constant, because the parameter is still
+    # named in the signature and the comments — verified by reintroducing
+    # exactly that, which the looser assertion missed.
+    assert re.search(r"firmware_ver\s*===\s*priorVersion", claim), \
+        "the rollback wording must be gated on the device having come back " \
+        "on the version it was running BEFORE the push, not on a bare " \
+        "mismatch with the target"
+
+    # Every caller has to supply it, or the gate silently reads undefined
+    # and the claim quietly becomes unreachable instead of wrong.
+    calls = re.findall(r"_pollReconnect\((?!targetVersion)([^)]*)\)", src)
+    assert calls, "no _pollReconnect call sites found"
+    for args in calls:
+        assert "," in args, f"_pollReconnect({args}) is missing priorVersion"


### PR DESCRIPTION
A clean-tree local build deployed perfectly and the dashboard announced **"auto-rolled back"**. Two bugs, one in each half.

## The extractor knew one scheme; compile.sh produces another

| embedded | when | matched before |
|---|---|---|
| `v2.12.0-63-g99628d3` | clean tree (`git describe`) — **current** | no |
| `20260614-1152-dev` | dirty tree only | yes |

So every clean local build extracted nothing, got a synthetic `local-<timestamp>` label, and could never match what the device reported on reboot.

**Bare `vX.Y.Z` is deliberately still not matched.** A Go binary embeds its dependencies' module versions — measured on the real firmware: **102 occurrences, 9 distinct**, including `v0.41.0` (x/sys), `v1.5.3` (gorilla/websocket), `v1.0.3` (GoTinyAlsa). Ours sorted first on that build by luck; a dependency landing earlier would label the deploy with someone else's version. The `-N-gSHA` suffix is unique, so only the suffixed form is accepted.

## The dashboard asserted a rollback it couldn't know

`_pollReconnect` inferred one from `firmware_ver !== targetVersion` alone — sound for a release, false for a local build. It now takes the version the device ran **before** the push:

- back on the target → success
- back on the prior one → a genuine rollback, and **only this** says so
- anything else → what was seen, what was expected, no verdict

## Verified by reintroducing each half

Extractor reverted, extractor widened to bare `vX.Y.Z`, and the rollback gate replaced by a constant.

The third initially **passed** — asserting that `priorVersion` appears before the wording is satisfied by the parameter name in the signature. It now asserts the comparison itself. Worth noting as the same class of thing this PR fixes: a check that looks right and matches nothing that matters.

728 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)