### PR TITLE
Fix #337: drop the thinking-phase low tier, whose cause was fixed elsewhere

### DIFF
--- a/controller/em_barge.py
+++ b/controller/em_barge.py
@@ -73,11 +73,34 @@ def decide(*,
 
     * **playback** — the response is audible, so the microphone is dominated
       by the device's own speech. Low bar, two consecutive frames.
-    * **thinking** — nothing is playing yet, so the bar is the normal wake
-      threshold. One frame clears it outright; two consecutive frames at a
-      low tier also count, because a person repeating themselves into a
-      silent device is a strong signal and the cost of missing it is a turn
-      that ignores them.
+    * **thinking** — nothing is playing yet, so there is no echo to talk
+      over and no reason to lower the bar. One frame at the normal wake
+      threshold, and nothing else.
+
+      There used to be a second, lower tier here: two consecutive frames at
+      `max(0.2, 0.4 * wake_threshold)`. Removed in #337, and the reason it
+      existed is the reason it had to go.
+
+      It was added for one observation (2026-07-12): a GENUINE barge
+      plateauing at 0.240/0.242 against a threshold of 0.50, missed, and the
+      unwanted answer played in full. But that reading was depressed by the
+      watcher scoring a COLD model — it resets per turn, and the first
+      FEATURE_WINDOW chunks score reset noise as much as the room. That
+      cause was fixed separately by `em_oww_warmup`, which gates the
+      watcher until its window is clean. The compensation was never removed.
+
+      What was left is a bar sitting in the warm-noise band. Measured across
+      505 near-misses and 30 real detections on a live fleet: **no genuine
+      wake word scored below 0.502, and noise reached 0.462.** On 2026-08-25
+      two trusted, warm frames at 0.206/0.238 cancelled a real request. A
+      person actually repeating themselves says the wake word, scores like
+      it, and is caught by the branch above.
+
+      The cost of getting this wrong is not a missed barge. A false barge
+      while thinking discards the request before speech recognition has run
+      (`outcome=barged`, `text=''`), reopens the microphone at someone who
+      did not ask for it, and starts a phantom turn that keeps the device
+      deaf for its whole length.
     """
     if in_playback:
         if score >= barge_threshold and prev_score >= barge_threshold:
@@ -90,23 +113,5 @@ def decide(*,
 
     if score >= wake_threshold:
         return BargeDecision(True, f"score={score:.3f} >= {wake_threshold:.2f}")
-
-    low_tier = low_tier_for(wake_threshold)
-    if score >= low_tier and prev_score >= low_tier:
-        return BargeDecision(
-            True,
-            f"scores {prev_score:.3f}/{score:.3f} — two consecutive frames "
-            f">= low tier {low_tier:.2f}",
-        )
     return BargeDecision(False, "")
 
-
-def low_tier_for(wake_threshold: float) -> float:
-    """
-    The lower bar used during thinking, when two frames agree.
-
-    Floored at 0.2 so that lowering the wake threshold cannot drag this down
-    to somewhere noise reaches — the floor is what stops a sensitivity
-    setting quietly becoming a self-trigger setting.
-    """
-    return max(0.2, 0.4 * wake_threshold)

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -1080,15 +1080,15 @@ async def _barge_watcher(device: Device, playback_started: asyncio.Event):
     speech-over-TTS scores are depressed and barge_threshold sits well
     below the wake threshold (~0.05–0.10). During thinking nothing is
     playing — scores are normal, and using the low barge threshold there
-    would fire on random speech — so detection is two-tier: a single frame
-    at the normal wake threshold fires immediately, and two CONSECUTIVE
-    frames at a low tier (0.4× wake threshold, floored at 0.2) also fire.
-    The low tier exists because a genuine barge attempt over the watcher's
-    cold-started model can plateau below the wake threshold (observed
-    2026-07-12: 0.240/0.242 on consecutive frames vs threshold 0.50 —
-    missed, and the unwanted answer played in full), while random speech
-    near-misses are isolated single frames — two elevated frames in a row
-    is wake-word-shaped evidence.
+    would fire on random speech — so a single frame at the normal wake
+    threshold fires, and nothing below it does.
+
+    There was a second, lower tier until #337, added for a genuine barge
+    that plateaued at 0.240/0.242 against a threshold of 0.50 (2026-07-12)
+    and was missed. That reading came off a COLD model, which is the fault
+    `em_oww_warmup` was later written to fix; the compensation outlived its
+    cause and became pure false-positive surface, cancelling a real request
+    at 0.206/0.238 on 2026-08-25. See em_barge.decide.
 
     On detection: set barge_detected + cancel_event. During playback that
     aborts stream_speaker and the drain sleep, plus a device speaker_flush

--- a/controller/tests/test_barge.py
+++ b/controller/tests/test_barge.py
@@ -81,27 +81,32 @@ def test_one_frame_at_the_full_wake_threshold_fires_while_thinking():
     assert "two consecutive" not in d.note
 
 
-def test_two_low_tier_frames_fire_while_thinking():
-    d = thinking(0.25, prev=0.25)
-    assert d.fired is True
-    assert "low tier" in d.note
-
-
-def test_one_low_tier_frame_does_not_fire_while_thinking():
-    assert thinking(0.25, prev=0.0).fired is False
-
-
-def test_the_low_tier_has_a_floor():
+def test_noise_does_not_fire_while_thinking_however_often_it_repeats():
     """
-    A sensitivity setting must not quietly become a self-trigger setting:
-    0.4 x a low wake threshold would otherwise reach down into noise.
+    #337. There used to be a second tier here — two consecutive frames at
+    max(0.2, 0.4 * wake_threshold) — on the reasoning that someone repeating
+    themselves into a silent device is a strong signal.
+
+    Measured on a live fleet across 505 near-misses and 30 real detections:
+    no genuine wake word scored below 0.502, and noise reached 0.462. The
+    tier's floor of 0.2 was inside the noise band, so it could only ever
+    fire on noise. It cost a real turn on 2026-08-25 — the request was
+    discarded before speech recognition ran and the microphone reopened at
+    the user, who asked the Echo why it was listening.
     """
-    assert em_barge.low_tier_for(0.1) == 0.2
-    assert em_barge.low_tier_for(0.5) == 0.2
-    assert em_barge.low_tier_for(0.9) == pytest.approx(0.36)
+    for score in (0.206, 0.238, 0.25, 0.36, 0.462):
+        assert thinking(score, prev=score).fired is False, \
+            f"{score} is a noise-band score and must not barge"
 
 
-# ── Shape ─────────────────────────────────────────────────────────────────────
+def test_a_person_repeating_themselves_is_still_caught():
+    """
+    The case the low tier existed for. Someone saying the wake word again
+    scores like someone saying the wake word — the branch above catches it,
+    which is why removing the tier costs nothing.
+    """
+    assert thinking(0.502).fired is True
+    assert thinking(WAKE).fired is True
 
 def test_a_decision_that_did_not_fire_carries_no_reason():
     """So a caller cannot log a justification for something that never fired."""


### PR DESCRIPTION
A device cancelled a real request on room noise while thinking, then reopened the microphone at the user. The next utterance, which became the turn, was *"Hello. Why are you listening?"*

```
21:39:34  Barge watcher: score 0.206
21:39:34  Barge watcher: score 0.238
21:39:34  Barge-in: wake word during thinking — two consecutive frames >= low tier 0.20
21:39:34  [TURN] outcome=barged  text=''
```

## The tier's cause was fixed elsewhere, and the tier stayed

It was added for one observation (2026-07-12): a **genuine** barge plateauing at 0.240/0.242 against a threshold of 0.50, missed, and the unwanted answer played in full.

That reading was depressed because the watcher scores a **cold** model — it resets per turn, and the first `FEATURE_WINDOW` chunks score reset noise as much as the room. **`em_oww_warmup` was later written to fix exactly that**, and it gates this watcher until the window is clean.

The compensation outlived its cause. What remained is a bar sitting in the warm-noise band — and tonight's 0.206/0.238 were trusted, warm scores.

## The measurement

Across 505 near-misses and 30 real detections on a live fleet:

| | |
|---|---|
| real wake words | min **0.502**, median 0.877 |
| noise near-misses | median 0.071, p99 0.349, **max 0.462** |
| near-misses ≥ 0.20 | 3.56% |

`low_tier_for`'s own docstring said the 0.2 floor existed *"so that lowering the wake threshold cannot drag this down to somewhere noise reaches"* — 0.2 is exactly where noise reaches.

## Why removal costs nothing

The case the tier existed for is a person repeating themselves. A person repeating themselves says the wake word, scores like it (≥0.502), and is caught by the branch above.

## Why it mattered

Not a missed barge. A false barge while thinking **discards the request before speech recognition runs** (`outcome=barged`, `text=''`), reopens the microphone at somebody who didn't ask, and starts a phantom turn that keeps the device deaf for its whole length (#195).

Both docstrings describing the tier are corrected rather than deleted — the 2026-07-12 observation is real and worth keeping. It's the conclusion drawn from it that the warm-up fix invalidated.

747 tests pass.

Fixes #337
