### PR TITLE
docs: a reference baseline for what a healthy turn costs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,55 @@ Hardware findings are the next most valuable, because most of us have one kind
 of Echo in one kind of room. If something behaves differently on your unit,
 that is worth an issue on its own.
 
+## Where to help
+
+Every open issue carries three labels, and between them they should tell you
+whether to start writing code.
+
+**State — read this one first.**
+
+| | |
+|---|---|
+| `ready` | Specified well enough that a PR can be reviewed against the issue text. Start here. |
+| `needs-design` | The problem is agreed, the solution is not. Comment with an approach before writing code. |
+| `needs-decision` | Waiting on a call about direction. A PR cannot settle it. |
+| `blocked` | Waiting on another issue, named in the body. |
+| `needs-reporter` | Waiting on someone outside the project. |
+| `needs-triage` | Just arrived; a maintainer has not read it properly yet. |
+
+**Area** — `area:device` (Go, on the Echo), `area:controller` (Python server),
+`area:dashboard`, `area:provisioning` (rooting, wizard, OTA), `area:ha`
+(add-on, ESPHome, entities), `area:forge` (wake word trainer), `area:docs`.
+
+**Signal** — `good first issue` is small and self-contained. `help wanted` is
+something we would rather not do ourselves. `hardware:welcome` needs a rooted
+Echo to do at all, and those are the ones we most want help with, because most
+of us have one kind of Echo in one kind of room. `needs-hardware` is the
+opposite: it needs measurement on our own bench before anyone can act.
+
+**Before you start, check nobody else has.** `claimed` means there is an open
+PR — GitHub only lets us assign collaborators, so that label is how an outside
+contributor's work in progress is marked. Say so on the issue when you pick
+one up and we will add it.
+
+`ready` is an invitation, and we mean it. If an issue is labelled `ready` and
+a PR arrives that implements it, that PR was not premature — if we got the
+label wrong, that is ours to fix, not yours.
+
+## Milestones and releases
+
+Issues are grouped by the release they are meant to land in, and a milestone
+is a theme rather than a bucket:
+
+- **2.21.0** — controller GA, in early access now. Closed to new work.
+- **2.22.0** — link resilience. The audio path survives a bad link (#140).
+- **3.0.0** — Sendspin multi-room, and the output chain moves to the device
+  (#272).
+
+An issue with no milestone is not scheduled, which is not the same as
+unwanted. A `ready` issue outside a milestone is still a fine thing to pick
+up.
+
 ## Before you open a PR
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,21 @@ one up and we will add it.
 a PR arrives that implements it, that PR was not premature — if we got the
 label wrong, that is ours to fix, not yours.
 
+### Quick links
+
+Saved searches for the common questions. Counts move; the filters do not.
+
+- [Ready to pick up](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Aready%20-label%3Aclaimed%20-label%3Aneeds-hardware) — Specified, unclaimed, nothing external blocking it.
+- [Good first issue](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22good%20first%20issue%22%20-label%3Aclaimed) — Small and self-contained.
+- [Needs a device](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Ahardware%3Awelcome) — Can only be done with a rooted Echo — the ones we most want help with.
+- [Open bugs](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Abug%20label%3Aready) — Confirmed and specified.
+- [Design not settled](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Aneeds-design) — Comment before writing code.
+- [Someone is on it](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Aclaimed) — Check before starting.
+
+By area: [device](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Aarea%3Adevice) · [controller](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Aarea%3Acontroller) · [dashboard](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Aarea%3Adashboard) · [provisioning](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Aarea%3Aprovisioning) · [ha](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Aarea%3Aha) · [forge](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Aarea%3Aforge) · [docs](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20label%3Aarea%3Adocs)
+
+By release: [2.21.0](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20milestone%3A2.21.0) · [2.22.0](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20milestone%3A2.22.0) · [3.0.0](https://github.com/wilbowes/EchoMuse/issues?q=is%3Aopen%20is%3Aissue%20milestone%3A3.0.0)
+
 ## Milestones and releases
 
 Issues are grouped by the release they are meant to land in, and a milestone

--- a/docs/voice-pipeline.md
+++ b/docs/voice-pipeline.md
@@ -279,3 +279,59 @@ behaviour — pause for the turn, resume after.
 3. **Boring and continuous beats clever and gated.** The always-on,
    unprocessed wake stream replaced a cleverer design that degraded over
    days. When in doubt, the pipeline chooses the predictable option.
+
+## What a healthy turn looks like
+
+If your Echo feels slow, the useful question is *which stage* is slow — the
+answer sends you to a completely different component each time. These are
+measured on the reference setup below, so you have something to compare
+against rather than a feeling.
+
+A "turn on the office light" command, end to end:
+
+| Stage | What it is | Reference |
+|---|---|---|
+| wake → first frame | the Echo starts streaming | **3ms** |
+| speech | you talking, until Home Assistant's VAD says you stopped | 3.1s |
+| **speech recognition** | Whisper turning audio into text | **1.8s** |
+| **intent** | Home Assistant deciding what you meant, and generating speech | **0.04s** |
+| fetch | downloading the spoken reply | 0.4s |
+| playback | the reply, spoken | 2.2s |
+| **total** | wake word to finished | **7.1s** |
+
+Most of that is you speaking and the assistant replying. The part a slow
+system inflates is **speech recognition**, and it is the stage most sensitive
+to how much CPU the machine running it has: on two shared cores the same
+commands took **4.8s median and up to 20.5s**, against 2.1s median and a
+1.6–2.6s spread on four. Nothing else in the pipeline changed.
+
+A local intent like a light or a timer resolves in **tens of milliseconds**.
+If your *intent* stage is seconds rather than milliseconds, you are probably
+routing through a conversation agent (an LLM) rather than Home Assistant's
+built-in intents — which is a choice, not a fault, but it is worth knowing
+which one you made.
+
+Two things worth knowing before you compare:
+
+- **The first request after a restart is always slow**, because the speech
+  model loads on demand. Discard it.
+- **These numbers are a reference, not a target.** A slower machine is not
+  broken. The point is to tell "my speech recognition takes 15 seconds" from
+  "my Echo is not responding", because only one of those is about EchoMuse.
+
+### The reference setup
+
+| | |
+|---|---|
+| Home Assistant | OS 18.2, Core 2026.8.3, in a VM |
+| CPU / RAM | 4 vCPU, 8GB |
+| Speech to text | Whisper add-on, `faster-whisper`, model `auto` |
+| Text to speech | Piper |
+| EchoMuse controller | Home Assistant add-on |
+| Devices | 2 × Echo Dot 2nd gen, on-device wake word, 2.4GHz WiFi |
+
+Home Assistant, Whisper, Piper, Music Assistant and the EchoMuse controller
+all share those four cores. Speech recognition is the hungriest of them by a
+wide margin, so if you run other add-ons on the same box, that is the one
+that will feel it.
+


### PR DESCRIPTION
Adds a **What a healthy turn looks like** section to `docs/voice-pipeline.md`: a per-stage table from a real "turn on the office light" turn, plus the setup it was measured on.

**Why:** three of tonight's four investigations ended at "not our bug", each after an evening of log reading. Without a reference, a user can't tell "my speech recognition takes 15 seconds" from "my Echo isn't responding" — and only one of those is about EchoMuse.

The headline comparison is in there because it's the most useful single fact: on **two** shared cores, speech recognition ran **4.8s median, up to 20.5s**; on **four**, **2.1s median, 1.6–2.6s**. Nothing else in the pipeline changed. Intent for a light is 0.04s either way.

Two caveats included so the comparison isn't misused: the first request after a restart loads the model and is always slow, and a slower machine isn't a broken one.