### PR TITLE
Early Access 2.22.0-ea.2

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## 2.22.0-ea.2 (Early Access)
+
+**Deleting an Echo now actually removes it, and the dashboard stops claiming
+things are fine when they are not.** Everything here was found on a running
+Early Access controller rather than in testing, which is the point of the
+channel.
+
+**There is nothing to do before updating.** No database migration, no firmware
+requirement, nothing to change on your devices. Your Echoes keep their Home
+Assistant entities.
+
+### Deleting an Echo removes it
+
+A deleted Echo carried on working. It vanished from the dashboard and kept
+serving conversations, kept its Home Assistant port and kept listening for the
+wake word, only coming back as a new device when something else interrupted
+its connection — a reboot, a controller restart, a moment of bad wifi. So
+"delete it and add it again" worked eventually, or never, depending on the
+weather.
+
+Adding it back had a second fault behind the first. The new entry inherited
+the port the old one had been deleted to move off, so the Status panel showed
+no voice port at all and the Bluetooth proxy panel disappeared with it. One
+cause, two panels, neither pointing at it.
+
+### The dashboard says whether Home Assistant is connected
+
+An Echo that Home Assistant has never connected to looked exactly like one
+that works: **Online, idle**. Nothing on the page distinguished them, so the
+usual cause — a stale Home Assistant entry after a device was re-added —
+looked like the Echo was broken.
+
+The Status panel now has a **Voice assistant** row that reads the same thing
+the conversation itself reads, so it cannot disagree with what actually
+happens:
+
+```
+Voice assistant     HA connected · port 16003
+Voice assistant     Waiting for HA · port 16003
+```
+
+### Announcements no longer throw an error in Home Assistant
+
+Every announcement the Echo made raised an error inside Home Assistant, with
+nothing visible to show for it. The Echo was reporting a playback state Home
+Assistant's ESPHome integration has no name for. It now reports one it does.
+
+### A dashboard tab left open no longer asks forever
+
+When a dashboard session expired, the page kept asking for the device list
+every five seconds and quietly discarding the refusal. The list simply stopped
+updating, which reads as a controller that has stopped responding, and there
+was no way to tell from the page that you had been signed out. One tab left
+open overnight made 1262 refused requests.
+
+An expired session now returns you to the sign-in page.
+
+### Support bundles reach back further
+
+Roughly half of a support bundle's log was one measurement, repeated: a line
+for every network timing blip on every Echo, thousands of them, when the same
+figures are already recorded properly with a total to compare them against.
+Blips that actually delayed audio are still logged one by one; the rest are
+summarised.
+
+Combined with the fix above, a bundle now covers substantially more of the
+period before the problem you are reporting.
+
 ## 2.22.0-ea.1 (Early Access)
 
 **Timers.** Ask the Echo to set one and it rings on the Echo itself, with the

--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -17,7 +17,7 @@ name: "EchoMuse (Early Access)"
 # derives from the controller-v* tag (controller-v2.18.0 -> 2.18.0). Bump
 # both together: Supervisor pulls `image:version`, so a version with no
 # matching tag on GHCR fails to install.
-version: "2.22.0-ea.1"
+version: "2.22.0-ea.2"
 # Pull the published multi-arch image rather than building on the user's
 # machine. Without this Supervisor builds from this directory's Dockerfile,
 # which downloads a few hundred MB on whatever the user runs Home Assistant

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## 2.22.0-ea.2 (Early Access)
+
+**Deleting an Echo now actually removes it, and the dashboard stops claiming
+things are fine when they are not.** Everything here was found on a running
+Early Access controller rather than in testing, which is the point of the
+channel.
+
+**There is nothing to do before updating.** No database migration, no firmware
+requirement, nothing to change on your devices. Your Echoes keep their Home
+Assistant entities.
+
+### Deleting an Echo removes it
+
+A deleted Echo carried on working. It vanished from the dashboard and kept
+serving conversations, kept its Home Assistant port and kept listening for the
+wake word, only coming back as a new device when something else interrupted
+its connection — a reboot, a controller restart, a moment of bad wifi. So
+"delete it and add it again" worked eventually, or never, depending on the
+weather.
+
+Adding it back had a second fault behind the first. The new entry inherited
+the port the old one had been deleted to move off, so the Status panel showed
+no voice port at all and the Bluetooth proxy panel disappeared with it. One
+cause, two panels, neither pointing at it.
+
+### The dashboard says whether Home Assistant is connected
+
+An Echo that Home Assistant has never connected to looked exactly like one
+that works: **Online, idle**. Nothing on the page distinguished them, so the
+usual cause — a stale Home Assistant entry after a device was re-added —
+looked like the Echo was broken.
+
+The Status panel now has a **Voice assistant** row that reads the same thing
+the conversation itself reads, so it cannot disagree with what actually
+happens:
+
+```
+Voice assistant     HA connected · port 16003
+Voice assistant     Waiting for HA · port 16003
+```
+
+### Announcements no longer throw an error in Home Assistant
+
+Every announcement the Echo made raised an error inside Home Assistant, with
+nothing visible to show for it. The Echo was reporting a playback state Home
+Assistant's ESPHome integration has no name for. It now reports one it does.
+
+### A dashboard tab left open no longer asks forever
+
+When a dashboard session expired, the page kept asking for the device list
+every five seconds and quietly discarding the refusal. The list simply stopped
+updating, which reads as a controller that has stopped responding, and there
+was no way to tell from the page that you had been signed out. One tab left
+open overnight made 1262 refused requests.
+
+An expired session now returns you to the sign-in page.
+
+### Support bundles reach back further
+
+Roughly half of a support bundle's log was one measurement, repeated: a line
+for every network timing blip on every Echo, thousands of them, when the same
+figures are already recorded properly with a total to compare them against.
+Blips that actually delayed audio are still logged one by one; the rest are
+summarised.
+
+Combined with the fix above, a bundle now covers substantially more of the
+period before the problem you are reporting.
+
 ## 2.22.0-ea.1 (Early Access)
 
 **Timers.** Ask the Echo to set one and it rings on the Echo itself, with the


### PR DESCRIPTION
Cuts **2.22.0-ea.2** — six controller fixes since ea.1, **no firmware change** (zero `device/` commits since v2.13.0).

## What's in it

| | |
|---|---|
| `78395a2` + #355 | deleting a device closes its control plane, and drops its satellite |
| #350 | the Voice assistant status row (closes #349) |
| #356 | stop sending ANNOUNCING |
| #361 | the expired-session poll loop |
| #362 | RTT log coalescing |

**Everything here was found on the running EA controller, not in testing** — and none of it has run on hardware yet, which is what the soak is for.

The two that matter most aren't the two that sound most serious. Deleting a device is what a user actually hits, and it was broken in two places at once. The other pair is about being able to diagnose the *next* problem: #361 and #362 were **79% of a 6000-line log pull**, which reached back only 12h57m as a result.

## Verified rather than asserted

No migration and no firmware requirement, both checked rather than assumed: zero commits touching `em_db.py` since `ff9a5da`, zero touching `device/`, no new config keys. Version moved with `tools/sync_channels.py --set-version` rather than by hand; `--check` clean, 834 tests pass.

## Soak targets

1. **Drive an announcement deliberately** — #356 changes that path, and 15 hours of ea.1 never made one.
2. **Delete a device and re-add it** — the fix, and the manoeuvre that failed twice last night.
3. **Pull a device's power** — also zero link drops in ea.1.
4. Read the log and confirm it got quiet.

ea.1 answered its own headline target: a timer fired during an in-flight turn and the controller logged `waited for the in-flight turn to finish before ringing`. #167 and #319 work together. Timer **dismissal** is a separate matter and is not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
