### PR TITLE
Fix #331: drain the limiter tail before padding the final period

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -828,6 +828,30 @@ class Device:
         # an investigation on 2026-07-20.
         send_seconds = 0.0
         first_send_time = None
+
+        async def send_period(chunk: bytes) -> None:
+            """Send one whole device period, stamping the first one."""
+            nonlocal first_send_time, send_seconds
+            if first_send_time is None:
+                first_send_time = asyncio.get_event_loop().time()
+                self.playback_send_t0 = first_send_time
+                await self._set_speaking(True)
+                log.info(
+                    f"[{self.device_id}] First streamed PCM period "
+                    "sent to device"
+                )
+            _t_send = asyncio.get_event_loop().time()
+            await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
+            send_seconds += asyncio.get_event_loop().time() - _t_send
+
+        async def drain_whole_periods() -> None:
+            while len(pending) >= SPEAKER_BYTES:
+                if self.cancel_event.is_set():
+                    break
+                chunk = bytes(pending[:SPEAKER_BYTES])
+                del pending[:SPEAKER_BYTES]
+                await send_period(chunk)
+
         try:
             async for pcm in pcm_chunks:
                 if self.cancel_event.is_set():
@@ -837,22 +861,7 @@ class Device:
                 pending.extend(stream_eq.process(pcm))
                 eq_seconds += asyncio.get_event_loop().time() - eq_started
 
-                while len(pending) >= SPEAKER_BYTES:
-                    if self.cancel_event.is_set():
-                        break
-                    chunk = bytes(pending[:SPEAKER_BYTES])
-                    del pending[:SPEAKER_BYTES]
-                    if first_send_time is None:
-                        first_send_time = asyncio.get_event_loop().time()
-                        self.playback_send_t0 = first_send_time
-                        await self._set_speaking(True)
-                        log.info(
-                            f"[{self.device_id}] First streamed PCM period "
-                            "sent to device"
-                        )
-                    _t_send = asyncio.get_event_loop().time()
-                    await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
-                    send_seconds += asyncio.get_event_loop().time() - _t_send
+                await drain_whole_periods()
 
             # The limiter holds a look-ahead tail; without this the last few
             # ms of every response are dropped. Inaudible on a long track and
@@ -861,20 +870,20 @@ class Device:
             if not self.cancel_event.is_set():
                 pending.extend(stream_eq.flush())
 
+            # The flush can push `pending` back over a period, so it has to be
+            # drained again before the remainder is padded. It used to pad
+            # straight from here, and `bytes(SPEAKER_BYTES - len(chunk))` is a
+            # ValueError once that goes negative: the drain loop above leaves
+            # 0-4095 bytes and the tail adds 478, so any remainder over 3618
+            # killed the response — 11.7% of them, measured as `negative
+            # count` on the 2026-08-25 soak (#331). The invariant is that a
+            # period is drained after the flush, not that the tail is small
+            # enough to fit.
+            await drain_whole_periods()
+
             if pending and not self.cancel_event.is_set():
-                chunk = bytes(pending)
-                chunk += bytes(SPEAKER_BYTES - len(chunk))
-                if first_send_time is None:
-                    first_send_time = asyncio.get_event_loop().time()
-                    self.playback_send_t0 = first_send_time
-                    await self._set_speaking(True)
-                    log.info(
-                        f"[{self.device_id}] First streamed PCM period "
-                        "sent to device"
-                    )
-                _t_send = asyncio.get_event_loop().time()
-                await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
-                send_seconds += asyncio.get_event_loop().time() - _t_send
+                chunk = bytes(pending) + bytes(SPEAKER_BYTES - len(pending))
+                await send_period(chunk)
         finally:
             # NOT where speaking clears — see the note in stream_speaker.
             # One EOS terminates the complete response. Sending EOS per HTTP

--- a/controller/tests/test_speaker_periods.py
+++ b/controller/tests/test_speaker_periods.py
@@ -1,0 +1,109 @@
+"""
+#331: the limiter's look-ahead tail can push the final buffer back over a
+device period, and the pad that follows it must not go negative.
+
+`Device.stream_speaker_chunks` drains `pending` in whole periods, then
+appends `stream_eq.flush()` — the limiter's held look-ahead — and pads what
+is left up to one period. It padded straight from there, and
+
+    chunk += bytes(SPEAKER_BYTES - len(chunk))
+
+raises `ValueError: negative count` the moment the flush pushes the
+remainder past a period. Measured on the 2026-08-25 soak as one turn ending
+`tts_error` with `tts_bytes=0`, ~1.7s after playback had started.
+
+The suite cannot import `em_controller`, so the numbers come from the
+importable half of the chain and the ordering is pinned against the source.
+"""
+
+import re
+from pathlib import Path
+
+import numpy as np
+
+import em_eq
+import em_limiter
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+SRC = (CONTROLLER / "em_controller.py").read_text()
+
+SPEAKER_PERIOD = int(re.search(r"^SPEAKER_PERIOD\s*=\s*(\d+)", SRC, re.M).group(1))
+SPEAKER_BYTES = SPEAKER_PERIOD * 2
+
+
+def _stream_body() -> str:
+    """
+    stream_speaker_chunks with comments stripped.
+
+    The comments there necessarily quote the expression they exist to warn
+    about, so a source search that includes them matches the warning rather
+    than the code — which is how the first version of this test failed.
+    """
+    body = SRC[SRC.index("async def stream_speaker_chunks"):]
+    body = body[:body.index("\n# The live device registry")]
+    return "\n".join(
+        line for line in body.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _tail_bytes() -> int:
+    """The real flush tail, measured off a real chain rather than derived."""
+    eq = em_eq.StreamingEQ(48000, limiter=em_limiter.Limiter(48000))
+    pcm = (np.random.default_rng(0).integers(-8000, 8000, 48000)
+           .astype(np.int16).tobytes())
+    eq.process(pcm)
+    return len(eq.flush())
+
+
+def test_the_limiter_actually_holds_a_tail():
+    """If this ever became zero the bug would vanish for the wrong reason."""
+    assert _tail_bytes() > 0
+
+
+def test_the_tail_can_push_the_remainder_past_a_period():
+    """
+    The arithmetic that makes the bug reachable, stated as a fact about the
+    real constants rather than a comment that can go stale.
+
+    The drain loop leaves 0..SPEAKER_BYTES-1 bytes. Anything above
+    SPEAKER_BYTES - tail overflows once the tail is appended, which for a
+    uniform remainder is tail/SPEAKER_BYTES of all responses.
+    """
+    tail = _tail_bytes()
+    largest_remainder = SPEAKER_BYTES - 1
+    assert largest_remainder + tail > SPEAKER_BYTES, (
+        "the tail can no longer overflow a period — if that is deliberate, "
+        "this test should be deleted along with the second drain"
+    )
+
+
+def test_the_flush_is_drained_before_the_remainder_is_padded():
+    """
+    The fix, and the thing that must not be tidied away: a period has to be
+    drained AFTER the flush. Padding straight from the flush is the bug, and
+    it fails as a ValueError rather than as bad audio.
+    """
+    body = _stream_body()
+    flush = body.index("stream_eq.flush()")
+    pad = body.index("bytes(SPEAKER_BYTES - len(")
+    between = body[flush:pad]
+    assert "drain_whole_periods()" in between, (
+        "the limiter tail must be drained into whole periods before the "
+        "remainder is padded, or the pad length goes negative"
+    )
+
+
+def test_the_pad_can_never_be_negative_by_construction():
+    """
+    The padded value must be the remainder AFTER the drain, so it is < one
+    period by construction. Padding `len(chunk)` where chunk already includes
+    an undrained tail is what went negative.
+    """
+    body = _stream_body()
+    pad_line = re.search(r"bytes\(SPEAKER_BYTES - len\((\w+)\)\)", body)
+    assert pad_line, "the final pad has moved — re-pin this test"
+    padded = pad_line.group(1)
+    assert padded == "pending", (
+        f"the pad is measured against `{padded}`; it must be `pending`, which "
+        "the drain above has just reduced below one period"
+    )


### PR DESCRIPTION
About one TTS response in nine died at the very end with `ValueError: negative count`, ending the turn `tts_error`.

`stream_speaker_chunks` drained `pending` in whole periods, appended the limiter's look-ahead tail, then padded what was left:

```python
chunk += bytes(SPEAKER_BYTES - len(chunk))   # ValueError once this goes negative
```

The drain loop leaves 0–4095 bytes; the tail adds **478** (`lookahead - 1` = 239 samples at 48kHz mono S16). Any remainder over 3618 threw — **478/4096 = 11.7%** of responses. Observed 1 in 17 on the 2026-08-25 soak (5.9%), consistent within sampling noise.

**The fix is not a bigger pad or a guard on the subtraction.** The invariant is that a period is drained *after* the flush; the tail being small enough to fit was never something the code was entitled to assume. Draining again also removes the quieter half — a remainder landing exactly on a period boundary would have been sent with no pad at all.

The two send blocks became one nested `send_period`, because the fix needs a third caller and the first-frame stamping was already duplicated. Nothing about the stamping, send timing or EOS changes.

**Tests** measure the tail off a real `StreamingEQ` rather than deriving it, so the arithmetic stops being a comment that can go stale, and pin the ordering against the source (the suite cannot import `em_controller`). Both source guards were verified by reintroducing the bug. They strip comments before searching — the comments here quote the expression they warn about, and the first version matched the warning instead of the code.

**Not #324.** That reporter's log shows a data-plane keepalive timeout mid-stream, which is a link failure. Same user-visible shape, different cause.

741 tests pass.

Fixes #331
