### PR TITLE
[oww_forge] fix: piper_voices.py is missing from docker image

### DIFF
--- a/oww_forge/Dockerfile
+++ b/oww_forge/Dockerfile
@@ -73,7 +73,7 @@ RUN sed -i 's/torch.load(checkpoint_path, map_location=device)/torch.load(checkp
       /usr/local/lib/python3.11/site-packages/dp/model/model.py \
     && grep -q "weights_only=False" /usr/local/lib/python3.11/site-packages/dp/model/model.py
 
-COPY forge.py google_tts.py forge_web.py config.template.yml /opt/forge/
+COPY forge.py google_tts.py forge_web.py piper_voices.py config.template.yml /opt/forge/
 COPY static/ /opt/forge/static/
 
 WORKDIR /data


### PR DESCRIPTION
`piper_voices` is simply missing from the image, when trying to use the play button or the "hear each spelling" button in the UI I get an error 500. Log says:

```
Error handling request from 172.18.0.1
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_protocol.py", line 575, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/aiohttp/web_app.py", line 559, in _handle
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/forge/forge_web.py", line 587, in api_voices
    import piper_voices
ModuleNotFoundError: No module named 'piper_voices'
```

The fix is simple: include piper_voices in the dockerfile 😉 