### PR TITLE
Early Access 2.22.0-ea.3

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 2.22.0-ea.3 (Early Access)
+
+**Stopping a ringing timer no longer leaves the Echo deaf.** One fix, and it
+is worth taking straight away if you use timers at all.
+
+**There is nothing to do before updating.** No database migration, no firmware
+requirement, nothing to change on your devices.
+
+### Stopping a timer while it is chiming
+
+Press the button, or say stop, while the alarm was actually sounding — rather
+than in the pause between chimes — and the Echo went quiet as it should, but
+then stopped responding to its wake word entirely. Saying the wake word lit the
+ring for a while and did nothing else. The dashboard went on showing the Echo
+as **Speaking** the whole time. It stayed that way until the controller was
+restarted.
+
+The chime sounds for most of each cycle, so this caught roughly three
+dismissals in four, which is why it looked occasional rather than reliable.
+
+If you are on an affected version and it happens, pressing the button once more
+recovers the Echo — that takes a different path and clears the stuck state.
+
 ## 2.22.0-ea.2 (Early Access)
 
 **Deleting an Echo now actually removes it, and the dashboard stops claiming

--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -17,7 +17,7 @@ name: "EchoMuse (Early Access)"
 # derives from the controller-v* tag (controller-v2.18.0 -> 2.18.0). Bump
 # both together: Supervisor pulls `image:version`, so a version with no
 # matching tag on GHCR fails to install.
-version: "2.22.0-ea.2"
+version: "2.22.0-ea.3"
 # Pull the published multi-arch image rather than building on the user's
 # machine. Without this Supervisor builds from this directory's Dockerfile,
 # which downloads a few hundred MB on whatever the user runs Home Assistant

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 2.22.0-ea.3 (Early Access)
+
+**Stopping a ringing timer no longer leaves the Echo deaf.** One fix, and it
+is worth taking straight away if you use timers at all.
+
+**There is nothing to do before updating.** No database migration, no firmware
+requirement, nothing to change on your devices.
+
+### Stopping a timer while it is chiming
+
+Press the button, or say stop, while the alarm was actually sounding — rather
+than in the pause between chimes — and the Echo went quiet as it should, but
+then stopped responding to its wake word entirely. Saying the wake word lit the
+ring for a while and did nothing else. The dashboard went on showing the Echo
+as **Speaking** the whole time. It stayed that way until the controller was
+restarted.
+
+The chime sounds for most of each cycle, so this caught roughly three
+dismissals in four, which is why it looked occasional rather than reliable.
+
+If you are on an affected version and it happens, pressing the button once more
+recovers the Echo — that takes a different path and clears the stuck state.
+
 ## 2.22.0-ea.2 (Early Access)
 
 **Deleting an Echo now actually removes it, and the dashboard stops claiming


### PR DESCRIPTION
Cuts **2.22.0-ea.3** — one fix, three hours after ea.2, because **ea.2 is not safe to soak**.

#366 leaves a device deaf after a timer is dismissed mid-chime, and a deaf device cannot exercise any of ea.2's own soak targets. Found on ea.2 itself, an hour after it published.

## What's in it

| | |
|---|---|
| #367 | clear `speaking` in the `finally` (fixes #366) |

No firmware change (zero `device/` commits since v2.13.0), no migration (zero `em_db.py` commits since the ea.2 tag), no new config keys. Version moved with `sync_channels.py --set-version`, `--check` clean, 838 tests pass.

## Deliberately not in this build

**#368** — the `apt-get upgrade` fix for the image scan. Green and correct, but it changes which base packages ship, and that would make a bad soak result ambiguous. It goes in before GA.

## Soak targets

Unchanged from ea.2, and **none of them were reachable on it once a timer had been dismissed**:

1. **An announcement, driven deliberately** — #356 changed that path and it has still never been exercised.
2. **Delete a device and re-add it.**
3. **Pull a device's power** — #315's grace and the #354 window.
4. **Dismiss a timer mid-chime, twice, then check the wake word still works.** That is this fix, and the mid-chime timing is the part that matters — the gap between chimes never reproduced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
