### PR TITLE
Fix #299: wake watchdog stands down when the data plane explains the silence

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -186,6 +186,14 @@ SPEAKER_PRIME_SECONDS = 1.1
 # the lock is ALSO free, which no running turn allows.
 OWW_PAUSE_STUCK_S = 180.0
 
+# How long a freshly established data connection gets to deliver its first
+# mic frame before the wake watchdog stops treating the silence as
+# "device still warming up" and starts the zombie-stream ladder (#299,
+# review on PR #311: a boolean guard made the Office-style zombie — deaf
+# for hours — unrecoverable, because no frame ever arrives on the fresh
+# connection and only the escalation repairs it).
+FRESH_CONN_GRACE_S = 30.0
+
 # Restarting the wake listener must never become a hot loop. A listener that
 # raises IMMEDIATELY on start would otherwise be recreated from its own done
 # callback as fast as the event loop can run it, which starves everything
@@ -318,8 +326,12 @@ class Device:
         # #299: whether ANY mic frame has arrived on the CURRENT data
         # connection. Cleared by handle_data on every new connection; set
         # by the wake listener when a frame flows. Lets the no-frames
-        # watchdog tell "transport dropping" apart from "stream dead".
+        # watchdog tell "transport dropping" apart from "stream dead" —
+        # but only within a grace window (see the watchdog: a connection
+        # that stays silent BEYOND it is a zombie stream, and the ladder
+        # is that case's only repair).
         self.frames_seen_this_connection: bool = False
+        self.data_connected_at: float = 0.0
 
         # Tunable at runtime — updated when a config push arrives.
         # wake_word_listener reads this each detection cycle rather than
@@ -2059,22 +2071,36 @@ async def wake_word_listener(device: Device):
                     continue
                 # #299: "no frames" has two causes, and the ladder below
                 # assumes only one (a zombie stream device-side still holding
-                # micActive). If the data plane is down — or a fresh one has
-                # not delivered a single frame yet — the absence of frames is
-                # explained by the transport. Acting put extra control-plane
-                # traffic on an already failing link and restarted a mic
-                # pipeline that was working (bedroom, 2026-08-23: AEC resyncs
-                # 3, 4, 5, 6 after escalations into a dropping connection).
-                # Stand down; do not count the outage against the streak —
-                # once frames flow again it resets on its own below.
-                if device.data_ws is None or not device.frames_seen_this_connection:
-                    log.debug(
-                        f"[{device.device_id}] OWW: no mic frames, but the "
-                        f"data plane is "
-                        + ("down" if device.data_ws is None else "fresh")
-                        + " — nothing to repair"
-                    )
+                # micActive). The distinction needs BOTH state and time:
+                #
+                #   - data plane fully down → frames are explained by the
+                #     transport; nothing to point a repair at. Stand down,
+                #     do not count the outage against the streak.
+                #   - connected, but no frame since the connection opened:
+                #     ambiguous! Freshness says give the device a moment;
+                #     but past the grace window this silence IS the
+                #     zombie-stream signature — the device still streams to
+                #     a superseded socket, no frame will EVER arrive on the
+                #     fresh one, and the escalation below is the only repair
+                #     (Office, 2026-07-16: deaf 4.7h without it — which is
+                #     exactly why this guard is time-bounded rather than a
+                #     boolean, per the review on PR #311).
+                if device.data_ws is None:
                     continue
+                if not device.frames_seen_this_connection:
+                    if loop.time() - device.data_connected_at < FRESH_CONN_GRACE_S:
+                        log.debug(
+                            f"[{device.device_id}] OWW: no mic frames yet on a "
+                            f"fresh data connection — giving it "
+                            f"{FRESH_CONN_GRACE_S:.0f}s before treating the "
+                            f"silence as a zombie stream"
+                        )
+                        continue
+                    log.warning(
+                        f"[{device.device_id}] OWW: data connection is up but "
+                        f"delivered no frame in {FRESH_CONN_GRACE_S:.0f}s — "
+                        f"treating as zombie stream"
+                    )
                 dead_streak += 1
                 if dead_streak < 3:
                     log.warning(
@@ -3348,9 +3374,10 @@ async def handle_data(ws: WebSocketServerProtocol, secure: bool = False):
 
         device.data_ws = ws
         # #299: a fresh connection has by definition sent nothing yet — the
-        # no-frames watchdog must not start counting against the device
-        # until its first frame flows.
+        # no-frames watchdog gives it FRESH_CONN_GRACE_S before treating
+        # the silence as a zombie stream.
         device.frames_seen_this_connection = False
+        device.data_connected_at = asyncio.get_event_loop().time()
         device.data_ready.set()
         log.info(f"[data] Data connection established: {device_id}")
 

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -315,6 +315,11 @@ class Device:
         self.volume: float = _device_level_to_ha(85)
 
         self.data_ready = asyncio.Event()
+        # #299: whether ANY mic frame has arrived on the CURRENT data
+        # connection. Cleared by handle_data on every new connection; set
+        # by the wake listener when a frame flows. Lets the no-frames
+        # watchdog tell "transport dropping" apart from "stream dead".
+        self.frames_seen_this_connection: bool = False
 
         # Tunable at runtime — updated when a config push arrives.
         # wake_word_listener reads this each detection cycle rather than
@@ -1998,6 +2003,9 @@ async def wake_word_listener(device: Device):
                 payload = await asyncio.wait_for(
                     device.mic_queue.get(), timeout=10.0
                 )
+                # #299: a frame on this connection — the watchdog's link
+                # guard below may stand down from here on.
+                device.frames_seen_this_connection = True
             except asyncio.TimeoutError:
                 # The wake stream is ungated and continuous (device sends
                 # every 80ms, silence included — hardware mute still produces
@@ -2048,6 +2056,24 @@ async def wake_word_listener(device: Device):
                     # (and device.muted clears with the mute_state message),
                     # so the watchdog resumes naturally if that ever fails.
                     dead_streak = 0
+                    continue
+                # #299: "no frames" has two causes, and the ladder below
+                # assumes only one (a zombie stream device-side still holding
+                # micActive). If the data plane is down — or a fresh one has
+                # not delivered a single frame yet — the absence of frames is
+                # explained by the transport. Acting put extra control-plane
+                # traffic on an already failing link and restarted a mic
+                # pipeline that was working (bedroom, 2026-08-23: AEC resyncs
+                # 3, 4, 5, 6 after escalations into a dropping connection).
+                # Stand down; do not count the outage against the streak —
+                # once frames flow again it resets on its own below.
+                if device.data_ws is None or not device.frames_seen_this_connection:
+                    log.debug(
+                        f"[{device.device_id}] OWW: no mic frames, but the "
+                        f"data plane is "
+                        + ("down" if device.data_ws is None else "fresh")
+                        + " — nothing to repair"
+                    )
                     continue
                 dead_streak += 1
                 if dead_streak < 3:
@@ -3321,6 +3347,10 @@ async def handle_data(ws: WebSocketServerProtocol, secure: bool = False):
             return
 
         device.data_ws = ws
+        # #299: a fresh connection has by definition sent nothing yet — the
+        # no-frames watchdog must not start counting against the device
+        # until its first frame flows.
+        device.frames_seen_this_connection = False
         device.data_ready.set()
         log.info(f"[data] Data connection established: {device_id}")
 

--- a/controller/tests/test_wake_watchdog.py
+++ b/controller/tests/test_wake_watchdog.py
@@ -8,9 +8,13 @@ extra control-plane traffic on an already failing link, and a working
 mic pipeline torn down and rebuilt (bedroom, 2026-08-23: AEC resyncs
 3, 4, 5, 6).
 
-The fix: "no frames" with the data plane down — or on a connection that
-has not delivered a single frame yet — is explained. Stand down; do not
-count it against the streak either.
+The distinction needs state AND time (review on PR #311): a boolean
+"fresh connection" guard made the zombie case unrecoverable, because a
+device streaming to a superseded socket never delivers a frame on the
+fresh one — so the flag never flipped and the escalation that repairs
+the Office-style 4.7-hour deafness could never run. The guard is
+therefore time-bounded: fresh connections get FRESH_CONN_GRACE_S; past
+that, silence IS the zombie signature and the ladder runs.
 
 em_controller is deliberately not importable here (see conftest); these
 are shape guards on the shipped source.
@@ -27,41 +31,51 @@ def _listener_src() -> str:
     return src[start:start + 30_000]
 
 
-def test_the_guard_sits_before_the_escalation_ladder():
+def test_link_down_stands_down_before_the_ladder():
     src = _listener_src()
-    guard = src.index("device.data_ws is None or not device.frames_seen_this_connection")
+    guard = src.index("if device.data_ws is None:")
     ladder = src.index("dead_streak += 1", guard)
     assert guard < ladder, \
-        "the link guard must stand down BEFORE dead_streak counts or mic_start fires"
-    # And before both escalation stages:
-    esc = src.index("mic_stop()", guard)
-    assert guard < esc
-
-
-def test_an_outage_does_not_count_against_the_streak():
-    """
-    The muted branch resets the streak (expected silence); the outage branch
-    must NOT reset it either — a streak surviving a short blip stays honest —
-    it just freezes while the transport is down. So: continue without
-    touching dead_streak between guard and frame arrival.
-    """
-    src = _listener_src()
-    guard = src.index("device.data_ws is None or not device.frames_seen_this_connection")
+        "a fully down data plane must stand the watchdog down first"
     branch_end = src.find("continue", guard)
     between = src[guard:branch_end]
-    assert "dead_streak" not in between, \
-        "the outage branch must neither increment nor reset the streak"
+    assert "dead_streak" not in between and "mic_start" not in between, \
+        "a down link must neither count nor repair"
 
 
-def test_a_new_connection_clears_the_flag_and_frames_set_it():
-    """handle_data clears on connect; the wake listener sets on first frame.
-    File position reflects definition order, not runtime — so pin each site
-    inside its own function rather than comparing offsets."""
+def test_fresh_connection_gets_a_bounded_grace():
+    src = _listener_src()
+    fresh = src.index("not device.frames_seen_this_connection")
+    grace = src.index("FRESH_CONN_GRACE_S", fresh)
+    branch_end = src.find("continue", grace)
+    between = src[grace:branch_end]
+    assert "dead_streak" not in between and "mic_start" not in between, \
+        "within the grace window the watchdog must stand down"
+    assert src[branch_end:].startswith("continue")
+
+
+def test_past_the_grace_the_ladder_runs_zombie_repair():
+    """
+    The reason the guard is time-bounded: a zombie stream never delivers a
+    frame on the fresh connection, so an unbounded grace would be the
+    Office incident (deaf 4.7h) again. Past the window, silence must fall
+    through to the escalation ladder.
+    """
+    src = _listener_src()
+    grace_check = src.index("< FRESH_CONN_GRACE_S")
+    after = src[grace_check:src.index("dead_streak = 0", grace_check)]
+    assert "zombie" in after, "past-grace silence must be named as the zombie case"
+    ladder = after.find("dead_streak += 1")
+    assert ladder != -1, \
+        "past the grace window the escalation ladder must be reachable"
+
+
+def test_both_time_sources_are_updated():
     src = (CONTROLLER / "em_controller.py").read_text()
-    hd = src[src.index("device.data_ws = ws"):]  # handle_data body
+    hd = src[src.index("device.data_ws = ws"):]
     hd = hd[:hd.index("async def", 10)]
-    assert "frames_seen_this_connection = False" in hd, \
-        "a new data connection must clear the flag"
+    assert "data_connected_at" in hd, \
+        "handle_data must timestamp each new connection"
     wl = src[src.index("payload = await asyncio.wait_for("):
              src.index("except asyncio.TimeoutError")]
     assert "frames_seen_this_connection = True" in wl, \

--- a/controller/tests/test_wake_watchdog.py
+++ b/controller/tests/test_wake_watchdog.py
@@ -1,0 +1,68 @@
+"""
+#299: the wake-stream watchdog treated a dropped link as a broken mic.
+
+On a lossy link, no mic frames arrive because the transport keeps
+dropping — but the watchdog's escalation ladder (defensive mic_start,
+then mic_stop+mic_start) assumed a zombie stream device-side and acted:
+extra control-plane traffic on an already failing link, and a working
+mic pipeline torn down and rebuilt (bedroom, 2026-08-23: AEC resyncs
+3, 4, 5, 6).
+
+The fix: "no frames" with the data plane down — or on a connection that
+has not delivered a single frame yet — is explained. Stand down; do not
+count it against the streak either.
+
+em_controller is deliberately not importable here (see conftest); these
+are shape guards on the shipped source.
+"""
+
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _listener_src() -> str:
+    src = (CONTROLLER / "em_controller.py").read_text()
+    start = src.index("async def wake_word_listener")
+    return src[start:start + 30_000]
+
+
+def test_the_guard_sits_before_the_escalation_ladder():
+    src = _listener_src()
+    guard = src.index("device.data_ws is None or not device.frames_seen_this_connection")
+    ladder = src.index("dead_streak += 1", guard)
+    assert guard < ladder, \
+        "the link guard must stand down BEFORE dead_streak counts or mic_start fires"
+    # And before both escalation stages:
+    esc = src.index("mic_stop()", guard)
+    assert guard < esc
+
+
+def test_an_outage_does_not_count_against_the_streak():
+    """
+    The muted branch resets the streak (expected silence); the outage branch
+    must NOT reset it either — a streak surviving a short blip stays honest —
+    it just freezes while the transport is down. So: continue without
+    touching dead_streak between guard and frame arrival.
+    """
+    src = _listener_src()
+    guard = src.index("device.data_ws is None or not device.frames_seen_this_connection")
+    branch_end = src.find("continue", guard)
+    between = src[guard:branch_end]
+    assert "dead_streak" not in between, \
+        "the outage branch must neither increment nor reset the streak"
+
+
+def test_a_new_connection_clears_the_flag_and_frames_set_it():
+    """handle_data clears on connect; the wake listener sets on first frame.
+    File position reflects definition order, not runtime — so pin each site
+    inside its own function rather than comparing offsets."""
+    src = (CONTROLLER / "em_controller.py").read_text()
+    hd = src[src.index("device.data_ws = ws"):]  # handle_data body
+    hd = hd[:hd.index("async def", 10)]
+    assert "frames_seen_this_connection = False" in hd, \
+        "a new data connection must clear the flag"
+    wl = src[src.index("payload = await asyncio.wait_for("):
+             src.index("except asyncio.TimeoutError")]
+    assert "frames_seen_this_connection = True" in wl, \
+        "a delivered frame must set the flag"


### PR DESCRIPTION
The wake-stream watchdog now distinguishes "transport dropping frames" from "stream dead" before escalating.

- Data plane down, or a fresh connection that has not delivered a frame yet: stand down entirely — no defensive mic_start, no mic_stop+mic_start escalation, debug log only, and the outage does not count against dead_streak.
- Data plane connected and frames have flowed: the existing zombie-stream ladder runs unchanged (that case is real — Office, deaf 4.7h).

Measured impact on the bedroom device from #140: escalations into a dropping link restarted a working mic pipeline (AEC resyncs 3→6) and put extra control-plane traffic exactly where the link was already failing.

Fixes #299
