### PR TITLE
Record what today cost, where the next person will look

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,17 @@ Device firmware and controller are versioned independently from the same repo:
 
   The notice is **advisory only and must stay that way** (`tests/test_deploy.py` enforces GET-only + no mutating call in the banner): the controller is the user's container, updated with their own `docker compose pull`. An in-app update would restart the process serving the page, mid-request, with no way to report the outcome. Note a locally-built image defaults `EM_CONTROLLER_VERSION` to `dev`, which resolves to `unknown` and correctly shows nothing — pass `--build-arg EM_CONTROLLER_VERSION=$(git describe --tags --match 'controller-v*')` for a local build that knows what it is. Version comparison lives in `version.py` (`parse`/`compare`) so it is unit-testable without aiohttp; a build between tags parses **equal** to its tag and is ahead, not behind.
 
+**The release workflow does NOT build — it re-tags the image the main build
+already published for that commit.** `controller-release.yml` looks for
+`:sha-<short>` and fails with "No image published for this commit" if
+`Controller Build (main)` has not finished. So the order is **merge → wait for
+`Controller Build (main)` to go green on the merge commit → then push the
+tag**, and a tag pushed seconds after a merge fails on a race rather than on
+anything being wrong. Hit on 2026-08-28 cutting `2.22.0-ea.4`: the build had
+started 23 seconds earlier and the release checked while it was still pushing.
+The recovery is only `gh run rerun <id>` once the build finishes — the tag,
+the commit and the annotation are all fine and must not be re-cut.
+
 **`--cleanup=verbatim` is not optional if the notes use Markdown headings.**
 `git tag -a` defaults to `--cleanup=strip`, which treats a line beginning with
 `#` as a comment and deletes **the whole line** — so `## Volume` does not lose

--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -748,6 +748,30 @@ holds the matchers and constants; `start_timer_alarm` / `stop_timer_alarm` /
 ~5.5s of device buffer after it has been stopped), and an unanswered ring stops
 at `MAX_RING_S` = 120s.
 
+**The ring asks before writing the plane; the announcement does not, and that
+is #373.** `_ring_timer_alarm` gates every burst on `speaker_busy` because two
+writers would interleave frames on `0x02` — but `_standalone_play` performs no
+such check and streams straight into a chime already in flight. Measured
+2026-08-28: an announcement landing between bursts plays, one landing during a
+burst is **inaudible**. Both paths also share a single `device.playback_done`
+Event, so one device report satisfies two waiters (observed as two `Playback
+complete` lines in the same millisecond, and an announcement whose wait ended
+after a chime's duration rather than its own). **The exclusion being
+one-directional is the bug** — do not "fix" it by blocking announcements while
+ringing, because HA blocks on the announce call holding `_is_announcing` and a
+120s `MAX_RING_S` would fail every other announcement to that satellite. See
+`docs/audio-states.md` §6 Q4 for the options, including the longer-term move of
+the alarm onto the music plane (which needs `audio_mix` gating, or the alarm is
+silent on firmware that cannot mix).
+
+**A cancelled playback must release `speaking` (#366).** `_run_post_turn_playback`
+clears it in the `finally`, beside `speaker_busy`, and shielded — it used to sit
+after the try, so `stop_timer_alarm`'s cancel skipped it and the flag stayed set
+for the life of the process. That is not a cosmetic tile: the wake listener
+skips every frame while `speaking` is set and no alarm is ringing, so the device
+went **permanently deaf** after a mid-chime dismissal. Roughly three dismissals
+in four hit it, the chime being 1.68s of every 2.3s.
+
 **HA hands ringing to the satellite and expects the satellite to own dismissal**
 — the same shape its own Voice PE hardware has. So the dismissal is recognised
 here, from the transcript HA already sends, rather than waiting for a CANCELLED
@@ -1272,6 +1296,20 @@ caller is `stream_speaker`'s `finally`, which is also reached when barge-in
 cancels the task mid-send; a plain `except Exception` does not catch the
 `CancelledError` that arises there, and a dashboard push is not worth failing a
 speaker stream over. The assignment is synchronous and always happens.
+
+**Every route that ends a turn's speech must call `_enter_thinking`, and there
+are two (#370).** HA's `STT_VAD_END` event and the device VAD sentinel in
+`_stream_mic_audio` both mean "the user stopped talking"; only the first was
+wired to `on_thinking`, so a turn ending on the sentinel held the listening ring
+through the whole STT/intent/TTS window — ~11s measured. It presented as "the
+button is slower than the wake word" and the trigger is a red herring: there is
+exactly ONE deliberate branch on it in the turn path (`preroll_discard`), and
+which endpoint route wins is a race. 33/33 wake turns ended on HA's VAD, 11/11
+button turns on the sentinel, but nothing holds that on a slower link.
+`_enter_thinking` is idempotent because on a slow turn both routes fire.
+`tests/test_thinking_transition.py` pins that `_on_thinking` has exactly **one
+call site**, so a third endpoint route gets the ring right for free — and that
+the no-speech timeout deliberately does NOT enter it, since nothing was said.
 
 Note `em_player` must **not** set `device.speaking` for music — it makes the
 wake loop drop frames, deafening the device for the length of a song.


### PR DESCRIPTION
Four things learned the expensive way today, none derivable from the code they describe.

**`CLAUDE.md`, versioning — the release workflow does not build.** It re-tags the image `Controller Build (main)` already published for that commit, and fails with *"No image published for this commit"* if that build hasn't finished. Cutting `2.22.0-ea.4` hit it: the tag went up 23 seconds after the merge, while the build was still pushing. The order is **merge → wait for green → tag**, and the recovery is `gh run rerun`, **not** re-cutting the tag, which is fine.

**`controller/CLAUDE.md`, timers — #373**, the announcement that writes the speaker plane without taking it. Recorded with the reason *not* to fix it by blocking announcements: HA blocks on the announce call holding `_is_announcing`, so a 120s `MAX_RING_S` fails every other announcement to that satellite. Points at `audio-states.md` §6 Q4 for the options.

**Same section — #366**, why the `speaking` clear lives in the `finally`. A cancelled playback that skipped it left the wake listener skipping every frame, so the device went permanently deaf after a mid-chime dismissal. Worth stating as a rule rather than leaving as a shielded line someone tidies away.

**Dashboard state — #370**, that every route ending a turn's speech must call `_enter_thinking`, and there are two. Includes the measurement that makes the trigger a red herring (33/33 wake turns ended on HA's VAD, 11/11 button turns on the sentinel — but nothing holds that on a slower link) and the invariant the test pins: `_on_thinking` has exactly one call site, so a third route gets the ring right for free.

Docs only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
