### PR TITLE
Docs: a UAT checklist and an FAQ, so a report arrives usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ issue with a support bundle attached (Dashboard → Support → Download bundle)
 it carries the logs, versions and metrics needed to diagnose something
 remotely, with transcripts, recordings and network names excluded.
 
+Before filing, check the [FAQ](docs/faq.md) — it collects the workarounds for
+the things that come up most. If you'd like to test systematically, the
+[UAT guide](docs/uat.md) is a checklist of what to try and how to report it.
+
 ---
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ walkthroughs welcome.
 | [Quickstart](quickstart.md) | Zero to talking to your Dot: controller install, first-run setup, device approval, Home Assistant hookup, everyday use. |
 | [Configuration Guide](configuration.md) | Every dashboard setting explained in plain language — what it does, when to touch it, and how to tune it. Ends with [what leaves your network](configuration.md#what-leaves-your-network) — there is no telemetry, and the one outbound connection is named. |
 | [The Voice Pipeline, Explained](voice-pipeline.md) | How your voice travels from the microphones to Home Assistant and back, stage by stage, with the benefits and caveats of each design choice. |
+| [FAQ](faq.md) | Quick answers and workarounds for the things that come up most — rooting refusals, wizard failures, update problems, wake word tuning, privacy. Check here before filing. |
+| [User Acceptance Testing](uat.md) | A checklist for confirming EchoMuse does what it claims on your hardware, and how to report what doesn't. Includes the known faults not worth re-filing. |
 | [Moving to the Home Assistant add-on](migrate-to-addon.md) | Migrating an existing Docker install to the add-on without losing your devices, settings or Home Assistant entities. Read the part about `tls/` before you start. |
 
 Deeper technical references live elsewhere:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,340 @@
+# FAQ
+
+Quick answers and workarounds for the things that come up most. Where an
+answer has a longer version, it links to it.
+
+If your problem isn't here, the [UAT guide](uat.md) has a list of known open
+faults worth checking before you file, and
+[support-bundle.md](support-bundle.md) explains what to attach.
+
+---
+
+## Rooting and unlocking
+
+### The unlock won't run on my Mac.
+**It needs Linux.** The unlock is
+[R0rt1z2's work on XDA](https://xdaforums.com/t/unlock-root-twrp-unbrick-amazon-echo-dot-2nd-gen-2016-biscuit.4761416/),
+not ours, and it doesn't work on macOS. A live USB is enough — the unlock is
+the only step that needs Linux. Everything after it, including the
+provisioning wizard, runs from a Chromium-based browser on any OS.
+
+### `brick.sh` refuses with "restricted on locked hw".
+**Your Dot isn't on the latest FireOS.** The exploit only works on current
+firmware.
+
+1. Pair the Dot to an Amazon account (any account — make a throwaway) so it
+   gets on WiFi.
+2. Mute it and leave it plugged in for 20–30 minutes. Muting stops wake words
+   interrupting the update. You may need two of these unattended rounds.
+3. Then say "Alexa, check for software updates" to jump it to current.
+4. Retry `brick.sh`.
+
+Two things contributors have hit along the way: if the Alexa app won't pair a
+very old Dot, select **Echo Tap** in the app to get the old hotspot pairing
+flow; and turn **off** any file manager that auto-mounts USB devices, because
+it grabs the handshake and makes later adb steps fail with unhelpful errors.
+
+### Sideloading FireOS 5.5.5.4 fails with a red flash of the ring.
+Sideload it again. It generally works on the second attempt.
+
+### Deeper questions about the unlock itself.
+Those belong on the [XDA thread](https://xdaforums.com/t/unlock-root-twrp-unbrick-amazon-echo-dot-2nd-gen-2016-biscuit.4761416/).
+We link to it rather than copying it, deliberately — a copy goes stale without
+anyone noticing.
+
+### Did I brick it?
+**Probably not permanently.** A Dot stuck in preloader is usually
+recoverable — see the recovery notes on the XDA thread. Don't flash anything
+else at it until you've asked.
+
+---
+
+## The provisioning wizard
+
+### The wizard can't see my device, or says it's in use by another program.
+**Run `adb kill-server` first.** A running adb server on your machine holds
+the device and the browser can't claim it. This is the single most common
+provisioning failure.
+
+### The device picker shows nothing.
+Use **Chrome or Edge**. The wizard talks to the device over WebUSB and other
+browsers vary. Brave in particular is unconfirmed.
+
+### The wizard says it needs a secure context.
+If you reach Home Assistant over plain `http://`, the browser blocks WebUSB.
+Add your HA URL at `chrome://flags/#unsafely-treat-insecure-origin-as-secure`
+— e.g. `http://homeassistant.local:8123` — and restart the browser. Tracked as
+[#170](https://github.com/wilbowes/EchoMuse/issues/170).
+
+### The USB connection drops immediately after a reboot step.
+Known on some devices ([#79](https://github.com/wilbowes/EchoMuse/issues/79)).
+Setting `persist.sys.usb.config` to `mtp,adb` before the reboot keeps it on
+the bus. If you hit this, please add your `getprop ro.build.fingerprint` and
+`getprop persist.sys.usb.config` to that issue — we can't reproduce it and
+want to know why some devices arrive unconfigured.
+
+### A wizard step failed and I don't know why.
+Every failed step offers diagnostics. Grab those before retrying — the state
+the device is in is the diagnostic, and retrying destroys it.
+
+---
+
+## Controller and dashboard
+
+### Add-on or Docker container — which should I run?
+Whichever suits you. **Both are first-class** and neither is improved at the
+other's expense. The add-on is easier if you already run Home Assistant OS;
+the container is the answer if the controller lives elsewhere.
+
+### I'm read-only in the dashboard under the add-on and can't get admin back.
+Fixed — **update the controller**. The rule now counts Home Assistant admins
+who can sign in through ingress, so the first HA user gets admin. On the first
+page load after updating, the dashboard re-reads your role from the server and
+corrects itself; you shouldn't need to do anything else.
+
+If you're stranded on an older build, in the browser console:
+
+```js
+['em_token','em_role','em_auth_via'].forEach(k => localStorage.removeItem(k));
+location.reload();
+```
+
+Background: [#235](https://github.com/wilbowes/EchoMuse/issues/235).
+
+### How do I update the controller?
+```
+docker compose pull && docker compose up -d
+```
+or update the add-on from Home Assistant. **The dashboard's update notice is
+advisory and always will be** — the controller is your container, and a
+process cannot restart itself mid-request and then tell you how it went.
+
+### The update notice shows no release notes.
+Notes come from the tag annotation. If they're empty, that's ours to fix —
+please file it with the version you're on.
+
+### The dashboard shows my device as Online but nothing works.
+Check **Device → Status → Voice assistant**. `Waiting for HA` means Home
+Assistant has never connected to that satellite — usually a stale HA config
+entry after a device was re-added. Delete the ESPHome entry in HA and
+re-discover it.
+
+### Where is my data?
+SQLite beside the controller — in `/data` for the add-on, in the mounted
+volume for the container. Back that directory up; it holds devices, users,
+config, activity history and the TLS CA.
+
+### Can I move the controller to a different IP?
+Yes. Devices find it over mDNS and the TLS certificate deliberately identifies
+it by name, not address, so it can move freely. **Static endpoints for routed
+or tunnelled networks are in progress** —
+[#106](https://github.com/wilbowes/EchoMuse/issues/106) /
+[#166](https://github.com/wilbowes/EchoMuse/issues/166).
+
+---
+
+## Home Assistant
+
+### The "Set up voice satellite" dialog times out and needs Retry.
+**Known, and it's cosmetic** — press Retry and it completes. The jingle plays,
+the satellite is set up, and HA's dialog gives up before it hears back.
+[#219](https://github.com/wilbowes/EchoMuse/issues/219).
+
+### Home Assistant rejects my device: "Unexpected device found at …".
+An HA ESPHome config entry is keyed on host **and port**, and it's pointing at
+a port that now belongs to a different device — usually after deleting and
+re-adding devices, or switching release channels. **Delete the stale ESPHome
+entry in HA and re-discover.** Note that this gives the device new
+`entity_id`s, so automations referring to the old ones need updating.
+
+### Every announcement throws an error in HA's log.
+Fixed — update the controller. We were sending a media player state HA has no
+mapping for.
+
+### Can I use two different wake words for two different assistants?
+**Not yet, but Home Assistant's half already works.** HA picks a pipeline from
+the wake word phrase reported by the satellite, and we now report it. What's
+missing is running more than one wake word model at a time. Tracked as
+[#112](https://github.com/wilbowes/EchoMuse/issues/112).
+
+### Music Assistant behaves oddly.
+See [#210](https://github.com/wilbowes/EchoMuse/issues/210) — and please add
+your setup, that one needs more reports than it has.
+
+### The device isn't offered as a target for "start a conversation".
+Not implemented yet. [#335](https://github.com/wilbowes/EchoMuse/issues/335).
+
+---
+
+## Voice, wake words and audio
+
+### It doesn't wake reliably.
+In order:
+
+1. **Config → Wake word → Sensitivity**, move toward Eager.
+2. **Config → Microphones → mic gain**, if the room is large or you're far
+   from the device.
+3. Try a different model. The stock openWakeWord models vary a lot in how well
+   they suit a given voice.
+
+If it still misses at normal speaking distance in a quiet room, that's worth a
+report with the model name and the distance.
+
+### It wakes when nobody said anything.
+Move Sensitivity toward Precise. If it fires with the TV on specifically,
+[#294](https://github.com/wilbowes/EchoMuse/issues/294) is the open work on
+that — say what was playing.
+
+### Can I use my own wake word?
+Yes — [oww_forge](../oww_forge/README.md) trains one, and you install it in
+the dashboard under **Config → Wake word → + Custom model**. Prefer the
+published Docker image over building it yourself; the upstream pins that make
+it work are only preserved in a published artifact.
+
+### How do I hear what the device actually sent to speech-to-text?
+**Config → Microphones → Advanced → save utterances.** The audio then appears
+per-turn on the device's **Activity** tab. That is exactly the audio Whisper
+received, which makes it the right thing to listen to when transcription is
+wrong.
+
+### The audio distorts when it's loud.
+Check **Config → Playback**: the limiter and bass guard should be on. If it
+still distorts, report the volume percentage — the number is the diagnostic.
+
+### It sounds worse than stock Alexa did.
+Partly true and partly fixed. A DAC clipping fault above unity gain was found
+and corrected, which was most of it. What remains is that stock applies a
+substantial driver correction we don't yet —
+[#247](https://github.com/wilbowes/EchoMuse/issues/247).
+
+### Music pauses instead of ducking under a voice response.
+Ducking needs firmware that advertises audio mixing. Update the device
+firmware; if it still pauses, check Device → Status and report it.
+
+### Long responses cut off part-way.
+Known: [#324](https://github.com/wilbowes/EchoMuse/issues/324). A support
+bundle with the time it happened genuinely helps here.
+
+### Can I interrupt it while it's talking?
+Yes — say the wake word again. Enable it under **Config → Wake word →
+Barge-in** if it isn't already.
+
+### Does it do timers?
+Yes, as of the current release — ask for one the way you'd expect. **Stopping
+a ringing timer by voice is known to be unreliable**, and that half is still
+being worked on. Report what you said and what happened; the wording people
+actually use is the useful part.
+
+---
+
+## Devices and the fleet
+
+### A firmware update failed.
+Fixed in `controller-v2.18.0` — **update the controller first**, then retry.
+Two faults were behind it: the transfer deleted the fallback slot before
+sending anything, and one error message covered five different outcomes.
+
+If you're on an older controller, the workaround that worked: update one
+device at a time, with the device close to an access point.
+
+**Never power-cycle a device mid-update.**
+
+### A device stopped responding after an update.
+Device → **Updates** offers a rollback to the previous slot. If that doesn't
+help, a support bundle plus the time it happened is the right report.
+
+### I deleted a device and it kept working.
+Fixed — update the controller. A deleted device now drops its connection and
+comes back as pending.
+
+### I re-added a device and its voice port is missing.
+Same fix, same answer: update the controller.
+
+### My device changed its Home Assistant entity IDs.
+That happens whenever a device is deleted and re-added — HA keys entities on
+identity, and a re-added device is a new one. There's no way to carry the old
+IDs across. Rename the entities in HA if you need the old names back.
+
+### One device settings, or all of them?
+Config is scoped per section. A device follows the fleet for every section it
+doesn't override, so changing one device's Ring settings leaves its mic and
+wake word tracking fleet changes. **Device → Status → Config** tells you which
+it is.
+
+### Two devices both answer when I say the wake word.
+They shouldn't — arbitration picks one. **Config → Wake word → Arbitration
+window** widens the window devices are compared in. If both still answer,
+report it.
+
+### Can I swap a dead Echo for a new one and keep its history?
+Not yet — [#133](https://github.com/wilbowes/EchoMuse/issues/133).
+
+### The device won't reconnect to WiFi after a reboot.
+If your network has no internet access, this is a known Android behaviour
+blocking auto-join — [#317](https://github.com/wilbowes/EchoMuse/issues/317).
+
+### There's no ambient light sensor on my device.
+Some Dots ship a second-source sensor that binds a different driver. Known,
+and the fix is unverifiable on our hardware —
+[#90](https://github.com/wilbowes/EchoMuse/issues/90) — so a report from
+affected hardware is genuinely useful.
+
+---
+
+## Privacy
+
+### Does EchoMuse phone home?
+**No.** No telemetry, no analytics, no crash reporting, no install counter.
+The consequence is stated plainly in
+[configuration.md](configuration.md#what-leaves-your-network): nobody,
+including the maintainers, knows how many people use it.
+
+### What does leave my network, then?
+One thing: the controller asks `api.github.com` once an hour what the newest
+release is, so the dashboard can tell you an update exists. Firmware is
+downloaded from GitHub when you choose to update. Set
+`update_check_interval` to `0` to stop even that.
+
+### Is my voice audio sent anywhere?
+It goes from the device to your controller to your Home Assistant, over your
+LAN. Where it goes after that is whatever speech-to-text you configured in
+HA — that choice is yours, not ours.
+
+### Is a support bundle safe to attach to a public issue?
+Yes, by design. It's an allowlist: no transcripts, no saved audio, no WiFi
+SSIDs, no IP addresses, no device labels you wrote, no credentials, no file
+paths. It's plain JSON — [open it first](support-bundle.md) rather than take
+our word for it.
+
+### Is the link between device and controller encrypted?
+It can be, and should be. Device → **Status** → press **Secure link** if the
+Link row reads `plain ws`. **The ESPHome connection to Home Assistant is
+still plaintext**, including mic audio —
+[#341](https://github.com/wilbowes/EchoMuse/issues/341).
+
+---
+
+## Hardware and scope
+
+### Will this work on an Echo Dot Gen 3 / Show / Studio?
+Only Echo Dot Gen 2 ("biscuit") is supported today. **Echo Show 8 support is
+in review** ([#358](https://github.com/wilbowes/EchoMuse/pull/358)) and Echo
+Show 5 is being worked on ([#36](https://github.com/wilbowes/EchoMuse/issues/36)).
+Other boards are welcome — the Android-specific surface is about twenty call
+sites, so a new board is mostly a mic/speaker/LED/button binding.
+
+### Does it depend on Amazon's software?
+Barely, and keeping it that way is deliberate. It's a Linux daemon using ALSA,
+i2c, evdev and sysfs that happens to run on Android because that's what
+shipped on the box. A change that makes an Amazon blob load-bearing is going
+the wrong way, even when it sounds better.
+
+### Is there a video of it working?
+Yes — see [#193](https://github.com/wilbowes/EchoMuse/issues/193), which
+collects community recordings.
+
+### I want to help. Where do I start?
+Issues labelled **`good first issue`** and **`ready`** are the ones with a
+settled design. Anything labelled `needs-design` or `needs-decision` is not
+ready to be built yet, however small it looks — check with us first so you
+don't write something we then have to decline.

--- a/docs/uat.md
+++ b/docs/uat.md
@@ -1,0 +1,475 @@
+# User Acceptance Testing
+
+**A checklist for confirming EchoMuse actually does what it claims on your
+hardware, in your house, with your Home Assistant.** Work through as much of it
+as applies to you and tell us what failed. Partial results are useful — one
+section done properly beats a whole pass skimmed.
+
+Nothing here needs a developer. Every test is a thing you can do from the
+dashboard, the device, or Home Assistant.
+
+---
+
+## Before you start
+
+**Record these four numbers.** Every report needs them, and half of the
+questions we ask back are one of these.
+
+| | Where |
+|---|---|
+| Controller version | Dashboard header |
+| Firmware version | Device → **Status** tab |
+| Home Assistant version | HA → Settings → About |
+| Hardware | Echo Dot Gen 2, or which board |
+
+**Use a copy of your setup if you can.** Some of these tests delete a device
+or push credentials. Where a test is destructive it says so in bold.
+
+### How to report a failure
+
+1. Open an issue: <https://github.com/wilbowes/EchoMuse/issues>
+2. Give the **test ID** (e.g. `D3`), what you expected, what happened.
+3. Attach a support bundle — **Settings → Support → Collect bundle**, then
+   Download. It contains no transcripts, no SSIDs, no device labels, no
+   credentials; see [support-bundle.md](support-bundle.md) for exactly what is
+   and isn't in it. Open it before you send it.
+4. Note the **wall-clock time** the failure happened. The bundle's logs are
+   timestamped and that is how we find it.
+
+### Two things that are not bugs
+
+- **A control shown greyed out with a reason under it.** The controller asks
+  each device what it can do and disables what your firmware doesn't
+  implement. That is working as designed. A control that is *enabled* and
+  silently does nothing is a bug — report that.
+- **A setting that reads differently on one device than the fleet.** Config is
+  scoped per section. Device → Status → `Config` row says `Fleet` or
+  `Local override (n of 6)`.
+
+### Already known — please don't re-file
+
+Check these before opening anything. If your symptom matches, add your
+version numbers to the existing issue instead.
+
+| Symptom | Issue |
+|---|---|
+| HA's "Set up voice satellite" dialog times out and needs Retry, after the jingle plays | [#219](https://github.com/wilbowes/EchoMuse/issues/219) |
+| Playback cuts off part-way through a long spoken response | [#324](https://github.com/wilbowes/EchoMuse/issues/324) |
+| Radio / stream playback is interrupted | [#325](https://github.com/wilbowes/EchoMuse/issues/325) |
+| Unplugging the headphone jack stalls the mic and drops the device | [#117](https://github.com/wilbowes/EchoMuse/issues/117) |
+| Odd behaviour with something plugged into the aux jack | [#141](https://github.com/wilbowes/EchoMuse/issues/141) |
+| Ambient light sensor missing on a device with a `G090LF` serial | [#90](https://github.com/wilbowes/EchoMuse/issues/90) |
+| WiFi never reconnects after a reboot on a network with no internet | [#317](https://github.com/wilbowes/EchoMuse/issues/317) |
+| Music started elsewhere stays silent until a voice turn finishes | [#262](https://github.com/wilbowes/EchoMuse/issues/262) |
+| Double/triple tap detected unreliably | [#115](https://github.com/wilbowes/EchoMuse/issues/115) |
+| High CPU on the device | [#176](https://github.com/wilbowes/EchoMuse/issues/176) |
+
+---
+
+## A — Getting a device on
+
+### A1 · Root and provision a device
+**Do:** Run the provisioning wizard end to end on a device that has never been
+rooted. Follow [rooting.md](rooting.md).
+**Expect:** Every step reports success, and the device reboots into a state
+where the dashboard sees it.
+**Flag:** Any step that says it succeeded but left the device wrong. Include
+the wizard's diagnostics — it offers them on a failed step.
+
+### A2 · The device appears and can be approved
+**Do:** Open the dashboard. Find the new device.
+**Expect:** It appears as pending with an **Approve** tab and nothing else.
+After approving, the full tab set appears: Status, Activity, Config, Console,
+Updates, Logs.
+**Flag:** A device that never appears, or appears already approved.
+
+### A3 · Status reads true
+**Do:** Device → **Status**.
+**Expect:** Serial, firmware version, WiFi network, volume, Link, Config
+scope, Voice assistant row — all populated, none showing `—` for something
+that plainly exists.
+**Flag:** Any row reading `—` while the thing it describes is working.
+
+### A4 · Reboot survival
+**Do:** Pull power from the device. Wait for it to boot.
+**Expect:** It rejoins on its own within a couple of minutes, no dashboard
+action needed, and keeps its volume and mute state from before.
+**Flag:** A device that needs re-approving, or comes back at a different
+volume.
+
+### A5 · Controller restart survival
+**Do:** Restart the controller (add-on restart, or `docker compose restart`).
+**Expect:** Devices reconnect on their own. Settings, users, and history are
+all still there.
+**Flag:** Anything that had to be set up again.
+
+---
+
+## B — Home Assistant
+
+### B1 · The satellite is discovered
+**Do:** HA → Settings → Devices & Services. Look for an ESPHome discovery for
+your device.
+**Expect:** It offers to add. After adding, the device page shows an
+**Assist satellite** entity.
+**Flag:** No discovery at all; or discovery pointing at the wrong device.
+
+### B2 · Voice assistant status is honest
+**Do:** Device → **Status** → **Voice assistant** row.
+**Expect:** `HA connected · port NNNNN` while HA is connected. Stop HA — it
+should change to `Waiting for HA`.
+**Flag:** A row that says HA is connected when it isn't, or vice versa.
+
+### B3 · A full voice turn
+**Do:** Say the wake word, then ask something with a spoken answer.
+**Expect:** Ring lights on wake → response spoken from the device speaker →
+ring returns to idle. Device → **Activity** shows the turn with an `ok`
+outcome.
+**Flag:** Any turn that ends in something other than `ok` when you spoke
+normally. Give the outcome string from Activity.
+
+### B4 · Announcements
+**Do:** Call `assist_satellite.announce` from HA Developer Tools against your
+device.
+**Expect:** It plays, and the service call returns without error.
+**Flag:** Errors in HA's log, or an announcement that plays but never
+completes.
+
+### B5 · Action button entity
+**Do:** Hold the action (dot) button ~1s. Watch HA → the device's **Action
+Button** event entity.
+**Expect:** A `long` event fires. A short tap starts a voice turn instead
+(unless you enabled "tap is an event").
+**Flag:** No event entity present on a device whose firmware supports holds;
+or a hold that starts a turn.
+
+### B6 · Ambient light sensor
+**Do:** Cover the device, then shine a light at it. Watch the **Ambient
+Light** sensor in HA.
+**Expect:** Lux moves. On hardware with no readable sensor there should be
+**no entity at all** — not an entity stuck at 0.
+**Flag:** An entity permanently reading 0 or unavailable.
+
+---
+
+## C — Wake word
+
+### C1 · The default wake word
+**Do:** Say it from a normal seated distance, ten times, in a quiet room.
+**Expect:** At least 8 of 10 wake the device.
+**Flag:** Fewer than 8. Say the distance and the model.
+
+### C2 · False wakes
+**Do:** Leave the device in a room with TV or conversation for an hour.
+**Expect:** Zero or one spurious wakes.
+**Flag:** More than that. Note what was playing.
+
+### C3 · Sensitivity moves the needle
+**Do:** Config → Wake word → move Sensitivity toward Eager. Repeat C1.
+**Expect:** More wakes, and more false wakes. The change takes effect without
+restarting anything.
+**Flag:** A setting that saves but changes nothing.
+
+### C4 · A custom model installs and works
+**Do:** Train one with [oww_forge](../oww_forge/README.md), then Config → Wake
+word → **+ Custom model** → upload.
+**Expect:** It appears in the list, can be selected, and the device wakes on
+it.
+**Flag:** A model that uploads and is selectable but never triggers — that is
+a specific known class of bug and worth a report.
+
+### C5 · On-device wake word
+**Do:** Config → Wake word → turn on on-device detection.
+**Expect:** Wakes still work. Device → Activity still records turns.
+**Flag:** Wakes that stop entirely, or wake latency that gets noticeably
+worse.
+
+### C6 · Multiple devices don't both answer
+**Do:** With two devices in earshot, say the wake word once.
+**Expect:** One device answers. The other doesn't.
+**Flag:** Both answering, or neither.
+
+---
+
+## D — Audio out
+
+### D1 · Volume
+**Do:** Change volume from the dashboard, from HA, and with the device's own
+volume buttons.
+**Expect:** All three agree, and the level survives a reboot.
+**Flag:** Any of the three disagreeing with the others.
+
+### D2 · Speech is intelligible at low volume
+**Do:** Set volume to ~20%, ask something with a long answer.
+**Expect:** Clear speech, no distortion.
+**Flag:** Distortion, clipping, or crackle. Say the volume level.
+
+### D3 · Speech is clean at high volume
+**Do:** Set volume to 100%, ask the same question.
+**Expect:** Loud, but not buzzing or breaking up.
+**Flag:** Distortion at a specific percentage — the number matters.
+
+### D4 · EQ does something
+**Do:** Config → Playback → move the EQ faders, or pick a preset.
+**Expect:** An audible change on the next thing spoken, no restart.
+**Flag:** No audible difference, or a change that needs a reboot.
+
+### D5 · Speaker protection
+**Do:** Config → Playback → confirm limiter and bass guard are on. Play
+something bass-heavy loud.
+**Expect:** It stays controlled. Turn the limiter off and it should get
+noticeably worse.
+**Flag:** No difference with them on or off.
+
+### D6 · The headphone jack
+**Do:** Plug into the 3.5mm jack.
+**Expect:** Audio moves to the jack.
+**Flag:** Anything beyond the known jack faults in the table above.
+
+---
+
+## E — Music and ducking
+
+### E1 · Music plays
+**Do:** Send music to the device from HA (Music Assistant or a media_player
+call).
+**Expect:** It plays.
+**Flag:** Silence, stutter, or a stream that stops after a fixed interval.
+
+### E2 · Music ducks under a voice turn
+**Do:** With music playing, say the wake word and ask something.
+**Expect:** Music drops in volume, the answer is spoken over it, music returns
+to level. It should **duck**, not pause, on firmware that supports mixing.
+**Flag:** A full pause on a device whose Status shows it can mix; music that
+never comes back up; or a duck that leaves music permanently quiet.
+
+### E3 · Duck depth is adjustable
+**Do:** Config → Playback → change duck depth. Repeat E2.
+**Expect:** Audibly different depth.
+**Flag:** No change.
+
+### E4 · Barge-in
+**Do:** During a long spoken answer, say the wake word again.
+**Expect:** The answer stops and the device listens to you.
+**Flag:** The answer continuing to the end; or the new turn being refused.
+Give the Activity outcome for the second turn.
+
+---
+
+## F — Timers and alarms
+
+*Recently changed — this is the area most worth testing carefully.*
+
+### F1 · A timer rings
+**Do:** "Set a timer for one minute."
+**Expect:** The device rings at one minute.
+**Flag:** No ring, or a ring on the wrong device.
+
+### F2 · Stopping the ring
+**Do:** While it rings, tell it to stop.
+**Expect:** It stops.
+**Flag:** A ring that won't stop by voice. Note whether the button stops it.
+
+### F3 · A timer firing during a voice turn
+**Do:** Set a short timer, then start another voice turn so the timer fires
+mid-answer.
+**Expect:** Both are handled sensibly — you hear both, neither is lost, and
+the device returns to idle afterwards.
+**Flag:** Audio that stops dead, a device stuck ringing, or a turn that never
+completes. **This combination is new and is exactly what we want tested.**
+
+### F4 · A timer firing under ducked music
+**Do:** Music playing, timer fires.
+**Expect:** The alarm is heard over the music, then music returns to full
+level.
+**Flag:** Music that stays ducked, or an alarm you can't hear.
+
+---
+
+## G — Buttons and LEDs
+
+### G1 · Action button starts a turn
+**Do:** Tap the dot button.
+**Expect:** Same behaviour as a wake word.
+**Flag:** No response, or a delayed one.
+
+### G2 · Mute is real
+**Do:** Press mute. Try the wake word. Try the action button.
+**Expect:** Red ring, and no voice turn happens by either route. The mic is
+off in hardware, not just ignored.
+**Flag:** A turn starting while muted.
+
+### G3 · Unmute restores
+**Do:** Press mute again.
+**Expect:** Ring returns to idle, wake works immediately.
+**Flag:** Needing a reboot to get the mic back.
+
+### G4 · Ring states match what's happening
+**Do:** Watch the ring through a full turn.
+**Expect:** Distinct listening / thinking / speaking states, back to idle at
+the end. See [led-ring-states.md](led-ring-states.md).
+**Flag:** A ring left lit after a turn ends, or stuck on one colour.
+
+### G5 · Ring colours are configurable
+**Do:** Config → Ring → change listen and think colours.
+**Expect:** Next turn uses them.
+**Flag:** No change, or a change needing a restart.
+
+---
+
+## H — Bluetooth proxy
+
+### H1 · The proxy is offered
+**Do:** Config → Bluetooth → enable. Check HA → Settings → Devices & Services.
+**Expect:** The device appears as a Bluetooth proxy.
+**Flag:** Enabled in the dashboard but absent in HA.
+
+### H2 · It finds something
+**Do:** Bring a BLE device (a thermometer, a tracker) near it.
+**Expect:** HA sees it via this proxy.
+**Flag:** No discoveries at all after 10 minutes.
+
+### H3 · It survives a reboot
+**Do:** Reboot the device.
+**Expect:** Proxy comes back on its own.
+**Flag:** Needing to toggle it off and on.
+
+---
+
+## I — Security and the device link
+
+### I1 · Secure link
+**Do:** Device → Status. If Link reads `plain ws`, press **Secure link**.
+**Expect:** The device reconnects within a few seconds and Link reads
+`wss (TLS)`.
+**Flag:** A device that goes offline and stays there. (It should redial.)
+
+### I2 · Credentials survive a reboot
+**Do:** Reboot a TLS device.
+**Expect:** Comes back on `wss (TLS)`.
+**Flag:** Falling back to plain.
+
+### I3 · Login is enforced
+**Do:** Log out. Try to open the dashboard, and try an API URL directly.
+**Expect:** Both refuse.
+**Flag:** Anything reachable logged out.
+
+### I4 · Non-admin accounts are limited
+**Do:** Create a non-admin user. Log in as them.
+**Expect:** No Console tab, no Updates tab, no Support tab, no user
+management.
+**Flag:** Any admin action a non-admin can reach.
+
+---
+
+## J — Updates
+
+### J1 · Firmware update is offered
+**Do:** Device → **Updates**.
+**Expect:** It shows the installed version and the latest release, and offers
+the update only when there is one.
+**Flag:** An update offered when you're already current, or none offered when
+you're behind.
+
+### J2 · **Destructive** — apply a firmware update
+**Do:** Run the update. Watch it through.
+**Expect:** It transfers, the device reboots, and comes back on the new
+version, keeping its settings.
+**Flag:** A device that doesn't come back, or comes back on the old version
+while claiming success. **Do not power-cycle it mid-update.** If it does not
+return after five minutes, say so in the report before doing anything else —
+the state it is in is the diagnostic.
+
+### J3 · Controller update notice
+**Do:** When a controller release exists that is newer than yours.
+**Expect:** A notice in the dashboard, with readable release notes. It should
+tell you to update — it must never update itself.
+**Flag:** A notice with empty notes; or any button that claims to perform the
+update.
+
+---
+
+## K — The dashboard
+
+### K1 · Activity is accurate
+**Do:** Do five turns. Open Device → **Activity**.
+**Expect:** Five turns, with sensible outcomes and timings.
+**Flag:** Missing turns, or timings that are obviously wrong.
+
+### K2 · Logs load
+**Do:** Device → **Logs**.
+**Expect:** Recent lines, from both device and controller.
+**Flag:** An empty view on a device that has been running.
+
+### K3 · Config scoping
+**Do:** Change one section (say Ring) on one device only.
+**Expect:** Status → Config reads `Local override (1 of 6)`. Change a fleet
+setting in a *different* section — this device should follow it.
+**Flag:** An override that leaks into other sections, or a device that stops
+tracking the fleet entirely.
+
+### K4 · It works on a phone
+**Do:** Open the dashboard on a phone.
+**Expect:** Usable. Nothing cut off, no horizontal scrolling.
+**Flag:** Anything unreachable at that width. Screenshot helps.
+
+### K5 · Contrast and readability
+**Do:** Look at it in both light and dark.
+**Expect:** Everything readable.
+**Flag:** Low-contrast text — with a screenshot.
+
+### K6 · Support bundle
+**Do:** Settings → Support → Collect bundle → Download. Open the file.
+**Expect:** Valid JSON. **No transcripts, no WiFi SSID, no IP addresses, no
+device labels you wrote, no tokens.**
+**Flag:** Anything private in it. Report that privately rather than in a
+public issue, and don't attach the bundle.
+
+---
+
+## L — Failure handling
+
+### L1 · Losing the controller
+**Do:** Stop the controller while a device is idle.
+**Expect:** The device notices, indicates it, and reconnects on its own when
+the controller returns — no reboot, no re-approval.
+**Flag:** A device that never comes back, or comes back only after a power
+cycle.
+
+### L2 · Losing WiFi
+**Do:** Take the AP down for a minute, then bring it back.
+**Expect:** The device rejoins on its own.
+**Flag:** A device that stays off the network. (Note the known issue #317 for
+networks with no internet.)
+
+### L3 · Losing Home Assistant
+**Do:** Stop HA. Say the wake word.
+**Expect:** The failure is visible — the Voice assistant row should not read
+healthy. When HA returns, turns work again without touching anything.
+**Flag:** A dashboard that reads healthy with HA down.
+
+### L4 · **Destructive** — deleting a device
+**Do:** Delete a device from the dashboard.
+**Expect:** It disconnects, disappears, and comes back as *pending* rather
+than silently continuing to serve. Re-approve it.
+**Flag:** A deleted device that keeps working; or a re-added device whose
+Status shows no voice port.
+
+---
+
+## Reporting a whole pass
+
+If you run a full pass, one issue with a table is more useful than one issue
+per test:
+
+```
+Controller: 2.21.0    Firmware: v2.13.0    HA: 2026.8.3    Hardware: Echo Dot Gen 2
+
+A1 pass   A2 pass   A3 pass   A4 pass   A5 pass
+B1 pass   B2 pass   B3 pass   B4 FAIL   B5 pass   B6 n/a
+C1 pass (9/10)  C2 FAIL (4 false wakes in an hour, TV on)  ...
+```
+
+`pass` / `fail` / `n/a` / `skipped`. For each fail, a paragraph and a support
+bundle. Anything you couldn't test is as useful to know as a failure — it
+tells us which parts of this guide nobody can actually follow.


### PR DESCRIPTION
Two documents aimed at the same gap: people hit a problem, and what reaches us is a sentence with no versions, no bundle, and no way to tell whether it is already known.

## `docs/uat.md` — 55 numbered tests, 12 areas

Each one is Do / Expect / Flag, runnable without a developer.

**What it front-loads matters more than the tests:** the four version numbers every report needs, how to attach a bundle, and a known-faults table so a testing wave does not produce ten more copies of #219, #324 and #117.

It also names the two things that are **not** bugs — a capability-gated control disabled with its reason, and a device reading differently from the fleet because its config is scoped. Both look like faults; neither is one.

Section F (timers) is called out as the one to test hardest: #167 and #319 landed hours apart on 27 Aug and had never run together.

## `docs/faq.md` — the answers already given, collected

Every one is sourced from a real thread rather than invented:

- `adb kill-server` for the wizard (#230)
- latest FireOS before `brick.sh`, plus @electroflame's Echo Tap pairing and auto-mount warnings (#318)
- Linux for the unlock, any browser for the rest (#213)
- save utterances to hear what STT actually got (#236)
- one at a time near an AP for a failed OTA, and the controller update that fixed it (#121)
- the `localStorage` escape for the admin lockout (#235)

## Two constraints held throughout

**Nothing sends a user to EA** — the channels share no storage, and a fresh CA strands their devices. **No issue number is cited as a promise** — the ones that appear describe what is open, not what is coming.

Both are linked from `README.md` and `docs/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
