### PR TITLE
Drop a deleted device's satellite, or the next registration inherits its port

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -952,6 +952,12 @@ async def _delete_device(request: web.Request) -> web.Response:
     await loop.run_in_executor(None, db.delete_device, device_id)
     # Row gone → reconcile tears down any BT proxy listener/mDNS for it.
     await em_ble_proxy.reconcile(device_id)
+    # The satellite needs the same, and had no equivalent: it survives an
+    # ordinary disconnect on purpose, so a delete used to leave it in
+    # `_servers` holding the old port for a re-added device to inherit
+    # silently. Lazy import — em_esphome imports em_api at module level.
+    import em_esphome
+    await em_esphome.device_deleted(device_id)
     # ...and the device is told to redial, or it never notices it was deleted.
     # Link auth is decided once, at register time, so a connected device keeps
     # running on the socket it already has: it vanishes from the dashboard and

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -2293,6 +2293,37 @@ async def stop_esphome_servers() -> None:
     log.info("ESPHome servers stopped")
 
 
+async def device_deleted(device_id: str) -> None:
+    """
+    Drop a deleted device's satellite entirely — listener, mDNS record and
+    registry entry.
+
+    `device_disconnected` deliberately keeps the server object across a
+    disconnect (the port is the device's for good), so without this a delete
+    leaves it in `_servers` holding the OLD port. A re-added device then meets
+    that stale entry in `device_connected`, returns early on "already
+    listening", and never reaches `assign_esphome_port` — so it silently keeps
+    the port it was supposed to be leaving, under the previous row's label and
+    MAC, while its new DB row reads `esphome_api_port` NULL and the dashboard
+    shows no port at all. Measured 2026-08-27 on the EA controller, where the
+    delete was specifically an attempt to move a device off a colliding port.
+
+    Reusing the port is not a risk this creates: `assign_esphome_port` only
+    ever moves the counter forwards, so the number is retired either way.
+    """
+    server = _servers.pop(device_id, None)
+    _pending_caps.pop(device_id, None)
+    if server is None:
+        return
+    if server._mdns_info and _azc:
+        try:
+            await _azc.async_unregister_service(server._mdns_info)
+        except Exception as e:
+            log.warning(f"[{device_id}] mDNS deregistration failed: {e}")
+    await server.stop()
+    log.info(f"[esphome.{device_id[-8:]}] satellite removed (device deleted)")
+
+
 def get_server(device_id: str) -> Optional[DeviceESPhomeServer]:
     """Return the DeviceESPhomeServer for a device, or None."""
     return _servers.get(device_id)

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1740,3 +1740,34 @@ def test_deleting_a_device_bounces_its_link():
         "the row must be gone before the device is told to redial, or it "
         "re-registers into the row being deleted"
     )
+
+
+def test_deleting_a_device_drops_its_satellite():
+    """
+    `device_disconnected` keeps the DeviceESPhomeServer across a disconnect on
+    purpose — the port belongs to that device for good. So a delete that does
+    not remove it leaves the old port sitting in `_servers`, and a re-added
+    device meets it in `device_connected`, returns early on "already
+    listening", and never reaches assign_esphome_port: it keeps the port it
+    was being deleted to move OFF, under the previous row's label and MAC,
+    while its new row reads esphome_api_port NULL and the dashboard shows no
+    port at all.
+
+    The BT proxy already had this (`em_ble_proxy.reconcile`); the satellite
+    did not.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+    fn  = _fn_body(src, "_delete_device")
+    code = "\n".join(l for l in fn.splitlines() if not l.lstrip().startswith("#"))
+
+    assert "em_esphome.device_deleted(device_id)" in code, (
+        "a deleted device's satellite must be dropped, or its port outlives "
+        "the row and the next registration inherits it"
+    )
+
+    esp = (CONTROLLER / "em_esphome.py").read_text()
+    body = _fn_body(esp, "device_deleted")
+    assert "_servers.pop(device_id" in body, (
+        "stopping the listener is not enough — the registry entry is what "
+        "device_connected finds and reuses"
+    )


### PR DESCRIPTION
Deleting a device left its `DeviceESPhomeServer` in `_servers`, so a re-added device silently kept the port it was deleted to move off.

`device_disconnected` keeps the server across a disconnect on purpose — the port belongs to that device for good — and nothing removed it on delete. A re-added device then met the stale entry in `device_connected`, took the "already listening" early return, and never reached `assign_esphome_port`.

**The visible symptom is a dashboard fault.** The new row reads `esphome_api_port` NULL, so the Status panel shows no port — and the BT proxy panel disappears too, since its port is derived from the voice port (`BLE proxy enabled but device has no ESPHome voice port yet — deferring`). One bug, two panels, neither pointing at the cause.

Measured on the EA controller 2026-08-27, where the delete was specifically an attempt to move devices off 16001/16002 after a channel switch — HA keys its config entries on host+port and was rejecting every satellite with `Unexpected device found`. Deleting was the right move and did nothing, twice.

Reusing a port is not a risk this introduces: `assign_esphome_port` only ever moves the counter forwards, so the number is retired either way. The BT proxy already had this via `em_ble_proxy.reconcile()`; only the satellite was missing it.

Follows 78395a2 on main, which closes the control plane on delete so the device redials at all.

- `tests/test_deploy.py::test_deleting_a_device_drops_its_satellite` pins both the call and the `_servers.pop` — stopping the listener alone leaves the entry `device_connected` finds.
- 820 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)