### PR TITLE
Both endpoint routes enter thinking, not just the one HA drives

### DIFF
--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -415,10 +415,47 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         # cleared at turn end.
         self._on_tts_received   = None   # async callable(pcm_url_or_bytes)
         self._on_thinking       = None   # async callable()
+        # A turn can end in two places — HA's STT_VAD_END event, or our own
+        # device VAD sentinel — and both mean "the user stopped talking".
+        # _enter_thinking() is the single transition both call; this makes it
+        # once per turn, since on a slow turn both routes fire.
+        self._thinking_entered  = False
         self._on_stt_end        = None   # async callable(text: str)
         self._on_announce       = None   # async callable(pcm_bytes) — set only during an active voice turn (run_esphome_voice_turn); None otherwise. The standalone-announce path (setup wizard, push TTS) does NOT use this — it reads self._owning_server._standalone_play live at call time instead, since that value can legitimately change after this satellite was constructed (see _announce_play_cb).
 
     # ── Message handling ─────────────────────────────────────────────────
+
+    def _enter_thinking(self) -> None:
+        """
+        The user stopped talking. Ring to the spinner, dashboard out of
+        Listening, `thinking` set — whatever on_thinking does.
+
+        **Every route that concludes a turn's speech has ended must call
+        this**, and there are two: HA's STT_VAD_END event, and our own device
+        VAD sentinel in _stream_mic_audio. Wiring it to only the first is
+        what #370 was: a turn ending on the sentinel sent `end=True` to HA
+        and then sat on the listening ring through the whole STT-to-TTS
+        window — measured at ~11s on this fleet, with no indication it had
+        heard you finish.
+
+        It presented as "the button is slower than the wake word", and it is
+        not really about the trigger at all. Which route wins is a race
+        between two VAD timers; the trigger only correlates with the winner
+        (33/33 wake turns ended on HA's VAD, 11/11 button turns on the
+        sentinel, measured 2026-08-28). Nothing guarantees that correlation
+        holds on a slower link, so fixing the button case specifically would
+        have left a wake turn free to lose the same transition. The trigger
+        decides how a turn STARTS; nothing after it should differ.
+
+        Idempotent because on a slow turn both routes genuinely fire — the
+        sentinel sends end=True and HA can still emit STT_VAD_END for the
+        same silence.
+        """
+        if self._thinking_entered or self._turn_cancelled:
+            return
+        self._thinking_entered = True
+        if self._on_thinking:
+            asyncio.create_task(self._on_thinking())
 
     def _device_has(self, cap: str) -> bool:
         srv = self._owning_server
@@ -807,8 +844,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             # VAD is the endpointing authority for the turn from here on —
             # the device's own RMS gate becomes advisory (see review §3.1).
             self._ha_vad_end.set()
-            if self._on_thinking and not self._turn_cancelled:
-                asyncio.create_task(self._on_thinking())
+            self._enter_thinking()
 
         elif event_type == ET.VOICE_ASSISTANT_STT_END:
             text = data.get("text", "")
@@ -1101,6 +1137,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._no_speech_timeout     = False
         self._ha_vad_end.clear()
         self._ha_vad_start.clear()
+        self._thinking_entered = False
         self._on_thinking    = on_thinking
         self._on_announce    = None   # set below after announcement path is confirmed
         self._trace          = trace  # may be None — all trace.x calls guard against this
@@ -1601,6 +1638,10 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     if self._trace and self._trace.t_vad_end_ms == -1:
                         self._trace.t_vad_end_ms = self._trace.elapsed_ms()
                     self._send_one(api_pb2.VoiceAssistantAudio(data=b"", end=True))
+                    # Same conclusion HA's STT_VAD_END reaches, so the same
+                    # transition (#370). Without it a turn ending here holds
+                    # the listening ring through STT, intent and TTS.
+                    self._enter_thinking()
                     return
 
                 if preroll_remaining > 0:

--- a/controller/tests/test_thinking_transition.py
+++ b/controller/tests/test_thinking_transition.py
@@ -1,0 +1,153 @@
+"""
+Every route that ends a turn's speech enters `thinking` the same way.
+
+A turn can conclude in two places — HA's STT_VAD_END event, and our own device
+VAD sentinel in _stream_mic_audio — and both mean the same thing: the user
+stopped talking. Only the first was wired to on_thinking, so a turn ending on
+the sentinel sent `end=True` to HA and then held the listening ring through
+the entire STT-to-TTS window. Measured at ~11s on the live fleet (#370).
+
+It presented as "a button-triggered turn is slower to notice I've finished
+than a wake word one", and the trigger is a red herring: there is exactly ONE
+deliberate branch on it in the whole turn path (preroll_discard, which a
+button turn legitimately skips). Which endpoint route wins is a race between
+two VAD timers. The trigger only correlated with the winner — 33/33 wake turns
+ended on HA's VAD, 11/11 button turns on the sentinel, 2026-08-28 — and
+nothing holds that correlation on a slower link.
+
+So these tests pin the convergence, not the button. The trigger decides how a
+turn starts; nothing after it differs.
+"""
+
+import ast
+from pathlib import Path
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+SRC = (CONTROLLER / "em_esphome.py").read_text()
+TREE = ast.parse(SRC)
+
+
+def _method(name: str):
+    for node in ast.walk(TREE):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in em_esphome.py — renamed?")
+
+
+def _self_calls(node) -> list[str]:
+    """`self.foo(...)` attribute names called anywhere under node."""
+    out = []
+    for sub in ast.walk(node):
+        if (isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Attribute)
+                and isinstance(sub.func.value, ast.Name)
+                and sub.func.value.id == "self"):
+            out.append(sub.func.attr)
+    return out
+
+
+def test_on_thinking_is_only_ever_invoked_from_one_place():
+    """
+    The invariant that makes a third endpoint route impossible to get wrong:
+    nothing calls `self._on_thinking()` directly. Add a new way for a turn to
+    end, call _enter_thinking, and the ring is correct for free.
+    """
+    offenders = []
+    for node in ast.walk(TREE):
+        if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            continue
+        if node.name == "_enter_thinking":
+            continue
+        if "_on_thinking" in _self_calls(node):
+            offenders.append(node.name)
+
+    assert not offenders, (
+        f"{offenders} call self._on_thinking() directly. Route it through "
+        "_enter_thinking() instead — it is idempotent and is what every "
+        "endpoint path shares."
+    )
+
+
+def test_enter_thinking_is_idempotent():
+    """
+    Both routes genuinely fire on a slow turn: the sentinel sends end=True and
+    HA can still emit STT_VAD_END for the same silence. Entering twice would
+    restart the spinner mid-turn.
+    """
+    fn = _method("_enter_thinking")
+    src = ast.unparse(fn)
+    assert "_thinking_entered" in src, (
+        "_enter_thinking must guard on _thinking_entered — both endpoint "
+        "routes can fire within one turn."
+    )
+    guards = [n for n in ast.walk(fn)
+              if isinstance(n, ast.If) and "_thinking_entered" in ast.unparse(n.test)]
+    assert guards, "_thinking_entered must be TESTED, not merely assigned."
+
+
+def test_the_flag_is_reset_per_turn():
+    """
+    Cleared where the other per-turn flags are. A flag that survived a turn
+    would suppress the transition for every turn after the first.
+    """
+    fn = _method("run_esphome_voice_turn")
+    assigned = any(
+        isinstance(n, ast.Assign)
+        and any(isinstance(t, ast.Attribute) and t.attr == "_thinking_entered"
+                for t in n.targets)
+        for n in ast.walk(fn)
+    )
+    assert assigned, (
+        "_thinking_entered must be reset in run_esphome_voice_turn beside "
+        "_ha_vad_end.clear() — otherwise only the first turn of a connection "
+        "ever shows thinking."
+    )
+
+    # It has to sit with the other per-turn flags, not somewhere that only
+    # runs on a subset of turns.
+    block = ast.unparse(fn)
+    assert "_ha_vad_end.clear()" in block, (
+        "the per-turn reset block moved out of run_esphome_voice_turn; this "
+        "test is anchored to it and needs to follow."
+    )
+
+
+def test_both_known_endpoint_routes_enter_thinking():
+    """
+    The two routes that exist today. If a third is added, the test above is
+    what catches it; this one pins that neither of these two regresses.
+    """
+    handler = _method("_handle_voice_event")
+    assert "_enter_thinking" in _self_calls(handler), (
+        "the STT_VAD_END branch must call _enter_thinking"
+    )
+
+    stream = _method("_stream_mic_audio")
+    assert "_enter_thinking" in _self_calls(stream), (
+        "the device VAD sentinel must call _enter_thinking — this is the "
+        "route that was missing it (#370)"
+    )
+
+
+def test_a_no_speech_timeout_does_not_enter_thinking():
+    """
+    The one end=True that is NOT a user finishing: the no-speech timeout
+    closes HA's pipeline having heard nothing. Showing the spinner there
+    would claim the Echo is working on a request nobody made.
+    """
+    stream = _method("_stream_mic_audio")
+
+    for node in ast.walk(stream):
+        if not isinstance(node, ast.If):
+            continue
+        if "VAD_SENTINEL_TIMEOUT" not in ast.unparse(node.test):
+            continue
+        assert "_enter_thinking" not in _self_calls(node), (
+            "the no-speech timeout branch must not enter thinking — nothing "
+            "was said, so there is nothing to think about."
+        )
+        return
+    raise AssertionError(
+        "the VAD_SENTINEL_TIMEOUT branch was not found in _stream_mic_audio; "
+        "if it moved, this test needs to follow it."
+    )


### PR DESCRIPTION
Fixes #370.

A turn ends in **two** places — HA's `STT_VAD_END` event, and our own device VAD sentinel in `_stream_mic_audio` — and both mean the user stopped talking. Only the first called `on_thinking`.

So a turn ending on the sentinel held the listening ring through the whole STT → intent → TTS window (~11s on this fleet) with nothing saying the Echo had heard you finish. `on_thinking_esphome` sets `thinking`, clears `listening`, pushes device state and starts the spinner — all four skipped.

## The trigger is a red herring

Reported as *"the button is slower than the wake word to notice I've finished"*. There is exactly **one** deliberate branch on the trigger in the turn path:

```python
preroll_discard = esphome.VOICE_PREROLL_DISCARD if is_wakeword else 0
```

correct, and everything after it is shared code.

## Measured

Three log windows, 2026-08-28:

| trigger | turns | `Thinking` fired | ended on |
|---|---|---|---|
| wake word | 33 | **33**, median 2.83s | HA's VAD, 33/33 |
| button | 11 | **0** | device sentinel, 11/11 |

The endpointing is **not** slower — 2.9s vs 3.3s, with button `vad_end` marginally the lower of the two. Only the feedback was missing.

## Why not just fix the button

Which route wins is a race between two VAD timers. The trigger correlates with the winner perfectly here, but **the mechanism for that correlation is not established** — plausibly the preroll gives HA's VAD a head start, and I have not verified it. Nothing holds it on a slower link, so a wake turn is free to lose the same transition.

`_enter_thinking` is the single convergence point both routes call, idempotent because on a slow turn both genuinely fire: the sentinel sends `end=True` and HA can still emit `STT_VAD_END` for the same silence.

**The no-speech timeout deliberately does not enter thinking.** It also sends `end=True`, but nothing was said, and a spinner there would claim the Echo is working on a request nobody made. Pinned by a test.

## Not a regression

Bound to `STT_VAD_END` alone since `08da0c2`, the original ESPHome integration. Newly *visible* because the dot button only recently acquired a routine reason to be pressed — #167 timers, and #366's recovery workaround.

## Tests

`tests/test_thinking_transition.py` pins the convergence, not the button. The load-bearing one is that **`_on_thinking` has exactly one call site** — add a third way for a turn to end, call `_enter_thinking`, and the ring is right for free.

Four of its five fail on the parent commit. The fifth caught a real error in this change: the per-turn reset lives in `run_esphome_voice_turn` and the test had guessed `trigger_voice_turn`.

843 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
