### PR TITLE
Early Access 2.22.0-ea.4

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 2.22.0-ea.4 (Early Access)
+
+**The ring now tells you it has stopped listening, whichever way you started
+the turn.** One fix.
+
+**There is nothing to do before updating.** No database migration, no firmware
+requirement, nothing to change on your devices.
+
+### The ring stays on "listening" after you have finished speaking
+
+Start a turn with the button rather than the wake word and the ring kept its
+listening animation from the moment you pressed it until the answer began —
+often ten seconds or more — with nothing to say the Echo had heard you stop.
+It made the Echo feel slow to react when it had in fact finished listening at
+the usual time, within about three seconds.
+
+A turn can finish in two ways: Home Assistant deciding you have stopped
+speaking, or the Echo deciding it for itself. Only the first switched the ring
+to its thinking spinner. Both do now.
+
+**This was never really about the button.** Which of the two gets there first
+is a matter of timing, and a wake word turn on a slow network could lose the
+same feedback. The fix applies to both, so it cannot come back on the other
+one.
+
+The time between finishing speaking and hearing a reply is unchanged — that is
+mostly speech-to-text, and it depends on the machine running Home Assistant.
+
 ## 2.22.0-ea.3 (Early Access)
 
 **Stopping a ringing timer no longer leaves the Echo deaf.** One fix, and it

--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -17,7 +17,7 @@ name: "EchoMuse (Early Access)"
 # derives from the controller-v* tag (controller-v2.18.0 -> 2.18.0). Bump
 # both together: Supervisor pulls `image:version`, so a version with no
 # matching tag on GHCR fails to install.
-version: "2.22.0-ea.3"
+version: "2.22.0-ea.4"
 # Pull the published multi-arch image rather than building on the user's
 # machine. Without this Supervisor builds from this directory's Dockerfile,
 # which downloads a few hundred MB on whatever the user runs Home Assistant

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 2.22.0-ea.4 (Early Access)
+
+**The ring now tells you it has stopped listening, whichever way you started
+the turn.** One fix.
+
+**There is nothing to do before updating.** No database migration, no firmware
+requirement, nothing to change on your devices.
+
+### The ring stays on "listening" after you have finished speaking
+
+Start a turn with the button rather than the wake word and the ring kept its
+listening animation from the moment you pressed it until the answer began —
+often ten seconds or more — with nothing to say the Echo had heard you stop.
+It made the Echo feel slow to react when it had in fact finished listening at
+the usual time, within about three seconds.
+
+A turn can finish in two ways: Home Assistant deciding you have stopped
+speaking, or the Echo deciding it for itself. Only the first switched the ring
+to its thinking spinner. Both do now.
+
+**This was never really about the button.** Which of the two gets there first
+is a matter of timing, and a wake word turn on a slow network could lose the
+same feedback. The fix applies to both, so it cannot come back on the other
+one.
+
+The time between finishing speaking and hearing a reply is unchanged — that is
+mostly speech-to-text, and it depends on the machine running Home Assistant.
+
 ## 2.22.0-ea.3 (Early Access)
 
 **Stopping a ringing timer no longer leaves the Echo deaf.** One fix, and it


### PR DESCRIPTION
Cuts **2.22.0-ea.4** — one fix, #371.

A turn ends either on HA's `STT_VAD_END` or on the device's own VAD sentinel, and only the first switched the ring to its spinner. A turn ending on the sentinel held the listening animation through the whole STT/intent/TTS window (~11s here), so the Echo read as slow to react when it had endpointed at the usual ~3s.

Reported from the soak as *"the button is slower than the wake word"*. **The trigger was a red herring** — 33/33 wake turns ended on HA's VAD and fired Thinking, 11/11 button turns ended on the sentinel and did not. Which route wins is a race, so the fix converges both rather than special-casing the button; a wake turn on a slower link was free to lose the same transition.

No firmware change, no migration, no new config keys — all checked against the ea.3 tag. 843 tests pass.

**Still out: #368** (`apt-get upgrade`). Green and correct, but it changes which base packages ship and would make a bad soak result ambiguous. Before GA.

## Soak targets

1. **An announcement, driven deliberately** — #356 changed that path and it has still never been exercised across four builds.
2. **Delete a device and re-add it.**
3. **Pull a device's power** — #315's grace, #354's window.
4. **Button-started turns** — the ring should reach the spinner a few seconds after you finish, not when the answer starts.

## ea.3 confirmed its own target on hardware

Three dismissals at **1.55s, 0.77s and 0.71s** into a chime, each cancelling a stream that got no `playback_stats`, each followed by a working turn — including a wake word 35 seconds later, which is the exact sequence that died on ea.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
