### PR TITLE
Coalesce idle RTT excursions, or half the log ring is one metric

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -72,6 +72,7 @@ COPY em_pki.py .
 COPY em_hostip.py .
 COPY em_ingressauth.py .
 COPY em_linkauth.py .
+COPY em_rttlog.py .
 COPY em_esphome.py .
 COPY em_ble_proxy.py .
 COPY em_oww_assets.py  ./

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -70,6 +70,7 @@ import em_api as api
 import em_pki
 import em_hostip
 import em_linkauth
+import em_rttlog
 import em_eq
 import em_limiter
 import em_mbc
@@ -587,6 +588,8 @@ class Device:
         # devices spend most of their life not in a turn. The discriminator
         # is the excursion RATE per state, not the raw count.
         self.rtt_samples_idle    = 0
+        # Log-line coalescing only — the counters above are the measurement.
+        self.rtt_log = em_rttlog.ExcursionLog(self.device_id)
 
     def is_busy(self) -> bool:
         """Whether this device was doing anything when a ping went out."""
@@ -3622,10 +3625,12 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                                 _rtt = int((loop.time() - _sent) * 1000)
                                 device.record_rtt(_rtt, _busy)
                                 if _rtt >= RTT_EXCURSION_MS:
-                                    log.info(
-                                        f"[{device_id}] RTT excursion: {_rtt}ms "
-                                        f"({'busy' if _busy else 'idle'})"
-                                    )
+                                    # Busy excursions log one for one; idle
+                                    # ones coalesce into a periodic summary.
+                                    _line = device.rtt_log.record(
+                                        _rtt, _busy, loop.time())
+                                    if _line:
+                                        log.info(_line)
                         pass
 
                     else:

--- a/controller/em_rttlog.py
+++ b/controller/em_rttlog.py
@@ -1,0 +1,73 @@
+"""
+Coalescing for control-plane RTT excursion log lines.
+
+Every ping over RTT_EXCURSION_MS used to write its own INFO line (#360). On a
+fleet of two devices that was 2880 lines in 13 hours — 48% of the controller's whole
+log ring — and it displaced the lines a support bundle is collected for. The
+measurement itself was never in those lines: `record_rtt` already counts
+excursions into `device_metrics` with an idle/busy denominator, so the log was
+a duplicate of a stored metric.
+
+Two kinds of excursion, and only one of them is bulk:
+
+- **Busy** — the device was in a turn or playing audio, so the excursion
+  delayed something audible. 23 of the 2880. Logged individually, as before.
+- **Idle** — the interesting property is the RATE, not any single sample.
+  Coalesced into one line per window, carrying the count and the worst.
+
+The tail of a window is emitted by the next excursion rather than by a timer.
+A window that never closes means the excursions stopped, which is the outcome
+worth having; the persisted counters are the authority either way.
+
+Pure and dependency-free so it can be tested without the websocket stack, for
+the reason em_linkauth is: the part worth getting right is a handful of lines
+buried in a module that pulls in openwakeword.
+"""
+
+from typing import Optional
+
+# How long idle excursions accumulate before a summary line is emitted.
+# Ten minutes keeps a bad link visible within a support bundle's reach while
+# costing ~6 lines an hour per device instead of ~220.
+IDLE_SUMMARY_SEC = 600.0
+
+
+class ExcursionLog:
+    """Per-device state for RTT excursion logging. One line in, one or none out."""
+
+    def __init__(self, device_id: str, summary_sec: float = IDLE_SUMMARY_SEC):
+        self.device_id = device_id
+        self.summary_sec = summary_sec
+        self.idle_count = 0
+        self.idle_worst_ms = 0
+        # Monotonic time the current idle window opened. None = no window.
+        self.idle_since: Optional[float] = None
+
+    def record(self, rtt_ms: int, busy: bool, now: float) -> Optional[str]:
+        """
+        Returns the line to log, or None.
+
+        `now` is a monotonic clock, passed in rather than read so the window
+        is testable.
+        """
+        if busy:
+            return f"[{self.device_id}] RTT excursion: {rtt_ms}ms (busy)"
+
+        if self.idle_since is None:
+            self.idle_since = now
+        self.idle_count += 1
+        self.idle_worst_ms = max(self.idle_worst_ms, rtt_ms)
+
+        if now - self.idle_since < self.summary_sec:
+            return None
+
+        # Report the window that actually elapsed, not the nominal one: the
+        # closing sample can arrive long after the window expired, and a line
+        # claiming 10m for a 3h gap would misstate the rate it exists to show.
+        mins = round((now - self.idle_since) / 60)
+        line = (f"[{self.device_id}] RTT: {self.idle_count} idle excursions "
+                f"in {mins}m, worst {self.idle_worst_ms}ms")
+        self.idle_count = 0
+        self.idle_worst_ms = 0
+        self.idle_since = None
+        return line

--- a/controller/tests/test_rttlog.py
+++ b/controller/tests/test_rttlog.py
@@ -1,0 +1,103 @@
+"""
+RTT excursion log coalescing.
+
+Measured on the EA controller 2026-08-28: 2880 excursion lines in 13 hours
+from two devices, 48% of the whole log ring, all of it duplicating counters
+already persisted to device_metrics. 23 of the 2880 were busy — the ones that
+actually delayed audio — and they were indistinguishable in the flood.
+"""
+
+import em_rttlog as R
+
+
+def log(device="dev1", summary_sec=600.0):
+    return R.ExcursionLog(device, summary_sec=summary_sec)
+
+
+# ─── Busy excursions are never coalesced ──────────────────────────────────────
+
+def test_busy_excursion_logs_immediately():
+    line = log().record(1011, busy=True, now=0.0)
+    assert line == "[dev1] RTT excursion: 1011ms (busy)"
+
+
+def test_every_busy_excursion_logs():
+    L = log()
+    assert L.record(900, busy=True, now=0.0)
+    assert L.record(950, busy=True, now=1.0)
+
+
+def test_busy_excursions_do_not_disturb_an_open_idle_window():
+    L = log()
+    L.record(600, busy=False, now=0.0)
+    L.record(900, busy=True, now=10.0)
+    assert L.idle_count == 1
+    # The idle window still closes on its own schedule, and the busy sample
+    # is not in its count or its worst.
+    line = L.record(700, busy=False, now=600.0)
+    assert "2 idle excursions" in line
+    assert "worst 700ms" in line
+
+
+# ─── Idle excursions coalesce ─────────────────────────────────────────────────
+
+def test_idle_excursion_is_silent_inside_the_window():
+    L = log()
+    assert L.record(600, busy=False, now=0.0) is None
+    assert L.record(700, busy=False, now=59.0) is None
+
+
+def test_window_closes_with_count_and_worst():
+    L = log()
+    for i in range(46):
+        L.record(500 + i, busy=False, now=float(i))
+    line = L.record(2140, busy=False, now=600.0)
+    assert line == "[dev1] RTT: 47 idle excursions in 10m, worst 2140ms"
+
+
+def test_window_resets_after_emitting():
+    L = log()
+    L.record(600, busy=False, now=0.0)
+    L.record(2000, busy=False, now=600.0)
+    assert L.idle_count == 0
+    assert L.idle_worst_ms == 0
+    assert L.idle_since is None
+    # The next window starts at the next excursion, not at the last emit.
+    assert L.record(700, busy=False, now=1200.0) is None
+    assert L.record(800, busy=False, now=1801.0) == \
+        "[dev1] RTT: 2 idle excursions in 10m, worst 800ms"
+
+
+def test_elapsed_is_reported_not_assumed():
+    """
+    A window is closed by the next excursion, which can arrive hours late.
+    Reporting the nominal 10m there would misstate the rate the line exists
+    to convey.
+    """
+    L = log()
+    L.record(600, busy=False, now=0.0)
+    line = L.record(700, busy=False, now=3600.0)
+    assert "in 60m" in line
+
+
+def test_a_quiet_link_emits_nothing():
+    """No timer, by design: no excursions means nothing to report."""
+    L = log()
+    assert L.idle_since is None
+    assert L.idle_count == 0
+
+
+# ─── The volume claim, as arithmetic ──────────────────────────────────────────
+
+def test_coalescing_is_worth_doing():
+    """
+    The measured EA rate — 1443 idle excursions from one device over 13h —
+    must come out as tens of lines, not thousands.
+    """
+    L = log()
+    emitted = 0
+    interval = (13 * 3600) / 1443
+    for i in range(1443):
+        if L.record(600, busy=False, now=i * interval):
+            emitted += 1
+    assert emitted <= 80, f"{emitted} lines is not a reduction"


### PR DESCRIPTION
Fixes #360.

Every ping at or over `RTT_EXCURSION_MS` wrote its own INFO line. **Measured on the EA controller across 13 hours and two devices: 2880 of them, 48% of a 6000-line pull.** With the HTTP access lines that is 79% of the ring, leaving ~1240 lines for everything a support bundle is collected to show, and the pull reached back only 12h57m.

## The lines never carried the measurement

`record_rtt` already counts excursions into `device_metrics` as `rtt_excursions` / `rtt_excursions_idle` against `rtt_samples_idle`, and `em_db` exposes both percentages. The stored form is strictly better than the log: it has the denominator, and #139's own reasoning is that the excursion **rate per state** is the discriminator, never a single sample.

## The two kinds are not equally bulky

| | count | treatment |
|---|---|---|
| **Busy** — delayed something audible | 23 | logged one for one, as before |
| **Idle** — only the rate is interesting | 2857 | one line per 10 min, count + worst |

Busy excursions were indistinguishable in the flood; now they are the only per-sample lines.

## `em_rttlog` is its own module, and pure

For the reason `em_linkauth` is: the part worth getting right is a handful of lines otherwise buried in a module the test suite deliberately does not import. `tests/test_rttlog.py` replays the measured 1443-excursion rate and asserts it comes out under 80 lines.

Two decisions inside it:

- **A window is closed by the next excursion, not by a timer.** A window that never closes means the excursions stopped, which is the outcome worth having, and the persisted counters are the authority either way.
- **The summary reports the elapsed time it measured**, not the nominal 10m. The closing sample can arrive hours late, and a line claiming 10m for a 3h gap would misstate the rate it exists to convey.

## This quiets the log, it does not improve the link

Same window: **144 excursions at or over 2s**, 1105 between 1s and 2s. That is #139 and is still open.

829 tests pass. The `Dockerfile` COPY is not optional — `test_dockerfile_copies_every_controller_module` catches a module that would be missing from the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
