### PR TITLE
Stop sending ANNOUNCING — HA cannot map it and throws on every announcement

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -718,13 +718,33 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             # this message at all — it fires when the device fetches the
             # CONNECTION_TEST_URL_BASE media id.
             #
-            # ANNOUNCING goes out now, synchronously, because it describes the
+            # The state goes out now, synchronously, because it describes the
             # state we are entering rather than one we have reached.
+            #
+            # It is PLAYING and NOT ANNOUNCING, however much ANNOUNCING is the
+            # truthful answer. HA's esphome media_player cannot map it:
+            #
+            #   File "homeassistant/components/esphome/media_player.py", line 115
+            #     return _STATES.from_esphome(self._state.state)
+            #   File "homeassistant/components/esphome/enum_mapper.py", line 28
+            #     return self._mapping[value]
+            #   KeyError: <MediaPlayerState.ANNOUNCING: 4>
+            #
+            # `MediaPlayerState.ANNOUNCING` is a real protobuf value (4) and
+            # `_STATES` has no entry for it, so every announcement we made
+            # raised inside `async_write_ha_state` — in the state-write path,
+            # which is nothing to do with the announcement's own result, so it
+            # surfaces as "Task exception was never retrieved" and nothing in
+            # HA's UI says a thing. Announcing state reaches the user through
+            # the assist_satellite entity's RESPONDING anyway; the media player
+            # claiming it buys nothing and costs an exception per announce.
+            # Measured on HA 2026.8.3, alongside the setup wizard stalling on
+            # SatelliteBusyError.
             log.info(f"[{self._log_name}] AnnounceRequest: media_id={msg.media_id!r} text={msg.text!r}")
             asyncio.create_task(self._run_announce(msg.media_id))
             yield api_pb2.MediaPlayerStateResponse(
                 key=MEDIA_PLAYER_KEY,
-                state=MediaPlayerState.ANNOUNCING,
+                state=MediaPlayerState.PLAYING,
                 volume=self._current_volume,
                 muted=False,
             )

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -550,10 +550,17 @@ def test_no_unjustified_hardcoded_media_state():
     while it was audibly playing. Fixing instances one at a time is how the
     second one survived the first fix, so this pins the rule.
 
-    Two remain legitimate and are named explicitly:
-      - PLAYING for play_media, documented as optimistic — the feed pushes
-        the authoritative state moments later.
-      - ANNOUNCING, a genuine transition with no em_player equivalent.
+    One remains legitimate: PLAYING, documented as optimistic — the feed
+    pushes the authoritative state moments later. It covers the announce
+    transition too, which used to send ANNOUNCING.
+
+    ANNOUNCING is now FORBIDDEN rather than merely unused. It is a real
+    protobuf value and the truthful one, and HA's esphome media_player has no
+    mapping for it — `_STATES.from_esphome` raises `KeyError:
+    <MediaPlayerState.ANNOUNCING: 4>` inside async_write_ha_state, on a path
+    unrelated to the announcement's own result, so it surfaces only as "Task
+    exception was never retrieved". Nothing in HA's UI says a word, which is
+    why it survived.
 
     Anything else must go through _media_state_msg(), which reads em_player
     truth.
@@ -561,7 +568,15 @@ def test_no_unjustified_hardcoded_media_state():
     from pathlib import Path
     src = (Path(__file__).resolve().parent.parent / "em_esphome.py").read_text()
 
-    allowed = {"MediaPlayerState.PLAYING", "MediaPlayerState.ANNOUNCING"}
+    code = "\n".join(
+        l for l in src.splitlines() if not l.lstrip().startswith("#")
+    )
+    assert "MediaPlayerState.ANNOUNCING" not in code, (
+        "HA cannot map ANNOUNCING — it raises KeyError in the entity state "
+        "write on every announcement"
+    )
+
+    allowed = {"MediaPlayerState.PLAYING"}
     found = [
         line.strip()
         for line in src.splitlines()


### PR DESCRIPTION
`MediaPlayerState.ANNOUNCING` is a real protobuf value (4) and the truthful answer for the announce transition. HA's esphome integration has no mapping for it:

```
File "homeassistant/components/esphome/media_player.py", line 115, in state
  return _STATES.from_esphome(self._state.state)
File "homeassistant/components/esphome/enum_mapper.py", line 28
  return self._mapping[value]
KeyError: <MediaPlayerState.ANNOUNCING: 4>
```

It raises inside `async_write_ha_state` — the entity state write, nothing to do with the announcement's own result — so it surfaces as "Task exception was never retrieved" with nothing in HA's UI to show for it. Every announcement we have ever made has been throwing.

`PLAYING` is mappable and is what is actually happening. Announcing state reaches the user through the assist_satellite entity's RESPONDING either way, so the media player claiming it bought nothing.

**Scope, honestly:** found while chasing the voice-satellite setup wizard stalling on `SatelliteBusyError` (HA 2026.8.3, EA controller — raised at 21:47:43.804, the same millisecond as our `AnnounceRequest`, so `_is_announcing` was already held). Whether this KeyError is what leaks `_is_announcing` is **not established** — HA's `async_internal_announce` has not been read. This fixes an exception we are definitely causing; it may or may not fix the stall.

`test_no_unjustified_hardcoded_media_state` now **forbids** ANNOUNCING rather than listing it as legitimate. 819 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)