### PR TITLE
Fix #261: reference-counted duck — overlapping owners no longer release early

### DIFF
--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -292,14 +292,25 @@ async def interrupt(device_id: str) -> None:
         # nothing is lost: no seek, no bookmark, no position drift on a
         # non-seekable flow stream, and no need for the entity to claim it is
         # playing while internally paused.
-        s.ducked = True
+        #
+        # #261: reference-counted, NOT boolean. Two overlapping owners —
+        # a barge-in turn, or an announcement landing mid-turn — both used to
+        # set one flag, and whichever finished FIRST popped it and sent
+        # duck:off while the other was still speaking: music back at full
+        # level under an unfinished answer. Each owner holds one count; the
+        # wire command goes out only on the 0→1 and 1→0 transitions.
+        s.duck_depth += 1
         # Yield the shared data plane to the response. The music keeps
         # playing from the device's own buffer while the feed holds off.
         s.lead_s = TURN_LEAD_S
-        try:
-            await device.send_control({"type": "duck", "on": True})
-        except Exception as e:
-            log.warning(f"[{device_id}] duck failed: {e}")
+        if s.duck_depth == 1:
+            try:
+                await device.send_control({"type": "duck", "on": True})
+                log.info(f"[{device_id}] duck ON (depth {s.duck_depth})")
+            except Exception as e:
+                log.warning(f"[{device_id}] duck failed: {e}")
+        else:
+            log.info(f"[{device_id}] duck held (depth {s.duck_depth})")
         return
 
     if s.state == PLAYING:
@@ -325,16 +336,22 @@ async def resume_interrupted(device_id: str) -> None:
     s.owned_by_turn = False
     pending, s.pending = s.pending, None
     resume_after, s.resume_after = s.resume_after, False
-    ducked, s.ducked = s.ducked, False
-    s.lead_s = LEAD_S
+    # #261: this release only unducks when it is the LAST owner leaving —
+    # otherwise the other speaker's tail competes with the music again.
+    was_ducking = s.duck_depth > 0
+    if was_ducking:
+        s.duck_depth -= 1
+    ducked_off = was_ducking and s.duck_depth == 0
+    s.lead_s = TURN_LEAD_S if s.duck_depth > 0 else LEAD_S
 
-    if ducked:
+    if ducked_off:
         # Release the duck before settling any deferred command, so the music
         # is already back at level by the time a stop or pause lands.
         device = _get_device(device_id) if _get_device else None
         if device is not None:
             try:
                 await device.send_control({"type": "duck", "on": False})
+                log.info(f"[{device_id}] duck released (depth 0)")
             except Exception as e:
                 log.warning(f"[{device_id}] unduck failed: {e}")
 
@@ -346,7 +363,7 @@ async def resume_interrupted(device_id: str) -> None:
             await s.resume()
         elif kind == "stop":
             await s.stop()
-        elif kind == "pause" and ducked:
+        elif kind == "pause" and was_ducking:
             # When we ducked, nothing was ever paused — so the user's pause
             # has to actually happen here. On the pausing path interrupt()
             # had already done it and dropping resume_after was the whole of
@@ -382,7 +399,7 @@ class MediaSession:
         # ducked: this turn lowered the music rather than pausing it (a device
         # that mixes). It changes what turn end has to do — there is nothing
         # to resume, but a deferred pause must actually be carried out.
-        self.ducked = False
+        self.duck_depth = 0   # #261: reference-counted, see interrupt()
         # Effective pacing lead. Reduced while a turn owns the speaker so the
         # music feed stops monopolising the shared data plane (see
         # TURN_LEAD_S); restored when the turn releases it.

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -1097,3 +1097,81 @@ def test_a_slow_but_recovering_source_is_not_killed(monkeypatch):
     types = [f[0] for f in device.data_frames]
     assert types.count(0x02) == 3 and types[-1] == 0x03, \
         "every period must have made it out before EOS"
+
+
+# ── #261: the duck is reference-counted, not boolean ─────────────────────────
+
+
+def test_overlapping_owners_release_the_duck_only_once():
+    """
+    The #261 hypothesis, pinned as behaviour: two overlapping owners (a
+    barge-in turn, an announcement landing mid-turn) both used to set one
+    boolean, and whichever finished FIRST sent duck:off while the other was
+    still speaking — music back at full level under an unfinished answer.
+    With a depth count the wire command goes out only on the 0→1 and 1→0
+    transitions.
+    """
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        em_player._sessions["office"] = s
+
+        await em_player.interrupt("office")      # owner A
+        await em_player.interrupt("office")      # owner B lands mid-turn
+        ducks_on = [m for m in device.control_msgs
+                    if m.get("type") == "duck" and m.get("on")]
+        assert len(ducks_on) == 1, "the second owner must not re-send duck:on"
+
+        await em_player.resume_interrupted("office")   # B finishes first
+        offs = [m for m in device.control_msgs
+                if m.get("type") == "duck" and not m.get("on")]
+        assert offs == [], "releasing one of two owners must NOT unduck"
+
+        await em_player.resume_interrupted("office")   # A finishes
+        offs = [m for m in device.control_msgs
+                if m.get("type") == "duck" and not m.get("on")]
+        assert len(offs) == 1, "unduck exactly once, when the last owner leaves"
+        return s
+    s = asyncio.run(main())
+    assert s.duck_depth == 0, "balanced interrupts/resumes must return to 0"
+
+
+def test_a_single_turn_still_ducks_and_releases_once():
+    """The common path is unchanged by the counting."""
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        await em_player.interrupt("office")
+        ducks = [m for m in device.control_msgs if m["type"] == "duck"]
+        assert ducks == [{"type": "duck", "on": True}]
+        await em_player.resume_interrupted("office")
+        ducks = [m for m in device.control_msgs if m["type"] == "duck"]
+        assert ducks == [{"type": "duck", "on": True},
+                         {"type": "duck", "on": False}]
+    asyncio.run(main())
+
+
+def test_resume_keeps_turn_pacing_while_another_owner_speaks():
+    """
+    lead_s must stay at TURN_LEAD_S while ANY owner still holds the duck —
+    restoring full pacing on the first release would let a deferred feed
+    race the remaining speaker.
+    """
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        em_player._sessions["office"] = s
+        await em_player.interrupt("office")
+        await em_player.interrupt("office")
+        await em_player.resume_interrupted("office")
+        assert s.lead_s == em_player.TURN_LEAD_S, \
+            "one release must not restore full pacing while another speaks"
+        await em_player.resume_interrupted("office")
+        assert s.lead_s == em_player.LEAD_S
+    asyncio.run(main())


### PR DESCRIPTION
Implements both parts of the issue:

**The instrumentation:** every duck transition now logs with depth (`duck ON (depth 1)`, `duck held (depth 2)`, `duck released (depth 0)`), so "never went out" and "released early" are distinguishable at last.

**The hypothesis, implemented:** the ducked boolean was not reentrant. Two overlapping owners both set it and whichever finished first popped it — music back at full level mid-answer. The duck is now a per-session depth count; wire commands only on the 0→1 / 1→0 transitions, and lead_s stays at turn pacing while any owner remains.

Single-turn behaviour unchanged (pinned by test); new tests cover the overlap case, the once-only unduck, and pacing.

Fixes #261
