### PR TITLE
Fix #197: Users tab in Settings — promote/demote without the API

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -2960,25 +2960,6 @@ async def _run_secure_link(device_id: str) -> None:
 # ─── System ───────────────────────────────────────────────────────────────────
 
 @auth.require_auth
-def _running_controller_module():
-    """
-    The module object the RUNNING controller executes as (#306).
-
-    em_start.py execvp's em_controller.py, so in production the running
-    code is __main__ — and `import em_controller` would load a SECOND,
-    never-initialised copy whose module state is all defaults. That is
-    why /api/system/status reported loop_lag_peak_ms: 0.0 next to a log
-    line saying the loop had stalled 881ms: the reader was reading a
-    fresh copy, not the live module. Resolve the running object instead
-    of importing by name. The lazy-import pattern itself stays — the
-    circular dependency is real — only the resolution changes.
-    """
-    main = sys.modules.get("__main__")
-    if main is not None and hasattr(main, "_loop_lag_peak_ms"):
-        return main
-    return sys.modules.get("em_controller")
-
-
 async def _get_system_status(request: web.Request) -> web.Response:
     """GET /api/system/status"""
     loop = asyncio.get_event_loop()
@@ -3029,6 +3010,30 @@ async def _get_system_status(request: web.Request) -> web.Response:
             and r["firmware_ver"] != release["version"]
         ),
     })
+
+
+def _running_controller_module():
+    """
+    The module object the RUNNING controller executes as (#306).
+
+    em_start.py execvp's em_controller.py, so in production the running
+    code is __main__ — and `import em_controller` would load a SECOND,
+    never-initialised copy whose module state is all defaults. That is
+    why /api/system/status reported loop_lag_peak_ms: 0.0 next to a log
+    line saying the loop had stalled 881ms: the reader was reading a
+    fresh copy, not the live module. Resolve the running object instead
+    of importing by name. The lazy-import pattern itself stays — the
+    circular dependency is real — only the resolution changes.
+
+    Placement note (#309 review): this deliberately sits BELOW its two
+    callers' section divider rather than directly above a decorated
+    function — between `@auth.require_auth` and `_get_system_status` it
+    stole the decorator, leaving the status endpoint unauthenticated.
+    """
+    main = sys.modules.get("__main__")
+    if main is not None and hasattr(main, "_loop_lag_peak_ms"):
+        return main
+    return sys.modules.get("em_controller")
 
 
 @auth.require_admin

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -41,6 +41,7 @@ import platform
 import re
 import shutil
 import sqlite3 as _sqlite3
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -2959,14 +2960,34 @@ async def _run_secure_link(device_id: str) -> None:
 # ─── System ───────────────────────────────────────────────────────────────────
 
 @auth.require_auth
+def _running_controller_module():
+    """
+    The module object the RUNNING controller executes as (#306).
+
+    em_start.py execvp's em_controller.py, so in production the running
+    code is __main__ — and `import em_controller` would load a SECOND,
+    never-initialised copy whose module state is all defaults. That is
+    why /api/system/status reported loop_lag_peak_ms: 0.0 next to a log
+    line saying the loop had stalled 881ms: the reader was reading a
+    fresh copy, not the live module. Resolve the running object instead
+    of importing by name. The lazy-import pattern itself stays — the
+    circular dependency is real — only the resolution changes.
+    """
+    main = sys.modules.get("__main__")
+    if main is not None and hasattr(main, "_loop_lag_peak_ms"):
+        return main
+    return sys.modules.get("em_controller")
+
+
 async def _get_system_status(request: web.Request) -> web.Response:
     """GET /api/system/status"""
     loop = asyncio.get_event_loop()
     all_rows = await loop.run_in_executor(None, db.get_all_devices)
     release = await _get_cached_release()
 
-    # Lazy import — em_controller imports em_api at module level.
-    import em_controller as _ctrl
+    # Lazy resolution — em_controller imports em_api at module level, and
+    # importing by name would load a second, uninitialised copy (#306).
+    _ctrl = _running_controller_module()
 
     return _ok({
         "controller_version": CONTROLLER_VERSION,
@@ -4079,8 +4100,9 @@ def _controller_stats() -> dict:
     """
     stats: dict[str, Any] = {}
     try:
-        import em_controller as _ctrl
-        stats["loop_lag_peak_ms"] = round(_ctrl._loop_lag_peak_ms, 1)
+        _ctrl = _running_controller_module()
+        if _ctrl is not None:
+            stats["loop_lag_peak_ms"] = round(_ctrl._loop_lag_peak_ms, 1)
     except Exception:
         pass
 

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5644,6 +5644,31 @@ function SettingsPanel({ globalConfig, onGlobalConfigChange, onClose, username, 
   const [bundle, setBundle]       = useState(null);  // {url, name, bytes}
   const [bundleErr, setBundleErr] = useState(null);
 
+  // #197: accounts and roles. The endpoints exist and are admin-only;
+  // what was missing was any screen calling them, which left "the wrong
+  // person opened the sidebar first" without an in-household recovery.
+  const [users, setUsers]         = useState(null);
+  const [usersMsg, setUsersMsg]   = useState(null);
+
+  function loadUsers() {
+    API.get('/api/users').then(setUsers)
+       .catch(e => setUsersMsg({ ok: false, text: e.error || 'Failed to load users' }));
+  }
+  useEffect(() => { if (tab === 'users') loadUsers(); }, [tab]);
+
+  async function setUserRole(id, role) {
+    setUsersMsg(null);
+    try {
+      await API.patch(`/api/users/${id}`, { role });
+      setUsers(prev => prev.map(u => u.id === id ? { ...u, role } : u));
+      setUsersMsg({ ok: true, text: 'Role updated.' });
+    } catch (e) {
+      // The server refuses the last-admin demotion and explains ha_linked
+      // refusals; pass its reason through rather than a generic failure.
+      setUsersMsg({ ok: false, text: e.error || 'Refused.' });
+    }
+  }
+
   // Object URLs pin their blob in memory until revoked; the panel closing is
   // the last moment we can still reach this one.
   useEffect(() => () => { if (bundle) URL.revokeObjectURL(bundle.url); }, [bundle]);
@@ -5706,8 +5731,8 @@ function SettingsPanel({ globalConfig, onGlobalConfigChange, onClose, username, 
 
   // Support is admin-only because the endpoint is: the bundle spans the whole
   // fleet, so a tab a non-admin can only be refused by is worse than no tab.
-  const TABS = isAdmin ? ['fleet', 'account', 'support'] : ['fleet', 'account'];
-  const TAB_LABELS = { fleet: 'Config', account: 'Account', support: 'Support' };
+  const TABS = isAdmin ? ['fleet', 'users', 'account', 'support'] : ['fleet', 'account'];
+  const TAB_LABELS = { fleet: 'Config', users: 'Users', account: 'Account', support: 'Support' };
 
   return (
     <div style={{ position:'fixed', inset:0, background:'rgba(180,176,168,0.5)', display:'flex', alignItems:'center', justifyContent:'center', zIndex:200, backdropFilter:'blur(8px)' }}
@@ -5753,6 +5778,38 @@ function SettingsPanel({ globalConfig, onGlobalConfigChange, onClose, username, 
                 </div>
               )}
             </>
+          )}
+
+          {tab === 'users' && (
+            <div style={{ maxWidth: 640 }}>
+              <div style={{ fontFamily:"'DM Mono',monospace", fontSize:10, color:'var(--muted)', marginBottom:20, lineHeight:1.6 }}>
+                Admins approve devices, change config and can open a root shell to any device.
+                Read-only accounts see status only. An account with an HA badge gets its sign-in
+                from Home Assistant; its ROLE is still set here and never overwritten by a login.
+                The last admin cannot be demoted.
+              </div>
+              {(users || []).map(u => (
+                <div key={u.id} style={{ display:'flex', alignItems:'center', gap:12,
+                     padding:'10px 0', borderBottom:'1px solid var(--border)' }}>
+                  <div style={{ flex:1 }}>
+                    <div style={{ fontFamily:"'DM Sans',sans-serif", fontSize:14 }}>{u.username}</div>
+                    <div style={{ fontFamily:"'DM Mono',monospace", fontSize:10, color:'var(--muted)' }}>
+                      {u.role}{u.ha_linked ? ' · HA-linked' : ''}
+                    </div>
+                  </div>
+                  {u.role === 'admin'
+                    ? <Pill onClick={() => setUserRole(u.id, 'readonly')}>Demote to read-only</Pill>
+                    : <Pill accent onClick={() => setUserRole(u.id, 'admin')}>Promote to admin</Pill>}
+                </div>
+              ))}
+              {!users && !usersMsg && <div className="help">Loading…</div>}
+              {usersMsg && (
+                <div style={{ marginTop: 14, fontFamily: "'DM Mono',monospace", fontSize: 11,
+                  color: usersMsg.ok ? 'var(--ok)' : 'var(--error)' }}>
+                  {usersMsg.ok ? '✓ ' : ''}{usersMsg.text}
+                </div>
+              )}
+            </div>
           )}
 
           {tab === 'account' && (

--- a/controller/tests/test_loop_lag_reader.py
+++ b/controller/tests/test_loop_lag_reader.py
@@ -13,6 +13,7 @@ helper's source is extracted and executed in a stub namespace instead,
 testing the code that actually ships.
 """
 
+import re
 import sys
 import types
 from pathlib import Path
@@ -24,7 +25,8 @@ def _load_helper(monkeypatched_sys):
     src = (CONTROLLER / "em_api.py").read_text()
     start = src.index("def _running_controller_module")
     ends = [i for i in (src.find("\ndef ", start + 10),
-                        src.find("\nasync def ", start + 10)) if i != -1]
+                        src.find("\nasync def ", start + 10),
+                        src.find("\n@", start + 10)) if i != -1]
     ns = {"sys": monkeypatched_sys}
     exec(src[start:min(ends)], ns)
     return ns["_running_controller_module"]
@@ -68,3 +70,19 @@ def test_both_reader_sites_use_the_helper():
         "importing by name loads a second, uninitialised module copy"
     assert src.count("_running_controller_module()") >= 2, \
         "status endpoint AND support bundle must resolve via the helper"
+
+
+def test_the_helper_is_not_sandwiched_into_a_decorator():
+    """
+    #309 review: the helper originally landed BETWEEN @auth.require_auth
+    and _get_system_status — stealing the decorator, leaving the status
+    endpoint unauthenticated and raising on call. A decorator must be
+    immediately followed by the function it decorates.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+    for m in re.finditer(r"@auth\.require_auth\n(\w+)", src):
+        assert not m.group(1).startswith("_running_controller_module"), \
+            "the helper must never steal a decorator"
+    # And the status endpoint keeps its decorator:
+    pair = re.search(r"@auth\.require_auth\nasync def _get_system_status", src)
+    assert pair, "_get_system_status must remain decorated"

--- a/controller/tests/test_loop_lag_reader.py
+++ b/controller/tests/test_loop_lag_reader.py
@@ -1,0 +1,70 @@
+"""
+#306: /api/system/status and the support bundle reported loop_lag_peak_ms
+as 0.0 while the log right next to them showed the loop stalling at 881ms.
+
+Cause: em_start.py execvp's em_controller.py, so the running controller is
+__main__. The readers did `import em_controller`, which does not find
+__main__ under that name and loads a SECOND, never-initialised copy —
+reading defaults instead of the live monitor's peak.
+
+The fix resolves the running module object. em_api imports aiohttp and the
+whole stack, so it is deliberately not importable here (see conftest); the
+helper's source is extracted and executed in a stub namespace instead,
+testing the code that actually ships.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _load_helper(monkeypatched_sys):
+    src = (CONTROLLER / "em_api.py").read_text()
+    start = src.index("def _running_controller_module")
+    ends = [i for i in (src.find("\ndef ", start + 10),
+                        src.find("\nasync def ", start + 10)) if i != -1]
+    ns = {"sys": monkeypatched_sys}
+    exec(src[start:min(ends)], ns)
+    return ns["_running_controller_module"]
+
+
+def test_production_resolves_main_not_a_fresh_copy():
+    """In production __main__ IS the running em_controller: it carries the
+    attribute the monitor writes, so it must win over a name import."""
+    main = types.ModuleType("__main__")
+    main._loop_lag_peak_ms = 881.0          # what the monitor wrote
+    fake = types.SimpleNamespace(modules={"__main__": main})
+    got = _load_helper(fake)()
+    assert got is main, "the reader must resolve the RUNNING module"
+
+
+def test_under_pytest_the_imported_module_wins():
+    """Under pytest, __main__ is the test runner and has no such attribute;
+    then the explicitly imported em_controller module is correct."""
+    main = types.ModuleType("__main__")      # pytest's main: no attribute
+    ctrl = types.ModuleType("em_controller")
+    ctrl._loop_lag_peak_ms = 42.0
+    fake = types.SimpleNamespace(modules={"__main__": main,
+                                          "em_controller": ctrl})
+    got = _load_helper(fake)()
+    assert got is ctrl
+
+
+def test_neither_present_returns_none_without_raising():
+    fake = types.SimpleNamespace(modules={})
+    got = _load_helper(fake)()
+    assert got is None
+
+
+def test_both_reader_sites_use_the_helper():
+    """
+    The bug lived in two call sites doing `import em_controller as _ctrl`.
+    Neither may remain: both must go through the resolver.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+    assert "import em_controller as _ctrl" not in src, \
+        "importing by name loads a second, uninitialised module copy"
+    assert src.count("_running_controller_module()") >= 2, \
+        "status endpoint AND support bundle must resolve via the helper"

--- a/controller/tests/test_users_ui.py
+++ b/controller/tests/test_users_ui.py
@@ -1,0 +1,52 @@
+"""
+#197: role management needs a screen, not an API call.
+
+Under the add-on the first Home Assistant user to open the dashboard
+becomes admin; everyone after is read-only — and read-only is
+load-bearing (recordings and transcripts are admin-only, and the
+dashboard proxies a root shell to every device). The recovery path for
+"the wrong person clicked first" was asking them to make an
+authenticated API call on your behalf.
+
+GET /api/users and PATCH /api/users/{id} always existed and were tested;
+what was missing was any UI calling them. These guards pin that the
+Settings panel now carries that screen.
+"""
+
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _settings_src() -> str:
+    src = (CONTROLLER / "static" / "dashboard.jsx").read_text()
+    start = src.index("function SettingsPanel")
+    return src[start:start + 20_000]
+
+
+def test_users_tab_exists_and_is_admin_only():
+    tabs = _settings_src()[_settings_src().index("const TABS"):]
+    tabs = tabs[:tabs.index(";")]
+    assert "'users'" in tabs, "the Users tab must exist in Settings"
+    # TABS already gates on isAdmin for account/support; users rides along.
+    assert "isAdmin ?" in tabs
+
+
+def test_users_screen_calls_both_existing_endpoints():
+    src = _settings_src()
+    assert "'/api/users'" in src, "the screen must list accounts"
+    assert "API.patch(`/api/users/${id}`" in src or \
+           'API.patch("/api/users/"' in src, \
+        "the promote/demote control must call PATCH /api/users/{id}"
+
+
+def test_server_reason_reaches_the_user():
+    """
+    The server refuses demoting the last admin and explains ha_linked
+    accounts; a generic 'failed' would send users hunting a bug that
+    isn't there. The error field must be surfaced verbatim.
+    """
+    src = _settings_src()
+    fn = src[src.index("async function setUserRole"):]
+    fn = fn[:fn.index("async function loadUsers") if "async function loadUsers" in fn else 800]
+    assert "e.error ||" in fn, "the PATCH refusal reason must be shown"


### PR DESCRIPTION
The Settings panel gains a Users tab (admin-only): accounts with role and HA-linked badge, promote/demote per row, calling the existing GET /api/users and PATCH /api/users/{id}. The server's refusal reasons surface verbatim — "last admin" and ha_linked explanations are the cases a household actually hits.

Closes the gap where the recovery path for "the wrong person opened the sidebar first" was asking them for an authenticated API call. Server-side rules untouched; they were already correct and tested.

Fixes #197
