### PR TITLE
Fix #314: speaker ownership reference-counted, matching the duck

### DIFF
--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -282,8 +282,15 @@ async def interrupt(device_id: str) -> None:
     turn replaces that intent (see resume_interrupted).
     """
     s = _session(device_id)
+    # #314: ownership is reference-counted, exactly like the duck below.
+    # A nested owner (announcement landing mid-turn) must not release the
+    # turn's ownership when IT finishes, nor wipe a playback command the
+    # user issued during the turn — only the FIRST claim clears stale
+    # deferrals from before it started.
+    if s.owner_depth == 0:
+        s.pending = None
+    s.owner_depth += 1
     s.owned_by_turn = True
-    s.pending = None
 
     device = _get_device(device_id) if _get_device else None
     if device is not None and getattr(device, "audio_mix_capable", False):
@@ -333,9 +340,21 @@ async def resume_interrupted(device_id: str) -> None:
     s = _sessions.get(device_id)
     if s is None:
         return
-    s.owned_by_turn = False
-    pending, s.pending = s.pending, None
-    resume_after, s.resume_after = s.resume_after, False
+    # #314: same reference counting as the duck — ownership, pending and
+    # resume_after are released only by the LAST owner leaving. An earlier
+    # finisher leaves all three untouched: the voice turn still speaking
+    # keeps its shield against play_media landing on the response plane,
+    # and the user's deferred command survives an announcement that merely
+    # passed through.
+    if s.owner_depth > 0:
+        s.owner_depth -= 1
+    last_owner = s.owner_depth == 0
+    s.owned_by_turn = s.owner_depth > 0
+    if last_owner:
+        pending, s.pending = s.pending, None
+        resume_after, s.resume_after = s.resume_after, False
+    else:
+        pending, resume_after = None, False
     # #261: this release only unducks when it is the LAST owner leaving —
     # otherwise the other speaker's tail competes with the music again.
     was_ducking = s.duck_depth > 0
@@ -400,6 +419,7 @@ class MediaSession:
         # that mixes). It changes what turn end has to do — there is nothing
         # to resume, but a deferred pause must actually be carried out.
         self.duck_depth = 0   # #261: reference-counted, see interrupt()
+        self.owner_depth = 0  # #314: owners of the speaker, counted like the duck
         # Effective pacing lead. Reduced while a turn owns the speaker so the
         # music feed stops monopolising the shared data plane (see
         # TURN_LEAD_S); restored when the turn releases it.

--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -292,14 +292,25 @@ async def interrupt(device_id: str) -> None:
         # nothing is lost: no seek, no bookmark, no position drift on a
         # non-seekable flow stream, and no need for the entity to claim it is
         # playing while internally paused.
-        s.ducked = True
+        #
+        # #261: reference-counted, NOT boolean. Two overlapping owners —
+        # a barge-in turn, or an announcement landing mid-turn — both used to
+        # set one flag, and whichever finished FIRST popped it and sent
+        # duck:off while the other was still speaking: music back at full
+        # level under an unfinished answer. Each owner holds one count; the
+        # wire command goes out only on the 0→1 and 1→0 transitions.
+        s.duck_depth += 1
         # Yield the shared data plane to the response. The music keeps
         # playing from the device's own buffer while the feed holds off.
         s.lead_s = TURN_LEAD_S
-        try:
-            await device.send_control({"type": "duck", "on": True})
-        except Exception as e:
-            log.warning(f"[{device_id}] duck failed: {e}")
+        if s.duck_depth == 1:
+            try:
+                await device.send_control({"type": "duck", "on": True})
+                log.info(f"[{device_id}] duck ON (depth {s.duck_depth})")
+            except Exception as e:
+                log.warning(f"[{device_id}] duck failed: {e}")
+        else:
+            log.info(f"[{device_id}] duck held (depth {s.duck_depth})")
         return
 
     if s.state == PLAYING:
@@ -325,16 +336,22 @@ async def resume_interrupted(device_id: str) -> None:
     s.owned_by_turn = False
     pending, s.pending = s.pending, None
     resume_after, s.resume_after = s.resume_after, False
-    ducked, s.ducked = s.ducked, False
-    s.lead_s = LEAD_S
+    # #261: this release only unducks when it is the LAST owner leaving —
+    # otherwise the other speaker's tail competes with the music again.
+    was_ducking = s.duck_depth > 0
+    if was_ducking:
+        s.duck_depth -= 1
+    ducked_off = was_ducking and s.duck_depth == 0
+    s.lead_s = TURN_LEAD_S if s.duck_depth > 0 else LEAD_S
 
-    if ducked:
+    if ducked_off:
         # Release the duck before settling any deferred command, so the music
         # is already back at level by the time a stop or pause lands.
         device = _get_device(device_id) if _get_device else None
         if device is not None:
             try:
                 await device.send_control({"type": "duck", "on": False})
+                log.info(f"[{device_id}] duck released (depth 0)")
             except Exception as e:
                 log.warning(f"[{device_id}] unduck failed: {e}")
 
@@ -346,7 +363,7 @@ async def resume_interrupted(device_id: str) -> None:
             await s.resume()
         elif kind == "stop":
             await s.stop()
-        elif kind == "pause" and ducked:
+        elif kind == "pause" and was_ducking:
             # When we ducked, nothing was ever paused — so the user's pause
             # has to actually happen here. On the pausing path interrupt()
             # had already done it and dropping resume_after was the whole of
@@ -382,7 +399,7 @@ class MediaSession:
         # ducked: this turn lowered the music rather than pausing it (a device
         # that mixes). It changes what turn end has to do — there is nothing
         # to resume, but a deferred pause must actually be carried out.
-        self.ducked = False
+        self.duck_depth = 0   # #261: reference-counted, see interrupt()
         # Effective pacing lead. Reduced while a turn owns the speaker so the
         # music feed stops monopolising the shared data plane (see
         # TURN_LEAD_S); restored when the turn releases it.

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -156,6 +156,9 @@ def test_interrupt_resume_cycle_only_touches_playing_sessions():
         # Nothing playing: interrupt/resume are no-ops
         await em_player.interrupt("office")
         assert s.state == IDLE and not s.resume_after
+        # #314: ownership is counted — the cycle must balance, so release
+        # this no-op claim before the next scenario takes its own.
+        await em_player.resume_interrupted("office")
 
         await s.play("http://radio/stream")
         await asyncio.sleep(0.05)
@@ -1175,3 +1178,70 @@ def test_resume_keeps_turn_pacing_while_another_owner_speaks():
         await em_player.resume_interrupted("office")
         assert s.lead_s == em_player.LEAD_S
     asyncio.run(main())
+
+
+# ── #314: ownership is reference-counted like the duck ───────────────────────
+
+
+def test_announcement_midturn_does_not_release_ownership():
+    """
+    The exact sequence from #314: an announcement landing during a voice
+    turn used to release the turn's ownership when IT finished — so a
+    play_media arriving afterwards went straight to the wire, putting music
+    on the response plane while the answer was still speaking.
+    """
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        em_player._sessions["office"] = s
+
+        await em_player.interrupt("office")            # voice turn
+        await em_player.interrupt("office")            # announcement lands
+
+        await em_player.resume_interrupted("office")   # announcement ends
+        assert s.owned_by_turn is True, \
+            "the voice turn still speaks — ownership must survive"
+
+        await em_player.play("office", "http://radio/jazz")  # mid-answer!
+        assert s.pending == ("play", "http://radio/jazz"), \
+            "this command must be deferred, not put on the wire"
+
+        await em_player.resume_interrupted("office")   # voice turn ends
+        assert s.owned_by_turn is False
+        return device, s
+    device, s = asyncio.run(main())
+    offs = [m for m in device.control_msgs
+            if m.get("type") == "duck" and not m.get("on")]
+    assert len(offs) == 1
+
+
+def test_nested_interrupt_preserves_the_users_deferred_command():
+    """
+    The smaller fault of the same shape: a second interrupt() used to wipe
+    a pending command the user genuinely issued — 'play jazz' during a turn,
+    silently dropped because an announcement happened to land afterwards.
+    Only the FIRST claim clears stale deferrals.
+    """
+    async def main():
+        device = FakeDevice()
+        _wire(device)
+        s = StubSession("office", periods=2, endless=True)
+        em_player._sessions["office"] = s
+
+        await em_player.interrupt("office")              # voice turn
+        await em_player.play("office", "http://radio/jazz")
+        assert s.pending == ("play", "http://radio/jazz")
+
+        await em_player.interrupt("office")              # announcement
+        assert s.pending == ("play", "http://radio/jazz"), \
+            "a nested owner must not wipe the user's request"
+
+        await em_player.resume_interrupted("office")     # announcement ends
+        assert s.pending == ("play", "http://radio/jazz")
+
+        await em_player.resume_interrupted("office")     # voice turn ends
+        return s
+    s = asyncio.run(main())
+    assert s.pending is None, "settled by the last owner's resume"

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -1097,3 +1097,81 @@ def test_a_slow_but_recovering_source_is_not_killed(monkeypatch):
     types = [f[0] for f in device.data_frames]
     assert types.count(0x02) == 3 and types[-1] == 0x03, \
         "every period must have made it out before EOS"
+
+
+# ── #261: the duck is reference-counted, not boolean ─────────────────────────
+
+
+def test_overlapping_owners_release_the_duck_only_once():
+    """
+    The #261 hypothesis, pinned as behaviour: two overlapping owners (a
+    barge-in turn, an announcement landing mid-turn) both used to set one
+    boolean, and whichever finished FIRST sent duck:off while the other was
+    still speaking — music back at full level under an unfinished answer.
+    With a depth count the wire command goes out only on the 0→1 and 1→0
+    transitions.
+    """
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        em_player._sessions["office"] = s
+
+        await em_player.interrupt("office")      # owner A
+        await em_player.interrupt("office")      # owner B lands mid-turn
+        ducks_on = [m for m in device.control_msgs
+                    if m.get("type") == "duck" and m.get("on")]
+        assert len(ducks_on) == 1, "the second owner must not re-send duck:on"
+
+        await em_player.resume_interrupted("office")   # B finishes first
+        offs = [m for m in device.control_msgs
+                if m.get("type") == "duck" and not m.get("on")]
+        assert offs == [], "releasing one of two owners must NOT unduck"
+
+        await em_player.resume_interrupted("office")   # A finishes
+        offs = [m for m in device.control_msgs
+                if m.get("type") == "duck" and not m.get("on")]
+        assert len(offs) == 1, "unduck exactly once, when the last owner leaves"
+        return s
+    s = asyncio.run(main())
+    assert s.duck_depth == 0, "balanced interrupts/resumes must return to 0"
+
+
+def test_a_single_turn_still_ducks_and_releases_once():
+    """The common path is unchanged by the counting."""
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        await em_player.interrupt("office")
+        ducks = [m for m in device.control_msgs if m["type"] == "duck"]
+        assert ducks == [{"type": "duck", "on": True}]
+        await em_player.resume_interrupted("office")
+        ducks = [m for m in device.control_msgs if m["type"] == "duck"]
+        assert ducks == [{"type": "duck", "on": True},
+                         {"type": "duck", "on": False}]
+    asyncio.run(main())
+
+
+def test_resume_keeps_turn_pacing_while_another_owner_speaks():
+    """
+    lead_s must stay at TURN_LEAD_S while ANY owner still holds the duck —
+    restoring full pacing on the first release would let a deferred feed
+    race the remaining speaker.
+    """
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        em_player._sessions["office"] = s
+        await em_player.interrupt("office")
+        await em_player.interrupt("office")
+        await em_player.resume_interrupted("office")
+        assert s.lead_s == em_player.TURN_LEAD_S, \
+            "one release must not restore full pacing while another speaks"
+        await em_player.resume_interrupted("office")
+        assert s.lead_s == em_player.LEAD_S
+    asyncio.run(main())


### PR DESCRIPTION
Implements the design sketched in the issue: a separate `owner_depth` incremented unconditionally in `interrupt()`, with ownership, `pending` and `resume_after` released only on the 1→0 transition — while `duck_depth` stays the wire-command counter (it only increments on the mixing path; a pausing device has overlapping owners too).

Closes both faults from the issue: an announcement ending mid-turn no longer releases the voice turn's shield (a play_media arriving afterwards is deferred, not put on the response plane), and a nested interrupt no longer wipes the user's deferred command.

Stacked on #312. Tests cover the exact announcement-mid-turn sequence and the preserved user command.

Fixes #314
