### PR TITLE
Restore the mic stream after a data-plane reconnect

### DIFF
--- a/device/internal/client/data.go
+++ b/device/internal/client/data.go
@@ -148,6 +148,28 @@ type DataClient struct {
 	// defer in connect for the zombie-stream incident this guards against).
 	micConn *websocket.Conn
 
+	// micWanted is the controller's INTENT, which outlives any one data
+	// connection: true from mic_start until mic_stop, across however many
+	// drops happen in between. micActive above is the stream's STATE, and
+	// the two coming apart is the whole point.
+	//
+	// Without this the device goes deaf on any data-plane drop that the
+	// control plane survives. StartMic has exactly two callers — the
+	// controller's mic_start and unmute — so nothing restarted a stream
+	// that died with its socket, and the controller had no reconnect event
+	// to fire a fresh mic_start from because ITS connection never dropped.
+	// Measured twice on Test Echo 1: 34s deaf on 2026-08-29, 41s+ on
+	// 2026-08-30, both from a data-plane reset alone. The controller's
+	// zombie ladder does eventually repair it, which is why this reads as a
+	// slow recovery rather than a dead device — but the device knows it
+	// reconnected and can fix it in zero.
+	//
+	// Mute needs no special case here: muting calls StopMic, which clears
+	// this, and a mic_start arriving while muted is refused in cmd/server.go
+	// before it ever reaches StartMic.
+	micWanted     bool
+	micWantedLock bool
+
 	// beamReq carries a pending beam lock/unlock request from the control
 	// plane to the mic streaming goroutine. Beamformer methods are not safe
 	// to call from other goroutines (same reason beam.Unlock is deferred
@@ -265,6 +287,13 @@ func (d *DataClient) RequestBeamUnlock() {
 func (d *DataClient) StartMic(lockMic bool) {
 	d.micMu.Lock()
 	defer d.micMu.Unlock()
+	// Recorded BEFORE either early return, so an instruction that cannot be
+	// carried out right now is carried out when it can be. That covers the
+	// boot race as well as reconnects: the controller's first mic_start can
+	// beat the data connection into existence, which logs "no connection
+	// yet" and then waits for the controller to ask again — 39 seconds on
+	// 2026-08-30's boot.
+	d.micWanted, d.micWantedLock = true, lockMic
 	if d.micActive {
 		log.Println("[data] StartMic: already active — ignoring")
 		return
@@ -273,7 +302,7 @@ func (d *DataClient) StartMic(lockMic bool) {
 	conn := d.conn
 	d.connMu.Unlock()
 	if conn == nil {
-		log.Println("[data] StartMic: no connection yet")
+		log.Println("[data] StartMic: no connection yet — will start on connect")
 		return
 	}
 	d.micActive = true
@@ -283,9 +312,35 @@ func (d *DataClient) StartMic(lockMic bool) {
 	log.Println("[data] Mic streaming started")
 }
 
+// resumeMic restores the stream on a new data connection when the
+// controller's standing instruction is to stream.
+//
+// Reads the intent under micMu and releases it before calling StartMic,
+// which takes the same lock — the alternative is a StartMic variant that
+// assumes the lock is held, and two entry points into the stream-start path
+// is how the ownership guards around micConn got subtle in the first place.
+// The window between the two acquisitions is harmless: a StopMic landing in
+// it clears micWanted and StartMic's own micActive check makes a double
+// start a no-op.
+func (d *DataClient) resumeMic() {
+	d.micMu.Lock()
+	want, lockMic, active := d.micWanted, d.micWantedLock, d.micActive
+	d.micMu.Unlock()
+	if !want || active {
+		return
+	}
+	log.Println("[data] restoring mic stream on the new connection")
+	d.StartMic(lockMic)
+}
+
 func (d *DataClient) StopMic() {
 	d.micMu.Lock()
 	defer d.micMu.Unlock()
+	// Cleared even when no stream is running, and that is the point: a
+	// mic_stop (or a mute) arriving while the data plane is down must
+	// cancel the intent, or the next connect would restore a stream the
+	// controller has already asked to end.
+	d.micWanted = false
 	if !d.micActive {
 		return
 	}
@@ -385,6 +440,15 @@ func (d *DataClient) connect(ctx context.Context, baseURL string) error {
 		}
 		d.connMu.Unlock()
 	}()
+
+	// Restore the stream the previous connection took with it. Placed after
+	// the publish above because StartMic reads d.conn, and after the defer
+	// so a connection that dies immediately still cleans up.
+	//
+	// Deliberately NOT conditional on this being a reconnect: on a first
+	// connect micWanted is false unless a mic_start already arrived and
+	// could not be served, which is exactly the case worth serving.
+	d.resumeMic()
 
 	// Keepalive — see the wsPingInterval block comment. Deadline refreshes
 	// all happen on this (the read) goroutine: the pong handler runs inside

--- a/device/internal/client/mic_resume_test.go
+++ b/device/internal/client/mic_resume_test.go
@@ -1,0 +1,103 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/wilbowes/EchoMuse/internal/aec"
+)
+
+// The device went deaf on any data-plane drop the CONTROL plane survived.
+// StartMic had two callers — the controller's mic_start and unmute — so
+// nothing restarted a stream that died with its socket, and the controller
+// had no reconnect event to fire a fresh mic_start from. Measured twice on
+// Test Echo 1: 34s deaf (2026-08-29) and 41s+ (2026-08-30).
+//
+// The fix separates the controller's INTENT (micWanted, outlives any one
+// connection) from the stream's STATE (micActive, dies with its socket).
+// These cover the transitions rather than the socket plumbing, which
+// data_race_test.go already exercises.
+
+func newTestClient(t *testing.T) *DataClient {
+	t.Helper()
+	return NewDataClient("resume-test", newFanoutMic(), nil, aec.New())
+}
+
+func micIntent(d *DataClient) (want, active bool) {
+	d.micMu.Lock()
+	defer d.micMu.Unlock()
+	return d.micWanted, d.micActive
+}
+
+func TestAMicStartWithNoConnectionIsRememberedNotDiscarded(t *testing.T) {
+	// The boot race: the controller's first mic_start can beat the data
+	// connection into existence. Discarding it left the device waiting to
+	// be asked again — 39 seconds on 2026-08-30's boot.
+	d := newTestClient(t)
+	d.StartMic(false)
+
+	want, active := micIntent(d)
+	if !want {
+		t.Fatal("mic_start with no connection must record the intent")
+	}
+	if active {
+		t.Fatal("no connection — the stream cannot be active")
+	}
+}
+
+func TestStopClearsTheIntentEvenWithNoStreamRunning(t *testing.T) {
+	// A mic_stop or a mute arriving while the data plane is down has to
+	// cancel the intent, or the next connect restores a stream the
+	// controller has already ended.
+	d := newTestClient(t)
+	d.StartMic(false)
+	d.StopMic()
+
+	if want, _ := micIntent(d); want {
+		t.Fatal("StopMic must clear the intent even when no stream is running")
+	}
+}
+
+func TestResumeDoesNothingWithoutAStandingRequest(t *testing.T) {
+	// A device the controller has not asked to stream must not start
+	// streaming because a socket reconnected.
+	d := newTestClient(t)
+	d.resumeMic()
+
+	if _, active := micIntent(d); active {
+		t.Fatal("resume must not start a stream nobody asked for")
+	}
+}
+
+func TestResumeAfterAStopStaysStopped(t *testing.T) {
+	d := newTestClient(t)
+	d.StartMic(false)
+	d.StopMic()
+	d.resumeMic()
+
+	if _, active := micIntent(d); active {
+		t.Fatal("a stopped mic must stay stopped across a reconnect")
+	}
+}
+
+func TestTheLockFlagSurvivesForTheRestore(t *testing.T) {
+	// lockMic decides whether the beamformer locks to a perimeter mic for
+	// the turn. Restoring a locked stream as unlocked would silently move
+	// the device back to the omni mic mid-turn.
+	d := newTestClient(t)
+	d.StartMic(true)
+
+	d.micMu.Lock()
+	got := d.micWantedLock
+	d.micMu.Unlock()
+	if !got {
+		t.Fatal("lockMic must be remembered for the restore")
+	}
+
+	d.StartMic(false)
+	d.micMu.Lock()
+	got = d.micWantedLock
+	d.micMu.Unlock()
+	if got {
+		t.Fatal("a later unlocked request must replace the remembered flag")
+	}
+}


### PR DESCRIPTION
**The device goes deaf on any data-plane drop the CONTROL plane survives, and stays deaf until the controller notices.** `StartMic` has exactly two callers — the controller's `mic_start` and unmute — so nothing restarts a stream that died with its socket, and the controller has no reconnect event to fire a fresh `mic_start` from, because its own connection never dropped.

Measured on Test Echo 1 twice, from a data-plane reset alone: **34 seconds deaf** (2026-08-29) and **41+ seconds** (2026-08-30, still deaf at the end of the log).

```
04:33:51 [data] streamMic: send error: connection reset by peer
04:33:51 [data] streamMic: exited
04:33:56 [data] Identified as G090LF1180440C95
         <- nothing. No "Mic streaming started", ever again.
04:34:37 [mic] clock: 240.6s audio over 240.3s wall, stalls=0
```

That last line is the point: the capture path was healthy throughout. Nothing was broken except that the only thing which could restart the stream was on the other end of a connection with no reason to act.

## The change

Separates the controller's **intent** from the stream's **state**. `micWanted` is true from `mic_start` until `mic_stop` and outlives any number of dropped connections; `micActive` dies with its socket, as it must. A new data connection restores the stream when the standing instruction is to stream.

This also closes **the boot race**, which is the same fault from the other side: the controller's first `mic_start` can beat the data connection into existence, and `StartMic: no connection yet` discarded it and waited to be asked again — 39 seconds on 2026-08-30's boot. The intent is now recorded before either early return, so an instruction that cannot be served yet is served when it can be.

**Mute needs no special case.** Muting calls `StopMic`, which clears the intent, and a `mic_start` arriving while muted is refused in `cmd/server.go` before it reaches `StartMic`. `StopMic` clears the intent even with no stream running, so a stop landing while the data plane is down is not undone by the next connect.

## Why device-side rather than controller-side

The controller's zombie ladder does eventually repair this, which is why it reads as slow recovery rather than a dead device. But the ladder is bounded in tens of seconds and only runs because something else noticed — and the device already knows it reconnected. Fixing it here costs one flag and removes the whole class.

No protocol change; nothing the controller sends or expects moves. `go vet` clean, full device suite passes, and `-race` on `internal/client` passes with the existing zombie-stream and context-cancel cases, which are the ones that would catch an ownership mistake around `micConn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiXSQ86bzCWmzExdUPc8uo
