### PR TITLE
Store the BLE transport resets the device has been counting all along

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -91,6 +91,7 @@ COPY em_ingressauth.py .
 COPY em_linkauth.py .
 COPY em_rttlog.py .
 COPY em_esphome.py .
+COPY em_ble_health.py .
 COPY em_ble_proxy.py .
 COPY em_oww_assets.py  ./
 COPY em_oww_models.py .

--- a/controller/em_ble_health.py
+++ b/controller/em_ble_health.py
@@ -1,0 +1,68 @@
+"""BLE transport health: deciding when a reset counter is worth a warning.
+
+Split out as pure logic for the reason em_volume.py and em_linkauth.py were.
+Here the reason is also mechanical: em_ble_proxy imports zeroconf, which the
+CI test job does not install, so a test that reaches this decision through
+that module cannot run where it matters (see controller/CLAUDE.md on keeping
+the suite to pure-logic modules).
+
+WHY THE COUNTERS MATTER. `/dev/stpbt` is not a Bluetooth device — it is the
+MT8163's combo radio behind MediaTek's WMT stack, shared with WiFi. When a
+scan session fails, the scanner reopens the transport, and opening it
+triggers a BT function-on plus firmware patch download on the chip carrying
+the WiFi link. Observed once on Test Echo 1 (2026-08-30): stpbt read failure,
+reopen five seconds later, `network is unreachable` two seconds after that.
+
+WHY IT IS A RISE, NOT A VALUE. The device reports counters cumulative since
+ITS process start. They never fall on their own, so warning on "non-zero"
+would repeat one reset every 30 seconds forever and bury the next genuine
+one. And a counter that goes BACKWARDS means the device restarted, which
+rebases rather than reading as a negative delta — otherwise the first real
+reset after a reboot is swallowed all the way back up to the old total,
+which is exactly the window where resets matter most.
+"""
+
+from typing import NamedTuple, Optional
+
+
+class Observation(NamedTuple):
+    """The new baseline, and a warning when the counters climbed."""
+
+    restarts: int
+    errors: int
+    warning: Optional[str]
+
+
+def observe(
+    prev_restarts: int,
+    prev_errors: int,
+    restarts: int,
+    errors: int,
+) -> Observation:
+    """
+    Fold one stats report's BLE counters into the running baseline.
+
+    Returns the values to store plus a warning string when either counter
+    rose, or None when nothing happened worth saying — including the reboot
+    case, which rebases silently because a device restarting is not a
+    transport reset.
+    """
+    restarts = max(0, int(restarts or 0))
+    errors = max(0, int(errors or 0))
+    prev_restarts = max(0, int(prev_restarts or 0))
+    prev_errors = max(0, int(prev_errors or 0))
+
+    if restarts < prev_restarts or errors < prev_errors:
+        return Observation(restarts, errors, None)
+
+    if restarts == prev_restarts and errors == prev_errors:
+        return Observation(restarts, errors, None)
+
+    return Observation(
+        restarts,
+        errors,
+        f"BLE transport reset (+{restarts - prev_restarts} restarts, "
+        f"+{errors - prev_errors} errors; {restarts}/{errors} total) — "
+        f"reopening /dev/stpbt re-initialises the radio WiFi shares, "
+        f"so check for a link drop around now",
+    )

--- a/controller/em_ble_proxy.py
+++ b/controller/em_ble_proxy.py
@@ -160,6 +160,12 @@ class DeviceBleProxyServer:
         self.adverts_received = 0   # batches' adverts arriving from the device
         self.adverts_forwarded = 0  # actually sent to a subscribed HA
         self.adverts_seen = 0       # device-reported cumulative counter (stats)
+        # Transport health, device-reported and cumulative since ITS process
+        # start. Kept so update_stats can warn on a RISE rather than on a
+        # non-zero value — the counters never fall on their own, so warning
+        # on non-zero would repeat the same reset every 30s forever.
+        self.hci_restarts = 0
+        self.hci_errors   = 0
 
     def _protocol_factory(self):
         if self._active_satellite is not None:
@@ -413,6 +419,37 @@ def update_stats(device_id: str, ble_stats: dict) -> None:
     if proxy is None or not isinstance(ble_stats, dict):
         return
     proxy.adverts_seen = int(ble_stats.get("advertsSeen") or 0)
+
+    # Transport resets. These are worth a warning of their own because
+    # /dev/stpbt is NOT a Bluetooth-only device: it is the MT8163's combo
+    # radio behind MediaTek's WMT stack, shared with WiFi. A failed session
+    # makes the scanner reopen it, and opening it triggers a BT function-on
+    # plus firmware patch download on the chip carrying the WiFi link — so a
+    # BLE restart is a candidate explanation for a device that vanishes off
+    # the network entirely, which is a very different symptom from the
+    # gradual RTT/packet-loss degradation and should not be confused with it.
+    #
+    # Observed once (2026-08-30, Test Echo 1): stpbt read failed, reopen 5s
+    # later, `network is unreachable` 2s after that. Logged rather than acted
+    # on — the correlation is one occurrence, and the counters now persist in
+    # device_metrics so a second one is a query rather than an argument.
+    restarts = int(ble_stats.get("restarts") or 0)
+    errors   = int(ble_stats.get("hciErrors") or 0)
+    # A counter going BACKWARDS means the device process restarted, which
+    # rebases both. Treating that as a negative delta would silence the next
+    # genuine rise, so rebase instead of comparing.
+    if restarts < proxy.hci_restarts or errors < proxy.hci_errors:
+        proxy.hci_restarts, proxy.hci_errors = restarts, errors
+    elif restarts > proxy.hci_restarts or errors > proxy.hci_errors:
+        log.warning(
+            f"[bleproxy.{device_id[-8:]}] BLE transport reset "
+            f"(+{restarts - proxy.hci_restarts} restarts, "
+            f"+{errors - proxy.hci_errors} errors; {restarts}/{errors} total) "
+            f"— reopening /dev/stpbt re-initialises the radio WiFi shares, "
+            f"so check for a link drop around now"
+        )
+        proxy.hci_restarts, proxy.hci_errors = restarts, errors
+
     satellite = proxy.get_satellite()
     if satellite is not None:
         satellite.push_adverts_sensor(proxy.adverts_seen)
@@ -431,4 +468,9 @@ def get_status(device_id: str) -> Optional[dict]:
         "haSubscribed":     bool(satellite is not None and satellite.subscribed),
         "advertsReceived":  proxy.adverts_received,
         "advertsForwarded": proxy.adverts_forwarded,
+        # Transport resets, surfaced because a non-zero value here is the
+        # first thing to check against an unexplained link drop on this
+        # device — see update_stats for why a BLE restart can take WiFi out.
+        "hciRestarts":      proxy.hci_restarts,
+        "hciErrors":        proxy.hci_errors,
     }

--- a/controller/em_ble_proxy.py
+++ b/controller/em_ble_proxy.py
@@ -45,6 +45,8 @@ from esphome.satellite_server import SatelliteServerProtocol, serve, _HANDLED
 from esphome.feature_flags import BluetoothProxyFeature
 from esphome.vendor import api_pb2
 
+import em_ble_health
+
 log = logging.getLogger("echomuse.bleproxy")
 
 BT_PROXY_FLAGS = int(
@@ -420,35 +422,20 @@ def update_stats(device_id: str, ble_stats: dict) -> None:
         return
     proxy.adverts_seen = int(ble_stats.get("advertsSeen") or 0)
 
-    # Transport resets. These are worth a warning of their own because
-    # /dev/stpbt is NOT a Bluetooth-only device: it is the MT8163's combo
-    # radio behind MediaTek's WMT stack, shared with WiFi. A failed session
-    # makes the scanner reopen it, and opening it triggers a BT function-on
-    # plus firmware patch download on the chip carrying the WiFi link — so a
-    # BLE restart is a candidate explanation for a device that vanishes off
-    # the network entirely, which is a very different symptom from the
-    # gradual RTT/packet-loss degradation and should not be confused with it.
-    #
-    # Observed once (2026-08-30, Test Echo 1): stpbt read failed, reopen 5s
-    # later, `network is unreachable` 2s after that. Logged rather than acted
-    # on — the correlation is one occurrence, and the counters now persist in
-    # device_metrics so a second one is a query rather than an argument.
-    restarts = int(ble_stats.get("restarts") or 0)
-    errors   = int(ble_stats.get("hciErrors") or 0)
-    # A counter going BACKWARDS means the device process restarted, which
-    # rebases both. Treating that as a negative delta would silence the next
-    # genuine rise, so rebase instead of comparing.
-    if restarts < proxy.hci_restarts or errors < proxy.hci_errors:
-        proxy.hci_restarts, proxy.hci_errors = restarts, errors
-    elif restarts > proxy.hci_restarts or errors > proxy.hci_errors:
-        log.warning(
-            f"[bleproxy.{device_id[-8:]}] BLE transport reset "
-            f"(+{restarts - proxy.hci_restarts} restarts, "
-            f"+{errors - proxy.hci_errors} errors; {restarts}/{errors} total) "
-            f"— reopening /dev/stpbt re-initialises the radio WiFi shares, "
-            f"so check for a link drop around now"
-        )
-        proxy.hci_restarts, proxy.hci_errors = restarts, errors
+    # Transport resets. Worth a warning of their own because /dev/stpbt is
+    # NOT a Bluetooth-only device: it is the MT8163's combo radio behind
+    # MediaTek's WMT stack, shared with WiFi. See em_ble_health for the
+    # mechanism, why the signal is a RISE rather than a value, and why a
+    # counter going backwards rebases — the decision lives there as pure
+    # logic so it is testable without importing zeroconf through this
+    # module.
+    obs = em_ble_health.observe(
+        proxy.hci_restarts, proxy.hci_errors,
+        ble_stats.get("restarts"), ble_stats.get("hciErrors"),
+    )
+    proxy.hci_restarts, proxy.hci_errors = obs.restarts, obs.errors
+    if obs.warning:
+        log.warning(f"[bleproxy.{device_id[-8:]}] {obs.warning}")
 
     satellite = proxy.get_satellite()
     if satellite is not None:

--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -796,6 +796,36 @@ MIGRATIONS: list[str] = [
 
     UPDATE system_config SET value = '19' WHERE key = 'schema_version';
     """,
+
+    # ── v20 — BLE transport resets, because they may not be BLE's problem ────
+    #
+    # The device has always counted these (bluetooth.Scanner.Stats: restarts,
+    # hciErrors) and always sent them inside the stats message's `ble` object.
+    # em_ble_proxy.update_stats read `advertsSeen` and dropped both, so the
+    # numbers existed on the wire for a month and nowhere else — the fleet
+    # question "how often does the transport reset" had no stored answer.
+    #
+    # Worth storing because /dev/stpbt is not a Bluetooth device, it is the
+    # MT8163's COMBO radio behind MediaTek's WMT stack, shared with WiFi. The
+    # scanner's own recovery reopens it, and opening it triggers a BT
+    # function-on plus firmware patch download on that shared chip
+    # (scanner.go, `session`). Observed 2026-08-30 on Test Echo 1: stpbt read
+    # failed, the scanner reopened 5s later, and the WiFi interface went
+    # `network is unreachable` 2s after that. One occurrence, mechanism
+    # plausible, nothing stored anywhere that could say whether it is common.
+    #
+    # GAUGES, NOT SUMS. These are cumulative counters since the device's
+    # process start, not per-window deltas like the RTT fields above, so
+    # adding them every 30s would multiply a single reset into hundreds.
+    # Keeping the latest value makes an hour-to-hour difference the number of
+    # resets in that hour, and makes a DROP to a smaller value mean the
+    # device restarted — which is worth seeing rather than smoothing away.
+    """
+    ALTER TABLE device_metrics ADD COLUMN ble_restarts_last   INTEGER;
+    ALTER TABLE device_metrics ADD COLUMN ble_hci_errors_last INTEGER;
+
+    UPDATE system_config SET value = '20' WHERE key = 'schema_version';
+    """,
 ]
 
 # Post-migration fixups that need Python rather than SQL. Keyed by the schema
@@ -2070,6 +2100,13 @@ def record_device_stats(device_id: str, stats: dict) -> None:
     cores_on   = stats.get("coresOnline")
     cores_tot  = stats.get("coresTotal")
     therm_lim  = stats.get("thermalCoreLimit")
+    # BLE transport health, from the `ble` object the scanner fills in.
+    # Absent on every device with the proxy off, which stores as NULL and
+    # must not read as "zero resets" — a device that never opened the
+    # transport is not a device that opened it and never faltered.
+    _ble       = stats.get("ble") or {}
+    ble_restarts = _ble.get("restarts")
+    ble_hci_err  = _ble.get("hciErrors")
     with _tx() as conn:
         conn.execute(
             """
@@ -2084,11 +2121,13 @@ def record_device_stats(device_id: str, stats: dict) -> None:
                 rtt_excursions, rtt_excursions_idle, rtt_samples_idle,
                 cpu_temp_sum, cpu_temp_samples, cpu_temp_max, max_temp_max,
                 cores_online_last, cores_online_min, cores_total,
-                thermal_limit_min
+                thermal_limit_min,
+                ble_restarts_last, ble_hci_errors_last
             ) VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                       ?, ?, ?, ?, ?, ?, ?, ?, ?,
                       ?, ?, ?, ?, ?, ?, ?,
-                      ?, ?, ?, ?, ?, ?, ?, ?)
+                      ?, ?, ?, ?, ?, ?, ?, ?,
+                      ?, ?)
             ON CONFLICT (device_id, hour_ts) DO UPDATE SET
                 samples          = samples + 1,
                 cpu_sum          = cpu_sum + excluded.cpu_sum,
@@ -2158,7 +2197,16 @@ def record_device_stats(device_id: str, stats: dict) -> None:
                 END,
                 rtt_excursions      = rtt_excursions      + excluded.rtt_excursions,
                 rtt_excursions_idle = rtt_excursions_idle + excluded.rtt_excursions_idle,
-                rtt_samples_idle    = rtt_samples_idle    + excluded.rtt_samples_idle
+                rtt_samples_idle    = rtt_samples_idle    + excluded.rtt_samples_idle,
+                -- Latest value, never a sum: these are cumulative since the
+                -- device's process start (see the v20 migration). The count
+                -- of resets in an hour is the difference against the previous
+                -- hour's row, and a value SMALLER than the previous hour's
+                -- means the device restarted in between.
+                ble_restarts_last   = COALESCE(excluded.ble_restarts_last,
+                                               ble_restarts_last),
+                ble_hci_errors_last = COALESCE(excluded.ble_hci_errors_last,
+                                               ble_hci_errors_last)
             """,
             (
                 device_id, hour_ts,
@@ -2196,6 +2244,11 @@ def record_device_stats(device_id: str, stats: dict) -> None:
                 int(cores_on) if cores_on else None,
                 int(cores_tot) if cores_tot else None,
                 int(therm_lim) if therm_lim else None,
+                # NULL when the proxy is off, and 0 is a real value meaning
+                # "opened the transport, never faltered" — so `or None` would
+                # be wrong here in a way it is not for the gauges above.
+                int(ble_restarts) if ble_restarts is not None else None,
+                int(ble_hci_err) if ble_hci_err is not None else None,
             ),
         )
         conn.execute(

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1835,7 +1835,14 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                           {row('Home Assistant', haState, bp.haSubscribed ? 'var(--ok)' : undefined)}
                           {row('Forwarded to HA', String(bp.advertsForwarded ?? 0))}
                           {row('ESPHome port', String(bp.port))}
-                          {row('HCI errors / restarts', b ? `${b.hciErrors ?? 0} / ${b.restarts ?? 0}` : '—')}
+                          {/* Amber on any non-zero: reopening /dev/stpbt
+                              re-initialises the combo radio WiFi shares, so
+                              this is the first thing to check against an
+                              unexplained link drop on this device. */}
+                          {row('HCI errors / restarts',
+                               b ? `${b.hciErrors ?? 0} / ${b.restarts ?? 0}` : '—',
+                               b && ((b.hciErrors ?? 0) > 0 || (b.restarts ?? 0) > 0)
+                                 ? 'var(--warn)' : undefined)}
                         </div>
                       </div>
                     </Panel>

--- a/controller/tests/test_ble_transport_health.py
+++ b/controller/tests/test_ble_transport_health.py
@@ -1,0 +1,103 @@
+"""
+BLE transport resets, and why they are a link-drop diagnostic.
+
+`/dev/stpbt` is not a Bluetooth-only device — it is the MT8163's combo radio
+behind MediaTek's WMT stack, shared with WiFi. When a scan session fails the
+scanner reopens it, and opening it triggers a BT function-on plus firmware
+patch download on the chip carrying the WiFi link. Observed once on
+2026-08-30: stpbt read failure, reopen 5s later, `network is unreachable` 2s
+after that.
+
+The device has counted `restarts`/`hciErrors` since the proxy shipped and
+sent them in the stats message. update_stats read `advertsSeen` and dropped
+both, so nothing anywhere could say how often this happens. These guard the
+counting rule, which is the part that is easy to get wrong: the counters are
+cumulative on the DEVICE, so the signal is a RISE, not a non-zero value.
+"""
+
+import logging
+
+import pytest
+
+import em_ble_proxy
+
+
+@pytest.fixture()
+def proxy(monkeypatch):
+    p = em_ble_proxy.DeviceBleProxyServer(
+        device_id="G090LF1180440C95", label="Test Echo 1",
+        mac_address="90:f1:18:04:40:c9", port=6053,
+    )
+    monkeypatch.setitem(em_ble_proxy._proxies, p.device_id, p)
+    return p
+
+
+def _warnings(caplog):
+    return [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_a_rise_warns_once_not_every_report(proxy, caplog):
+    """
+    The counters never fall on their own, so warning on "non-zero" would
+    repeat the same reset every 30s forever and bury the next real one.
+    """
+    with caplog.at_level(logging.WARNING, logger="echomuse.bleproxy"):
+        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 1, "hciErrors": 1})
+        first = len(_warnings(caplog))
+        for _ in range(5):
+            em_ble_proxy.update_stats(proxy.device_id,
+                                      {"restarts": 1, "hciErrors": 1})
+        assert first == 1, "a rise must warn"
+        assert len(_warnings(caplog)) == 1, \
+            "an unchanged counter must not re-warn on every stats report"
+
+
+def test_a_second_rise_warns_again(proxy, caplog):
+    with caplog.at_level(logging.WARNING, logger="echomuse.bleproxy"):
+        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 1, "hciErrors": 0})
+        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 1, "hciErrors": 0})
+        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 2, "hciErrors": 0})
+    assert len(_warnings(caplog)) == 2
+
+
+def test_a_clean_transport_never_warns(proxy, caplog):
+    with caplog.at_level(logging.WARNING, logger="echomuse.bleproxy"):
+        for _ in range(10):
+            em_ble_proxy.update_stats(proxy.device_id,
+                                      {"advertsSeen": 900, "restarts": 0,
+                                       "hciErrors": 0})
+    assert _warnings(caplog) == []
+
+
+def test_a_device_restart_rebases_instead_of_going_negative(proxy, caplog):
+    """
+    A device reboot resets both counters to 0. Treating that as a negative
+    delta and leaving the stored value high would silence the next genuine
+    rise all the way back up to the old total — which is precisely the
+    window after a reboot, when resets matter most.
+    """
+    with caplog.at_level(logging.WARNING, logger="echomuse.bleproxy"):
+        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 9, "hciErrors": 9})
+        before = len(_warnings(caplog))
+        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 0, "hciErrors": 0})
+        assert len(_warnings(caplog)) == before, \
+            "a rebase is not a reset event and must not warn"
+        assert proxy.hci_restarts == 0, "counters must rebase to the new baseline"
+        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 1, "hciErrors": 0})
+        assert len(_warnings(caplog)) == before + 1, \
+            "the first rise after a reboot must still warn"
+
+
+def test_status_surfaces_the_counters(proxy):
+    em_ble_proxy.update_stats(proxy.device_id, {"restarts": 4, "hciErrors": 6})
+    st = em_ble_proxy.get_status(proxy.device_id)
+    assert st["hciRestarts"] == 4
+    assert st["hciErrors"] == 6
+
+
+def test_a_missing_ble_object_is_not_an_error(proxy):
+    """Firmware predating the counters, and any non-dict, must be ignored."""
+    em_ble_proxy.update_stats(proxy.device_id, {})
+    em_ble_proxy.update_stats(proxy.device_id, None)
+    em_ble_proxy.update_stats("unknown-device", {"restarts": 3})
+    assert proxy.hci_restarts == 0

--- a/controller/tests/test_ble_transport_health.py
+++ b/controller/tests/test_ble_transport_health.py
@@ -9,95 +9,99 @@ patch download on the chip carrying the WiFi link. Observed once on
 after that.
 
 The device has counted `restarts`/`hciErrors` since the proxy shipped and
-sent them in the stats message. update_stats read `advertsSeen` and dropped
-both, so nothing anywhere could say how often this happens. These guard the
-counting rule, which is the part that is easy to get wrong: the counters are
-cumulative on the DEVICE, so the signal is a RISE, not a non-zero value.
+sent them in the stats message. `update_stats` read `advertsSeen` and
+dropped both, so nothing anywhere could say how often this happens.
+
+These test `em_ble_health` rather than reaching the decision through
+`em_ble_proxy`, which imports zeroconf — a dependency the CI test job does
+not install, so a test routed through that module passes locally and cannot
+run where it matters. That is the same reason the logic was split out at
+all; see controller/CLAUDE.md on keeping the suite to pure-logic modules.
 """
 
-import logging
+import re
+from pathlib import Path
 
-import pytest
+import em_ble_health as health
 
-import em_ble_proxy
-
-
-@pytest.fixture()
-def proxy(monkeypatch):
-    p = em_ble_proxy.DeviceBleProxyServer(
-        device_id="G090LF1180440C95", label="Test Echo 1",
-        mac_address="90:f1:18:04:40:c9", port=6053,
-    )
-    monkeypatch.setitem(em_ble_proxy._proxies, p.device_id, p)
-    return p
+CONTROLLER = Path(__file__).resolve().parents[1]
 
 
-def _warnings(caplog):
-    return [r for r in caplog.records if r.levelno >= logging.WARNING]
+def test_a_rise_warns():
+    obs = health.observe(0, 0, 1, 1)
+    assert obs.warning is not None
+    assert (obs.restarts, obs.errors) == (1, 1)
 
 
-def test_a_rise_warns_once_not_every_report(proxy, caplog):
+def test_an_unchanged_counter_does_not_re_warn():
     """
     The counters never fall on their own, so warning on "non-zero" would
     repeat the same reset every 30s forever and bury the next real one.
     """
-    with caplog.at_level(logging.WARNING, logger="echomuse.bleproxy"):
-        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 1, "hciErrors": 1})
-        first = len(_warnings(caplog))
-        for _ in range(5):
-            em_ble_proxy.update_stats(proxy.device_id,
-                                      {"restarts": 1, "hciErrors": 1})
-        assert first == 1, "a rise must warn"
-        assert len(_warnings(caplog)) == 1, \
-            "an unchanged counter must not re-warn on every stats report"
+    obs = health.observe(1, 1, 1, 1)
+    assert obs.warning is None
+    assert (obs.restarts, obs.errors) == (1, 1)
 
 
-def test_a_second_rise_warns_again(proxy, caplog):
-    with caplog.at_level(logging.WARNING, logger="echomuse.bleproxy"):
-        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 1, "hciErrors": 0})
-        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 1, "hciErrors": 0})
-        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 2, "hciErrors": 0})
-    assert len(_warnings(caplog)) == 2
+def test_either_counter_rising_is_enough():
+    assert health.observe(1, 0, 2, 0).warning is not None, "restarts alone"
+    assert health.observe(1, 0, 1, 1).warning is not None, "errors alone"
 
 
-def test_a_clean_transport_never_warns(proxy, caplog):
-    with caplog.at_level(logging.WARNING, logger="echomuse.bleproxy"):
-        for _ in range(10):
-            em_ble_proxy.update_stats(proxy.device_id,
-                                      {"advertsSeen": 900, "restarts": 0,
-                                       "hciErrors": 0})
-    assert _warnings(caplog) == []
+def test_the_warning_names_the_delta_and_the_total():
+    obs = health.observe(2, 3, 5, 9)
+    assert "+3 restarts" in obs.warning
+    assert "+6 errors" in obs.warning
+    assert "5/9 total" in obs.warning
 
 
-def test_a_device_restart_rebases_instead_of_going_negative(proxy, caplog):
+def test_a_clean_transport_never_warns():
+    prev = (0, 0)
+    for _ in range(10):
+        obs = health.observe(prev[0], prev[1], 0, 0)
+        assert obs.warning is None
+        prev = (obs.restarts, obs.errors)
+
+
+def test_a_device_restart_rebases_instead_of_going_negative():
     """
-    A device reboot resets both counters to 0. Treating that as a negative
-    delta and leaving the stored value high would silence the next genuine
-    rise all the way back up to the old total — which is precisely the
-    window after a reboot, when resets matter most.
+    A reboot resets both counters to 0. Treating that as a negative delta
+    and keeping the old baseline would silence the next genuine rise all the
+    way back up to the old total — precisely the window after a reboot, when
+    resets matter most.
     """
-    with caplog.at_level(logging.WARNING, logger="echomuse.bleproxy"):
-        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 9, "hciErrors": 9})
-        before = len(_warnings(caplog))
-        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 0, "hciErrors": 0})
-        assert len(_warnings(caplog)) == before, \
-            "a rebase is not a reset event and must not warn"
-        assert proxy.hci_restarts == 0, "counters must rebase to the new baseline"
-        em_ble_proxy.update_stats(proxy.device_id, {"restarts": 1, "hciErrors": 0})
-        assert len(_warnings(caplog)) == before + 1, \
-            "the first rise after a reboot must still warn"
+    obs = health.observe(9, 9, 0, 0)
+    assert obs.warning is None, "a rebase is not a reset event"
+    assert (obs.restarts, obs.errors) == (0, 0), "must adopt the new baseline"
+
+    after = health.observe(obs.restarts, obs.errors, 1, 0)
+    assert after.warning is not None, "the first rise after a reboot must warn"
 
 
-def test_status_surfaces_the_counters(proxy):
-    em_ble_proxy.update_stats(proxy.device_id, {"restarts": 4, "hciErrors": 6})
-    st = em_ble_proxy.get_status(proxy.device_id)
-    assert st["hciRestarts"] == 4
-    assert st["hciErrors"] == 6
+def test_missing_counters_are_treated_as_zero_not_as_a_crash():
+    """Firmware predating the counters sends neither field."""
+    obs = health.observe(0, 0, None, None)
+    assert obs.warning is None
+    assert (obs.restarts, obs.errors) == (0, 0)
 
 
-def test_a_missing_ble_object_is_not_an_error(proxy):
-    """Firmware predating the counters, and any non-dict, must be ignored."""
-    em_ble_proxy.update_stats(proxy.device_id, {})
-    em_ble_proxy.update_stats(proxy.device_id, None)
-    em_ble_proxy.update_stats("unknown-device", {"restarts": 3})
-    assert proxy.hci_restarts == 0
+# ── The wiring, asserted on source ───────────────────────────────────────────
+#
+# em_ble_proxy cannot be imported here (zeroconf), so the two facts that make
+# the pure logic above reach anything are checked against the file.
+
+def test_the_proxy_routes_its_counters_through_this_module():
+    src = (CONTROLLER / "em_ble_proxy.py").read_text()
+    assert "import em_ble_health" in src
+    assert re.search(r"em_ble_health\.observe\(", src), \
+        "update_stats must use the shared decision, not its own copy"
+
+
+def test_the_status_payload_surfaces_the_counters():
+    """
+    A non-zero value here is the first thing to check against an unexplained
+    link drop on that device, so it has to reach the dashboard.
+    """
+    src = (CONTROLLER / "em_ble_proxy.py").read_text()
+    assert '"hciRestarts"' in src
+    assert '"hciErrors"' in src

--- a/controller/tests/test_db_instrumentation.py
+++ b/controller/tests/test_db_instrumentation.py
@@ -444,3 +444,71 @@ def test_barge_in_turn_records_the_threshold_it_actually_cleared(fresh_db):
     # The comparison logic in em_api treats this as NOT comparable, because the
     # controller's bar (0.10) is below the device's (0.5).
     assert r["wake_threshold"] < r["dev_threshold"]
+
+
+# ── v20: BLE transport resets ────────────────────────────────────────────────
+#
+# The device has counted these since the proxy shipped and sent them inside
+# the stats message's `ble` object; nothing stored them, so "how often does
+# the transport reset" had no answer for the fleet. They matter because
+# /dev/stpbt is the combo radio WiFi also uses.
+
+def test_device_metrics_has_ble_transport_columns(fresh_db):
+    cols = _cols("device_metrics")
+    for c in ("ble_restarts_last", "ble_hci_errors_last"):
+        assert c in cols, f"device_metrics.{c} missing"
+
+
+def test_ble_counters_are_gauges_not_sums(fresh_db):
+    """
+    They are cumulative on the DEVICE, so summing them here multiplies one
+    reset into hundreds — at a report every 30s, an hour of a device sitting
+    at restarts=3 would store 360.
+    """
+    for _ in range(4):
+        db.record_device_stats("D", {"cpuPct": 1.0, "ble": {"restarts": 3,
+                                                            "hciErrors": 7}})
+    row = db._conn.execute(
+        "SELECT ble_restarts_last, ble_hci_errors_last, samples "
+        "FROM device_metrics WHERE device_id = 'D'"
+    ).fetchone()
+    assert row["samples"] == 4, "precondition: four reports folded into the row"
+    assert row["ble_restarts_last"] == 3, "restarts must be a gauge, not a sum"
+    assert row["ble_hci_errors_last"] == 7, "errors must be a gauge, not a sum"
+
+
+def test_a_later_report_replaces_the_earlier_count(fresh_db):
+    db.record_device_stats("D", {"cpuPct": 1.0, "ble": {"restarts": 1, "hciErrors": 1}})
+    db.record_device_stats("D", {"cpuPct": 1.0, "ble": {"restarts": 5, "hciErrors": 9}})
+    row = db._conn.execute(
+        "SELECT ble_restarts_last, ble_hci_errors_last "
+        "FROM device_metrics WHERE device_id = 'D'"
+    ).fetchone()
+    assert (row["ble_restarts_last"], row["ble_hci_errors_last"]) == (5, 9)
+
+
+def test_proxy_off_stores_null_not_zero(fresh_db):
+    """
+    A device with the proxy off never opens the transport, which is not the
+    same fact as opening it and never faltering. Zero would make the two
+    indistinguishable in exactly the query this column exists for.
+    """
+    db.record_device_stats("D", {"cpuPct": 1.0})
+    row = db._conn.execute(
+        "SELECT ble_restarts_last, ble_hci_errors_last "
+        "FROM device_metrics WHERE device_id = 'D'"
+    ).fetchone()
+    assert row["ble_restarts_last"] is None
+    assert row["ble_hci_errors_last"] is None
+
+
+def test_zero_is_stored_as_zero(fresh_db):
+    """The other side of the NULL rule: an enabled proxy reporting a clean
+    transport must store 0, not fall through to NULL on falsiness."""
+    db.record_device_stats("D", {"cpuPct": 1.0, "ble": {"restarts": 0, "hciErrors": 0}})
+    row = db._conn.execute(
+        "SELECT ble_restarts_last, ble_hci_errors_last "
+        "FROM device_metrics WHERE device_id = 'D'"
+    ).fetchone()
+    assert row["ble_restarts_last"] == 0
+    assert row["ble_hci_errors_last"] == 0

--- a/controller/tests/test_esphome_mac.py
+++ b/controller/tests/test_esphome_mac.py
@@ -109,10 +109,22 @@ def _legacy_fleet(tmp_path, serials):
     db.init(str(path))
     for i, s in enumerate(serials):
         db.register_new_device(s, f"10.0.0.{i+2}", "v2.12.0")
-    # Rewind to v18 with the column dropped, as a real pre-v19 database is.
+    # Rewind to v18, as a real pre-v19 database is.
+    #
+    # EVERY column added after v18 has to go, not just esphome_mac: init()
+    # re-runs all of MIGRATIONS[18:], and an ALTER TABLE ADD COLUMN that
+    # finds its column already there fails the whole migration and takes
+    # init() down with it. Dropping only this test's own column made these
+    # cases fail the moment v20 was appended, which is a fragile helper
+    # rather than a real regression — so the set is derived from the
+    # migration SQL and needs no editing next time.
+    import re
     with db._tx() as conn:
         conn.execute("UPDATE devices SET esphome_mac = NULL")
-        conn.execute("ALTER TABLE devices DROP COLUMN esphome_mac")
+        for sql in db.MIGRATIONS[18:]:
+            for table, col in re.findall(
+                    r"ALTER TABLE (\w+)\s+ADD COLUMN (\w+)", sql):
+                conn.execute(f"ALTER TABLE {table} DROP COLUMN {col}")
         conn.execute("UPDATE system_config SET value = '18' WHERE key = 'schema_version'")
     db._conn.close(); db._conn = None
     db.init(str(path))            # runs v19 + its fixup
@@ -158,7 +170,15 @@ def test_migrations_are_append_only():
     The stored schema_version is an index into MIGRATIONS, so appending to a
     deployed entry corrupts every database that already ran it. v19 must be a
     new entry, and v18 must be untouched.
+
+    The length is pinned deliberately. Bumping it is the one moment somebody
+    adding a migration has to look at this file and confirm they APPENDED
+    rather than edited — which is the mistake this guards, and the one that
+    broke every stats write and disconnect-looped the fleet when it happened.
     """
-    assert len(db.MIGRATIONS) == 19
+    assert len(db.MIGRATIONS) == 20
     assert "esphome_mac" in db.MIGRATIONS[18]
     assert "esphome_mac" not in db.MIGRATIONS[17]
+    # v20 is its own entry and did not get appended onto v19's.
+    assert "ble_restarts_last" in db.MIGRATIONS[19]
+    assert "ble_restarts_last" not in db.MIGRATIONS[18]


### PR DESCRIPTION
**The device has been counting BLE transport resets since the proxy shipped and sending them in every stats report. Nothing stored them.** `em_ble_proxy.update_stats` read `advertsSeen` and dropped `restarts` and `hciErrors` on the floor, so the fleet question "how often does this happen, and does it line up with link drops" had no answer anywhere.

That matters because **`/dev/stpbt` is not a Bluetooth device**. It is the MT8163's combo radio behind MediaTek's WMT stack, shared with WiFi, and opening it triggers a BT function-on plus firmware patch download on the chip carrying the WiFi link (`scanner.go`, `session`). So the scanner's own recovery re-initialises the radio the device is connected over. Observed once, Test Echo 1, 2026-08-30:

```
04:00:41 [ble] scan session ended: read /dev/stpbt: ... non-socket
04:00:46 [ble] passive scan running          <- reopen
04:00:48 [data] dial 10.10.1.81:8770: network is unreachable
```

## What changes

- **Schema v20** stores both counters per hour in `device_metrics` as **gauges, not sums**. They are cumulative since the device's process start, so summing at a report every 30s multiplies one reset into hundreds. The latest value makes an hour-to-hour difference the count for that hour, and a value that DROPS means the device restarted. **NULL when the proxy is off** — a device that never opened the transport is not one that opened it and never faltered, and 0 would collapse exactly the distinction the column exists for.
- **`update_stats` warns on a RISE**, never on a non-zero value: the counters never fall on their own, so the latter would repeat one reset every 30s forever and bury the next. A counter going backwards **rebases** rather than reading as a negative delta — otherwise the first genuine reset after a reboot is swallowed all the way back up to the old total.
- The dashboard already showed the pair live; it now goes **amber** when either is non-zero, since that is the first thing to check against an unexplained drop on that device.

## What this does NOT say

Bluetooth is **not** a new candidate for the connectivity history, and this should not be stretched into one. `bleProxyEnabled` defaults `False`, so most devices never open the transport; the RTT excursions were root-caused to packet loss and TCP RTO in #139; and the Lounge/Office swap showed those follow the **location**, crossing over cleanly when the hardware moved rooms (44%→19% one way, 10%→38% the other). This is a different symptom — an interface vanishing outright rather than degrading — and worth telling apart from that family rather than merging into it.

One occurrence plus a plausible mechanism is not a diagnosis. The point of this change is that the second occurrence becomes a query instead of an argument.

## Also fixed

The **v19 test helper** rewound to v18 by dropping only its own column, so appending *any* later migration made three unrelated cases fail on a duplicate-column ALTER. Not a regression in the migration — a fragile helper that would have ambushed the next person to add one. It now derives the drop set from the migration SQL.

`test_migrations_are_append_only` goes to 20, and the pinned length stays pinned on purpose: editing that number is the one moment somebody adding a migration has to confirm they appended rather than edited.

Controller-only, no device change — the wire already carried this. 861 tests pass; `dashboard.jsx` still compiles under the esbuild version the Dockerfile pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiXSQ86bzCWmzExdUPc8uo
