### PR TITLE
Fix #316: cylon sweep while hunting, orange pulse only for give-up

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5663,8 +5663,9 @@ function SettingsPanel({ globalConfig, onGlobalConfigChange, onClose, username, 
       setUsers(prev => prev.map(u => u.id === id ? { ...u, role } : u));
       setUsersMsg({ ok: true, text: 'Role updated.' });
     } catch (e) {
-      // The server refuses the last-admin demotion and explains ha_linked
-      // refusals; pass its reason through rather than a generic failure.
+      // The server's only refusal here is the last-admin demotion
+      // (ha_linked is display-only — it never causes a refusal); pass its
+      // reason through rather than a generic failure.
       setUsersMsg({ ok: false, text: e.error || 'Refused.' });
     }
   }

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -209,6 +209,19 @@ func main() {
 		}
 	})
 
+	// #316: hunting — actively working through the endpoint list. Cylon
+	// sweep; the orange give-up pulse takes over only after a full cycle
+	// over all endpoints has failed (see control.go's failedCycles).
+	controlClient.OnConnecting(func() {
+		s.StopAnim()
+		if pulseCancel != nil {
+			pulseCancel()
+		}
+		pulseCtx, cancel := context.WithCancel(ctx)
+		pulseCancel = cancel
+		go cylonSweep(pulseCtx, s)
+	})
+
 	controlClient.OnDisconnected(func() {
 		// Stop any device-local animation: the controller that owned it is
 		// gone, and the pulse below would otherwise fight its ticker.
@@ -1020,6 +1033,31 @@ func allLEDs(r, g, b uint8) []led.Led {
 }
 
 // ─── LED animations ───────────────────────────────────────────────────────────
+
+// cylonSweep — mirrored blue sweep while actively hunting for a controller
+// (#316). Two comets converge at the bottom of the ring and reunite at the
+// top; the reversal distinguishes it from the controller-driven spin
+// pattern. Layer 3 of the ring ladder, same shape as the two pulses: a
+// context-cancelled goroutine on a ticker, cancelled by OnConnected. The
+// frame math lives in server.CylonFrame so it stays unit-testable.
+func cylonSweep(ctx context.Context, s *server.Server) {
+	const stepMs = 70
+	pos, dir := 0, 1
+	ticker := time.NewTicker(stepMs * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.SetLEDs(server.CylonFrame(pos, dir), nil)
+			pos += dir
+			if pos == 6 || pos == 0 {
+				dir = -dir
+			}
+		}
+	}
+}
 
 // pulseOrange — sine-wave orange pulse while disconnected from server.
 func pulseOrange(ctx context.Context, s *server.Server) {

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -73,6 +73,8 @@ type ControlClient struct {
 	ledAnimCallback       LEDAnimCallback
 	micStartCallback      MicStartCallback
 	micStopCallback       MicStopCallback
+	connectingCallback StateCallback
+	failedCycles       int
 	disconnectedCallback  StateCallback
 	connectedCallback     StateCallback
 	pendingCallback       StateCallback
@@ -119,6 +121,7 @@ func NewControlClient(
 
 func (c *ControlClient) OnLEDAnim(cb LEDAnimCallback)             { c.ledAnimCallback = cb }
 func (c *ControlClient) OnDisconnected(cb StateCallback)           { c.disconnectedCallback = cb }
+func (c *ControlClient) OnConnecting(cb StateCallback)             { c.connectingCallback = cb }
 func (c *ControlClient) OnConnected(cb StateCallback)             { c.connectedCallback = cb }
 func (c *ControlClient) OnPending(cb StateCallback)               { c.pendingCallback = cb }
 func (c *ControlClient) OnConfigApplied(cb ConfigAppliedCallback) { c.configAppliedCallback = cb }
@@ -142,13 +145,21 @@ func (c *ControlClient) IsConnected() bool {
 var errPending = fmt.Errorf("pending approval")
 
 func (c *ControlClient) Run(ctx context.Context, data *DataClient) error {
+	// #316: two link states, not one. The first pass over the endpoint list
+	// is "connecting" (cylon sweep); once a full cycle has failed, the state
+	// becomes "disconnected" (orange pulse) — still trying vs given up for
+	// now are different facts, and the split stops a cylon running all night
+	// at a controller that is not coming back.
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
-		// Show orange pulse while searching for server
-		if c.disconnectedCallback != nil {
+		if c.failedCycles == 0 {
+			if c.connectingCallback != nil {
+				c.connectingCallback()
+			}
+		} else if c.disconnectedCallback != nil {
 			c.disconnectedCallback()
 		}
 
@@ -206,9 +217,9 @@ func (c *ControlClient) Run(ctx context.Context, data *DataClient) error {
 		default:
 			if err != nil {
 				log.Printf("[control] Connection lost: %v — reconnecting in 5s", err)
-			}
-			if c.disconnectedCallback != nil {
-				c.disconnectedCallback()
+				// #316: a full cycle failed — hand the ring from the cylon
+				// sweep to the orange give-up pulse (top of next iteration).
+				c.failedCycles++
 			}
 			select {
 			case <-ctx.Done():
@@ -324,6 +335,7 @@ func (c *ControlClient) connect(ctx context.Context, server *discovery.ServerInf
 
 	if c.connectedCallback != nil {
 		c.connectedCallback()
+		c.failedCycles = 0 // #316: next drop starts hunting again with the sweep
 	}
 	data.NotifyReady(baseURL)
 

--- a/device/internal/server/cylon.go
+++ b/device/internal/server/cylon.go
@@ -16,29 +16,33 @@ import "github.com/wilbowes/EchoMuse/pkg/led"
 // lives in cmd/server.go beside the two link-state pulses (layer 3 of the
 // ring ladder, docs/led-ring-states.md).
 func CylonFrame(pos, dir int) []led.Led {
+	// One blue-violet hue, dimmed as a whole. Scaling blue alone would leave
+	// the fixed red and green dominating the dimmer trail pixels, swinging
+	// their hue toward the states this pattern has to stay clear of.
 	const (
-		head      = uint8(140)
-		trailByte = uint8(50)
-		r         = uint8(30)
-		g         = uint8(55)
+		head  = uint8(140)
+		trail = uint8(50)
+		r     = uint8(30)
+		g     = uint8(55)
 	)
 	frame := make([]led.Led, 12)
 	dot := func(i int, b uint8) {
 		i = ((i % 12) + 12) % 12
-		frame[i] = led.Led{ID: i, R: r, G: g, B: b}
+		dim := func(c uint8) uint8 { return uint8(uint16(c) * uint16(b) / uint16(head)) }
+		frame[i] = led.Led{ID: i, R: dim(r), G: dim(g), B: b}
 	}
-	trail := pos - dir
-	if trail < 0 || trail > 6 {
-		trail = pos + dir // fold at the turning point
+	trailPos := pos - dir
+	if trailPos < 0 || trailPos > 6 {
+		trailPos = pos + dir // fold at the turning point
 	}
 	for _, p := range []int{pos, (12 - pos) % 12} {
 		dot(p, head)
 	}
-	for _, p := range []int{trail, (12 - trail) % 12} {
+	for _, p := range []int{trailPos, (12 - trailPos) % 12} {
 		if p == (12-pos)%12 || p == pos {
 			continue // converging: head already covers the mirror dot
 		}
-		dot(p, trailByte)
+		dot(p, trail)
 	}
 	return frame
 }

--- a/device/internal/server/cylon.go
+++ b/device/internal/server/cylon.go
@@ -1,0 +1,44 @@
+package server
+
+import "github.com/wilbowes/EchoMuse/pkg/led"
+
+// CylonFrame renders one frame of the mirrored hunting sweep (#316): two
+// comets at pos and its mirror (12-pos) sweep 0..6 and back, converging at
+// the bottom of the ring and reuniting at the top. The direction reversal
+// is what distinguishes it from the controller-driven spin pattern; the
+// blue-violet keeps it clear of red (mute), orange (link down), cyan
+// (volume arc) and white (pending approval).
+//
+// dir is the sweep direction (+1/-1); the trail folds at the turning
+// points, which is how a comet behaves there anyway.
+//
+// Pure so the frame math is unit-testable — the goroutine that drives it
+// lives in cmd/server.go beside the two link-state pulses (layer 3 of the
+// ring ladder, docs/led-ring-states.md).
+func CylonFrame(pos, dir int) []led.Led {
+	const (
+		head      = uint8(140)
+		trailByte = uint8(50)
+		r         = uint8(30)
+		g         = uint8(55)
+	)
+	frame := make([]led.Led, 12)
+	dot := func(i int, b uint8) {
+		i = ((i % 12) + 12) % 12
+		frame[i] = led.Led{ID: i, R: r, G: g, B: b}
+	}
+	trail := pos - dir
+	if trail < 0 || trail > 6 {
+		trail = pos + dir // fold at the turning point
+	}
+	for _, p := range []int{pos, (12 - pos) % 12} {
+		dot(p, head)
+	}
+	for _, p := range []int{trail, (12 - trail) % 12} {
+		if p == (12-pos)%12 || p == pos {
+			continue // converging: head already covers the mirror dot
+		}
+		dot(p, trailByte)
+	}
+	return frame
+}

--- a/device/internal/server/cylon_test.go
+++ b/device/internal/server/cylon_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/wilbowes/EchoMuse/pkg/led"
+)
+
+func litIndices(f []led.Led) map[int]bool {
+	out := map[int]bool{}
+	for _, l := range f {
+		if l.B > 0 || l.R > 0 || l.G > 0 {
+			out[l.ID] = true
+		}
+	}
+	return out
+}
+
+// #316: the sweep is mirrored — heads at pos and 12-pos, so the pattern is
+// symmetric around the front axis and reads as deliberate rather than as a
+// glitch.
+func TestCylonFrameIsMirrored(t *testing.T) {
+	for pos := 0; pos <= 6; pos++ {
+		lit := litIndices(CylonFrame(pos, +1))
+		for i := range lit {
+			mirror := (12 - i) % 12
+			if !lit[mirror] {
+				t.Fatalf("pos %d: LED %d lit but mirror %d dark — not symmetric", pos, i, mirror)
+			}
+		}
+	}
+}
+
+func TestCylonHeadsOutshineTheTrail(t *testing.T) {
+	f := CylonFrame(3, +1)
+	var head, trail led.Led
+	for _, l := range f {
+		if l.ID == 3 {
+			head = l
+		}
+		if l.ID == 2 {
+			trail = l
+		}
+	}
+	if head.B <= trail.B {
+		t.Fatalf("head (%d) must outshine trail (%d) to read as a comet", head.B, trail.B)
+	}
+}
+
+// The colour must stay clear of the four taken states: red (mute), orange
+// (link down), cyan (volume arc), white (pending approval). Blue-violet:
+// red low relative to blue, green never dominating.
+func TestCylonColourAvoidsTheTakenStates(t *testing.T) {
+	for _, d := range []int{+1, -1} {
+		for pos := 0; pos <= 6; pos++ {
+			for _, l := range CylonFrame(pos, d) {
+				if l.B == 0 && l.R == 0 && l.G == 0 {
+					continue
+				}
+				if l.R > l.B/2 {
+					t.Fatalf("red channel too high — collides with mute red or link orange")
+				}
+				if l.G > l.B {
+					t.Fatalf("green dominates — drifts toward cyan (volume arc)")
+				}
+			}
+		}
+	}
+}
+
+func TestCylonTrailFoldsAtTheTurningPoints(t *testing.T) {
+	// Top turn (pos=0 heading up): head on 0, trails on 1/11.
+	lit := litIndices(CylonFrame(0, +1))
+	want := map[int]bool{0: true, 1: true, 11: true}
+	for i := range lit {
+		if !want[i] {
+			t.Fatalf("pos=0: unexpected LED %d lit", i)
+		}
+	}
+	// Bottom turn (pos=6 heading down): comets merged on 6, trails spread
+	// back up both sides (5/7's mirror 11).
+	lit = litIndices(CylonFrame(6, -1))
+	want2 := map[int]bool{5: true, 6: true, 7: true}
+	for i := range lit {
+		if !want2[i] {
+			t.Fatalf("pos=6: unexpected LED %d lit", i)
+		}
+	}
+}

--- a/docs/led-ring-states.md
+++ b/docs/led-ring-states.md
@@ -47,7 +47,7 @@ expiry.
 |---|---|---|---|---|---|
 | 1 | **Volume arc** | Cyan, N of 12 proportional | 2s window (`volumeLEDSecs`) | Device-local; physical presses only | `volume.go:145` |
 | 2 | **Mute ring** | Solid red `(180,0,0)` + button LED (gpio444, active-high) | Until unmuted; survives reboot + OTA | **Device-sovereign**, persisted to `/data/local/etc/echomuse/state.json` | `mute.go:132` |
-| 3 | **Link state** | Orange sine pulse (disconnected) / white slow pulse (pending approval) | Until link resolves | Device-local | `cmd/server.go:161,174` |
+| 3 | **Link state** | Blue cylon sweep (connecting — hunting for a controller, #316) / orange sine pulse (disconnected — a full endpoint cycle failed) / white slow pulse (pending approval) | Until link resolves | Device-local | `cmd/server.go` `cylonSweep`/`pulseOrange`/`pulseWhite` (currently :1025/:1050) |
 | 4 | **Turn / media animation** | `solid` · `spin` · `rotate` · `pulse` · `meter` · `off`, scene-coloured | Until replaced or `ttlSec` expires (30s listening / 135s spinner / per-response for the meter) | Controller-specified, device-rendered | `animator.go:53` |
 | 5 | **Direction overlay** | Base ring colour brightened toward white at the beam angle | While listening ring is up | Device-local, requires `listeningLEDs` | `server.go:269` |
 | 6 | **Idle** | All off | — | — | — |


### PR DESCRIPTION
The ring can now say "I am looking for a controller": a mirrored blue cylon sweep while actively hunting, keeping the orange sine pulse only for the give-up state (a full endpoint cycle failed). The two-state split follows the design settled on 2026-08-23 — still trying and given up for now are different facts, and this stops the cylon running all night at a controller that is not coming back.

Device-side only: no controller change, no capability negotiation, no protocol field — older firmware keeps pulsing orange.

- control.go counts full failed cycles, reset on successful registration; OnConnecting fires for the first pass, OnDisconnected after a cycle failed
- cmd/server.go: cylonSweep goroutine beside the two pulses, same context-cancelled shape
- frame math in server.CylonFrame (unit-tested): mirrored geometry, head-vs-trail contrast, colour clearance against mute-red/link-orange/volume-cyan/pending-white, turn-point folding
- docs/led-ring-states.md layer 3 updated; stale :161,174 references corrected

Fixes #316
