### PR TITLE
Route every 401 through one handler, or a dead session polls forever

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -33,6 +33,27 @@ const API = {
   token: null,
   role: null,
 
+  // Set by App to its logout handler. Every 401 below routes through
+  // `unauthorized()` rather than only the call sites that remember to check,
+  // because the ones that forget do not fail visibly — they retry.
+  //
+  // A left-open tab did exactly that on the EA controller (#359): the 5s poll
+  // caught its own 401 and discarded it, so an expired session produced 1262
+  // consecutive 401s over 13 hours, every 5 seconds, with nothing on screen
+  // saying the session had died. It also cost 21% of the controller's log
+  // ring, which is the half that hurts someone else — a support bundle
+  // collected in that state reaches back hours less far.
+  onUnauthorized: null,
+  _unauthFired: false,
+
+  // Guarded, because every in-flight request 401s at once and the logout
+  // handler's own POST /api/auth/logout would re-enter this.
+  unauthorized() {
+    if (this._unauthFired) return;
+    this._unauthFired = true;
+    if (this.onUnauthorized) this.onUnauthorized();
+  },
+
   headers() {
     const h = { 'Content-Type': 'application/json' };
     if (this.token) h['Authorization'] = `Bearer ${this.token}`;
@@ -41,7 +62,7 @@ const API = {
 
   async get(path) {
     const r = await fetch(ingressPath(path), { headers: this.headers() });
-    if (r.status === 401) throw { code: 'not_authenticated', status: 401 };
+    if (r.status === 401) { API.unauthorized(); throw { code: 'not_authenticated', status: 401 }; }
     const data = await r.json();
     if (!r.ok) throw data;
     return data;
@@ -49,7 +70,7 @@ const API = {
 
   async post(path, body) {
     const r = await fetch(ingressPath(path), { method: 'POST', headers: this.headers(), body: JSON.stringify(body) });
-    if (r.status === 401) throw { code: 'not_authenticated', status: 401 };
+    if (r.status === 401) { API.unauthorized(); throw { code: 'not_authenticated', status: 401 }; }
     const data = await r.json();
     if (!r.ok) throw data;
     return data;
@@ -57,7 +78,7 @@ const API = {
 
   async patch(path, body) {
     const r = await fetch(ingressPath(path), { method: 'PATCH', headers: this.headers(), body: JSON.stringify(body) });
-    if (r.status === 401) throw { code: 'not_authenticated', status: 401 };
+    if (r.status === 401) { API.unauthorized(); throw { code: 'not_authenticated', status: 401 }; }
     const data = await r.json();
     if (!r.ok) throw data;
     return data;
@@ -65,7 +86,7 @@ const API = {
 
   async del(path) {
     const r = await fetch(ingressPath(path), { method: 'DELETE', headers: this.headers() });
-    if (r.status === 401) throw { code: 'not_authenticated', status: 401 };
+    if (r.status === 401) { API.unauthorized(); throw { code: 'not_authenticated', status: 401 }; }
     const data = await r.json();
     if (!r.ok) throw data;
     return data;
@@ -79,7 +100,7 @@ const API = {
     const h = {};
     if (this.token) h['Authorization'] = `Bearer ${this.token}`;
     const r = await fetch(ingressPath(path), { headers: h });
-    if (r.status === 401) throw { code: 'not_authenticated', status: 401 };
+    if (r.status === 401) { API.unauthorized(); throw { code: 'not_authenticated', status: 401 }; }
     if (!r.ok) {
       let data = { code: 'error', status: r.status };
       try { data = await r.json(); } catch {}
@@ -94,7 +115,7 @@ const API = {
     const form = new FormData();
     form.append(fieldName, file);
     const r = await fetch(ingressPath(path), { method: 'POST', headers: h, body: form });
-    if (r.status === 401) throw { code: 'not_authenticated', status: 401 };
+    if (r.status === 401) { API.unauthorized(); throw { code: 'not_authenticated', status: 401 }; }
     const data = await r.json();
     if (!r.ok) throw data;
     return data;
@@ -5937,8 +5958,13 @@ function App() {
     location.replace('.');
   }
 
-  // Restore token on mount
-  useEffect(() => { if (token) API.token = token; }, []);
+  // Restore token on mount, and give API somewhere to send a dead session.
+  // handleLogout only clears storage and navigates, so binding the first
+  // render's copy is safe.
+  useEffect(() => {
+    if (token) API.token = token;
+    API.onUnauthorized = handleLogout;
+  }, []);
 
   // Reconcile the cached role against the server's.
   //
@@ -6051,7 +6077,13 @@ function App() {
       }, 5000);
     };
 
-    // Polling fallback — catches anything the WebSocket misses
+    // Polling fallback — catches anything the WebSocket misses.
+    //
+    // The catch stays broad: a blip must not tear the dashboard down. A dead
+    // session is not a blip, and it is not handled here — API.unauthorized()
+    // has already fired by the time this runs. Before that existed, this line
+    // was where an expired session went to be forgotten, five seconds at a
+    // time, indefinitely.
     const poll = setInterval(() => {
       API.get('/api/devices').then(setDevices).catch(() => {});
     }, 5000);


### PR DESCRIPTION
Fixes #359.

An expired dashboard session kept asking. The polling fallback beside the events WebSocket ran every 5s and did `.catch(() => {})`, so its 401 was discarded and the interval carried on. `token` is React state seeded from `localStorage` and nothing re-reads it, so only a fresh page load notices the session is gone — and a tab left open never gets one.

**Measured on the EA controller:** 1262 consecutive 401s on `/api/devices` from one Firefox tab, 02:50 → 15:38, exactly 5s apart, still going when the log was pulled.

## Two costs, and the second lands on someone else

- **Nothing on screen said the session had died.** The device list simply stopped updating, which reads as a controller that has stopped responding.
- **21% of a 6000-line log pull**, which reached back only 12h57m as a result. A support bundle collected with a stale tab open covers materially less time — the same harm as #351, from a different source.

## Why it isn't a one-line patch to the poll

The initial load already handled this (`if (e.code === 'not_authenticated') handleLogout()`), which is why it only ever showed on old tabs. Patching the poll to match leaves the next `.catch(() => {})` free to reintroduce it. The check moves into `API` instead: every 401 calls `API.unauthorized()`, which `App` binds to `handleLogout` on mount.

**A call site that forgets to check does not fail visibly — it retries.** That is how this survived.

Guarded with a fired-once flag for two reasons: every in-flight request 401s at the same moment, and `handleLogout`'s own `POST /api/auth/logout` would otherwise re-enter it.

829 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
