### PR TITLE
Docs: correct three statements tonight's changes made false

### DIFF
--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -320,12 +320,32 @@ halves, both required:
 - **HA acknowledges an abort with no wire message at all**, so the barrier is
   ordering, never a timeout: after an abort, discard every event until the next
   `RUN_START`, which is necessarily ours. `em_runbarrier` holds that state.
-  Armed **only** by an abort and bounded to **one turn**, so the
-  `_ha_never_started` path above — a genuine `RUN_END` with no `RUN_START`,
-  which stalled the satellite setup dialog when it was missed — stays
-  untouched. `RUN_START` releases the barrier and is itself **delivered**, not
+  Bounded to **one turn**, so the `_ha_never_started` path above — a genuine
+  `RUN_END` with no `RUN_START`, which stalled the satellite setup dialog when
+  it was missed — stays untouched. `RUN_START` releases the barrier and is itself **delivered**, not
   swallowed; eating it would leave `_run_started` False and re-arm the same bug
   for the turn's own terminal `RUN_END`.
+- **A barge is not the only way to orphan a run, and the guard belongs at
+  teardown.** Any turn that stops waiting while HA is still working leaves the
+  run live: a `timeout` gives up after 30s, and `no_speech` never sends the
+  `end=True` sentinel at all. Both used to walk away silently, and the stale
+  `RUN_END` then landed on the NEXT turn, which had not seen its own
+  `RUN_START` — `_ha_never_started` read it as terminal and killed that turn in
+  ~3ms. Measured 2026-08-25: every `pipeline_refused` in a 15-hour sample
+  followed a timeout, none followed a good turn, so one slow HA intent cost
+  three turns and asking again was the guaranteed failure.
+  `timeout` was fixed on its own path first (#329) and `no_speech` — the far
+  more common one — sat one branch away, so the guard moved to the turn's
+  `finally` (#333): `if self._run_started and not self._run_finished:
+  end_ha_run()`. That is the invariant, and it covers returns nobody has
+  written yet. `_run_finished` is set by both branches where HA genuinely ends
+  a run, so an ordinary turn tears down with nothing to do.
+  `end_ha_run` is split out of `abort_ha_run` because **teardown is not a
+  barge** — letting it default `_turn_end_reason` to "barged" would invent a
+  cause on every turn that merely stopped waiting — and it is **idempotent**,
+  because a barge ends the run and then teardown runs anyway, and a second
+  `start=False` there races the *interrupting* turn's pipeline, which is the
+  failure the barrier exists to prevent.
 
 **A low barge threshold needs TWO consecutive frames, and the reason it went
 unnoticed is that responses used to be short.** The watcher scores 80ms frames

--- a/controller/em_runbarrier.py
+++ b/controller/em_runbarrier.py
@@ -12,7 +12,12 @@ audio queue and cancels the TTS streaming task, then overwrites `_pipeline_task`
 *without cancelling the previous one* — so starting a second run orphans the
 first, which keeps emitting events onto the same socket.
 
-Barge-in is the only place we overlap two runs. Measured on 2026-08-17: five
+Barge-in is the obvious place two runs overlap, and not the only one: any
+turn that stops waiting while HA is still working leaves a live run behind
+it — a `timeout` after 30s, or a `no_speech` that never sends the end
+sentinel. Those are caught at turn teardown rather than per-path, because
+fixing the path that noticed is how `no_speech` sat uncovered while
+`timeout` was fixed beside it (#333). Measured on 2026-08-17: five
 barge-ins, five interrupting turns dead in 4-17ms with zero audio captured. The
 aborted run's RUN_END arrived ~4ms after the new turn started, the new turn had
 not yet seen a RUN_START of its own, and the "HA ended a run it never started"

--- a/docs/voice-pipeline.md
+++ b/docs/voice-pipeline.md
@@ -139,7 +139,8 @@ wake word?" Cross the sensitivity bar and the conversation starts.
 
 With more than one device online, the **first** Echo to hear you answers
 straight away, and any other device detecting the same word within the
-**arbitration window** (default 700ms, configurable) stands down silently.
+**arbitration window** (default 700ms, configurable) stands down silently,
+its ring going dark as soon as the other device claims the turn.
 One utterance, one response, even in earshot of two devices — and no added
 latency, because the winner claims the turn on the spot rather than waiting
 out the window.


### PR DESCRIPTION
Three statements that were true when written and stopped being true this evening.

- `controller/CLAUDE.md` said the run barrier is "armed **only** by an abort". Since #333 turn teardown arms it too. Replaced with the rule, and why it sits at teardown rather than on each early return.
- `em_runbarrier`'s docstring opened *"Barge-in is the only place we overlap two runs."* A timeout and a `no_speech` both leave a run live — which is how `no_speech` sat uncovered while `timeout` was fixed one branch away.
- `docs/voice-pipeline.md` said a device losing arbitration "stands down silently". It then sat lit for up to 30s (#326). The code now matches the doc, so the doc says so.

748 tests pass.