### PR TITLE
Say what breaks, rather than that something is load-bearing

### DIFF
--- a/controller/tests/test_playback_state_release.py
+++ b/controller/tests/test_playback_state_release.py
@@ -119,7 +119,7 @@ def test_the_clear_survives_the_cancellation_that_triggered_it():
 def test_the_wake_listener_still_gates_on_speaking():
     """
     Pins the other half of the pair. If this guard is ever removed, the bug
-    above stops being fatal and the tests above stop being load-bearing — so
+    above stops being fatal and the tests above stop protecting anything — so
     a future reader should be told they moved together, not discover it.
     """
     src = (CONTROLLER / "em_controller.py").read_text()

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -326,7 +326,7 @@ sites, so a new board is mostly a mic/speaker/LED/button binding.
 ### Does it depend on Amazon's software?
 Barely, and keeping it that way is deliberate. It's a Linux daemon using ALSA,
 i2c, evdev and sysfs that happens to run on Android because that's what
-shipped on the box. A change that makes an Amazon blob load-bearing is going
+shipped on the box. A change that puts an Amazon blob back in the audio path is going
 the wrong way, even when it sounds better.
 
 ### Is there a video of it working?


### PR DESCRIPTION
Two instances from today, both mine — the FAQ's answer on Amazon dependence and a test docstring.

The phrase does no work. *"The tests above stop protecting anything"* names the consequence; *"stop being load-bearing"* only asserts there is one.

Pre-existing uses in `CLAUDE.md` are untouched — they are the project's own record rather than today's prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)