### PR TITLE
Fix #329: a timed-out turn must serialise like an aborted one

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -1081,6 +1081,21 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             except asyncio.TimeoutError:
                 log.warning(f"[{self._log_name}] Timeout waiting for TTS response from HA")
                 if trace: trace.outcome = "timeout"
+                # A timeout orphans HA's run exactly as an abort does — we
+                # walk away while the pipeline is still live — so it needs
+                # the same serialisation. Without this the stale run's
+                # RUN_END lands on the NEXT turn, which has not seen its own
+                # RUN_START yet, and _ha_never_started reads it as terminal:
+                # the turn dies pipeline_refused in ~3ms with zero audio.
+                # Measured on the 2026-08-25 soak, 4 of 4 — every refusal in
+                # 15 hours followed a timeout, none followed a good turn, and
+                # the user re-asking twice got refused twice.
+                #
+                # The reason is set FIRST because abort_ha_run defaults it to
+                # "barged": a timeout is not a barge, nobody spoke over
+                # anything, and _turn_end_reason is meant to be the cause.
+                self._turn_end_reason = "timeout"
+                self.abort_ha_run()
                 return
 
             if self._turn_cancelled:

--- a/controller/tests/test_barge_serialisation.py
+++ b/controller/tests/test_barge_serialisation.py
@@ -228,3 +228,29 @@ def test_the_unarmed_run_end_path_is_still_there():
         "the RUN_END-without-RUN_START discriminator is gone"
     )
     assert "self._ha_never_started = True" in ESPHOME_SRC
+
+
+def test_a_timeout_serialises_the_same_way_a_barge_does():
+    """
+    A timeout orphans HA's run exactly as an abort does — we stop waiting
+    while the pipeline is still live — so it needs the same barrier.
+
+    Without it the stale run's RUN_END lands on the NEXT turn, which has not
+    seen its own RUN_START, and _ha_never_started reads it as terminal.
+    Measured on the 2026-08-25 soak: all four pipeline_refused turns in 15
+    hours immediately followed a timeout and none followed a good turn, so
+    the user re-asking after a slow intent was refused in ~3ms, twice.
+    """
+    # Anchored on the message, not on `except asyncio.TimeoutError:` — there
+    # are two, and the earlier one is the mic-streaming hard cap, which
+    # deliberately falls through to this wait rather than abandoning the run.
+    body = ESPHOME_SRC[ESPHOME_SRC.index("Timeout waiting for TTS response from HA"):]
+    body = body[:body.index("\n            if self._turn_cancelled:")]
+    assert "abort_ha_run()" in body, \
+        "a timed-out turn must abort HA's run and arm the barrier"
+    # abort_ha_run defaults the reason to "barged". Nobody spoke over
+    # anything here, and _turn_end_reason is the CAUSE.
+    assert '_turn_end_reason = "timeout"' in body, \
+        "the reason must be set before abort_ha_run defaults it to barged"
+    assert body.index('_turn_end_reason = "timeout"') < body.index("abort_ha_run()"), \
+        "setting it after the call is too late — the default has already won"


### PR DESCRIPTION
A turn that times out waiting for HA poisoned the next turn. `abort_ha_run()` on the timeout path fixes it.

Measured on the 2026-08-25 EA soak (2.21.0-ea.5, 15.3 hours, 17 turns): **every `pipeline_refused` followed a `timeout`, four for four, none followed a good turn.**

```
11:29:15  timeout           (32738ms)
11:29:20  pipeline_refused  (3ms)
11:29:25  pipeline_refused  (8ms)   ← asked twice, refused twice
```

**Why:** the TTS wait gave up after 30s and returned, sending no `start=False` and arming no barrier. HA's pipeline stayed live and its `RUN_END` landed on the *next* turn, which had not seen its own `RUN_START` — `_ha_never_started` read it as terminal. Same fault #194 fixed for barge-in, on a path the barrier was never wired into.

`_turn_end_reason` is set before the call because `abort_ha_run` defaults it to `"barged"`, and that field is the cause rather than the phase — the default would put a fabricated barge in the record of every slow HA intent.

**Not addressed here:** the timeouts themselves are HA-side (all three were `play some music on <device>`, STT fine, no TTS URL within 30s). That is a separate investigation, but it is why this path is reachable in ordinary use rather than only after a barge.

The test anchors on the log message rather than `except asyncio.TimeoutError:` — there are two, and the earlier one is the mic-streaming hard cap which deliberately falls through. The first version of the test guarded the wrong block and passed.

738 tests pass.

Fixes #329
