### PR TITLE
Upgrade the base image's own packages, or we ship Debian's fixes late

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -4,8 +4,25 @@ FROM python:3.12-slim
 LABEL org.opencontainers.image.source="https://github.com/wilbowes/EchoMuse" \
       org.opencontainers.image.description="EchoMuse controller — Echo Dot Gen 2 open-source voice assistant satellite"
 WORKDIR /app
-# Install curl for vendoring JS dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends curl ffmpeg && rm -rf /var/lib/apt/lists/*
+# `upgrade` before `install`, and it is not cosmetic (#365). A Debian
+# security update reaches stable-security days to weeks before
+# python:3.12-slim is rebuilt carrying it, and installing packages does
+# not touch the ones the base already has — so every image built in that
+# window shipped a vulnerable package whose fix was already in the archive
+# the build had configured. The weekly scan was red for three Mondays on
+# exactly that: util-linux, which then self-resolved when the base image
+# was rebuilt, with openssl (CVE-2026-14456) sitting in the same window
+# behind it. A gate scoped to "findings a rebuild can act on" has to mean
+# a rebuild acts on them.
+#
+# `upgrade`, never `dist-upgrade` — the latter can remove packages, and a
+# base-image build is not the place to discover which. This does make the
+# layer's contents depend on when it was built, but so do the unpinned
+# apt install below and the floating base tag; it adds no new class of
+# nondeterminism.
+#
+# curl is for vendoring JS dependencies.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends curl ffmpeg && rm -rf /var/lib/apt/lists/*
 # Install Python dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Fixes #365. **The weekly image scan has been red for three Mondays because the build never applies Debian security updates the base image hasn't picked up yet.**

## What actually gates the run

The Security tab shows 100 open alerts, which overstates it. The SARIF step uploads MEDIUM+ with no `ignore-unfixed`; the step that *fails* is HIGH/CRITICAL **with a fix available**. Scanning the freshly built `2.22.0-ea.2` with exactly the CI gate:

```
Total: 3 (HIGH: 3, CRITICAL: 0)

libssl3t64               CVE-2026-14456  HIGH  3.5.6-1~deb13u2 -> 3.5.7-1~deb13u2
openssl                  CVE-2026-14456  HIGH  3.5.6-1~deb13u2 -> 3.5.7-1~deb13u2
openssl-provider-legacy  CVE-2026-14456  HIGH  3.5.6-1~deb13u2 -> 3.5.7-1~deb13u2
```

Three findings, one CVE, one source package. Everything else — the three `perl-base` criticals, `libexpat1`, the ffmpeg libraries — has no upstream fix and is correctly ignored.

## The mechanism, and `util-linux` showing both halves of it

`apt-get install` doesn't touch what the base already carries, and a Debian security update lands in `stable-security` well before `python:3.12-slim` is rebuilt with it.

The 24 Aug scan flagged four HIGH CVEs against `util-linux` 2.41-5. **Today's build already has the fixed 2.41.5-0+deb13u1** — not because anything here changed, but because the base image was rebuilt in the meantime. Two weeks red, then green on its own, with openssl now sitting in the same window behind it.

## Verified before writing, not after

Inside the published image:

```
# apt-get --just-print upgrade
Inst openssl-provider-legacy [3.5.6-1~deb13u2] (3.5.7-1~deb13u2 Debian-Security:13/stable-security)
Inst libssl3t64             [3.5.6-1~deb13u2] (3.5.7-1~deb13u2 Debian-Security:13/stable-security)
Inst openssl                [3.5.6-1~deb13u2] (3.5.7-1~deb13u2 Debian-Security:13/stable-security)
```

Three packages, no others, no removals. Building the same base plus this line and rescanning with the CI gate returns **nothing**.

## Two notes

`upgrade`, never `dist-upgrade` — the latter can remove packages and a base-image build is not where you want to find out which. And yes, this makes the layer depend on when it was built; the unpinned apt install on the same line and the floating base tag already do, so it adds no new class of nondeterminism.

Worth doing rather than waiting out, on the workflow's own argument: *"an unfixable advisory going red every week teaches everyone to ignore the badge, which costs more than the job earns."* A badge that goes green on its own two weeks later, with nobody having acted, teaches the same lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
