### PR TITLE
Say why a device WebSocket closed

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -89,6 +89,7 @@ COPY em_pki.py .
 COPY em_hostip.py .
 COPY em_ingressauth.py .
 COPY em_linkauth.py .
+COPY em_wsclose.py .
 COPY em_rttlog.py .
 COPY em_esphome.py .
 COPY em_ble_health.py .

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -70,6 +70,7 @@ import em_api as api
 import em_pki
 import em_hostip
 import em_linkauth
+import em_wsclose
 import em_rttlog
 import em_eq
 import em_limiter
@@ -109,6 +110,10 @@ log = logging.getLogger("echomuse")
 # controller's own log, not just the relayed per-device one.
 api.install_log_ring(_LOG_FORMAT)
 
+# websockets' own logger stays quiet — its per-connection chatter is not
+# useful — but that ALSO silenced its account of why a connection closed,
+# and the handlers below discarded the exception carrying the close frames.
+# em_wsclose renders that ourselves, so the reason survives the silence.
 logging.getLogger("websockets.server").setLevel(logging.CRITICAL)
 
 
@@ -3736,8 +3741,13 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
     except asyncio.TimeoutError:
         log.warning(f"[control] Registration timeout from {remote}")
 
-    except websockets.exceptions.ConnectionClosed:
-        pass
+    except websockets.exceptions.ConnectionClosed as e:
+        _close_why = em_wsclose.from_exception(e)
+        _msg = f"[control] Connection closed: {em_wsclose.describe(*_close_why)}"
+        if em_wsclose.is_routine(_close_why[0], _close_why[2]):
+            log.info(_msg)
+        else:
+            log.warning(_msg)
 
     except Exception as e:
         log.error(f"[control] Handler error: {e}")
@@ -3820,6 +3830,10 @@ async def _release_device_services(device) -> None:
 async def handle_data(ws: WebSocketServerProtocol, secure: bool = False):
     device = None
     remote = ws.remote_address
+    # Initialised here, not in the handler below: the finally block reports
+    # it on EVERY exit path, including the ones that never raise
+    # ConnectionClosed at all.
+    _close_why = (None, None, None, None)
 
     try:
         raw = await asyncio.wait_for(ws.recv(), timeout=10.0)
@@ -3923,8 +3937,10 @@ async def handle_data(ws: WebSocketServerProtocol, secure: bool = False):
     except asyncio.TimeoutError:
         log.warning(f"[data] Identify timeout from {remote}")
 
-    except websockets.exceptions.ConnectionClosed:
-        pass
+    except websockets.exceptions.ConnectionClosed as e:
+        # Keep the reason — see em_wsclose. Discarding it here is what made
+        # three sessions of intermittent mid-response drops undiagnosable.
+        _close_why = em_wsclose.from_exception(e)
 
     except Exception as e:
         log.error(f"[data] Handler error: {e}")
@@ -3934,7 +3950,15 @@ async def handle_data(ws: WebSocketServerProtocol, secure: bool = False):
             if device.data_ws is ws:
                 device.data_ws = None
                 device.data_ready.clear()
-            log.info(f"[data] Data connection closed: {device.device_id}")
+            _msg = (f"[data] Data connection closed: {device.device_id} — "
+                    f"{em_wsclose.describe(*_close_why)}")
+            if em_wsclose.is_routine(_close_why[0], _close_why[2]):
+                log.info(_msg)
+            else:
+                # A device dropping every few minutes on a keepalive timeout
+                # is indistinguishable from one that never dropped, in a log
+                # of INFO lines.
+                log.warning(_msg)
 
 
 # ─── Router ───────────────────────────────────────────────────────────────────

--- a/controller/em_wsclose.py
+++ b/controller/em_wsclose.py
@@ -1,0 +1,109 @@
+"""Why a device WebSocket closed, in words, from the close frames.
+
+Every device-plane drop has logged "Data connection closed: <id>" and nothing
+else, because the reason was being discarded in two places at once:
+`except websockets.exceptions.ConnectionClosed: pass` threw away the
+exception carrying the close frames, and `websockets.server` is pinned to
+CRITICAL so the library's own account of it never printed either. Three
+sessions of chasing intermittent mid-response drops had timing to reason
+from and no stated cause (2026-08-30).
+
+Pure so it can be tested: em_controller imports websockets and aiohttp and
+cannot be imported by the CI test job, which is the same reason em_volume,
+em_linkauth and em_ble_health live on their own.
+
+WHICH SIDE CLOSED IS THE WHOLE POINT. A close frame we SENT means the
+controller gave up on the device; one we RECEIVED means the device or its
+network went first; neither means the TCP connection died with no close
+frame at all, which is a network event rather than a decision. Those three
+want different investigations, and the log line has to say which it was.
+
+The case this was written for is `sent 1011 keepalive ping timeout`: the
+server pings every 20s and closes if no pong arrives within 10s
+(`websockets.serve(ping_interval=20, ping_timeout=10)`), so a link saturated
+by a burst of response audio can lose the pong and take the connection with
+it. That reads as the device failing when it is the pacing.
+"""
+
+from typing import Optional
+
+# Close codes worth naming. Anything else is rendered as its number, which
+# is more honest than a wrong guess.
+_CODES = {
+    1000: "normal",
+    1001: "going away",
+    1002: "protocol error",
+    1003: "unsupported data",
+    1005: "no status",
+    1006: "abnormal — no close frame",
+    1007: "invalid payload",
+    1008: "policy violation",
+    1009: "message too big",
+    1011: "internal error",
+    1012: "service restart",
+    1013: "try again later",
+    1015: "TLS failure",
+}
+
+# Codes that mean an ordinary, expected end of connection. Everything else is
+# worth a warning: a device that reconnects every few minutes on 1011 looks
+# identical, in a log of INFO lines, to one that never dropped at all.
+ROUTINE = frozenset({1000, 1001})
+
+
+def _one(code: Optional[int], reason: Optional[str]) -> str:
+    name = _CODES.get(code, "unknown")
+    text = (reason or "").strip()
+    return f"{code} ({name}){f' {text!r}' if text else ''}"
+
+
+def describe(
+    sent_code: Optional[int] = None,
+    sent_reason: Optional[str] = None,
+    rcvd_code: Optional[int] = None,
+    rcvd_reason: Optional[str] = None,
+) -> str:
+    """
+    One clause naming who closed the connection and why.
+
+    Both frames are reported when both exist — a clean shutdown echoes the
+    code back, and a mismatch between what we sent and what came back is
+    itself worth seeing.
+    """
+    if sent_code is None and rcvd_code is None:
+        return "closed with no close frame either way (TCP reset or link loss)"
+    if sent_code is not None and rcvd_code is not None:
+        return f"we closed {_one(sent_code, sent_reason)}, peer echoed {_one(rcvd_code, rcvd_reason)}"
+    if sent_code is not None:
+        return f"we closed it: {_one(sent_code, sent_reason)}"
+    return f"peer closed it: {_one(rcvd_code, rcvd_reason)}"
+
+
+def is_routine(sent_code: Optional[int], rcvd_code: Optional[int]) -> bool:
+    """
+    Whether this close is the ordinary end of a connection.
+
+    A missing code is NOT routine: it means the socket died without either
+    side saying so, which is exactly the case being hunted.
+    """
+    code = sent_code if sent_code is not None else rcvd_code
+    return code in ROUTINE
+
+
+def from_exception(exc) -> tuple:
+    """
+    Pull (sent_code, sent_reason, rcvd_code, rcvd_reason) off a
+    websockets ConnectionClosed.
+
+    Duck-typed against `.sent` / `.rcvd` rather than the `.code` / `.reason`
+    shorthand, which is deprecated in websockets 15 and emits a warning per
+    access; requirements pin 17.0.1, where relying on it would be a bet.
+    Everything is fetched defensively so a library change degrades to a
+    vaguer log line instead of raising inside an exception handler.
+    """
+    sent = getattr(exc, "sent", None)
+    rcvd = getattr(exc, "rcvd", None)
+    return (
+        getattr(sent, "code", None), getattr(sent, "reason", None),
+        getattr(rcvd, "code", None), getattr(rcvd, "reason", None),
+    )

--- a/controller/em_wsclose.py
+++ b/controller/em_wsclose.py
@@ -15,7 +15,8 @@ em_linkauth and em_ble_health live on their own.
 WHICH SIDE CLOSED IS THE WHOLE POINT. A close frame we SENT means the
 controller gave up on the device; one we RECEIVED means the device or its
 network went first; neither means the TCP connection died with no close
-frame at all, which is a network event rather than a decision. Those three
+frame at all, which is a network event rather than a decision (or, more rarely, a handler
+error, which logs its own line). Those three
 want different investigations, and the log line has to say which it was.
 
 The case this was written for is `sent 1011 keepalive ping timeout`: the
@@ -71,7 +72,12 @@ def describe(
     itself worth seeing.
     """
     if sent_code is None and rcvd_code is None:
-        return "closed with no close frame either way (TCP reset or link loss)"
+        # No cause asserted. This is also reached when the handler exits
+        # on something other than a close — a generic error, which logs
+        # its own line just above — and a diagnostic that guesses is the
+        # habit this module exists to break.
+        return ("closed with no close frame either way "
+                "(TCP reset, link loss, or an error logged above)")
     if sent_code is not None and rcvd_code is not None:
         return f"we closed {_one(sent_code, sent_reason)}, peer echoed {_one(rcvd_code, rcvd_reason)}"
     if sent_code is not None:

--- a/controller/tests/test_ws_close_reason.py
+++ b/controller/tests/test_ws_close_reason.py
@@ -1,0 +1,141 @@
+"""
+Why a device WebSocket closed — the line that did not exist.
+
+Every device-plane drop logged "Data connection closed: <id>" and nothing
+more, because the reason was discarded twice over: the handlers caught
+`ConnectionClosed` and `pass`ed, throwing away the exception carrying the
+close frames, and `websockets.server` is pinned to CRITICAL so the library
+never printed its own account either. Three sessions chasing intermittent
+mid-response drops had timing to reason from and no stated cause
+(2026-08-30).
+
+em_controller imports websockets and aiohttp and cannot be imported by the
+CI test job, so the rendering lives in em_wsclose and is tested here; that
+the handlers actually call it is asserted against the source.
+"""
+
+import re
+from pathlib import Path
+
+import em_wsclose as wsc
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+class _Close:
+    """Duck-type of websockets.frames.Close."""
+
+    def __init__(self, code, reason=""):
+        self.code = code
+        self.reason = reason
+
+
+class _Exc:
+    def __init__(self, sent=None, rcvd=None):
+        self.sent = sent
+        self.rcvd = rcvd
+
+
+# ── Which side closed ────────────────────────────────────────────────────────
+#
+# The three cases want different investigations, so the line has to say which
+# it was: we gave up on the device, the device went first, or the TCP
+# connection died with nobody saying anything.
+
+def test_a_close_we_sent_is_attributed_to_us():
+    out = wsc.describe(1011, "keepalive ping timeout", None, None)
+    assert "we closed" in out
+    assert "1011" in out and "keepalive ping timeout" in out
+
+
+def test_a_close_the_peer_sent_is_attributed_to_them():
+    out = wsc.describe(None, None, 1001, "going away")
+    assert "peer closed" in out
+    assert "1001" in out
+
+
+def test_no_frame_either_way_says_so_rather_than_guessing():
+    """
+    The socket died with neither side announcing it — a network event, not a
+    decision, and it must not be reported as one.
+    """
+    out = wsc.describe(None, None, None, None)
+    assert "no close frame" in out
+    assert "TCP reset or link loss" in out
+
+
+def test_both_frames_are_reported_when_both_exist():
+    out = wsc.describe(1000, "", 1000, "")
+    assert "we closed" in out and "echoed" in out
+
+
+# ── Severity ─────────────────────────────────────────────────────────────────
+
+def test_an_ordinary_close_is_routine():
+    assert wsc.is_routine(1000, 1000)
+    assert wsc.is_routine(None, 1001)
+
+
+def test_a_keepalive_timeout_is_not_routine():
+    """The case this was written for. 1011 landing at INFO would leave a
+    device dropping every few minutes looking identical to one that never
+    dropped at all."""
+    assert not wsc.is_routine(1011, None)
+
+
+def test_a_missing_code_is_not_routine():
+    """
+    No code means the socket died without either side saying so, which is
+    exactly what is being hunted — it must not be filed as a clean exit.
+    """
+    assert not wsc.is_routine(None, None)
+
+
+# ── Extraction ───────────────────────────────────────────────────────────────
+
+def test_the_frames_are_read_off_the_exception():
+    parts = wsc.from_exception(
+        _Exc(sent=_Close(1011, "keepalive ping timeout"), rcvd=None))
+    assert parts == (1011, "keepalive ping timeout", None, None)
+    assert wsc.describe(*parts).startswith("we closed it")
+
+
+def test_an_exception_without_frames_degrades_instead_of_raising():
+    """
+    `.sent`/`.rcvd` are used rather than the `.code`/`.reason` shorthand,
+    which is deprecated in websockets 15 and warns on every access while
+    requirements pin 17.0.1. A library change must cost a vaguer log line,
+    never an exception raised inside an exception handler.
+    """
+    assert wsc.from_exception(object()) == (None, None, None, None)
+    assert wsc.from_exception(_Exc()) == (None, None, None, None)
+
+
+def test_an_unknown_code_is_rendered_not_guessed():
+    out = wsc.describe(4999, "custom", None, None)
+    assert "4999" in out and "unknown" in out
+
+
+# ── The wiring, asserted on source ───────────────────────────────────────────
+
+def test_both_device_planes_report_the_reason():
+    src = (CONTROLLER / "em_controller.py").read_text()
+    assert "import em_wsclose" in src
+    # The bug was `except ConnectionClosed: pass` — two of them, one per
+    # plane. Neither may come back.
+    assert not re.search(r"except websockets\.exceptions\.ConnectionClosed:\s*\n\s*pass",
+                         src), "a plane is discarding the close reason again"
+    assert len(re.findall(r"em_wsclose\.from_exception\(", src)) >= 2, \
+        "both the control and data planes must capture the close frames"
+
+
+def test_the_data_plane_cannot_report_an_unset_reason():
+    """
+    The finally block logs on EVERY exit path, including the ones that never
+    raise ConnectionClosed, so the tuple has to exist before the try.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    handler = src[src.index("async def handle_data("):]
+    handler = handler[:handler.index("\n    try:")]
+    assert "_close_why = (None, None, None, None)" in handler, \
+        "_close_why must be initialised before the try, or the finally NameErrors"

--- a/controller/tests/test_ws_close_reason.py
+++ b/controller/tests/test_ws_close_reason.py
@@ -61,7 +61,9 @@ def test_no_frame_either_way_says_so_rather_than_guessing():
     """
     out = wsc.describe(None, None, None, None)
     assert "no close frame" in out
-    assert "TCP reset or link loss" in out
+    # No single cause asserted: this is also the path taken when the handler
+    # exits on a generic error rather than a close.
+    assert "TCP reset" in out and "error logged above" in out
 
 
 def test_both_frames_are_reported_when_both_exist():


### PR DESCRIPTION
**Every device-plane drop has logged "Data connection closed: `<id>`" and nothing else.** The reason was being discarded twice over:

```
em_controller.py:112   logging.getLogger("websockets.server").setLevel(logging.CRITICAL)
em_controller.py:3739  except ConnectionClosed: pass    # control plane
em_controller.py:3926  except ConnectionClosed: pass    # data plane
```

The first silences the library's own account of the close; the other two throw away the exception carrying the close frames, at the one point where they exist. Three sessions chasing intermittent mid-response drops on Test Echo 1 have had timing to reason from and no stated cause — which is why this is its own change rather than a line inside the eventual fix.

Both planes now say it:

```
[data] Data connection closed: G090LF1180440C95 —
       we closed it: 1011 (internal error) 'keepalive ping timeout'
```

## The three cases, kept apart

**Which side closed is the point.** A frame we SENT means the controller gave up on the device; one we RECEIVED means the device or its network went first; neither means the TCP connection died with nobody saying anything. Those want different investigations, so the line distinguishes them rather than reporting "closed".

**Non-routine closes log at WARNING**, and only 1000/1001 are routine. A device dropping every few minutes on a keepalive timeout is otherwise indistinguishable, in a log of INFO lines, from one that never dropped. A **missing** code counts as non-routine for the same reason: a socket that died without either side announcing it is exactly the case being hunted.

## Version safety

The frames are read off `.sent`/`.rcvd`, not the `.code`/`.reason` shorthand — deprecated in websockets 15, warns on every access, and requirements pin **17.0.1**, where relying on it would be a bet. Every attribute is fetched defensively so a library change costs a vaguer log line rather than raising inside an exception handler. Verified against the real library across all four shapes with warnings promoted to errors:

| | rendered |
|---|---|
| server keepalive timeout | `we closed it: 1011 (internal error) 'keepalive ping timeout'` |
| peer went away | `peer closed it: 1001 (going away)` |
| clean both ways | `we closed 1000 (normal), peer echoed 1000 (normal)` |
| abnormal, no frames | `closed with no close frame either way (TCP reset or link loss)` |

`em_wsclose` is a separate module because `em_controller` imports websockets and aiohttp and cannot be imported by the CI test job — same reason as `em_volume`, `em_linkauth` and `em_ble_health`. That the handlers call it is asserted against the source, including that neither `except ConnectionClosed: pass` comes back.

`_close_why` is initialised before the `try` in `handle_data`: the `finally` reports on every exit path, including the ones that never raise `ConnectionClosed`, and would otherwise `NameError` on the normal path.

## This diagnoses, it does not fix

The leading candidate is the pong timeout — `ping_interval=20`/`ping_timeout=10` against a link the controller has just saturated pushing **3.4MB of response audio in 21.3s, 9.8s of it blocked in socket writes** — but that is inference from timing, which is the thing this change exists to stop us doing. #140 is where the fix belongs once the next drop states its own cause.

Controller-only, no device change. 878 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiXSQ86bzCWmzExdUPc8uo
