### PR TITLE
Fix #306: loop_lag_peak_ms reads the running module, not a fresh import

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -2960,25 +2960,6 @@ async def _run_secure_link(device_id: str) -> None:
 # ─── System ───────────────────────────────────────────────────────────────────
 
 @auth.require_auth
-def _running_controller_module():
-    """
-    The module object the RUNNING controller executes as (#306).
-
-    em_start.py execvp's em_controller.py, so in production the running
-    code is __main__ — and `import em_controller` would load a SECOND,
-    never-initialised copy whose module state is all defaults. That is
-    why /api/system/status reported loop_lag_peak_ms: 0.0 next to a log
-    line saying the loop had stalled 881ms: the reader was reading a
-    fresh copy, not the live module. Resolve the running object instead
-    of importing by name. The lazy-import pattern itself stays — the
-    circular dependency is real — only the resolution changes.
-    """
-    main = sys.modules.get("__main__")
-    if main is not None and hasattr(main, "_loop_lag_peak_ms"):
-        return main
-    return sys.modules.get("em_controller")
-
-
 async def _get_system_status(request: web.Request) -> web.Response:
     """GET /api/system/status"""
     loop = asyncio.get_event_loop()
@@ -3029,6 +3010,30 @@ async def _get_system_status(request: web.Request) -> web.Response:
             and r["firmware_ver"] != release["version"]
         ),
     })
+
+
+def _running_controller_module():
+    """
+    The module object the RUNNING controller executes as (#306).
+
+    em_start.py execvp's em_controller.py, so in production the running
+    code is __main__ — and `import em_controller` would load a SECOND,
+    never-initialised copy whose module state is all defaults. That is
+    why /api/system/status reported loop_lag_peak_ms: 0.0 next to a log
+    line saying the loop had stalled 881ms: the reader was reading a
+    fresh copy, not the live module. Resolve the running object instead
+    of importing by name. The lazy-import pattern itself stays — the
+    circular dependency is real — only the resolution changes.
+
+    Placement note (#309 review): this deliberately sits BELOW its two
+    callers' section divider rather than directly above a decorated
+    function — between `@auth.require_auth` and `_get_system_status` it
+    stole the decorator, leaving the status endpoint unauthenticated.
+    """
+    main = sys.modules.get("__main__")
+    if main is not None and hasattr(main, "_loop_lag_peak_ms"):
+        return main
+    return sys.modules.get("em_controller")
 
 
 @auth.require_admin

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -41,6 +41,7 @@ import platform
 import re
 import shutil
 import sqlite3 as _sqlite3
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -2959,14 +2960,34 @@ async def _run_secure_link(device_id: str) -> None:
 # ─── System ───────────────────────────────────────────────────────────────────
 
 @auth.require_auth
+def _running_controller_module():
+    """
+    The module object the RUNNING controller executes as (#306).
+
+    em_start.py execvp's em_controller.py, so in production the running
+    code is __main__ — and `import em_controller` would load a SECOND,
+    never-initialised copy whose module state is all defaults. That is
+    why /api/system/status reported loop_lag_peak_ms: 0.0 next to a log
+    line saying the loop had stalled 881ms: the reader was reading a
+    fresh copy, not the live module. Resolve the running object instead
+    of importing by name. The lazy-import pattern itself stays — the
+    circular dependency is real — only the resolution changes.
+    """
+    main = sys.modules.get("__main__")
+    if main is not None and hasattr(main, "_loop_lag_peak_ms"):
+        return main
+    return sys.modules.get("em_controller")
+
+
 async def _get_system_status(request: web.Request) -> web.Response:
     """GET /api/system/status"""
     loop = asyncio.get_event_loop()
     all_rows = await loop.run_in_executor(None, db.get_all_devices)
     release = await _get_cached_release()
 
-    # Lazy import — em_controller imports em_api at module level.
-    import em_controller as _ctrl
+    # Lazy resolution — em_controller imports em_api at module level, and
+    # importing by name would load a second, uninitialised copy (#306).
+    _ctrl = _running_controller_module()
 
     return _ok({
         "controller_version": CONTROLLER_VERSION,
@@ -4079,8 +4100,9 @@ def _controller_stats() -> dict:
     """
     stats: dict[str, Any] = {}
     try:
-        import em_controller as _ctrl
-        stats["loop_lag_peak_ms"] = round(_ctrl._loop_lag_peak_ms, 1)
+        _ctrl = _running_controller_module()
+        if _ctrl is not None:
+            stats["loop_lag_peak_ms"] = round(_ctrl._loop_lag_peak_ms, 1)
     except Exception:
         pass
 

--- a/controller/tests/test_loop_lag_reader.py
+++ b/controller/tests/test_loop_lag_reader.py
@@ -13,6 +13,7 @@ helper's source is extracted and executed in a stub namespace instead,
 testing the code that actually ships.
 """
 
+import re
 import sys
 import types
 from pathlib import Path
@@ -24,7 +25,8 @@ def _load_helper(monkeypatched_sys):
     src = (CONTROLLER / "em_api.py").read_text()
     start = src.index("def _running_controller_module")
     ends = [i for i in (src.find("\ndef ", start + 10),
-                        src.find("\nasync def ", start + 10)) if i != -1]
+                        src.find("\nasync def ", start + 10),
+                        src.find("\n@", start + 10)) if i != -1]
     ns = {"sys": monkeypatched_sys}
     exec(src[start:min(ends)], ns)
     return ns["_running_controller_module"]
@@ -68,3 +70,19 @@ def test_both_reader_sites_use_the_helper():
         "importing by name loads a second, uninitialised module copy"
     assert src.count("_running_controller_module()") >= 2, \
         "status endpoint AND support bundle must resolve via the helper"
+
+
+def test_the_helper_is_not_sandwiched_into_a_decorator():
+    """
+    #309 review: the helper originally landed BETWEEN @auth.require_auth
+    and _get_system_status — stealing the decorator, leaving the status
+    endpoint unauthenticated and raising on call. A decorator must be
+    immediately followed by the function it decorates.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+    for m in re.finditer(r"@auth\.require_auth\n(\w+)", src):
+        assert not m.group(1).startswith("_running_controller_module"), \
+            "the helper must never steal a decorator"
+    # And the status endpoint keeps its decorator:
+    pair = re.search(r"@auth\.require_auth\nasync def _get_system_status", src)
+    assert pair, "_get_system_status must remain decorated"

--- a/controller/tests/test_loop_lag_reader.py
+++ b/controller/tests/test_loop_lag_reader.py
@@ -1,0 +1,70 @@
+"""
+#306: /api/system/status and the support bundle reported loop_lag_peak_ms
+as 0.0 while the log right next to them showed the loop stalling at 881ms.
+
+Cause: em_start.py execvp's em_controller.py, so the running controller is
+__main__. The readers did `import em_controller`, which does not find
+__main__ under that name and loads a SECOND, never-initialised copy —
+reading defaults instead of the live monitor's peak.
+
+The fix resolves the running module object. em_api imports aiohttp and the
+whole stack, so it is deliberately not importable here (see conftest); the
+helper's source is extracted and executed in a stub namespace instead,
+testing the code that actually ships.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _load_helper(monkeypatched_sys):
+    src = (CONTROLLER / "em_api.py").read_text()
+    start = src.index("def _running_controller_module")
+    ends = [i for i in (src.find("\ndef ", start + 10),
+                        src.find("\nasync def ", start + 10)) if i != -1]
+    ns = {"sys": monkeypatched_sys}
+    exec(src[start:min(ends)], ns)
+    return ns["_running_controller_module"]
+
+
+def test_production_resolves_main_not_a_fresh_copy():
+    """In production __main__ IS the running em_controller: it carries the
+    attribute the monitor writes, so it must win over a name import."""
+    main = types.ModuleType("__main__")
+    main._loop_lag_peak_ms = 881.0          # what the monitor wrote
+    fake = types.SimpleNamespace(modules={"__main__": main})
+    got = _load_helper(fake)()
+    assert got is main, "the reader must resolve the RUNNING module"
+
+
+def test_under_pytest_the_imported_module_wins():
+    """Under pytest, __main__ is the test runner and has no such attribute;
+    then the explicitly imported em_controller module is correct."""
+    main = types.ModuleType("__main__")      # pytest's main: no attribute
+    ctrl = types.ModuleType("em_controller")
+    ctrl._loop_lag_peak_ms = 42.0
+    fake = types.SimpleNamespace(modules={"__main__": main,
+                                          "em_controller": ctrl})
+    got = _load_helper(fake)()
+    assert got is ctrl
+
+
+def test_neither_present_returns_none_without_raising():
+    fake = types.SimpleNamespace(modules={})
+    got = _load_helper(fake)()
+    assert got is None
+
+
+def test_both_reader_sites_use_the_helper():
+    """
+    The bug lived in two call sites doing `import em_controller as _ctrl`.
+    Neither may remain: both must go through the resolver.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+    assert "import em_controller as _ctrl" not in src, \
+        "importing by name loads a second, uninitialised module copy"
+    assert src.count("_running_controller_module()") >= 2, \
+        "status endpoint AND support bundle must resolve via the helper"


### PR DESCRIPTION
The status endpoint and support bundle resolved `import em_controller`, which under em_start.py's execvp loads a second, never-initialised copy of the module - so both reported a peak of 0.0 while their own log tail showed an 881ms stall.

Both sites now go through `_running_controller_module()`: `__main__` when it carries the monitor attribute (production), the named module otherwise (tests). The lazy-import pattern stays; only the resolution changes. Guard test pins that no call site regresses to importing by name.

Fixes #306
