### PR TITLE
Clear speaking in the finally, or a dismissed timer leaves the device deaf

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -1461,13 +1461,29 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
     finally:
         device.speaker_busy -= 1
 
-    # The real end of audio, not the end of the socket write. The device reports
-    # playback_stats once its audio channel drains after EOS, and everything
-    # above waits for exactly that — so this is the one place that knows the
-    # speaker has actually stopped. Clearing it in the stream task's finally
-    # instead dropped the tile out of Speaking seconds early, the same mistake
-    # the ring made until 2026-07-24.
-    await device._set_speaking(False)
+        # The real end of audio, not the end of the socket write. The device
+        # reports playback_stats once its audio channel drains after EOS, and
+        # everything above waits for exactly that — so this is the one place
+        # that knows the speaker has actually stopped. Clearing it in the
+        # stream task's finally instead dropped the tile out of Speaking
+        # seconds early, the same mistake the ring made until 2026-07-24.
+        #
+        # IN the finally, for exactly the reason speaker_busy is (#366). This
+        # sat after the try, so a CANCELLED playback never reached it and
+        # `speaking` stayed set for the life of the process. stop_timer_alarm
+        # cancels the ring task, and the chime occupies 1.68s of every 2.3s —
+        # so roughly three dismissals in four land mid-burst and leak it. The
+        # cost is not a wrong tile: the wake listener skips every frame while
+        # `speaking` is set and the alarm is not ringing, so the device goes
+        # permanently deaf, its parked on-device wake never collected and its
+        # ring left to expire on TTL.
+        #
+        # shield so the clear survives the cancellation that caused it, and
+        # suppress so a failure here cannot replace the exception on its way
+        # out. The flag itself is assigned synchronously inside _set_speaking,
+        # so it is cleared even if the dashboard push never lands.
+        with contextlib.suppress(BaseException):
+            await asyncio.shield(device._set_speaking(False))
 
 
 # ── Timer alarm ──────────────────────────────────────────────────────────────

--- a/controller/tests/test_playback_state_release.py
+++ b/controller/tests/test_playback_state_release.py
@@ -1,0 +1,141 @@
+"""
+`speaking` must be cleared on EVERY exit from _run_post_turn_playback.
+
+Found live on 2026-08-28, EA 2.22.0-ea.2. A timer alarm dismissed with the dot
+button left the dashboard showing Speaking, and then the device stopped
+answering its wake word entirely — ring lighting on the device's own local
+paint and expiring on TTL, with nothing in the log between the parked
+`oww_wake` and silence.
+
+One cause, three symptoms:
+
+  stop_timer_alarm cancels the ring task -> CancelledError raised inside
+  _run_post_turn_playback -> the `finally` runs (speaker_busy is decremented)
+  -> the exception propagates -> `await device._set_speaking(False)`, which sat
+  AFTER the try, is never reached.
+
+`speaking` then stays set for the life of the process, and the wake listener's
+guard is `if device.speaking and not ringing: continue` — so once the alarm
+stops ringing the device is deaf, permanently, and never even reaches
+model.predict().
+
+The chime occupies 1.68s out of every 2.3s (em_timers), so about three
+dismissals in four land mid-burst. That is why it presents as intermittent.
+
+This is an AST check rather than a text search: a grep for the call finds the
+comment explaining it and passes anyway, which has now happened five times in
+this suite (see the source-guard notes in test_deploy.py).
+"""
+
+import ast
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _function(name: str) -> ast.AsyncFunctionDef:
+    tree = ast.parse((CONTROLLER / "em_controller.py").read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in em_controller.py — renamed?")
+
+
+def _calls_in(nodes) -> list[str]:
+    """Dotted names of every call appearing anywhere under `nodes`."""
+    out = []
+    for n in nodes:
+        for sub in ast.walk(n):
+            if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute):
+                out.append(sub.func.attr)
+    return out
+
+
+def _try_blocks(fn) -> list[ast.Try]:
+    return [n for n in ast.walk(fn) if isinstance(n, ast.Try) and n.finalbody]
+
+
+def test_speaking_is_cleared_in_a_finally():
+    """
+    The clear must be reachable when the coroutine is cancelled, which means
+    inside a finally. Anywhere else and a dismissed alarm leaves the device
+    deaf until the controller restarts.
+    """
+    fn = _function("_run_post_turn_playback")
+
+    in_finally = any(
+        "_set_speaking" in _calls_in(t.finalbody) for t in _try_blocks(fn)
+    )
+    assert in_finally, (
+        "_run_post_turn_playback must clear `speaking` from a finally. "
+        "Cancellation skips anything after the try, and the wake listener "
+        "goes deaf while the flag is set."
+    )
+
+
+def test_speaker_busy_is_cleared_in_a_finally():
+    """The sibling invariant, and the one that was already right."""
+    fn = _function("_run_post_turn_playback")
+
+    released = False
+    for t in _try_blocks(fn):
+        for n in t.finalbody:
+            for sub in ast.walk(n):
+                if (isinstance(sub, ast.AugAssign)
+                        and isinstance(sub.target, ast.Attribute)
+                        and sub.target.attr == "speaker_busy"):
+                    released = True
+    assert released, (
+        "speaker_busy must be decremented from a finally — a leaked count "
+        "blocks the timer ring for the life of the process."
+    )
+
+
+def test_the_clear_survives_the_cancellation_that_triggered_it():
+    """
+    Awaiting plainly in a finally during cancellation can be interrupted
+    before it completes. The clear is shielded so it still runs, and the
+    shield must be the thing wrapping the _set_speaking call rather than
+    something else in the same block.
+    """
+    fn = _function("_run_post_turn_playback")
+
+    shielded = False
+    for t in _try_blocks(fn):
+        for n in t.finalbody:
+            for sub in ast.walk(n):
+                if (isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Attribute)
+                        and sub.func.attr == "shield"
+                        and "_set_speaking" in _calls_in(sub.args)):
+                    shielded = True
+    assert shielded, (
+        "the _set_speaking(False) in the finally must be wrapped in "
+        "asyncio.shield, or the cancellation that caused it can interrupt "
+        "the clear as well."
+    )
+
+
+def test_the_wake_listener_still_gates_on_speaking():
+    """
+    Pins the other half of the pair. If this guard is ever removed, the bug
+    above stops being fatal and the tests above stop being load-bearing — so
+    a future reader should be told they moved together, not discover it.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    tree = ast.parse(src)
+
+    found = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        names = {n.attr for n in ast.walk(node.test) if isinstance(n, ast.Attribute)}
+        if "speaking" in names and any(
+            isinstance(b, ast.Continue) for b in node.body
+        ):
+            found = True
+    assert found, (
+        "the wake listener no longer skips frames while `speaking` is set. "
+        "If that is deliberate, test_speaking_is_cleared_in_a_finally is no "
+        "longer protecting against a deaf device and its docstring is stale."
+    )


### PR DESCRIPTION
Fixes #366. **A timer dismissed mid-chime left the device permanently deaf** — found live on `2.22.0-ea.2` an hour after it was published.

## The one-line cause

```python
    finally:
        device.speaker_busy -= 1

    # The real end of audio, not the end of the socket write. ...
    await device._set_speaking(False)     # <- after the try
```

`stop_timer_alarm` dismisses by cancelling the ring task. The `CancelledError` lands inside `_run_post_turn_playback`, the `finally` runs, and the exception propagates straight past the clear.

`speaker_busy`'s own comment already states the rule this line broke — *"try/finally because a cancelled turn that leaked it would block the ring for the life of the process."* Same reasoning, one flag over, never applied.

## Why it's a dead device, not a wrong tile

```python
ringing = device.timer_alarm_ringing
if device.speaking and not ringing:
    continue
```

Once the alarm stops ringing, every mic frame is skipped before `model.predict()`, and the `oww_wake` the firmware parked in `pending_wake` is never collected — the listener is what collects it. The device answers nothing, lights its ring off its own local paint, and lets it expire on TTL.

## Measured

`2.22.0-ea.2`, 2026-08-28 18:21 — ten chime bursts streamed, **nine** `Playback complete` lines:

```
18:21:17,389  Streaming 262622 bytes ... awaiting device playback_stats (est 3.8s, timeout 17.7s)
18:21:19,017  Dot button — dismissing timer alarm
                            <- no completion for that stream, ever
18:22:05,614  on-device wake: score=0.6286156 (device triggered)
                            <- and nothing after it
```

The chime is **1.68s of every 2.3s**, so about three dismissals in four land mid-burst. That is why it reads as intermittent rather than "timers break the device".

## Scope

Not button-specific — every dismissal route calls `stop_timer_alarm`: the button, a spoken dismissal, and HA cancelling a still-running timer. Present since #167; nothing in ea.2 caused it.

## The fix

`shield()` so the clear survives the cancellation that caused it, `suppress()` so a failure in the finally cannot replace the exception on its way out. The assignment inside `_set_speaking` is synchronous, so the flag clears even if the dashboard push never lands.

`tests/test_playback_state_release.py` walks the AST rather than grepping — a text search for the call finds the comment explaining it and passes anyway, the fifth time that has come up here. **Two of its four tests fail on the parent commit.** The fourth pins the wake listener's guard, so if that is ever removed the reader is told the two moved together rather than discovering it.

838 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
