### PR TITLE
Fix #315: control-plane drop gets a reconnect grace, like the data plane

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -266,6 +266,13 @@ _ha_volume_to_device = em_volume.ha_volume_to_device
 # ~5.5s, so a blip inside this window is inaudible.
 DATA_RECONNECT_GRACE_S = 3.0
 
+# #315: the control plane gets the same treatment the data plane has had —
+# a device whose control connection drops during a controller restart, an
+# add-on update or a link excursion keeps its ESPHome entities, BLE proxy
+# and media session for this long before they are released. The device's
+# own reconnect (endpoint pinned, per #106) lands well inside the window.
+CONTROL_RECONNECT_GRACE_S = 5.0
+
 
 class Device:
     def __init__(
@@ -3280,10 +3287,43 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                 # an offline device rather than up to one stats report stale.
                 db.touch_device_seen(device.device_id)
                 _devices.pop(device.device_id, None)
-                await api.notify_device_disconnected(device.device_id)
-                await esphome.device_disconnected(device.device_id)
-                await em_ble_proxy.device_disconnected(device.device_id)
-                em_player.device_gone(device.device_id)
+                # #315: the services stay up for a grace window instead of
+                # being torn down immediately — a four-second link blip used
+                # to deregister the HA entities, drop the BLE proxy and kill
+                # the media session, then rebuild all of it when the device
+                # returned on its own.
+                asyncio.create_task(
+                    _release_device_services(device)
+                ).add_done_callback(_log_task_exception)
+
+
+async def _release_device_services(device) -> None:
+    """
+    Release a device's services CONTROL_RECONNECT_GRACE_S after its control
+    connection closed — unless a replacement connection registered in the
+    meantime (#315). Mirrors the data plane's DATA_RECONNECT_GRACE_S.
+
+    esphome.device_connected() is idempotent (a still-listening port is
+    kept and only the callbacks are refreshed), so holding services
+    through a blip costs nothing on reconnect.
+    """
+    try:
+        await asyncio.sleep(CONTROL_RECONNECT_GRACE_S)
+        current = _devices.get(device.device_id)
+        if current is not None and current is not device:
+            return  # replacement is live; it owns the services now
+        log.info(
+            f"[{device.device_id}] control connection not restored within "
+            f"{CONTROL_RECONNECT_GRACE_S:.0f}s — releasing services"
+        )
+        await api.notify_device_disconnected(device.device_id)
+        await esphome.device_disconnected(device.device_id)
+        await em_ble_proxy.device_disconnected(device.device_id)
+        em_player.device_gone(device.device_id)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        log.error(f"[{device.device_id}] delayed service release failed: {e}")
 
 
 # ─── Data plane handler ───────────────────────────────────────────────────────

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5663,8 +5663,9 @@ function SettingsPanel({ globalConfig, onGlobalConfigChange, onClose, username, 
       setUsers(prev => prev.map(u => u.id === id ? { ...u, role } : u));
       setUsersMsg({ ok: true, text: 'Role updated.' });
     } catch (e) {
-      // The server refuses the last-admin demotion and explains ha_linked
-      // refusals; pass its reason through rather than a generic failure.
+      // The server's only refusal here is the last-admin demotion
+      // (ha_linked is display-only — it never causes a refusal); pass its
+      // reason through rather than a generic failure.
       setUsersMsg({ ok: false, text: e.error || 'Refused.' });
     }
   }

--- a/controller/tests/test_control_grace.py
+++ b/controller/tests/test_control_grace.py
@@ -1,0 +1,66 @@
+"""
+#315: a control-plane drop used to tear down a device's services
+immediately — HA entities deregistered, BLE proxy dropped, media session
+killed — and rebuilt all of it when the device returned seconds later.
+The data plane has had DATA_RECONNECT_GRACE_S for exactly this reason;
+the control plane never got the equivalent.
+
+em_controller is deliberately not importable here (see conftest); these
+are shape guards on the shipped source.
+"""
+
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _finally_src() -> str:
+    src = (CONTROLLER / "em_controller.py").read_text()
+    start = src.index("log.info(f\"[control] Device disconnected")
+    end = src.index("# ─── Data plane handler", start)
+    return src[start:end]
+
+
+def test_teardown_is_deferred_not_immediate():
+    src = (CONTROLLER / "em_controller.py").read_text()
+    start = src.index('log.info(f"[control] Device disconnected')
+    seg = src[start:start + 1200]
+    task_call = seg.index("asyncio.create_task(")
+    sync_path = seg[:task_call]
+    for call in ("esphome.device_disconnected",
+                 "em_ble_proxy.device_disconnected",
+                 "device_gone", "notify_device_disconnected"):
+        assert call not in sync_path, \
+            f"{call} must move into the grace task, not run on close"
+    assert "_release_device_services" in seg[task_call:], \
+        "the close path must hand over to the grace task"
+
+
+def test_the_grace_task_checks_for_a_replacement():
+    src = (CONTROLLER / "em_controller.py").read_text()
+    start = src.index("async def _release_device_services")
+    task = src[start:start + 2500]
+    assert "CONTROL_RECONNECT_GRACE_S" in task
+    assert "_devices.get(device.device_id)" in task, \
+        "the task must check whether a replacement registered"
+    for call in ("notify_device_disconnected", "esphome.device_disconnected",
+                 "em_ble_proxy.device_disconnected", "device_gone"):
+        assert call in task, f"{call} belongs in the deferred release"
+
+
+def test_the_grace_window_exists_and_is_documented():
+    src = (CONTROLLER / "em_controller.py").read_text()
+    assert "CONTROL_RECONNECT_GRACE_S" in src
+    # The data-plane constant this mirrors:
+    assert "DATA_RECONNECT_GRACE_S = 3.0" in src
+
+
+def test_the_stale_connection_guard_survives():
+    """
+    The 2026-07-14 guard solves a different ordering problem (close arriving
+    AFTER a replacement registered) and must stay untouched.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    # the message wraps across two f-string lines — match the fragments
+    assert "replacement is active" in src and "services up" in src, \
+        "the out-of-order stale guard is still needed alongside the grace"


### PR DESCRIPTION
A control-plane drop used to tear down a device's services immediately — HA entities gone, BLE proxy dropped, media session killed — then rebuild everything when the device returned seconds later. The bedroom device (2026-08-23) paid that full teardown/rebuild twice on a saturated link where nothing was actually broken.

The close path now defers to a grace task (CONTROL_RECONNECT_GRACE_S = 5s, mirroring the data plane's DATA_RECONNECT_GRACE_S): services are released only if no replacement connection registered meanwhile. esphome.device_connected is idempotent, so holding through a blip costs nothing on reconnect. The media session survives short outages like the data feed does. The 2026-07-14 stale-close guard stays untouched — different ordering problem, correctly solved.

Fixes #315
