### PR TITLE
Early Access 2.22.0-ea.7, and write down what today cost to find

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1812,3 +1812,117 @@ with its own leakage, so a weaker 440Hz component would not have shown. It
 does not affect production — the wire is mono and the device duplicates L=R —
 but it decides which channel is the correct reference if that ever changes.
 
+## 2026-08-30 — the long-response cutout, root-caused; and why the AEC is stuck at ~10dB
+
+Two answers today, both of which had been mistaken for other things.
+
+### Long responses were cutting off mid-sentence, and it was never the network
+
+Three sessions of testing had been ruined by the same drop, and it kept
+reading as a link fault because that is what the symptom looks like. It is
+not. The chain is mechanical, and every link is in our own code:
+
+1. the voice path sent every period as fast as the socket accepted, with TCP
+   backpressure as the only brake
+2. the device's WebSocket read goroutine calls `PumpPeriod` **inline** per
+   `0x02` frame
+3. `pump()` ends in a **blocking** channel send, on a channel 128 periods
+   (~5.5s) deep
+4. once full, that goroutine blocks inside `PumpPeriod` and stops calling
+   `ReadMessage`
+5. gorilla fires the pong handler only **inside** `ReadMessage` — a blocked
+   device cannot answer a keepalive ping
+6. we ping every 20s and close after 10s without a pong
+7. the buffer drains at realtime, so the block outlasts the timeout
+8. `1011 keepalive ping timeout`, mid-response
+
+Measured: **3,397,174 bytes — 35.4s of audio — sent in 21.3s**, 9.8s of it
+blocked in socket writes, connection closed five seconds later. Short
+responses never reproduce it because they never fill 5.5s, which is why six
+weeks of it read as intermittent.
+
+**The music plane had already solved this and voice never got the fix.**
+`em_player.LEAD_S` has been 4.0s since 2026-07-25, sized against the device's
+own depth with ~1.4s of headroom, and its comment states the constraint
+exactly. Voice queued the whole response. That asymmetry was the bug, and
+`VOICE_LEAD_S` = 4.0 now matches.
+
+**Sending faster bought nothing** — the point worth keeping. The device holds
+~5.5s and no more, so everything beyond that sat in TCP buffers, which are
+lost on a reconnect exactly like audio never sent. The excess never improved
+stall resilience. It only bought the block.
+
+**Two diagnostics had to be built before this was findable.** Every drop had
+logged `Data connection closed: <id>` and nothing else, because
+`except ConnectionClosed: pass` discarded the close frames and
+`websockets.server` is pinned to CRITICAL. Three sessions had timing to
+reason from and no stated cause. `em_wsclose` now renders the frames, and
+says which SIDE closed — we gave up on the device, the device went first, or
+the socket died with nobody saying anything are three different
+investigations.
+
+### The AEC is not limited by its reference, and never was
+
+**We vendored `mdf.c` and not `preprocess.c`.** speexdsp's own documented AEC
+is two stages: `speex_echo_cancellation` then `speex_preprocess_run` with
+`SPEEX_PREPROCESS_SET_ECHO_STATE` for residual echo suppression. We run the
+first and skip the second.
+
+That explains the number. A linear adaptive filter cancels only the *linear*
+part of an echo path, and a speaker 4cm from the mics in a small plastic
+enclosure, coupling mechanically through the chassis, is substantially
+nonlinear. **10–14dB is the textbook ceiling for linear-only AEC against a
+nonlinear loudspeaker**, and it is where we sit whichever reference we use.
+
+**So the hardware reference (#385) reaching parity is the correct result, not
+a disappointment.** The reference was never the limiting factor. What ch7/ch8
+buys is *alignment* — which is precisely what we measured, deleting the ring,
+the decimator, `aecDelayMs` and the occupancy governor while holding the same
+attenuation. Amazon's extra dB comes from the AFE's post-processing, not from
+the loopback.
+
+Caveat before anyone reaches for `preprocess.c`: a residual suppressor is
+gain-based and attenuates near-end speech during double-talk, which is
+exactly what barge-in needs preserved. It would very likely improve the `att`
+number and could make barge-in worse. Measure it, do not assume it.
+
+### Also today
+
+**The device went deaf for 34–41 seconds after any data-plane drop the
+control plane survived.** `StartMic` had two callers — the controller's
+`mic_start` and unmute — so nothing restarted a stream that died with its
+socket, and the controller had no reconnect event to fire a fresh
+`mic_start` from because its own connection never dropped. Fixed by
+separating the controller's INTENT from the stream's STATE; recovery is now
+~5s, verified on hardware. The same fault from the other side closed a
+39-second hole at boot, where the first `mic_start` could beat the data
+connection into existence and was discarded.
+
+**A BLE transport reset is a candidate for a total link drop**, and the
+counters proving it were being thrown away. `/dev/stpbt` is the MT8163's
+combo radio behind MediaTek's WMT stack, shared with WiFi, and the scanner's
+own recovery reopens it — triggering a BT function-on and firmware patch
+download on the chip carrying the link. Seen once (stpbt read failure,
+reopen 5s later, `network is unreachable` 2s after that). The device had
+counted `restarts`/`hciErrors` since the proxy shipped;
+`em_ble_proxy.update_stats` read `advertsSeen` and dropped both. Now stored
+per hour as gauges. **This does NOT explain the connectivity history
+generally** — the proxy defaults off, #139 root-caused the RTT excursions to
+packet loss and TCP RTO, and the Lounge/Office swap showed those follow the
+location. Different symptom, kept apart deliberately.
+
+**Seven AEC instances would fit.** "One canceller per mic won't run on an
+A53" had been asserted without measuring. Benchmarked: one canceller is
+95.7µs per 32ms period and seven are 674µs on an i5-12500 — 0.30% and 2.1%
+of one core, so roughly 30–55% of an A53 core. Affordable. Whether it is
+*worth* it depends on how much the beamformer's channel switching actually
+costs the filter, which is one dashboard toggle away and still unmeasured.
+Also: tail 150ms is only 17% cheaper than 300ms, because the cost is
+dominated by fixed per-frame FFT work rather than filter length — so a tail
+sweep is nearly free either way.
+
+**Three test helpers failed the same way in one day**: source-slicing guards
+that used an unanchored `index()` or dropped only their own migration column,
+so any unrelated addition broke them with no clue why. Worth watching for as
+a class.
+

--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 2.22.0-ea.7 (Early Access)
+
+**Long spoken answers no longer cut off part-way through.** That is the whole
+release, and it has been happening for weeks.
+
+**There is nothing to do before updating.** No database migration, no firmware
+requirement, nothing to change on your devices.
+
+### Why a long answer stopped mid-sentence
+
+Ask for something that takes a minute to say and the Echo would go quiet
+part-way through, then sit there looking like it was still speaking. Short
+answers were always fine, which made it look like a network problem that came
+and went.
+
+It was not the network. The controller was sending the whole answer to the Echo
+as fast as the connection would carry it — around 35 seconds of speech pushed
+across in 21. The Echo can only hold about five and a half seconds of audio
+ahead of what it is playing, so the rest piled up, and while the Echo was busy
+working through the backlog it stopped answering the controller's "are you
+still there?" checks. After ten seconds without an answer the controller
+assumed it had lost the Echo and hung up — mid-sentence.
+
+The controller now sends the answer four seconds ahead of what is playing and
+no further. Nothing is lost by slowing down: the Echo could never hold more
+than five and a half seconds anyway, so everything sent beyond that was
+queueing on the network rather than reaching the speaker. Music has worked this
+way since July; spoken answers simply never got the same treatment.
+
+You should notice nothing except that long answers now finish.
+
+### An Echo stopped listening for up to 40 seconds after a network blip
+
+If the audio connection dropped while the main connection stayed up, the Echo
+would stop listening and not start again until the controller eventually
+noticed — measured at 34 and 41 seconds on our own test device. It is now about
+five, because the Echo restarts listening itself as soon as it reconnects
+instead of waiting to be told. The same fix closes a gap at start-up where an
+Echo could sit not listening for around 40 seconds after booting.
+
+**This part needs firmware.** It is a device change, and device firmware ships
+separately from the controller — an Echo running v2.13.0 or earlier still has
+the old behaviour.
+
+### Better answers when something does go wrong
+
+Two diagnostic changes, both invisible unless you go looking:
+
+- When a connection to an Echo closes, the log now says **why**, and which side
+  hung up. Every drop used to log "connection closed" and nothing else, which
+  is what made the problem above take so long to find.
+- Bluetooth proxy resets are now recorded. On these Echos, Bluetooth and Wi-Fi
+  share one radio, so a Bluetooth hiccup can take the network with it. If you
+  use the Bluetooth proxy and see an Echo drop off, the Bluetooth panel now
+  shows whether the radio restarted around then.
+
 ## 2.22.0-ea.6 (Early Access)
 
 **An Echo with no Home Assistant connection now says so every time you speak to

--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -17,7 +17,7 @@ name: "EchoMuse (Early Access)"
 # derives from the controller-v* tag (controller-v2.18.0 -> 2.18.0). Bump
 # both together: Supervisor pulls `image:version`, so a version with no
 # matching tag on GHCR fails to install.
-version: "2.22.0-ea.6"
+version: "2.22.0-ea.7"
 # Pull the published multi-arch image rather than building on the user's
 # machine. Without this Supervisor builds from this directory's Dockerfile,
 # which downloads a few hundred MB on whatever the user runs Home Assistant

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 2.22.0-ea.7 (Early Access)
+
+**Long spoken answers no longer cut off part-way through.** That is the whole
+release, and it has been happening for weeks.
+
+**There is nothing to do before updating.** No database migration, no firmware
+requirement, nothing to change on your devices.
+
+### Why a long answer stopped mid-sentence
+
+Ask for something that takes a minute to say and the Echo would go quiet
+part-way through, then sit there looking like it was still speaking. Short
+answers were always fine, which made it look like a network problem that came
+and went.
+
+It was not the network. The controller was sending the whole answer to the Echo
+as fast as the connection would carry it — around 35 seconds of speech pushed
+across in 21. The Echo can only hold about five and a half seconds of audio
+ahead of what it is playing, so the rest piled up, and while the Echo was busy
+working through the backlog it stopped answering the controller's "are you
+still there?" checks. After ten seconds without an answer the controller
+assumed it had lost the Echo and hung up — mid-sentence.
+
+The controller now sends the answer four seconds ahead of what is playing and
+no further. Nothing is lost by slowing down: the Echo could never hold more
+than five and a half seconds anyway, so everything sent beyond that was
+queueing on the network rather than reaching the speaker. Music has worked this
+way since July; spoken answers simply never got the same treatment.
+
+You should notice nothing except that long answers now finish.
+
+### An Echo stopped listening for up to 40 seconds after a network blip
+
+If the audio connection dropped while the main connection stayed up, the Echo
+would stop listening and not start again until the controller eventually
+noticed — measured at 34 and 41 seconds on our own test device. It is now about
+five, because the Echo restarts listening itself as soon as it reconnects
+instead of waiting to be told. The same fix closes a gap at start-up where an
+Echo could sit not listening for around 40 seconds after booting.
+
+**This part needs firmware.** It is a device change, and device firmware ships
+separately from the controller — an Echo running v2.13.0 or earlier still has
+the old behaviour.
+
+### Better answers when something does go wrong
+
+Two diagnostic changes, both invisible unless you go looking:
+
+- When a connection to an Echo closes, the log now says **why**, and which side
+  hung up. Every drop used to log "connection closed" and nothing else, which
+  is what made the problem above take so long to find.
+- Bluetooth proxy resets are now recorded. On these Echos, Bluetooth and Wi-Fi
+  share one radio, so a Bluetooth hiccup can take the network with it. If you
+  use the Bluetooth proxy and see an Echo drop off, the Bluetooth panel now
+  shows whether the radio restarted around then.
+
 ## 2.22.0-ea.6 (Early Access)
 
 **An Echo with no Home Assistant connection now says so every time you speak to

--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -550,7 +550,54 @@ Two guards sit in front of that, both tested by reintroducing the bug:
     **A device with no HA behind it stands down BEFORE arbitration, and never runs the turn at all** (`em_esphome.can_serve_turn`, the same `get_server`/`get_satellite` pair `trigger_voice_turn` refuses on, so a device counted as able cannot turn out to be unable a tick later). Detection order is a **proximity** proxy and says nothing about whether HA has ever dialled that device's satellite port, so unqualified first-detector-wins hands the utterance to an unlinked Echo, stands down the linked one, and the winner then dies `no_ha` in milliseconds: nothing answers, and the device that could have is the one that went dark. Measured on the fleet 2026-08-29 — a device scoring **0.912** lost to one scoring 0.609 that crossed 449ms earlier, so loudness and detection order do genuinely disagree; that is one observation and not a case for reopening best-SNR, which stays settled. The ordering is the guard: a check after the claim leaves the claim taken, and `tests/test_deploy.py` pins that `can_serve_turn` precedes `_wake_arbiter.claim` and gates it. `em_arbiter` deliberately does **not** know about any of this — a second copy of the rule is one that can disagree with the first.
 
     **The stand-down still records the wake and still plays the cue, every time** (`em_esphome.record_dropped_wake` + `_leds_turn_end`). Both matter for the same reason the row exists on the turn path: a wake during an HA outage that leaves no trace is indistinguishable from a device that heard nothing. And the cue reports the **device's state, not a turn's outcome**, so it fires whether or not another Echo took the utterance — gating it on losing would make it vanish exactly on the multi-device fleets where the confusion is worst. That is the correction to the first version of this, which only cued when the device ran its own doomed turn: standing in front of an unlinked Echo, you got a ring that lit and went dark while another room answered, which reads as a broken cue (Wil, 2026-08-29). The button path stands down identically — it is the control someone reaches for when the wake word appeared to do nothing, so silence there is the worst version of the bug.
-2. **Voice turn** — on wake or dot-button: drain stale frames → acquire `voice_lock` → stream mic to HA via the ESPHome satellite → receive TTS URL → **incrementally** fetch + ffmpeg-decode straight to 48kHz mono → **EQ → bass guard → limiter** (`em_eq.py`, `em_mbc.py`, `em_limiter.py` — see "The output chain" below for why that order) → stream back as 0x02 frames. `_stream_tts_audio` pipes the HTTP response into one long-lived ffmpeg and yields PCM as it decodes, so playback starts while HA is still generating — neither the encoded response nor the decoded speech is accumulated. **A retry is only safe before the first PCM has been emitted**; `_fetch_tts_audio` remains for callers that genuinely need the whole buffer
+2. **Voice turn** — on wake or dot-button: drain stale frames → acquire `voice_lock` → stream mic to HA via the ESPHome satellite → receive TTS URL → **incrementally** fetch + ffmpeg-decode straight to 48kHz mono → **EQ → bass guard → limiter** (`em_eq.py`, `em_mbc.py`, `em_limiter.py` — see "The output chain" below for why that order) → stream back as 0x02 frames, **paced to `VOICE_LEAD_S`=4.0s ahead of realtime** (see below). `_stream_tts_audio` pipes the HTTP response into one long-lived ffmpeg and yields PCM as it decodes, so playback starts while HA is still generating — neither the encoded response nor the decoded speech is accumulated. **A retry is only safe before the first PCM has been emitted**; `_fetch_tts_audio` remains for callers that genuinely need the whole buffer
+
+## Pacing: why the voice stream is held 4s ahead, not sent as fast as it can go
+
+**The voice path used to send every period as fast as the socket accepted, and
+that cut long responses off mid-sentence.** The chain is mechanical, and every
+link is in the code:
+
+1. `stream_speaker_chunks` drains every available period back to back, with TCP
+   backpressure as the only brake
+2. the device's WebSocket read goroutine calls `PumpPeriod` **inline** per
+   `0x02` frame (`data.go`)
+3. `pump()` ends in a **blocking** channel send, on a channel `audioChanDepth`
+   = 128 periods ≈ **5.5s** deep (`stream.go`)
+4. once full, that goroutine blocks inside `PumpPeriod` and stops calling
+   `ReadMessage`
+5. gorilla fires the pong handler only **inside** `ReadMessage`, so a blocked
+   device **cannot answer a keepalive ping**
+6. the controller pings every 20s and closes after 10s without a pong
+   (`websockets.serve(ping_interval=20, ping_timeout=10)`)
+7. the buffer drains at realtime, so the block outlasts the timeout
+8. `1011 keepalive ping timeout`, mid-response
+
+Measured on Test Echo 1, 2026-08-30: 3,397,174 bytes — **35.4s of audio sent in
+21.3s**, 9.8s of it blocked in socket writes, connection closed five seconds
+later. Short responses never reproduce it because they never fill 5.5s, which
+is exactly why it read as intermittent for three sessions.
+
+**Sending faster bought nothing.** The device holds ~5.5s and no more;
+everything beyond that sat in TCP buffers, which are lost on a reconnect
+exactly like audio that was never sent. The excess never improved stall
+resilience — it only bought the block.
+
+**`VOICE_LEAD_S` = 4.0 matches `em_player.LEAD_S`**, which reached the same
+number from the same constraint for the music plane. Music had been paced since
+2026-07-25; voice never was, and that asymmetry was the bug. `tests/
+test_voice_pacing.py` guards the lead against `audioChanDepth` **read from the
+Go source**, so raising one without the other fails in CI rather than on
+hardware.
+
+Three properties keep it safe: a stream behind realtime computes a **zero**
+delay (`em_pacing.lead_delay`), so a slow HA or a stalled link is never made
+worse; the **first period is exempt** and the lead builds at full speed, so the
+prime gate is as prompt as it ever was; and the wait is **raced against
+`cancel_event`** rather than a bare sleep, or pacing would add its own latency
+to barge-in. `send_ms` deliberately still excludes the pacing wait — it is
+documented as socket-write time, and folding a deliberate wait into it would
+recreate the misreading that cost an investigation on 2026-07-20.
 
 ## The output chain: EQ → bass guard → limiter
 


### PR DESCRIPTION
**Cuts EA 2.22.0-ea.7 and records the two findings behind it.** Pin set with `tools/sync_channels.py --set-version`; the CHANGELOG is edited in `controller/` so the generator produces the EA copy — `test_channels` catches the reverse, which is how the first attempt failed.

## The release

**Voice-stream pacing (#392)** is the whole release, and it is what stops long spoken answers cutting off mid-sentence.

The **mic-restart fix (#389)** is in the notes but is a **device** change and ships on its own `v*` tag. There has been no device release since `v2.13.0`, so the notes say it needs firmware rather than implying an EA update delivers it.

## What is written down, and why

**`controller/CLAUDE.md` gains a pacing section.** The eight-step chain from "send as fast as the socket takes it" to `1011 keepalive ping timeout` is not reconstructable from either half alone — it crosses from `stream_speaker_chunks` into the device's read goroutine and back out through gorilla's pong handler. It also records that **sending faster bought nothing**: the device holds ~5.5s, and the excess sat in TCP buffers a reconnect discards anyway. That is the part making the fix obviously free rather than a trade, and it is exactly the reasoning someone would otherwise re-litigate.

**JOURNAL records the day**, including the diagnostics that had to exist before the bug was findable — every drop logged `Data connection closed` and nothing else — and the AEC finding:

> We vendored `mdf.c` and not `preprocess.c`, so we run speexdsp's linear canceller without the residual echo suppressor its own documented usage pairs it with. **~10–14dB is the textbook ceiling for linear-only AEC against a nonlinear loudspeaker**, which means the reference was never the limiting factor — and #385 reaching parity is the correct result, not a disappointment.

Also noted: seven cancellers would fit on an A53 (measured — 674µs per 32ms period against 95.7µs for one), and three test helpers failed the same way in one day, all source-slicing guards that break on any unrelated addition.

Docs and release metadata only — no code. 886 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiXSQ86bzCWmzExdUPc8uo