### PR TITLE
Pace the voice stream, so a long response stops cutting itself off

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -89,6 +89,7 @@ COPY em_pki.py .
 COPY em_hostip.py .
 COPY em_ingressauth.py .
 COPY em_linkauth.py .
+COPY em_pacing.py .
 COPY em_wsclose.py .
 COPY em_rttlog.py .
 COPY em_esphome.py .

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -70,6 +70,7 @@ import em_api as api
 import em_pki
 import em_hostip
 import em_linkauth
+import em_pacing
 import em_wsclose
 import em_rttlog
 import em_eq
@@ -176,6 +177,41 @@ CHUNK_BYTES          = 1280 * 2   # 2560 bytes = 80ms at 16kHz S16_LE mono
 SPEAKER_RATE   = 48000
 SPEAKER_PERIOD = 2048
 SPEAKER_BYTES  = SPEAKER_PERIOD * 2       # 4096 bytes/period (mono S16)
+SPEAKER_PERIOD_SECONDS = SPEAKER_BYTES / (SPEAKER_RATE * 2)   # ~42.7ms
+
+# How far ahead of realtime a VOICE response may be queued.
+#
+# The voice path used to send every period as fast as the socket would take
+# it, with TCP backpressure as the only brake. That is what cut long
+# responses off mid-sentence, and the chain is mechanical:
+#
+#   1. controller pushes ~1.7x realtime, bounded only by the link
+#   2. the device's WS read goroutine calls PumpPeriod INLINE per 0x02 frame
+#   3. pump() ends in a BLOCKING channel send, on a channel 128 periods
+#      (~5.5s) deep
+#   4. once full, the read goroutine blocks inside PumpPeriod and stops
+#      calling ReadMessage
+#   5. gorilla fires the pong handler only INSIDE ReadMessage, so a blocked
+#      device cannot answer a ping
+#   6. we ping every 20s and close after 10s without a pong
+#   7. the buffer drains at realtime, so the block outlasts the timeout
+#   8. 1011 keepalive ping timeout, mid-response
+#
+# Measured on Test Echo 1, 2026-08-30: 3.4MB (35.4s of audio) sent in 21.3s,
+# 9.8s of that blocked in socket writes, connection closed 5s later. Short
+# responses never reproduce it because they never fill 5.5s.
+#
+# SENDING FASTER THAN THIS BUYS NOTHING. The device can hold 5.5s and no
+# more; everything beyond that sits in TCP buffers, which are lost on a
+# reconnect exactly like un-sent audio is. So the excess never improved
+# stall resilience — it only bought the block. Pacing to just under the
+# device's own depth keeps the same protection with none of the cost.
+#
+# 4.0s to match em_player.LEAD_S, which reached the same number from the
+# same constraint for the music plane: ~1.4s of headroom under audioChanDepth
+# so the feed can never outrun the device's channel. Voice had no equivalent,
+# and that asymmetry was the bug.
+VOICE_LEAD_S = 4.0
 
 # The device holds playback until ~this much audio is buffered (or EOS
 # arrives) — primePeriods in pcm_speaker.go. The post-playback drain sleep
@@ -923,10 +959,15 @@ class Device:
         # an investigation on 2026-07-20.
         send_seconds = 0.0
         first_send_time = None
+        # Audio actually handed to the socket, in seconds of playback, and
+        # the time pacing spent waiting. sent_seconds against wall time since
+        # the first period is the lead being held.
+        sent_seconds = 0.0
+        paced_seconds = 0.0
 
         async def send_period(chunk: bytes) -> None:
             """Send one whole device period, stamping the first one."""
-            nonlocal first_send_time, send_seconds
+            nonlocal first_send_time, send_seconds, sent_seconds, paced_seconds
             if first_send_time is None:
                 first_send_time = asyncio.get_event_loop().time()
                 self.playback_send_t0 = first_send_time
@@ -935,9 +976,34 @@ class Device:
                     f"[{self.device_id}] First streamed PCM period "
                     "sent to device"
                 )
+            else:
+                # Hold the queue to VOICE_LEAD_S ahead of realtime — see the
+                # constant for why sending faster is pure cost. The first
+                # period is exempt so nothing delays the start of playback,
+                # and the lead is then free to build at full speed until it
+                # is reached, which keeps the prime gate as prompt as it was.
+                delay = em_pacing.lead_delay(
+                    sent_seconds,
+                    asyncio.get_event_loop().time() - first_send_time,
+                    VOICE_LEAD_S,
+                )
+                if delay > 0:
+                    paced_seconds += delay
+                    # Raced against cancel_event, never a bare sleep: a
+                    # barge-in or mute has to land inside the pacing gap
+                    # rather than after it, or pacing would add its own
+                    # latency to the thing it must never delay.
+                    try:
+                        await asyncio.wait_for(
+                            self.cancel_event.wait(), timeout=delay)
+                    except asyncio.TimeoutError:
+                        pass
+                    if self.cancel_event.is_set():
+                        return
             _t_send = asyncio.get_event_loop().time()
             await self.send_data(bytes([SPEAKER_FRAME_TYPE]) + chunk)
             send_seconds += asyncio.get_event_loop().time() - _t_send
+            sent_seconds += SPEAKER_PERIOD_SECONDS
 
         async def drain_whole_periods() -> None:
             while len(pending) >= SPEAKER_BYTES:
@@ -988,7 +1054,8 @@ class Device:
             except BaseException:
                 pass
 
-        return total_pcm, int(eq_seconds * 1000), first_send_time, int(send_seconds * 1000)
+        return (total_pcm, int(eq_seconds * 1000), first_send_time,
+                int(send_seconds * 1000), int(paced_seconds * 1000))
 
 
 # The live device registry — keyed by device_id (ro.serialno).
@@ -1785,7 +1852,7 @@ async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
             log.info(f"[{device.device_id}] Cancelled during streamed playback")
             return 0
 
-        total_pcm, eq_ms, first_send_time, send_ms = stream_task.result()
+        total_pcm, eq_ms, first_send_time, send_ms, paced_ms = stream_task.result()
         device.playback_eq_ms = eq_ms
         device.playback_send_ms = send_ms
         stream_elapsed = asyncio.get_event_loop().time() - t_stream_start
@@ -1813,7 +1880,8 @@ async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
             f"[{device.device_id}] Streamed {total_pcm} bytes "
             f"({total_pcm//SPEAKER_BYTES} periods) in {stream_elapsed:.1f}s "
             f"while HA generated audio (socket writes {send_ms}ms — NOT "
-            f"delivery, see delivery_ms); awaiting device playback_stats "
+            f"delivery, see delivery_ms; paced {paced_ms}ms holding "
+            f"{VOICE_LEAD_S:.0f}s of lead); awaiting device playback_stats "
             f"(est {audio_duration:.1f}s, timeout {timeout:.1f}s)"
         )
         timeout_task = asyncio.create_task(asyncio.sleep(timeout))

--- a/controller/em_pacing.py
+++ b/controller/em_pacing.py
@@ -1,0 +1,43 @@
+"""How far ahead of realtime a device audio stream may be queued.
+
+One rule, extracted so it can be tested: em_controller imports websockets
+and aiohttp and cannot be imported by the CI test job, the same reason
+em_volume, em_linkauth, em_ble_health and em_wsclose live on their own.
+
+WHY PACING IS NOT OPTIONAL. The voice path used to send every period as fast
+as the socket would take it, and that cut long responses off mid-sentence.
+The device's WebSocket read goroutine calls PumpPeriod inline for each audio
+frame, and pump() ends in a BLOCKING send on a channel 128 periods (~5.5s)
+deep. Fill that channel and the read goroutine stops calling ReadMessage —
+which is the only place gorilla fires the pong handler, so the device cannot
+answer a keepalive ping. The controller pings every 20s and closes after 10s
+without a pong, and the buffer drains at realtime, so the block outlasts the
+timeout. Measured 2026-08-30: 35.4s of audio sent in 21.3s, 9.8s of it
+blocked in socket writes, `1011 keepalive ping timeout` five seconds later.
+
+WHY IT COSTS NOTHING. The device can hold ~5.5s and no more. Everything sent
+beyond that sits in TCP buffers, which are lost on a reconnect exactly like
+audio that was never sent — so the excess never bought stall resilience. It
+only bought the block.
+"""
+
+
+def lead_delay(sent_seconds: float, elapsed_seconds: float,
+               lead_seconds: float) -> float:
+    """
+    Seconds to wait before queueing more audio, to hold the stream at
+    `lead_seconds` ahead of realtime.
+
+    `sent_seconds` is audio handed to the socket measured in playback time;
+    `elapsed_seconds` is wall time since the first period went out. Their
+    difference is the lead currently held.
+
+    Never negative. A stream that has fallen BEHIND realtime — a slow
+    producer, a link stall — must not be told to wait, and must not be
+    handed a negative timeout, which asyncio.wait_for treats as an immediate
+    timeout rather than an error and would hide the condition.
+    """
+    ahead = sent_seconds - elapsed_seconds
+    if ahead <= lead_seconds:
+        return 0.0
+    return ahead - lead_seconds

--- a/controller/tests/test_voice_pacing.py
+++ b/controller/tests/test_voice_pacing.py
@@ -1,0 +1,121 @@
+"""
+Pacing the voice stream, and why it has to exist at all.
+
+The voice path sent every period as fast as the socket would take it. That
+cut long responses off mid-sentence, by a chain that is mechanical rather
+than probabilistic:
+
+  the device's WS read goroutine calls PumpPeriod INLINE per audio frame →
+  pump() ends in a BLOCKING send on a channel 128 periods (~5.5s) deep →
+  once full the read goroutine stops calling ReadMessage → gorilla fires the
+  pong handler only inside ReadMessage → the device cannot answer a ping →
+  we close after 10s without one → 1011 mid-response.
+
+Measured on Test Echo 1, 2026-08-30: 35.4s of audio sent in 21.3s, 9.8s of
+it blocked in socket writes, connection closed five seconds later. Short
+responses never reproduce it because they never fill 5.5s.
+
+em_controller cannot be imported here (websockets, aiohttp), so the rule is
+tested through em_pacing and the wiring is asserted against the source.
+"""
+
+import re
+from pathlib import Path
+
+import em_pacing
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+DEVICE = CONTROLLER.parent / "device"
+
+
+def test_no_delay_while_under_the_lead():
+    assert em_pacing.lead_delay(sent_seconds=2.0, elapsed_seconds=0.0,
+                                lead_seconds=4.0) == 0.0
+
+
+def test_the_delay_is_exactly_the_excess():
+    assert em_pacing.lead_delay(10.0, 3.0, 4.0) == 3.0
+
+
+def test_a_stream_behind_realtime_is_never_told_to_wait():
+    """
+    A slow producer or a link stall leaves the stream behind realtime.
+    Returning a negative here would be handed to asyncio.wait_for, which
+    treats a negative timeout as an immediate timeout rather than an error —
+    so the bug would not raise, it would just quietly stop pacing.
+    """
+    assert em_pacing.lead_delay(1.0, 9.0, 4.0) == 0.0
+    assert em_pacing.lead_delay(0.0, 0.0, 4.0) == 0.0
+
+
+def test_a_fast_producer_settles_at_the_lead_and_never_exceeds_it():
+    """
+    The property that actually matters: however fast audio is produced, the
+    queue ahead of the device converges to the lead and stays there.
+    """
+    lead, period = 4.0, 0.0427
+    now, sent, worst = 0.0, 0.0, 0.0
+    for _ in range(2000):                     # ~85s of audio
+        now += em_pacing.lead_delay(sent, now, lead)
+        sent += period
+        worst = max(worst, sent - now)
+    assert worst <= lead + period + 1e-9, f"queued {worst:.2f}s ahead"
+    assert sent - now > lead - period, "should hold the lead, not collapse to realtime"
+
+
+def test_the_lead_stays_under_the_device_buffer():
+    """
+    Cross-language guard. VOICE_LEAD_S must stay below the device's own
+    channel depth or the fix is void — the point is that the device's
+    channel never fills, and a lead at or above it fills it by design.
+
+    Read from the Go source rather than restated, so raising audioChanDepth
+    on one side and not the other is caught here instead of on hardware.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    lead = float(re.search(r"^VOICE_LEAD_S\s*=\s*([\d.]+)", src, re.M).group(1))
+    rate = int(re.search(r"^SPEAKER_RATE\s*=\s*(\d+)", src, re.M).group(1))
+    period = int(re.search(r"^SPEAKER_PERIOD\s*=\s*(\d+)", src, re.M).group(1))
+
+    go = (DEVICE / "internal/bindings/speaker/pcm_speaker.go").read_text()
+    depth = int(re.search(r"audioChanDepth\s*=\s*(\d+)", go).group(1))
+
+    device_seconds = depth * period / rate
+    assert lead < device_seconds, (
+        f"VOICE_LEAD_S={lead}s is not under the device's {device_seconds:.1f}s "
+        f"channel ({depth} periods) — the queue would fill it and block the "
+        f"read goroutine, which is the bug being fixed"
+    )
+    # Headroom, not a hairline pass: em_player.LEAD_S keeps ~1.4s for the
+    # same reason on the music plane.
+    assert device_seconds - lead >= 1.0, "less than 1s of headroom under the device buffer"
+
+
+# ── The wiring ───────────────────────────────────────────────────────────────
+
+def test_the_pacing_wait_is_raced_against_cancel():
+    """
+    A barge-in or mute must land INSIDE the pacing gap. A bare sleep would
+    add pacing latency to the one thing that must never be delayed.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    block = src[src.index("async def send_period("):]
+    block = block[:block.index("sent_seconds += SPEAKER_PERIOD_SECONDS")]
+    assert "em_pacing.lead_delay(" in block, "send_period must consult the pacer"
+    assert "cancel_event.wait()" in block, \
+        "the pacing wait must be raced against cancel_event, not a bare sleep"
+    assert "asyncio.sleep(" not in block, "a bare sleep here swallows a barge-in"
+
+
+def test_the_first_period_is_never_paced():
+    """
+    Nothing may delay the start of playback; the lead builds at full speed
+    until it is reached. Expressed as the pacer living in the `else` of the
+    first-period branch.
+    """
+    src = (CONTROLLER / "em_controller.py").read_text()
+    block = src[src.index("async def send_period("):]
+    block = block[:block.index("sent_seconds += SPEAKER_PERIOD_SECONDS")]
+    first = block.index("First streamed PCM period")
+    assert block.index("em_pacing.lead_delay(") > first, \
+        "pacing must come after the first-period branch, never before it"

--- a/controller/tests/test_wake_watchdog.py
+++ b/controller/tests/test_wake_watchdog.py
@@ -76,7 +76,11 @@ def test_both_time_sources_are_updated():
     hd = hd[:hd.index("async def", 10)]
     assert "data_connected_at" in hd, \
         "handle_data must timestamp each new connection"
-    wl = src[src.index("payload = await asyncio.wait_for("):
-             src.index("except asyncio.TimeoutError")]
+    # Both ends anchored from the SAME start, or the slice silently inverts:
+    # the end marker is searched from 0, so any `except asyncio.TimeoutError`
+    # appearing earlier in the file (voice-stream pacing added one) makes
+    # this src[later:earlier] — an empty string that fails with no clue why.
+    _wl_start = src.index("payload = await asyncio.wait_for(")
+    wl = src[_wl_start:src.index("except asyncio.TimeoutError", _wl_start)]
     assert "frames_seen_this_connection = True" in wl, \
         "a delivered frame must set the flag"


### PR DESCRIPTION
**Long responses have been cutting themselves off mid-sentence.** The chain is mechanical, not probabilistic, and every link is in the code:

1. The voice path sends every period as fast as the socket accepts — TCP backpressure is the only brake (`stream_speaker_chunks`)
2. The device's WS read goroutine calls `PumpPeriod` **inline** per `0x02` frame (`data.go:453`)
3. `pump()` ends in a **blocking** channel send, on a channel **128 periods ≈ 5.5s** deep (`stream.go:147`)
4. Once full, that goroutine blocks inside `PumpPeriod` and stops calling `ReadMessage`
5. gorilla fires the pong handler only **inside** `ReadMessage` — a blocked device cannot answer a keepalive ping
6. We ping every 20s and close after 10s without a pong
7. The buffer drains at realtime, so the block outlasts the timeout
8. → `1011 keepalive ping timeout`, mid-response

Measured on Test Echo 1, 2026-08-30: **3,397,174 bytes — 35.4s of audio — sent in 21.3s**, 9.8s of that blocked in socket writes, connection closed five seconds later. Short responses never reproduce it because they never fill 5.5s, which is why this reads as intermittent.

## The music plane already solved this

`em_player.LEAD_S` is 4.0s, and its comment reaches the same conclusion from the same constraint — *"~1.4s of headroom under the device's own depth so the feed can never outrun audioCh"*. **Voice had no equivalent.** That asymmetry was the bug, and `VOICE_LEAD_S` is 4.0 to match.

## Sending faster bought nothing

The device holds ~5.5s and no more. Everything beyond that sat in TCP buffers — **lost on a reconnect exactly like audio that was never sent**. So the excess never improved stall resilience; it only bought the block. Replaying the measured run:

| | send span | max queued ahead | device channel filled |
|---|---|---|---|
| unpaced (today) | 21.3s | **35.4s** | **yes** |
| paced, `VOICE_LEAD_S=4` | 31.3s | 4.0s | no |

## Three properties that keep it safe

- **Pacing can never slow a stream below its producer.** A run behind realtime computes a zero delay, so a slow HA or a stalled link is never made worse.
- **The first period is exempt**, and the lead builds at full speed until reached — the prime gate is exactly as prompt as it was.
- **The wait is raced against `cancel_event`, not a bare sleep.** Otherwise pacing would add its own latency to barge-in, the one thing it must never delay.

`send_ms` still deliberately excludes the pacing wait — it is documented as socket-write time that *"completes near-instantly however slow the link is"*, and folding a deliberate wait into it would recreate the misreading that cost an investigation on 2026-07-20. Paced time is reported separately.

## Testing

The rule lives in `em_pacing` so it can be tested — `em_controller` imports websockets and aiohttp and cannot be imported by the CI test job, same reason as `em_volume`, `em_linkauth`, `em_ble_health` and `em_wsclose`.

The lead is guarded against the device's `audioChanDepth` **read from the Go source**, so raising one without the other fails in CI rather than on hardware.

Also fixes a latent fragility in `test_wake_watchdog`: it sliced source with an unanchored `index()` for the end marker, so any `except asyncio.TimeoutError` appearing *earlier* in `em_controller` inverted the slice to an empty string and failed with no clue why. Pacing added one. Both ends now anchor from the same start.

Controller-only, no device change. 886 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiXSQ86bzCWmzExdUPc8uo
