### PR TITLE
Fix #349: say whether Home Assistant is on the other end of the voice port

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -4615,6 +4615,11 @@ def _merge_device(row) -> dict:
     """
     device_id = row["device_id"]
     live = _devices.get(device_id)
+    # Lazy, for the reason every other em_esphome call site here is lazy:
+    # em_esphome imports em_api at module level. After the first call this
+    # is a sys.modules lookup, which is what makes it affordable on a path
+    # that runs per device per dashboard poll.
+    import em_esphome
 
     return {
         # Persistent
@@ -4652,6 +4657,12 @@ def _merge_device(row) -> dict:
         # Controller-side BT proxy state — non-None only while the device's
         # bleProxyEnabled config has a proxy server instantiated.
         "bleProxy":         em_ble_proxy.get_status(device_id),
+        # Controller-side voice satellite state: whether Home Assistant is
+        # actually on the other end of this device's ESPHome port. Without
+        # it a device HA has never connected to renders as idle, which is
+        # the same thing a working device renders as (#349) — the wake word
+        # fires, the ring lights, and the turn dies in milliseconds.
+        "voiceSatellite":   em_esphome.get_status(device_id),
         # Device-link security: token issued (persistent) + whether the
         # current control connection came in over the TLS listener (live).
         "linkTokenIssued":  bool(row["token"]) if "token" in row.keys() else False,

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -2137,6 +2137,36 @@ def get_server(device_id: str) -> Optional[DeviceESPhomeServer]:
     return _servers.get(device_id)
 
 
+def get_status(device_id: str) -> Optional[dict]:
+    """
+    Controller-side voice satellite state for the dashboard (None when the
+    device has no server, which is itself the worst of the states below).
+
+    THIS MUST READ WHAT THE TURN PATH READS. `_start_esphome_voice_turn`
+    refuses a turn on exactly `get_server()` and `get_satellite()`, so those
+    are the two calls made here rather than a second opinion assembled from
+    flags beside them. A readout that can disagree with the decision it
+    describes is worse than none: it is the `speaking` drift (see the
+    dashboard notes in CLAUDE.md) waiting to happen on the panel someone
+    opens *because* the device is not answering.
+
+    THREE STATES, NOT FOUR. The BT proxy reports `haSubscribed` alongside
+    `haConnected` because a connected HA that has not subscribed to
+    advertisements is a real and distinct condition there. Voice has no
+    equivalent — the precondition is the satellite existing, full stop — so
+    there is deliberately no fourth field. Adding one would describe
+    something this code does not track.
+    """
+    server = _servers.get(device_id)
+    if server is None:
+        return None
+    return {
+        "port":        server.port,
+        "listening":   server._server is not None,
+        "haConnected": server.get_satellite() is not None,
+    }
+
+
 # ─── Voice turn trigger ───────────────────────────────────────────────────────
 
 async def _record_dropped_turn(device, trigger_label: str, wake_info) -> None:

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1674,7 +1674,37 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                     })())}
                     {row('Firmware', device.firmware_ver || '—')}
                     {row('WiFi network', s?.wifiSsid || '—')}
-                    {row('ESPHome port', device.esphome_port != null ? String(device.esphome_port) : '—')}
+                    {/* Was a bare port number, which answered "which port" and
+                        never the question anyone opens this panel with — is
+                        Home Assistant actually on the other end of it (#349).
+                        A device HA has never connected to is Online, idle and
+                        completely unable to answer, and until this row said so
+                        the only way to find out was to say the wake word and
+                        watch nothing happen. Measured on prod: 23 wake events
+                        in 14 hours that could not start a turn, with three
+                        tiles reading healthy throughout.
+
+                        The port stays, appended: it is what a stale HA config
+                        entry is keyed on, so it is the first thing needed the
+                        moment this row says Waiting. */}
+                    {row('Voice assistant', (() => {
+                      const vs = device.voiceSatellite;
+                      const p  = vs?.port ?? device.esphome_port;
+                      const at = p != null ? ` · port ${p}` : '';
+                      if (!vs)            return 'No satellite server';
+                      if (vs.haConnected) return `HA connected${at}`;
+                      if (vs.listening)   return `Waiting for HA${at}`;
+                      return `Port down${at}`;
+                    })(), (() => {
+                      const vs = device.voiceSatellite;
+                      // Not-connected is amber rather than red: HA reconnects
+                      // on its own from most of the ways this happens, and a
+                      // row that shouts during an ordinary restart is one
+                      // people learn to skip past — the #301 cry-wolf rule.
+                      if (!vs)            return 'var(--error)';
+                      if (vs.haConnected) return 'var(--ok)';
+                      return 'var(--warn)';
+                    })())}
                     {/* One row, not two. "Connected: Yes" plus "Last seen"
                         was redundant in both directions — while connected the
                         last-seen time says nothing, and while offline the

--- a/controller/tests/test_voice_satellite_status.py
+++ b/controller/tests/test_voice_satellite_status.py
@@ -1,0 +1,113 @@
+"""
+#349: a device with no Home Assistant connection must not read as healthy.
+
+`_start_esphome_voice_turn` refuses a turn on exactly two conditions —
+no registered server, or no active satellite — and neither reached the
+dashboard. `deviceState()` has no rank for it, so such a device renders
+as idle: the same thing a working device renders as. Measured on the
+production controller, 23 wake events in 14 hours could not start a turn
+while all three tiles read healthy throughout.
+
+These guards pin the three things that would each silently undo it. The
+suite cannot import em_esphome (it pulls in aiohttp via em_api), which is
+why this is source inspection rather than a call — the same constraint
+that put em_barge and em_runbarrier in their own modules.
+
+Comments are stripped before every source assertion. Three guards in this
+tree have matched the comment explaining a rule instead of the code
+implementing it; the shape of that bug is now known and designed out.
+"""
+
+import re
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _strip_py_comments(src: str) -> str:
+    """
+    Comments AND docstrings. Stripping only `#` lines is the version of this
+    helper that fails: the prose explaining why a field is absent names the
+    field, so the guard matches its own rationale and passes whatever the
+    code does. Written the wrong way first, caught by this file's own
+    fourth-state test, and left documented because it is now the third time
+    a source guard in this tree has done it.
+    """
+    src = re.sub(r'"""(?:.|\n)*?"""', "", src)
+    src = re.sub(r"'''(?:.|\n)*?'''", "", src)
+    return "\n".join(re.sub(r"#.*$", "", line) for line in src.splitlines())
+
+
+def _strip_js_comments(src: str) -> str:
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+    return "\n".join(re.sub(r"//.*$", "", line) for line in src.splitlines())
+
+
+def _fn_source(path: Path, header: str, strip) -> str:
+    src = strip(path.read_text())
+    start = src.index(header)
+    return src[start:start + 4_000]
+
+
+def test_get_status_reads_what_the_turn_path_reads():
+    """
+    The readout and the decision must come from one source.
+
+    A status assembled from flags beside the decision can disagree with
+    it, and it would do so on the panel someone opens *because* the
+    device is not answering. `speaking` drifted from its own push for
+    exactly this reason and cost a release.
+    """
+    body = _fn_source(CONTROLLER / "em_esphome.py",
+                      "def get_status(", _strip_py_comments)
+    assert "_servers.get(device_id)" in body, \
+        "server presence must be read from the same registry get_server uses"
+    assert "get_satellite()" in body, \
+        "HA presence must be the satellite the turn path requires, not a flag"
+
+
+def test_status_has_no_fourth_state():
+    """
+    The BT proxy reports haSubscribed because a connected-but-unsubscribed
+    HA is real there. Voice has no equivalent — the precondition is the
+    satellite existing — so a fourth field would describe something this
+    code does not track, and the dashboard would render a state that can
+    never be reached.
+    """
+    body = _fn_source(CONTROLLER / "em_esphome.py",
+                      "def get_status(", _strip_py_comments)
+    assert "haSubscribed" not in body
+    for field in ("port", "listening", "haConnected"):
+        assert f'"{field}"' in body, f"get_status must report {field}"
+
+
+def test_api_exposes_it_beside_the_bt_proxy():
+    """
+    Same payload, same shape, one poll. If this drops out, the dashboard
+    silently falls back to rendering nothing rather than erroring.
+    """
+    body = _fn_source(CONTROLLER / "em_api.py",
+                      "def _merge_device(", _strip_py_comments)
+    assert '"voiceSatellite"' in body
+    assert "em_esphome.get_status(device_id)" in body
+
+
+def test_dashboard_renders_the_state_and_not_just_the_port():
+    """
+    The row used to print a bare port number, which answered a question
+    nobody had. The port stays — it is what a stale HA config entry is
+    keyed on — but the state is what the row is for.
+    """
+    src = _strip_js_comments(
+        (CONTROLLER / "static" / "dashboard.jsx").read_text())
+    assert "device.voiceSatellite" in src, \
+        "the Status tab must read the satellite state"
+    assert "'Voice assistant'" in src, \
+        "the row must be labelled for what it reports, not for the protocol"
+    for state in ("HA connected", "Waiting for HA", "Port down",
+                  "No satellite server"):
+        assert state in src, f"missing the {state!r} state"
+    # A row that renders nothing when the field is absent is the failure
+    # this whole change exists to prevent, one level up.
+    assert "if (!vs)" in src, \
+        "a missing voiceSatellite must render as a fault, not as blank"


### PR DESCRIPTION
Closes #349. First occupant of #301's verdict layer.

A device Home Assistant has never connected to renders as **Online, idle** — the same thing a working device renders as. The turn path refuses on exactly `get_server()` and `get_satellite()` (`em_esphome.py:2347-2362`); neither reached the dashboard.

## Measured

Production controller, 14 hours after the 2.21.0 update:

| | |
|---|---|
| wake events that became a turn | 7 (3 `ok`, 4 `pipeline_refused`) |
| wake events that could not start one | **23** |
| HA connections, all three devices, whole window | 5 |

All three tiles read healthy throughout. The cause was mundane — the devices had not been re-added to HA after a channel switch — which is the argument *for* the row: one line would have answered it, and instead it took a log pull.

## Change

| | |
|---|---|
| `em_esphome.get_status()` | mirrors `em_ble_proxy.get_status` — `{port, listening, haConnected}` |
| `em_api._merge_device` | exposes `voiceSatellite`, beside `bleProxy` |
| `dashboard.jsx` | the `ESPHome port` row becomes **Voice assistant** |

```
Voice assistant     HA connected · port 16003      (ok)
Voice assistant     Waiting for HA · port 16003    (warn)
Voice assistant     Port down · port 16003         (warn)
Voice assistant     No satellite server            (error)
```

## Three decisions

- **It reads what the turn path reads** — the same two calls, not flags assembled beside them. A readout that can disagree with the decision it describes is worse than none, on the panel someone opens *because* the device is not answering.
- **Three states, not four.** The BT proxy reports `haSubscribed` because connected-but-unsubscribed is real there. Voice has no equivalent, so a fourth field would render a state that cannot occur.
- **The row replaces the port rather than joining it**, so the panel does not grow (#105). The port stays appended — it is what a stale HA config entry is keyed on.

Amber rather than red for not-connected: HA reconnects on its own from most routes into that state, and a row that shouts during an ordinary restart is one people learn to skip. #301's cry-wolf rule.

## Tests

`tests/test_voice_satellite_status.py`, four guards. The suite cannot import `em_esphome` (it pulls aiohttp via `em_api`), so these are source inspection — the same constraint that put `em_barge` and `em_runbarrier` in their own modules.

**The fourth-state guard passed while the code was wrong on the first attempt**: it greps for `haSubscribed` and matched the docstring explaining why the field is absent. Third time a source guard here has matched its own rationale, so the stripper now removes docstrings too and says why. The API guard was verified by renaming the field away and watching it fail.

Full suite green; `dashboard.jsx` compiles clean under the same esbuild invocation the image uses.

## Not in this PR

The EA/GA satellite port collision that produced the switchover in the first place — separate, and being handled by reprovisioning the EA devices onto the 161xx range.