### PR TITLE
Record why a turn ended early, not just that it did

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -1226,7 +1226,8 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
                         # old run MUST be aborted upstream first or its tail
                         # events land on the new turn and kill it
                         # (pipeline_refused, 5 of 5 attempts, 2026-08-17).
-                        esphome.cancel_voice_turn(device.device_id, abort_ha=True)
+                        esphome.cancel_voice_turn(
+                            device.device_id, abort_ha=True, reason="barged")
                     return
     finally:
         rms_mean = rms_sum / frames if frames else 0.0
@@ -2467,7 +2468,7 @@ async def handle_button_event(device: Device, event: dict):
         if action == em_button.CANCEL:
             log.info(f"[{device.device_id}] Dot button — cancelling voice turn")
             device.cancel_event.set()
-            esphome.cancel_voice_turn(device.device_id)
+            esphome.cancel_voice_turn(device.device_id, reason="cancelled")
             # Flush the device's speaker too, or cancelling DURING the spoken
             # response only stops the controller feeding it: the ring clears
             # while up to ~5.5s already in audioChanDepth plays out, and the
@@ -2884,7 +2885,7 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                                 f"cancelling"
                             )
                             device.cancel_event.set()
-                            esphome.cancel_voice_turn(device_id)
+                            esphome.cancel_voice_turn(device_id, reason="muted")
                             await device.send_control({"type": "speaker_flush"})
                         await api._push_event({
                             "type":      "device_update",

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -326,13 +326,18 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         # controller; only one turn active at a time.
         self._turn_active       = False
         self._turn_cancelled    = False
-        # A barge during PLAYBACK, which deliberately does NOT set
-        # _turn_cancelled — see abort_ha_run. Kept separate because that flag
-        # gates control flow (on_thinking, on_stt_end, the intent-ended
-        # check) and marking a delivered response cancelled would change what
-        # the turn DOES, not just what it is recorded as. This one is read by
-        # the outcome logic and nothing else.
-        self._turn_barged       = False
+        # WHY a turn ended early, as an outcome string. Separate from
+        # _turn_cancelled because that flag gates control flow (on_thinking,
+        # on_stt_end, the intent-ended check) while this only decides what is
+        # recorded — and because a barge during PLAYBACK deliberately does
+        # not set it at all (see abort_ha_run).
+        #
+        # The outcome is the CAUSE, not the phase. A dot button stops the
+        # response dead; a mute stops it dead and turns the microphone off;
+        # a wake word stops it in favour of another turn. Those are three
+        # different things to find in the stats, and recording all of them
+        # as "cancelled" loses the distinction the field is read for.
+        self._turn_end_reason: Optional[str] = None
         self._tts_audio_url:    Optional[str] = None
         self._tts_audio_data:   Optional[bytes] = None
         self._tts_event         = asyncio.Event()
@@ -962,7 +967,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
 
         self._turn_active           = True
         self._turn_cancelled        = False
-        self._turn_barged           = False
+        self._turn_end_reason       = None
         self._tts_event.clear()
         self._tts_audio_url         = None
         self._tts_audio_data        = None
@@ -1036,8 +1041,13 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 if trace: trace.outcome = "stream_timeout"
 
             if self._turn_cancelled:
-                log.info(f"[{self._log_name}] Turn cancelled during mic streaming")
-                if trace: trace.outcome = "cancelled"
+                # The outcome is the CAUSE, not the phase — see
+                # _turn_end_reason. A user talking over the assistant is a
+                # barge whether or not a response had started; a button is
+                # not, and a mute is its own thing.
+                why = self._turn_end_reason or "cancelled"
+                log.info(f"[{self._log_name}] Turn {why} during mic streaming")
+                if trace: trace.outcome = why
                 return
 
             if self._ha_never_started:
@@ -1074,8 +1084,11 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 return
 
             if self._turn_cancelled:
-                log.info(f"[{self._log_name}] Turn cancelled while waiting for TTS")
-                if trace: trace.outcome = "cancelled"
+                # The thinking-phase barge lands here: HA is mid-pipeline and
+                # nothing has been said yet, but the user has spoken over it.
+                why = self._turn_end_reason or "cancelled"
+                log.info(f"[{self._log_name}] Turn {why} while waiting for TTS")
+                if trace: trace.outcome = why
                 return
 
             if self._tts_audio_url:
@@ -1114,7 +1127,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 if trace:
                     trace.tts_bytes = pcm_bytes or 0
 
-                if self._turn_cancelled or self._turn_barged:
+                if self._turn_cancelled or self._turn_end_reason:
                     # #251: cut off mid-response. This used to fall through to
                     # the finally-default "ok", so a turn cancelled during
                     # playback was indistinguishable from an answered one —
@@ -1138,8 +1151,9 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     # was written for. Measured 2026-08-23: "Sing a song."
                     # cut off mid-song, logged `Cancelled during streamed
                     # buffer drain`, and persisted outcome=ok.
-                    log.info(f"[{self._log_name}] Turn cut off mid-response")
-                    if trace: trace.outcome = "barged"
+                    why = self._turn_end_reason or "cancelled"
+                    log.info(f"[{self._log_name}] Turn {why} mid-response")
+                    if trace: trace.outcome = why
                 elif pcm_bytes:
                     if trace: trace.outcome = "ok"
             else:
@@ -1533,7 +1547,8 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         if self._transport and not self._transport.is_closing():
             self._transport.close()
 
-    def cancel_turn(self, abort_ha: bool = False) -> None:
+    def cancel_turn(self, abort_ha: bool = False,
+                    reason: str = "cancelled") -> None:
         """
         Cancel an in-flight voice turn.
 
@@ -1560,6 +1575,19 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         else:
             log.info(f"[{self._log_name}] Turn cancelled (local only)")
         self._turn_cancelled = True
+        # WHY it was cancelled, which the outcome needs and the flag alone
+        # cannot say. _turn_cancelled is set by the dot button, by a mute and
+        # by a barge during thinking, and recording all three as "cancelled"
+        # makes a user talking over the assistant indistinguishable from a
+        # button press. #251 left this split out as "needs threading a reason
+        # through three call sites"; the reason it is now worth threading is
+        # that #250's detection signature — a barged turn followed by a turn
+        # triggered by barge-in — could only ever find a PLAYBACK barge, so a
+        # device false-triggering during thinking was invisible to the one
+        # query built to find it.
+        # First reason wins: a mute that follows a barge does not relabel it.
+        if self._turn_end_reason is None:
+            self._turn_end_reason = reason
         self._tts_event.set()  # unblock any waiting coroutine
 
     def abort_ha_run(self) -> None:
@@ -1586,7 +1614,8 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         # keyed on _turn_cancelled, which this path deliberately never sets,
         # so it covered the thinking barge and missed the playback one it was
         # actually written for.
-        self._turn_barged = True
+        if self._turn_end_reason is None:
+            self._turn_end_reason = "barged"
         if self._transport and not self._transport.is_closing():
             self._send_one(api_pb2.VoiceAssistantRequest(start=False))
         # Armed even if the transport is gone: the barrier is cheap, and a
@@ -2303,7 +2332,8 @@ async def trigger_voice_turn(
     return satellite._continue_conversation
 
 
-def cancel_voice_turn(device_id: str, abort_ha: bool = False) -> None:
+def cancel_voice_turn(device_id: str, abort_ha: bool = False,
+                      reason: str = "cancelled") -> None:
     """
     Cancel an in-flight ESPHome voice turn for a device.
 
@@ -2320,7 +2350,7 @@ def cancel_voice_turn(device_id: str, abort_ha: bool = False) -> None:
     satellite = server.get_satellite()
     if satellite is None:
         return
-    satellite.cancel_turn(abort_ha=abort_ha)
+    satellite.cancel_turn(abort_ha=abort_ha, reason=reason)
 
 
 def abort_ha_run(device_id: str) -> None:

--- a/controller/tests/test_turn_outcomes.py
+++ b/controller/tests/test_turn_outcomes.py
@@ -13,6 +13,7 @@ importable here (see conftest), so these are shape guards on the shipped
 source.
 """
 
+import re
 from pathlib import Path
 
 CONTROLLER = Path(__file__).resolve().parents[1]
@@ -22,31 +23,6 @@ def _turn_src() -> str:
     src = (CONTROLLER / "em_esphome.py").read_text()
     start = src.index("if self._tts_audio_url:")
     return src[start:start + 6000]
-
-
-def test_a_cancel_during_playback_records_barged_not_ok():
-    src = _turn_src()
-    assert 'trace.outcome = "barged"' in src, \
-        "a turn cut off mid-response must be distinguishable from an answer"
-    assert "_turn_cancelled" in src.split('trace.outcome = "barged"')[0], \
-        "the barged outcome must be gated on the cancel flag"
-    # The finally-block default must not be able to overwrite it back to ok:
-    # the barged branch has to sit BEFORE the unconditional default runs.
-    default = src.index("if not trace.outcome:")
-    assert src.index('"barged"') < default
-
-
-def test_barged_is_distinct_from_the_pre_playback_cancel():
-    """
-    "cancelled" already covers cuts during mic streaming and the TTS wait -
-    nothing had been said yet. "barged" means a response had begun. Both
-    must exist; collapsing them would blur 'user pressed the button early'
-    into 'something interrupted the answer'.
-    """
-    src = (CONTROLLER / "em_esphome.py").read_text()
-    assert src.count('trace.outcome = "cancelled"') >= 2, \
-        "the pre-playback cancel outcomes must stay"
-    assert 'trace.outcome = "barged"' in src
 
 
 def test_self_interruption_is_detectable_from_the_persisted_fields():
@@ -65,59 +41,82 @@ def test_self_interruption_is_detectable_from_the_persisted_fields():
 
 # ─── Both barge paths, because covering one is what caused the bug ───────────
 
-def test_the_playback_barge_path_also_marks_the_outcome():
+def test_each_cause_of_an_early_end_records_its_own_outcome():
     """
-    #251's fix keyed on `_turn_cancelled` and therefore covered the barge it
-    was NOT written for.
+    Three different things stop a turn and they are three different things to
+    find in the stats:
 
-    There are two paths and they set different flags:
+        dot button   -> "cancelled"   stops the response dead
+        mute         -> "muted"       stops it dead AND deafens the device
+        wake word    -> "barged"      stops it in favour of another turn
 
-        barge during THINKING  -> cancel_voice_turn()  -> _turn_cancelled
-        barge during PLAYBACK  -> abort_ha_run()       -> (nothing, by design)
+    Recording all three as "cancelled" is what made a user talking over the
+    assistant indistinguishable from a button press. It also blunted #250's
+    detection signature — a barged turn followed by a turn triggered by
+    barge-in — which could only ever find a PLAYBACK barge while a thinking
+    barge recorded "cancelled".
+    """
+    ctrl = (CONTROLLER / "em_controller.py").read_text()
+    calls = re.findall(r"cancel_voice_turn\(([^)]*)\)", ctrl, re.S)
+    assert len(calls) == 3, f"expected 3 call sites, got {len(calls)}"
 
-    abort_ha_run deliberately does not mark the turn cancelled — that flag
-    gates on_thinking, on_stt_end and the intent-ended check, so marking a
-    delivered response cancelled would change what the turn DOES. Its
-    docstring says so.
+    reasons = sorted(
+        re.search(r'reason="(\w+)"', c).group(1)
+        for c in calls if re.search(r'reason="(\w+)"', c)
+    )
+    assert reasons == ["barged", "cancelled", "muted"], (
+        f"each cancel path must name its own cause; got {reasons}"
+    )
 
-    The consequence, measured on hardware 2026-08-23: "Sing a song." was cut
-    off mid-song by a real barge, logged `Cancelled during streamed buffer
-    drain`, and persisted `outcome=ok`. The exact reading #251 existed to
-    prevent, on the exact case its description describes.
 
-    So abort_ha_run must record something, and the outcome must read both.
+def test_the_outcome_is_the_reason_at_every_phase():
+    """
+    A turn can end early during mic streaming, while waiting for TTS, or
+    mid-response. The PHASE used to decide the wording, which is how #251
+    fixed the barge it was not written for. All three now record the reason.
     """
     src = (CONTROLLER / "em_esphome.py").read_text()
+    reads = [l.strip() for l in src.splitlines()
+             if l.strip() == 'why = self._turn_end_reason or "cancelled"']
+    assert len(reads) == 3, (
+        f"all three early-end sites must record the reason; found {len(reads)}"
+    )
+    assert 'trace.outcome = why' in src
 
+
+def test_the_reason_survives_the_module_level_forwarder():
+    """
+    cancel_voice_turn forwards to the satellite. A parameter added to the
+    signature and dropped in the body is a silent no-op: the call compiles,
+    the reason never arrives, and every outcome quietly reads "cancelled".
+    """
+    src = (CONTROLLER / "em_esphome.py").read_text()
+    fwd = src[src.index("def cancel_voice_turn("):]
+    fwd = fwd[:fwd.index("\ndef ")]
+    assert "reason=reason" in fwd, \
+        "the forwarder must pass the reason through to cancel_turn"
+
+
+def test_the_playback_barge_still_records_without_a_cancel():
+    """
+    abort_ha_run is the PLAYBACK barge path and deliberately does not mark
+    the turn cancelled — that flag gates control flow. It must still record
+    the reason, or the case #251 was written for goes back to reading "ok".
+    """
+    src = (CONTROLLER / "em_esphome.py").read_text()
     abort = src[src.index("def abort_ha_run"):]
     abort = abort[:abort.index("\n\n\n")] if "\n\n\n" in abort else abort[:2000]
-    assert "_turn_barged" in abort, (
-        "abort_ha_run is the PLAYBACK barge path and must record that the "
-        "turn was cut off, even though it must not mark it cancelled"
-    )
-    assert "_turn_cancelled = True" not in abort, (
-        "abort_ha_run must NOT set _turn_cancelled — that flag changes "
-        "control flow, and its docstring explains why this path avoids it"
-    )
-
-    branch = src[src.index("# #251: cut off mid-response") - 200:]
-    branch = branch[:branch.index('trace.outcome = "barged"')]
-    assert "_turn_barged" in branch and "_turn_cancelled" in branch, (
-        "the outcome must read BOTH flags — one per barge path"
-    )
+    assert '"barged"' in abort and "_turn_end_reason" in abort
+    assert "_turn_cancelled = True" not in abort, \
+        "abort_ha_run must not mark the turn cancelled — see its docstring"
 
 
-def test_the_barged_flag_is_reset_per_turn():
+def test_the_reason_is_cleared_per_turn():
     """
-    A sticky flag would mark every later turn on the same satellite as
-    barged, which is the same class of wrong answer in the other direction.
-    Reset alongside _turn_cancelled at turn start, not only at construction.
+    A sticky reason would label every later turn on the same satellite,
+    which is the same wrong answer in the other direction.
     """
     src = (CONTROLLER / "em_esphome.py").read_text()
     start = src.index("self._turn_active           = True")
-    window = src[start:start + 400]
-    assert "_turn_barged" in window, (
-        "_turn_barged must be cleared where _turn_cancelled is, at turn "
-        "start — clearing it only in __init__ leaves it set for the life "
-        "of the connection"
-    )
+    assert "_turn_end_reason" in src[start:start + 400], \
+        "_turn_end_reason must be cleared at turn start, not only in __init__"


### PR DESCRIPTION
Found on hardware: a barge during **thinking** recorded `cancelled` while a barge during **playback** recorded `barged`. Both are barges.

The outcome was keyed on the **phase** the turn was in, when the useful question is the **cause**:

| cause | outcome | what it means |
|---|---|---|
| dot button | `cancelled` | stops the response dead |
| mute | `muted` | stops it dead **and** deafens the device |
| wake word | `barged` | stops it in favour of another turn |

Recording all three as `cancelled` made a user talking over the assistant indistinguishable from a button press. It also blunted the detection this was built for: **#250's signature is a barged turn followed by a turn triggered by barge-in**, which could only ever find the playback half — a device false-triggering on its own narration during *thinking* recorded `cancelled` and was invisible to the one query written to find it. Today's log had both (0.989 thinking, 0.295 playback) from the same fault.

## The change

`_turn_end_reason` replaces the `_turn_barged` boolean added yesterday — three causes don't want three booleans. First reason wins, so a mute following a barge doesn't relabel it.

It stays separate from `_turn_cancelled`, which gates control flow: `abort_ha_run` still records a reason **without** marking the turn cancelled, for its documented reason.

All three early-end sites record the reason rather than deciding from where they sit. That removes the class of bug that produced this — the mic-streaming and waiting-for-TTS paths return before the post-TTS branch, so anything keyed on phase covers some barges and not others.

## History

`muted` is a new value; past rows keep `cancelled` for mutes. **No migration** — the field is diagnostic, and rewriting old rows would assert a cause that was never recorded.

## Verification

Reintroduced all five parts independently: the mute reason, a phase site hardcoding `cancelled`, the forwarder dropping the argument, `abort_ha_run` not recording, and the per-turn reset. Each fails its own test. 729 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)