### PR TITLE
Fix #326: darken the ring on the device that loses arbitration

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -2338,6 +2338,17 @@ async def wake_word_listener(device: Device):
                             device.oww_paused_since = None
                             device.last_wake = None
                             await device.beam_unlock()
+                            # The loser is lit: since #263 the device draws
+                            # the listening ring at its own crossing, before
+                            # it can possibly know it will lose. Nothing else
+                            # on this path darkens it — leds_off and
+                            # _leds_turn_end both live on the turn path a
+                            # ceding device never reaches — so without this
+                            # the ring burns until listening_anim's 30s TTL
+                            # retires it. Plain off, not _leds_turn_end:
+                            # there was no turn, so an outcome cue would be
+                            # inventing one.
+                            await leds_off(device)
                             ceded = 0
                             while not device.voice_queue.empty():
                                 try:

--- a/controller/tests/test_local_wake_ring.py
+++ b/controller/tests/test_local_wake_ring.py
@@ -59,3 +59,24 @@ def test_the_go_config_message_carries_the_field():
     src = (ROOT / "device" / "internal" / "config" / "config.go").read_text()
     assert re.search(r'ListeningAnim\s+json\.RawMessage\s+`json:"listeningAnim,omitempty"`', src), \
         "the wire field must exist with the exact tag the controller sends"
+
+
+def test_the_arbitration_loser_gets_its_ring_turned_off():
+    """
+    #326: the flip side of drawing locally. The device lights the ring at
+    its own crossing, before arbitration has happened, so a device that
+    loses is lit with nothing on its path to darken it — leds_off and
+    _leds_turn_end are both on the turn path a ceding device never reaches.
+    It used to burn until listening_anim's 30s TTL expired.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    cede = src[src.index("if won_by != device.device_id:"):]
+    cede = cede[:cede.index("continue")]
+    # Comments on this path necessarily discuss the call they exclude.
+    code = "\n".join(
+        line for line in cede.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "leds_off(device)" in code, \
+        "a ceding device must be told to darken its ring"
+    assert "_leds_turn_end" not in code, \
+        "the loser had no turn, so it gets plain off, not an outcome cue"


### PR DESCRIPTION
The device that loses wake arbitration kept its ring lit for up to 30 seconds. Observed on hardware 2026-08-25.

`await leds_off(device)` on the cede path, before the `continue`.

**Why it was lit at all:** since #263 the device draws the listening ring locally at its own wake crossing — that is the point of #263, and it means the device lights up before it can know whether it will win. The controller's cede path unwound everything else about the losing turn (`oww_paused`, `last_wake`, the beam lock, the queued frames) and never touched the ring. Both calls that darken it, `leds_off` and `_leds_turn_end`, sit on the turn path a ceding device never reaches, so `listening_anim`'s `ttlSec: 30` was the only thing retiring it.

Plain `leds_off`, not `_leds_turn_end` — the loser had no turn, so an outcome cue would be inventing one. The 30s TTL stays as the backstop it was meant to be.

Test extends `test_local_wake_ring.py`, which already guards the other half of #263. It strips comments from the source slice first: a comment on this path necessarily names the call it is explaining why *not* to use, which failed the assertion on the first run.

738 tests pass.

Fixes #326
