### PR TITLE
Land #311, #312, #319, #320 — conflicts absorbed our side

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -186,6 +186,14 @@ SPEAKER_PRIME_SECONDS = 1.1
 # the lock is ALSO free, which no running turn allows.
 OWW_PAUSE_STUCK_S = 180.0
 
+# How long a freshly established data connection gets to deliver its first
+# mic frame before the wake watchdog stops treating the silence as
+# "device still warming up" and starts the zombie-stream ladder (#299,
+# review on PR #311: a boolean guard made the Office-style zombie — deaf
+# for hours — unrecoverable, because no frame ever arrives on the fresh
+# connection and only the escalation repairs it).
+FRESH_CONN_GRACE_S = 30.0
+
 # Restarting the wake listener must never become a hot loop. A listener that
 # raises IMMEDIATELY on start would otherwise be recreated from its own done
 # callback as fast as the event loop can run it, which starves everything
@@ -318,8 +326,12 @@ class Device:
         # #299: whether ANY mic frame has arrived on the CURRENT data
         # connection. Cleared by handle_data on every new connection; set
         # by the wake listener when a frame flows. Lets the no-frames
-        # watchdog tell "transport dropping" apart from "stream dead".
+        # watchdog tell "transport dropping" apart from "stream dead" —
+        # but only within a grace window (see the watchdog: a connection
+        # that stays silent BEYOND it is a zombie stream, and the ladder
+        # is that case's only repair).
         self.frames_seen_this_connection: bool = False
+        self.data_connected_at: float = 0.0
 
         # Tunable at runtime — updated when a config push arrives.
         # wake_word_listener reads this each detection cycle rather than
@@ -2059,22 +2071,36 @@ async def wake_word_listener(device: Device):
                     continue
                 # #299: "no frames" has two causes, and the ladder below
                 # assumes only one (a zombie stream device-side still holding
-                # micActive). If the data plane is down — or a fresh one has
-                # not delivered a single frame yet — the absence of frames is
-                # explained by the transport. Acting put extra control-plane
-                # traffic on an already failing link and restarted a mic
-                # pipeline that was working (bedroom, 2026-08-23: AEC resyncs
-                # 3, 4, 5, 6 after escalations into a dropping connection).
-                # Stand down; do not count the outage against the streak —
-                # once frames flow again it resets on its own below.
-                if device.data_ws is None or not device.frames_seen_this_connection:
-                    log.debug(
-                        f"[{device.device_id}] OWW: no mic frames, but the "
-                        f"data plane is "
-                        + ("down" if device.data_ws is None else "fresh")
-                        + " — nothing to repair"
-                    )
+                # micActive). The distinction needs BOTH state and time:
+                #
+                #   - data plane fully down → frames are explained by the
+                #     transport; nothing to point a repair at. Stand down,
+                #     do not count the outage against the streak.
+                #   - connected, but no frame since the connection opened:
+                #     ambiguous! Freshness says give the device a moment;
+                #     but past the grace window this silence IS the
+                #     zombie-stream signature — the device still streams to
+                #     a superseded socket, no frame will EVER arrive on the
+                #     fresh one, and the escalation below is the only repair
+                #     (Office, 2026-07-16: deaf 4.7h without it — which is
+                #     exactly why this guard is time-bounded rather than a
+                #     boolean, per the review on PR #311).
+                if device.data_ws is None:
                     continue
+                if not device.frames_seen_this_connection:
+                    if loop.time() - device.data_connected_at < FRESH_CONN_GRACE_S:
+                        log.debug(
+                            f"[{device.device_id}] OWW: no mic frames yet on a "
+                            f"fresh data connection — giving it "
+                            f"{FRESH_CONN_GRACE_S:.0f}s before treating the "
+                            f"silence as a zombie stream"
+                        )
+                        continue
+                    log.warning(
+                        f"[{device.device_id}] OWW: data connection is up but "
+                        f"delivered no frame in {FRESH_CONN_GRACE_S:.0f}s — "
+                        f"treating as zombie stream"
+                    )
                 dead_streak += 1
                 if dead_streak < 3:
                     log.warning(
@@ -3348,9 +3374,10 @@ async def handle_data(ws: WebSocketServerProtocol, secure: bool = False):
 
         device.data_ws = ws
         # #299: a fresh connection has by definition sent nothing yet — the
-        # no-frames watchdog must not start counting against the device
-        # until its first frame flows.
+        # no-frames watchdog gives it FRESH_CONN_GRACE_S before treating
+        # the silence as a zombie stream.
         device.frames_seen_this_connection = False
+        device.data_connected_at = asyncio.get_event_loop().time()
         device.data_ready.set()
         log.info(f"[data] Data connection established: {device_id}")
 

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -266,6 +266,13 @@ _ha_volume_to_device = em_volume.ha_volume_to_device
 # ~5.5s, so a blip inside this window is inaudible.
 DATA_RECONNECT_GRACE_S = 3.0
 
+# #315: the control plane gets the same treatment the data plane has had —
+# a device whose control connection drops during a controller restart, an
+# add-on update or a link excursion keeps its ESPHome entities, BLE proxy
+# and media session for this long before they are released. The device's
+# own reconnect (endpoint pinned, per #106) lands well inside the window.
+CONTROL_RECONNECT_GRACE_S = 5.0
+
 
 class Device:
     def __init__(
@@ -3280,10 +3287,43 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                 # an offline device rather than up to one stats report stale.
                 db.touch_device_seen(device.device_id)
                 _devices.pop(device.device_id, None)
-                await api.notify_device_disconnected(device.device_id)
-                await esphome.device_disconnected(device.device_id)
-                await em_ble_proxy.device_disconnected(device.device_id)
-                em_player.device_gone(device.device_id)
+                # #315: the services stay up for a grace window instead of
+                # being torn down immediately — a four-second link blip used
+                # to deregister the HA entities, drop the BLE proxy and kill
+                # the media session, then rebuild all of it when the device
+                # returned on its own.
+                asyncio.create_task(
+                    _release_device_services(device)
+                ).add_done_callback(_log_task_exception)
+
+
+async def _release_device_services(device) -> None:
+    """
+    Release a device's services CONTROL_RECONNECT_GRACE_S after its control
+    connection closed — unless a replacement connection registered in the
+    meantime (#315). Mirrors the data plane's DATA_RECONNECT_GRACE_S.
+
+    esphome.device_connected() is idempotent (a still-listening port is
+    kept and only the callbacks are refreshed), so holding services
+    through a blip costs nothing on reconnect.
+    """
+    try:
+        await asyncio.sleep(CONTROL_RECONNECT_GRACE_S)
+        current = _devices.get(device.device_id)
+        if current is not None and current is not device:
+            return  # replacement is live; it owns the services now
+        log.info(
+            f"[{device.device_id}] control connection not restored within "
+            f"{CONTROL_RECONNECT_GRACE_S:.0f}s — releasing services"
+        )
+        await api.notify_device_disconnected(device.device_id)
+        await esphome.device_disconnected(device.device_id)
+        await em_ble_proxy.device_disconnected(device.device_id)
+        em_player.device_gone(device.device_id)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        log.error(f"[{device.device_id}] delayed service release failed: {e}")
 
 
 # ─── Data plane handler ───────────────────────────────────────────────────────

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -315,6 +315,11 @@ class Device:
         self.volume: float = _device_level_to_ha(85)
 
         self.data_ready = asyncio.Event()
+        # #299: whether ANY mic frame has arrived on the CURRENT data
+        # connection. Cleared by handle_data on every new connection; set
+        # by the wake listener when a frame flows. Lets the no-frames
+        # watchdog tell "transport dropping" apart from "stream dead".
+        self.frames_seen_this_connection: bool = False
 
         # Tunable at runtime — updated when a config push arrives.
         # wake_word_listener reads this each detection cycle rather than
@@ -1998,6 +2003,9 @@ async def wake_word_listener(device: Device):
                 payload = await asyncio.wait_for(
                     device.mic_queue.get(), timeout=10.0
                 )
+                # #299: a frame on this connection — the watchdog's link
+                # guard below may stand down from here on.
+                device.frames_seen_this_connection = True
             except asyncio.TimeoutError:
                 # The wake stream is ungated and continuous (device sends
                 # every 80ms, silence included — hardware mute still produces
@@ -2048,6 +2056,24 @@ async def wake_word_listener(device: Device):
                     # (and device.muted clears with the mute_state message),
                     # so the watchdog resumes naturally if that ever fails.
                     dead_streak = 0
+                    continue
+                # #299: "no frames" has two causes, and the ladder below
+                # assumes only one (a zombie stream device-side still holding
+                # micActive). If the data plane is down — or a fresh one has
+                # not delivered a single frame yet — the absence of frames is
+                # explained by the transport. Acting put extra control-plane
+                # traffic on an already failing link and restarted a mic
+                # pipeline that was working (bedroom, 2026-08-23: AEC resyncs
+                # 3, 4, 5, 6 after escalations into a dropping connection).
+                # Stand down; do not count the outage against the streak —
+                # once frames flow again it resets on its own below.
+                if device.data_ws is None or not device.frames_seen_this_connection:
+                    log.debug(
+                        f"[{device.device_id}] OWW: no mic frames, but the "
+                        f"data plane is "
+                        + ("down" if device.data_ws is None else "fresh")
+                        + " — nothing to repair"
+                    )
                     continue
                 dead_streak += 1
                 if dead_streak < 3:
@@ -3321,6 +3347,10 @@ async def handle_data(ws: WebSocketServerProtocol, secure: bool = False):
             return
 
         device.data_ws = ws
+        # #299: a fresh connection has by definition sent nothing yet — the
+        # no-frames watchdog must not start counting against the device
+        # until its first frame flows.
+        device.frames_seen_this_connection = False
         device.data_ready.set()
         log.info(f"[data] Data connection established: {device_id}")
 

--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -282,8 +282,15 @@ async def interrupt(device_id: str) -> None:
     turn replaces that intent (see resume_interrupted).
     """
     s = _session(device_id)
+    # #314: ownership is reference-counted, exactly like the duck below.
+    # A nested owner (announcement landing mid-turn) must not release the
+    # turn's ownership when IT finishes, nor wipe a playback command the
+    # user issued during the turn — only the FIRST claim clears stale
+    # deferrals from before it started.
+    if s.owner_depth == 0:
+        s.pending = None
+    s.owner_depth += 1
     s.owned_by_turn = True
-    s.pending = None
 
     device = _get_device(device_id) if _get_device else None
     if device is not None and getattr(device, "audio_mix_capable", False):
@@ -333,9 +340,21 @@ async def resume_interrupted(device_id: str) -> None:
     s = _sessions.get(device_id)
     if s is None:
         return
-    s.owned_by_turn = False
-    pending, s.pending = s.pending, None
-    resume_after, s.resume_after = s.resume_after, False
+    # #314: same reference counting as the duck — ownership, pending and
+    # resume_after are released only by the LAST owner leaving. An earlier
+    # finisher leaves all three untouched: the voice turn still speaking
+    # keeps its shield against play_media landing on the response plane,
+    # and the user's deferred command survives an announcement that merely
+    # passed through.
+    if s.owner_depth > 0:
+        s.owner_depth -= 1
+    last_owner = s.owner_depth == 0
+    s.owned_by_turn = s.owner_depth > 0
+    if last_owner:
+        pending, s.pending = s.pending, None
+        resume_after, s.resume_after = s.resume_after, False
+    else:
+        pending, resume_after = None, False
     # #261: this release only unducks when it is the LAST owner leaving —
     # otherwise the other speaker's tail competes with the music again.
     was_ducking = s.duck_depth > 0
@@ -400,6 +419,7 @@ class MediaSession:
         # that mixes). It changes what turn end has to do — there is nothing
         # to resume, but a deferred pause must actually be carried out.
         self.duck_depth = 0   # #261: reference-counted, see interrupt()
+        self.owner_depth = 0  # #314: owners of the speaker, counted like the duck
         # Effective pacing lead. Reduced while a turn owns the speaker so the
         # music feed stops monopolising the shared data plane (see
         # TURN_LEAD_S); restored when the turn releases it.

--- a/controller/em_player.py
+++ b/controller/em_player.py
@@ -292,14 +292,25 @@ async def interrupt(device_id: str) -> None:
         # nothing is lost: no seek, no bookmark, no position drift on a
         # non-seekable flow stream, and no need for the entity to claim it is
         # playing while internally paused.
-        s.ducked = True
+        #
+        # #261: reference-counted, NOT boolean. Two overlapping owners —
+        # a barge-in turn, or an announcement landing mid-turn — both used to
+        # set one flag, and whichever finished FIRST popped it and sent
+        # duck:off while the other was still speaking: music back at full
+        # level under an unfinished answer. Each owner holds one count; the
+        # wire command goes out only on the 0→1 and 1→0 transitions.
+        s.duck_depth += 1
         # Yield the shared data plane to the response. The music keeps
         # playing from the device's own buffer while the feed holds off.
         s.lead_s = TURN_LEAD_S
-        try:
-            await device.send_control({"type": "duck", "on": True})
-        except Exception as e:
-            log.warning(f"[{device_id}] duck failed: {e}")
+        if s.duck_depth == 1:
+            try:
+                await device.send_control({"type": "duck", "on": True})
+                log.info(f"[{device_id}] duck ON (depth {s.duck_depth})")
+            except Exception as e:
+                log.warning(f"[{device_id}] duck failed: {e}")
+        else:
+            log.info(f"[{device_id}] duck held (depth {s.duck_depth})")
         return
 
     if s.state == PLAYING:
@@ -325,16 +336,22 @@ async def resume_interrupted(device_id: str) -> None:
     s.owned_by_turn = False
     pending, s.pending = s.pending, None
     resume_after, s.resume_after = s.resume_after, False
-    ducked, s.ducked = s.ducked, False
-    s.lead_s = LEAD_S
+    # #261: this release only unducks when it is the LAST owner leaving —
+    # otherwise the other speaker's tail competes with the music again.
+    was_ducking = s.duck_depth > 0
+    if was_ducking:
+        s.duck_depth -= 1
+    ducked_off = was_ducking and s.duck_depth == 0
+    s.lead_s = TURN_LEAD_S if s.duck_depth > 0 else LEAD_S
 
-    if ducked:
+    if ducked_off:
         # Release the duck before settling any deferred command, so the music
         # is already back at level by the time a stop or pause lands.
         device = _get_device(device_id) if _get_device else None
         if device is not None:
             try:
                 await device.send_control({"type": "duck", "on": False})
+                log.info(f"[{device_id}] duck released (depth 0)")
             except Exception as e:
                 log.warning(f"[{device_id}] unduck failed: {e}")
 
@@ -346,7 +363,7 @@ async def resume_interrupted(device_id: str) -> None:
             await s.resume()
         elif kind == "stop":
             await s.stop()
-        elif kind == "pause" and ducked:
+        elif kind == "pause" and was_ducking:
             # When we ducked, nothing was ever paused — so the user's pause
             # has to actually happen here. On the pausing path interrupt()
             # had already done it and dropping resume_after was the whole of
@@ -382,7 +399,7 @@ class MediaSession:
         # ducked: this turn lowered the music rather than pausing it (a device
         # that mixes). It changes what turn end has to do — there is nothing
         # to resume, but a deferred pause must actually be carried out.
-        self.ducked = False
+        self.duck_depth = 0   # #261: reference-counted, see interrupt()
         # Effective pacing lead. Reduced while a turn owns the speaker so the
         # music feed stops monopolising the shared data plane (see
         # TURN_LEAD_S); restored when the turn releases it.

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5663,8 +5663,9 @@ function SettingsPanel({ globalConfig, onGlobalConfigChange, onClose, username, 
       setUsers(prev => prev.map(u => u.id === id ? { ...u, role } : u));
       setUsersMsg({ ok: true, text: 'Role updated.' });
     } catch (e) {
-      // The server refuses the last-admin demotion and explains ha_linked
-      // refusals; pass its reason through rather than a generic failure.
+      // The server's only refusal here is the last-admin demotion
+      // (ha_linked is display-only — it never causes a refusal); pass its
+      // reason through rather than a generic failure.
       setUsersMsg({ ok: false, text: e.error || 'Refused.' });
     }
   }

--- a/controller/tests/test_control_grace.py
+++ b/controller/tests/test_control_grace.py
@@ -1,0 +1,66 @@
+"""
+#315: a control-plane drop used to tear down a device's services
+immediately — HA entities deregistered, BLE proxy dropped, media session
+killed — and rebuilt all of it when the device returned seconds later.
+The data plane has had DATA_RECONNECT_GRACE_S for exactly this reason;
+the control plane never got the equivalent.
+
+em_controller is deliberately not importable here (see conftest); these
+are shape guards on the shipped source.
+"""
+
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _finally_src() -> str:
+    src = (CONTROLLER / "em_controller.py").read_text()
+    start = src.index("log.info(f\"[control] Device disconnected")
+    end = src.index("# ─── Data plane handler", start)
+    return src[start:end]
+
+
+def test_teardown_is_deferred_not_immediate():
+    src = (CONTROLLER / "em_controller.py").read_text()
+    start = src.index('log.info(f"[control] Device disconnected')
+    seg = src[start:start + 1200]
+    task_call = seg.index("asyncio.create_task(")
+    sync_path = seg[:task_call]
+    for call in ("esphome.device_disconnected",
+                 "em_ble_proxy.device_disconnected",
+                 "device_gone", "notify_device_disconnected"):
+        assert call not in sync_path, \
+            f"{call} must move into the grace task, not run on close"
+    assert "_release_device_services" in seg[task_call:], \
+        "the close path must hand over to the grace task"
+
+
+def test_the_grace_task_checks_for_a_replacement():
+    src = (CONTROLLER / "em_controller.py").read_text()
+    start = src.index("async def _release_device_services")
+    task = src[start:start + 2500]
+    assert "CONTROL_RECONNECT_GRACE_S" in task
+    assert "_devices.get(device.device_id)" in task, \
+        "the task must check whether a replacement registered"
+    for call in ("notify_device_disconnected", "esphome.device_disconnected",
+                 "em_ble_proxy.device_disconnected", "device_gone"):
+        assert call in task, f"{call} belongs in the deferred release"
+
+
+def test_the_grace_window_exists_and_is_documented():
+    src = (CONTROLLER / "em_controller.py").read_text()
+    assert "CONTROL_RECONNECT_GRACE_S" in src
+    # The data-plane constant this mirrors:
+    assert "DATA_RECONNECT_GRACE_S = 3.0" in src
+
+
+def test_the_stale_connection_guard_survives():
+    """
+    The 2026-07-14 guard solves a different ordering problem (close arriving
+    AFTER a replacement registered) and must stay untouched.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    # the message wraps across two f-string lines — match the fragments
+    assert "replacement is active" in src and "services up" in src, \
+        "the out-of-order stale guard is still needed alongside the grace"

--- a/controller/tests/test_loop_lag_reader.py
+++ b/controller/tests/test_loop_lag_reader.py
@@ -72,17 +72,45 @@ def test_both_reader_sites_use_the_helper():
         "status endpoint AND support bundle must resolve via the helper"
 
 
-def test_the_helper_is_not_sandwiched_into_a_decorator():
+def test_every_auth_decorator_is_followed_by_the_function_it_decorates():
     """
-    #309 review: the helper originally landed BETWEEN @auth.require_auth
-    and _get_system_status — stealing the decorator, leaving the status
-    endpoint unauthenticated and raising on call. A decorator must be
-    immediately followed by the function it decorates.
+    #309 review: a helper landed BETWEEN @auth.require_auth and
+    _get_system_status — stealing the decorator, leaving the status endpoint
+    unauthenticated and raising on call.
+
+    The invariant is general, not about that one helper: EVERY
+    @auth.require_* must be immediately followed by the handler it decorates,
+    optionally after further decorators. A guard naming the helper passes for
+    every other sandwich anyone writes next, which is the shape the original
+    had — and an unauthenticated endpoint does not fail loudly, it serves.
+
+    Matched per LINE with the decorator first on the line. em_api.py contains
+    two PROSE mentions of these decorators, one of which is `Do NOT add
+    @auth.require_admin here` — so a whole-file regex counts a comment saying
+    the opposite of what it appears to say, and then asserts about the line
+    after it. That trap has been hit three times in this tree.
     """
-    src = (CONTROLLER / "em_api.py").read_text()
-    for m in re.finditer(r"@auth\.require_auth\n(\w+)", src):
-        assert not m.group(1).startswith("_running_controller_module"), \
-            "the helper must never steal a decorator"
-    # And the status endpoint keeps its decorator:
-    pair = re.search(r"@auth\.require_auth\nasync def _get_system_status", src)
-    assert pair, "_get_system_status must remain decorated"
+    lines = (CONTROLLER / "em_api.py").read_text().splitlines()
+    decorator = re.compile(r"\s*@auth\.require_(\w+)\s*$")
+    handler   = re.compile(r"\s*async def \w+\(\s*request\b")
+
+    sites = 0
+    for i, line in enumerate(lines):
+        m = decorator.match(line)
+        if not m:
+            continue
+        sites += 1
+        j = i + 1
+        while j < len(lines) and re.match(r"\s*@", lines[j]):
+            j += 1   # stacked decorators are fine; keep walking
+        following = lines[j] if j < len(lines) else "<end of file>"
+        assert handler.match(following), (
+            f"em_api.py:{i + 1}: @auth.require_{m.group(1)} is followed by "
+            f"{following.strip()!r}, not the async handler it decorates — "
+            f"whatever sits between them takes the decorator and the "
+            f"endpoint is left unauthenticated"
+        )
+
+    # A guard that silently matches nothing is the failure this replaced.
+    assert sites >= 40, \
+        f"expected the full decorator surface, found only {sites} sites"

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -156,6 +156,9 @@ def test_interrupt_resume_cycle_only_touches_playing_sessions():
         # Nothing playing: interrupt/resume are no-ops
         await em_player.interrupt("office")
         assert s.state == IDLE and not s.resume_after
+        # #314: ownership is counted — the cycle must balance, so release
+        # this no-op claim before the next scenario takes its own.
+        await em_player.resume_interrupted("office")
 
         await s.play("http://radio/stream")
         await asyncio.sleep(0.05)
@@ -1175,3 +1178,70 @@ def test_resume_keeps_turn_pacing_while_another_owner_speaks():
         await em_player.resume_interrupted("office")
         assert s.lead_s == em_player.LEAD_S
     asyncio.run(main())
+
+
+# ── #314: ownership is reference-counted like the duck ───────────────────────
+
+
+def test_announcement_midturn_does_not_release_ownership():
+    """
+    The exact sequence from #314: an announcement landing during a voice
+    turn used to release the turn's ownership when IT finished — so a
+    play_media arriving afterwards went straight to the wire, putting music
+    on the response plane while the answer was still speaking.
+    """
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        em_player._sessions["office"] = s
+
+        await em_player.interrupt("office")            # voice turn
+        await em_player.interrupt("office")            # announcement lands
+
+        await em_player.resume_interrupted("office")   # announcement ends
+        assert s.owned_by_turn is True, \
+            "the voice turn still speaks — ownership must survive"
+
+        await em_player.play("office", "http://radio/jazz")  # mid-answer!
+        assert s.pending == ("play", "http://radio/jazz"), \
+            "this command must be deferred, not put on the wire"
+
+        await em_player.resume_interrupted("office")   # voice turn ends
+        assert s.owned_by_turn is False
+        return device, s
+    device, s = asyncio.run(main())
+    offs = [m for m in device.control_msgs
+            if m.get("type") == "duck" and not m.get("on")]
+    assert len(offs) == 1
+
+
+def test_nested_interrupt_preserves_the_users_deferred_command():
+    """
+    The smaller fault of the same shape: a second interrupt() used to wipe
+    a pending command the user genuinely issued — 'play jazz' during a turn,
+    silently dropped because an announcement happened to land afterwards.
+    Only the FIRST claim clears stale deferrals.
+    """
+    async def main():
+        device = FakeDevice()
+        _wire(device)
+        s = StubSession("office", periods=2, endless=True)
+        em_player._sessions["office"] = s
+
+        await em_player.interrupt("office")              # voice turn
+        await em_player.play("office", "http://radio/jazz")
+        assert s.pending == ("play", "http://radio/jazz")
+
+        await em_player.interrupt("office")              # announcement
+        assert s.pending == ("play", "http://radio/jazz"), \
+            "a nested owner must not wipe the user's request"
+
+        await em_player.resume_interrupted("office")     # announcement ends
+        assert s.pending == ("play", "http://radio/jazz")
+
+        await em_player.resume_interrupted("office")     # voice turn ends
+        return s
+    s = asyncio.run(main())
+    assert s.pending is None, "settled by the last owner's resume"

--- a/controller/tests/test_player.py
+++ b/controller/tests/test_player.py
@@ -1097,3 +1097,81 @@ def test_a_slow_but_recovering_source_is_not_killed(monkeypatch):
     types = [f[0] for f in device.data_frames]
     assert types.count(0x02) == 3 and types[-1] == 0x03, \
         "every period must have made it out before EOS"
+
+
+# ── #261: the duck is reference-counted, not boolean ─────────────────────────
+
+
+def test_overlapping_owners_release_the_duck_only_once():
+    """
+    The #261 hypothesis, pinned as behaviour: two overlapping owners (a
+    barge-in turn, an announcement landing mid-turn) both used to set one
+    boolean, and whichever finished FIRST sent duck:off while the other was
+    still speaking — music back at full level under an unfinished answer.
+    With a depth count the wire command goes out only on the 0→1 and 1→0
+    transitions.
+    """
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        em_player._sessions["office"] = s
+
+        await em_player.interrupt("office")      # owner A
+        await em_player.interrupt("office")      # owner B lands mid-turn
+        ducks_on = [m for m in device.control_msgs
+                    if m.get("type") == "duck" and m.get("on")]
+        assert len(ducks_on) == 1, "the second owner must not re-send duck:on"
+
+        await em_player.resume_interrupted("office")   # B finishes first
+        offs = [m for m in device.control_msgs
+                if m.get("type") == "duck" and not m.get("on")]
+        assert offs == [], "releasing one of two owners must NOT unduck"
+
+        await em_player.resume_interrupted("office")   # A finishes
+        offs = [m for m in device.control_msgs
+                if m.get("type") == "duck" and not m.get("on")]
+        assert len(offs) == 1, "unduck exactly once, when the last owner leaves"
+        return s
+    s = asyncio.run(main())
+    assert s.duck_depth == 0, "balanced interrupts/resumes must return to 0"
+
+
+def test_a_single_turn_still_ducks_and_releases_once():
+    """The common path is unchanged by the counting."""
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        await em_player.interrupt("office")
+        ducks = [m for m in device.control_msgs if m["type"] == "duck"]
+        assert ducks == [{"type": "duck", "on": True}]
+        await em_player.resume_interrupted("office")
+        ducks = [m for m in device.control_msgs if m["type"] == "duck"]
+        assert ducks == [{"type": "duck", "on": True},
+                         {"type": "duck", "on": False}]
+    asyncio.run(main())
+
+
+def test_resume_keeps_turn_pacing_while_another_owner_speaks():
+    """
+    lead_s must stay at TURN_LEAD_S while ANY owner still holds the duck —
+    restoring full pacing on the first release would let a deferred feed
+    race the remaining speaker.
+    """
+    async def main():
+        device = FakeDevice()
+        device.audio_mix_capable = True
+        _wire(device)
+        s = StubSession("office", periods=0)
+        em_player._sessions["office"] = s
+        await em_player.interrupt("office")
+        await em_player.interrupt("office")
+        await em_player.resume_interrupted("office")
+        assert s.lead_s == em_player.TURN_LEAD_S, \
+            "one release must not restore full pacing while another speaks"
+        await em_player.resume_interrupted("office")
+        assert s.lead_s == em_player.LEAD_S
+    asyncio.run(main())

--- a/controller/tests/test_wake_watchdog.py
+++ b/controller/tests/test_wake_watchdog.py
@@ -8,9 +8,13 @@ extra control-plane traffic on an already failing link, and a working
 mic pipeline torn down and rebuilt (bedroom, 2026-08-23: AEC resyncs
 3, 4, 5, 6).
 
-The fix: "no frames" with the data plane down — or on a connection that
-has not delivered a single frame yet — is explained. Stand down; do not
-count it against the streak either.
+The distinction needs state AND time (review on PR #311): a boolean
+"fresh connection" guard made the zombie case unrecoverable, because a
+device streaming to a superseded socket never delivers a frame on the
+fresh one — so the flag never flipped and the escalation that repairs
+the Office-style 4.7-hour deafness could never run. The guard is
+therefore time-bounded: fresh connections get FRESH_CONN_GRACE_S; past
+that, silence IS the zombie signature and the ladder runs.
 
 em_controller is deliberately not importable here (see conftest); these
 are shape guards on the shipped source.
@@ -27,41 +31,51 @@ def _listener_src() -> str:
     return src[start:start + 30_000]
 
 
-def test_the_guard_sits_before_the_escalation_ladder():
+def test_link_down_stands_down_before_the_ladder():
     src = _listener_src()
-    guard = src.index("device.data_ws is None or not device.frames_seen_this_connection")
+    guard = src.index("if device.data_ws is None:")
     ladder = src.index("dead_streak += 1", guard)
     assert guard < ladder, \
-        "the link guard must stand down BEFORE dead_streak counts or mic_start fires"
-    # And before both escalation stages:
-    esc = src.index("mic_stop()", guard)
-    assert guard < esc
-
-
-def test_an_outage_does_not_count_against_the_streak():
-    """
-    The muted branch resets the streak (expected silence); the outage branch
-    must NOT reset it either — a streak surviving a short blip stays honest —
-    it just freezes while the transport is down. So: continue without
-    touching dead_streak between guard and frame arrival.
-    """
-    src = _listener_src()
-    guard = src.index("device.data_ws is None or not device.frames_seen_this_connection")
+        "a fully down data plane must stand the watchdog down first"
     branch_end = src.find("continue", guard)
     between = src[guard:branch_end]
-    assert "dead_streak" not in between, \
-        "the outage branch must neither increment nor reset the streak"
+    assert "dead_streak" not in between and "mic_start" not in between, \
+        "a down link must neither count nor repair"
 
 
-def test_a_new_connection_clears_the_flag_and_frames_set_it():
-    """handle_data clears on connect; the wake listener sets on first frame.
-    File position reflects definition order, not runtime — so pin each site
-    inside its own function rather than comparing offsets."""
+def test_fresh_connection_gets_a_bounded_grace():
+    src = _listener_src()
+    fresh = src.index("not device.frames_seen_this_connection")
+    grace = src.index("FRESH_CONN_GRACE_S", fresh)
+    branch_end = src.find("continue", grace)
+    between = src[grace:branch_end]
+    assert "dead_streak" not in between and "mic_start" not in between, \
+        "within the grace window the watchdog must stand down"
+    assert src[branch_end:].startswith("continue")
+
+
+def test_past_the_grace_the_ladder_runs_zombie_repair():
+    """
+    The reason the guard is time-bounded: a zombie stream never delivers a
+    frame on the fresh connection, so an unbounded grace would be the
+    Office incident (deaf 4.7h) again. Past the window, silence must fall
+    through to the escalation ladder.
+    """
+    src = _listener_src()
+    grace_check = src.index("< FRESH_CONN_GRACE_S")
+    after = src[grace_check:src.index("dead_streak = 0", grace_check)]
+    assert "zombie" in after, "past-grace silence must be named as the zombie case"
+    ladder = after.find("dead_streak += 1")
+    assert ladder != -1, \
+        "past the grace window the escalation ladder must be reachable"
+
+
+def test_both_time_sources_are_updated():
     src = (CONTROLLER / "em_controller.py").read_text()
-    hd = src[src.index("device.data_ws = ws"):]  # handle_data body
+    hd = src[src.index("device.data_ws = ws"):]
     hd = hd[:hd.index("async def", 10)]
-    assert "frames_seen_this_connection = False" in hd, \
-        "a new data connection must clear the flag"
+    assert "data_connected_at" in hd, \
+        "handle_data must timestamp each new connection"
     wl = src[src.index("payload = await asyncio.wait_for("):
              src.index("except asyncio.TimeoutError")]
     assert "frames_seen_this_connection = True" in wl, \

--- a/controller/tests/test_wake_watchdog.py
+++ b/controller/tests/test_wake_watchdog.py
@@ -1,0 +1,68 @@
+"""
+#299: the wake-stream watchdog treated a dropped link as a broken mic.
+
+On a lossy link, no mic frames arrive because the transport keeps
+dropping — but the watchdog's escalation ladder (defensive mic_start,
+then mic_stop+mic_start) assumed a zombie stream device-side and acted:
+extra control-plane traffic on an already failing link, and a working
+mic pipeline torn down and rebuilt (bedroom, 2026-08-23: AEC resyncs
+3, 4, 5, 6).
+
+The fix: "no frames" with the data plane down — or on a connection that
+has not delivered a single frame yet — is explained. Stand down; do not
+count it against the streak either.
+
+em_controller is deliberately not importable here (see conftest); these
+are shape guards on the shipped source.
+"""
+
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _listener_src() -> str:
+    src = (CONTROLLER / "em_controller.py").read_text()
+    start = src.index("async def wake_word_listener")
+    return src[start:start + 30_000]
+
+
+def test_the_guard_sits_before_the_escalation_ladder():
+    src = _listener_src()
+    guard = src.index("device.data_ws is None or not device.frames_seen_this_connection")
+    ladder = src.index("dead_streak += 1", guard)
+    assert guard < ladder, \
+        "the link guard must stand down BEFORE dead_streak counts or mic_start fires"
+    # And before both escalation stages:
+    esc = src.index("mic_stop()", guard)
+    assert guard < esc
+
+
+def test_an_outage_does_not_count_against_the_streak():
+    """
+    The muted branch resets the streak (expected silence); the outage branch
+    must NOT reset it either — a streak surviving a short blip stays honest —
+    it just freezes while the transport is down. So: continue without
+    touching dead_streak between guard and frame arrival.
+    """
+    src = _listener_src()
+    guard = src.index("device.data_ws is None or not device.frames_seen_this_connection")
+    branch_end = src.find("continue", guard)
+    between = src[guard:branch_end]
+    assert "dead_streak" not in between, \
+        "the outage branch must neither increment nor reset the streak"
+
+
+def test_a_new_connection_clears_the_flag_and_frames_set_it():
+    """handle_data clears on connect; the wake listener sets on first frame.
+    File position reflects definition order, not runtime — so pin each site
+    inside its own function rather than comparing offsets."""
+    src = (CONTROLLER / "em_controller.py").read_text()
+    hd = src[src.index("device.data_ws = ws"):]  # handle_data body
+    hd = hd[:hd.index("async def", 10)]
+    assert "frames_seen_this_connection = False" in hd, \
+        "a new data connection must clear the flag"
+    wl = src[src.index("payload = await asyncio.wait_for("):
+             src.index("except asyncio.TimeoutError")]
+    assert "frames_seen_this_connection = True" in wl, \
+        "a delivered frame must set the flag"


### PR DESCRIPTION
Lands @chr-braun's four PRs, green since 23 August. Merged rather than rebased, for #167's reason: the conflicts were ours.

## What's in it

| PR | Fixes | |
|---|---|---|
| #311 | #299 | Wake watchdog checks the data plane before deciding the mic is broken. Three states, not two — a connection silent past `FRESH_CONN_GRACE_S` is still the zombie stream the escalation ladder exists for. |
| #312 | #261 | Duck is reference-counted. Two overlapping owners both set one boolean; whichever finished first sent `duck: false` under an unfinished answer. |
| #319 | #314 | Speaker ownership refcounted to match, via a **separate** `owner_depth` — `duck_depth` only increments on the mixing path, so a pausing device has overlapping owners with no duck depth. `pending` now survives a nested `interrupt()`. |
| #320 | #315 | Control plane gets the grace the data plane has had since #28. A 4s blip used to deregister HA entities, drop the BLE proxy and kill the media session. |

#312 is an ancestor of #319, so both land together.

## The conflict, and why it's ours

#312 and #319 were CLEAN this morning. `b539c6a` (#346) landed on `em_player.py` and `tests/test_player.py` three hours ago and made them DIRTY — the same two files. The only real conflict was both sides appending tests to the end of `test_player.py`; `em_player.py` auto-merged. Resolved by taking his file and re-applying the four edits from #346 on top.

## One commit that isn't his

`979ca19` writes the general auth-decorator invariant. `9a75fed` (carried by #320) promises it in its message, but only the `dashboard.jsx` half survived the rebase off the abandoned #313 — so `main` still had the guard that names one helper and never looks at the 31 `require_admin` sites. Verified by reintroducing the sandwich.

818 tests pass locally.

Closes #311, closes #312, closes #319, closes #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)