### PR TITLE
Serialise HA's run at turn teardown, not on the path that noticed

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -350,6 +350,10 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         # see _handle_voice_event's RUN_END branch).
         self._intent_ended      = False
         self._run_started       = False
+        # Whether HA has told us this run is over. A run we started
+        # that has not finished is still emitting onto this socket,
+        # and its tail belongs to no turn but this one.
+        self._run_finished      = False
         self._ha_never_started  = False
         # Barge-in run serialisation — the protocol has no run id, so the
         # satellite is what keeps two runs from overlapping on one connection.
@@ -798,6 +802,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 # Unblocking both waiters mirrors the ERROR path below, which
                 # is the established shape for "HA is done, stop feeding it".
                 self._ha_never_started = True
+                self._run_finished = True
                 self._ha_vad_end.set()
                 self._tts_event.set()
                 return
@@ -813,6 +818,10 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             # through INTENT_END first, so this doesn't add a 30s stall for
             # that case — only a premature RUN_END before INTENT_END is held.
             if self._intent_ended or self._turn_cancelled:
+                # The genuine terminal RUN_END. Nothing more is coming for
+                # this run, so teardown has nothing left to serialise
+                # against — the overwhelmingly common case.
+                self._run_finished = True
                 self._tts_event.set()
             else:
                 log.debug(
@@ -973,6 +982,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._tts_audio_data        = None
         self._intent_ended          = False
         self._run_started           = False
+        self._run_finished          = False
         self._ha_never_started      = False
         # Takes ownership of an abort armed during the PREVIOUS turn (at the
         # barge). Deliberately not a plain reset: the arm has to survive this
@@ -1081,21 +1091,9 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             except asyncio.TimeoutError:
                 log.warning(f"[{self._log_name}] Timeout waiting for TTS response from HA")
                 if trace: trace.outcome = "timeout"
-                # A timeout orphans HA's run exactly as an abort does — we
-                # walk away while the pipeline is still live — so it needs
-                # the same serialisation. Without this the stale run's
-                # RUN_END lands on the NEXT turn, which has not seen its own
-                # RUN_START yet, and _ha_never_started reads it as terminal:
-                # the turn dies pipeline_refused in ~3ms with zero audio.
-                # Measured on the 2026-08-25 soak, 4 of 4 — every refusal in
-                # 15 hours followed a timeout, none followed a good turn, and
-                # the user re-asking twice got refused twice.
-                #
-                # The reason is set FIRST because abort_ha_run defaults it to
-                # "barged": a timeout is not a barge, nobody spoke over
-                # anything, and _turn_end_reason is meant to be the cause.
-                self._turn_end_reason = "timeout"
-                self.abort_ha_run()
+                # HA's run is still live here — that is what a timeout MEANS
+                # — but it is serialised at teardown along with every other
+                # abandoned turn, not on this path. See the note there.
                 return
 
             if self._turn_cancelled:
@@ -1198,6 +1196,25 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 # the feed is actually up.
                 self._send_one(self._media_state_msg())
             self._turn_active    = False
+            # A run we started that HA never told us finished is STILL LIVE,
+            # and its RUN_END will land on whichever turn is running when it
+            # arrives — which reads there as "HA ended a run it never
+            # started" and kills that turn in milliseconds.
+            #
+            # This is here rather than on each early return because the
+            # returns are the wrong place to hold the invariant: `timeout`
+            # was fixed on its own path (#329) while `no_speech` — the same
+            # fault, reached whenever a wake fires and nobody speaks — sat
+            # one branch away, its comment asserting there was no in-flight
+            # pipeline three lines after saying HA was listening. Teardown
+            # is the one place every abandoned turn passes through, so a
+            # return added later is covered without anyone remembering.
+            if self._run_started and not self._run_finished:
+                log.debug(
+                    f"[{self._log_name}] Turn ended with HA's run still live "
+                    f"— aborting it so its tail cannot reach the next turn"
+                )
+                self.end_ha_run()
             self._barrier.end_turn()
             self._on_thinking    = None
             self._on_announce    = None
@@ -1631,6 +1648,28 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         # actually written for.
         if self._turn_end_reason is None:
             self._turn_end_reason = "barged"
+        self.end_ha_run()
+
+    def end_ha_run(self) -> None:
+        """
+        Stop HA's pipeline and arm the run barrier. Touches no turn state.
+
+        This is the serialisation on its own, separated from `abort_ha_run`
+        so the turn teardown can use it. Teardown is not a barge: nobody
+        spoke over anything, and letting `abort_ha_run` default
+        `_turn_end_reason` to "barged" there would invent a cause on every
+        turn that simply stopped waiting.
+
+        Idempotent via `_run_finished`, which matters because a barge calls
+        this and then teardown would call it again — a second `start=False`
+        at that point races the interrupting turn's own pipeline, which is
+        the failure this whole mechanism exists to prevent.
+        """
+        if self._run_finished:
+            return
+        # From here on we are done with this run whatever HA does next, and
+        # that is exactly what makes a later event stale.
+        self._run_finished = True
         if self._transport and not self._transport.is_closing():
             self._send_one(api_pb2.VoiceAssistantRequest(start=False))
         # Armed even if the transport is gone: the barrier is cheap, and a

--- a/controller/tests/test_barge_serialisation.py
+++ b/controller/tests/test_barge_serialisation.py
@@ -230,27 +230,117 @@ def test_the_unarmed_run_end_path_is_still_there():
     assert "self._ha_never_started = True" in ESPHOME_SRC
 
 
-def test_a_timeout_serialises_the_same_way_a_barge_does():
+def _turn_body() -> str:
     """
-    A timeout orphans HA's run exactly as an abort does — we stop waiting
-    while the pipeline is still live — so it needs the same barrier.
+    run_esphome_voice_turn with comments stripped.
 
-    Without it the stale run's RUN_END lands on the NEXT turn, which has not
-    seen its own RUN_START, and _ha_never_started reads it as terminal.
-    Measured on the 2026-08-25 soak: all four pipeline_refused turns in 15
-    hours immediately followed a timeout and none followed a good turn, so
-    the user re-asking after a slow intent was refused in ~3ms, twice.
+    The comments in the teardown necessarily name the calls they explain, so
+    a source search including them matches the explanation and not the code.
     """
-    # Anchored on the message, not on `except asyncio.TimeoutError:` — there
-    # are two, and the earlier one is the mic-streaming hard cap, which
-    # deliberately falls through to this wait rather than abandoning the run.
-    body = ESPHOME_SRC[ESPHOME_SRC.index("Timeout waiting for TTS response from HA"):]
-    body = body[:body.index("\n            if self._turn_cancelled:")]
-    assert "abort_ha_run()" in body, \
-        "a timed-out turn must abort HA's run and arm the barrier"
-    # abort_ha_run defaults the reason to "barged". Nobody spoke over
-    # anything here, and _turn_end_reason is the CAUSE.
-    assert '_turn_end_reason = "timeout"' in body, \
-        "the reason must be set before abort_ha_run defaults it to barged"
-    assert body.index('_turn_end_reason = "timeout"') < body.index("abort_ha_run()"), \
-        "setting it after the call is too late — the default has already won"
+    start = ESPHOME_SRC.index("async def run_esphome_voice_turn")
+    body = ESPHOME_SRC[start:]
+    body = body[:re.search(r"\n    async def ", body[1:]).start() + 1]
+    return "\n".join(
+        l for l in body.splitlines() if not l.lstrip().startswith("#")
+    )
+
+
+def test_every_abandoned_turn_serialises_at_teardown():
+    """
+    #329, generalised. A run we started that HA never finished is still
+    emitting onto this connection, and its RUN_END lands on whatever turn is
+    running when it arrives — which reads there as "HA ended a run it never
+    started" and kills that turn in milliseconds.
+
+    Measured on the 2026-08-25 soak: all four pipeline_refused turns in 15
+    hours immediately followed a timeout, none followed a good turn.
+
+    The guard belongs at teardown, not on each early return. Fixing the
+    `timeout` path alone left `no_speech` — the same fault, reached whenever
+    a wake fires and nobody speaks — one branch away, with a comment
+    asserting there was no in-flight pipeline three lines after saying HA
+    was listening.
+    """
+    body = _turn_body()
+    assert "if self._run_started and not self._run_finished:" in body, \
+        "teardown must serialise a run HA never told us finished"
+    guard = body.index("if self._run_started and not self._run_finished:")
+    end_turn = body.index("self._barrier.end_turn()")
+    assert guard < end_turn, \
+        "the abort must arm the barrier before the turn drops it"
+
+
+def test_teardown_is_reached_by_every_return():
+    """
+    The guard above is only an invariant because every path runs it. If the
+    teardown ever stops being a `finally`, a return added later silently
+    opts out and the fault comes back on that path alone — which is exactly
+    how it survived the first time.
+    """
+    lines = _turn_body().splitlines()
+    tear = next(i for i, l in enumerate(lines) if "self._turn_active    = False" in l)
+    enclosing = next(
+        lines[i].strip() for i in range(tear, 0, -1)
+        if lines[i].strip() in ("try:", "finally:")
+    )
+    assert enclosing == "finally:", \
+        f"teardown sits under {enclosing!r}; an early return would skip it"
+
+
+def test_the_serialisation_lives_in_exactly_one_place():
+    """
+    Two call sites: the barge (via abort_ha_run) and teardown. A third would
+    mean a path deciding for itself, which is the shape that produced the
+    bug.
+    """
+    calls = ESPHOME_SRC.count("self.end_ha_run()")
+    assert calls == 2, (
+        f"end_ha_run has {calls} call sites; it should be abort_ha_run and "
+        "teardown only — a per-path abort is what left no_speech uncovered"
+    )
+
+
+def test_ending_the_run_is_idempotent():
+    """
+    A barge ends the run and then teardown runs anyway. A second
+    `start=False` at that moment races the INTERRUPTING turn's own pipeline
+    — the precise failure this whole mechanism exists to prevent — so the
+    flag must be set before anything is sent, not after.
+    """
+    fn = ESPHOME_SRC[ESPHOME_SRC.index("def end_ha_run"):][:4000]
+    # Past the docstring: it quotes `start=False` while explaining why the
+    # ordering matters, and matching that instead of the send is how the
+    # first version of this test failed. Third time today.
+    code = fn[fn.index('"""', fn.index('"""') + 3) + 3:]
+    code = "\n".join(l for l in code.splitlines() if not l.lstrip().startswith("#"))
+    early_out = code.index("return")
+    set_flag = code.index("self._run_finished = True")
+    send = code.index("start=False")
+    assert early_out < set_flag < send, \
+        "end_ha_run must bail on an already-finished run, and claim the run "\
+        "before it sends anything"
+
+
+def test_a_genuinely_finished_run_is_not_aborted():
+    """
+    The common case. Both branches where HA really ends a run must say so,
+    or every ordinary turn ends by aborting a pipeline that already
+    completed and arming a barrier the next turn does not need.
+    """
+    assert ESPHOME_SRC.count("self._run_finished = True") >= 3, (
+        "expected the flag set by end_ha_run plus both terminal RUN_END "
+        "branches"
+    )
+    never_started = ESPHOME_SRC[ESPHOME_SRC.index("self._ha_never_started = True"):][:200]
+    assert "self._run_finished = True" in never_started, \
+        "a run HA ended without starting is finished, not live"
+
+
+def test_the_flag_resets_per_turn():
+    """
+    Left set, it disables the serialisation for the life of the connection —
+    silently, and only for the multi-run case that is hard to reproduce.
+    """
+    body = _turn_body()
+    assert "self._run_finished          = False" in body, \
+        "the flag must be cleared at turn start beside _run_started"


### PR DESCRIPTION
#329 fixed the `timeout` return and left the identical fault one branch away.

`no_speech` also abandons a live HA run — reached whenever a wake word fires and nobody speaks — and its own comment says so, three lines apart:

> `_stream_mic_audio already skipped sending end=True to HA, so there's no in-flight HA pipeline to wait on`
> …
> `reaching here means HA was listening and nobody spoke`

If HA was listening, the pipeline **is** in flight; we simply never sent the sentinel that stops it.

## The sweep

Every `return` in `run_esphome_voice_turn`:

| outcome | tells HA anything? |
|---|---|
| barged / cancelled / muted | yes |
| `pipeline_refused` | n/a — HA already ended it |
| **`no_speech`** | **no — live fault** |
| `timeout` | yes (#329's point fix) |
| `tts_error` | no — HA has usually ended it by then |

## The fix

The guard moves to teardown, which is a `finally` and therefore the one place every abandoned turn passes through — **including returns nobody has written yet**. That is the actual invariant: a run we started and HA never finished is still emitting onto this socket. Fixing it per-path encodes which paths we happened to look at, which is what produced this in the first place.

- `_run_finished` is set by both branches where HA genuinely ends a run, so an ordinary turn tears down with nothing to do.
- `end_ha_run` is split out of `abort_ha_run` because **teardown is not a barge** — letting `abort_ha_run` default `_turn_end_reason` to `"barged"` there would invent a cause on every turn that simply stopped waiting.
- It is **idempotent**, because a barge ends the run and then teardown runs anyway, and a second `start=False` at that moment races the *interrupting* turn's pipeline — the exact race this mechanism exists to prevent.

## Tests

#329's test went with the point fix it pinned: it asserted the shape of a fix rather than an invariant, which is the failure mode named in the journal on 2026-08-23 and now on its fifth instance.

The replacements pin the invariant — teardown serialises, teardown is a `finally`, the call lives in exactly one place, ending is idempotent, a finished run is left alone, the flag resets per turn. Verified by reverting to the per-path fix (two fail) and by moving teardown out of the `finally` (one fails).

748 tests pass.
