### PR TITLE
Answer a question Home Assistant asks, instead of never being asked

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased
+
+**Your Echoes can now be asked a question by Home Assistant, and will listen for
+the answer.** Nothing to do before updating: no database migration, no firmware
+requirement, nothing to change on your devices.
+
+### Announce, then listen
+
+Home Assistant has two actions that speak to a satellite and then wait for a
+spoken reply — `assist_satellite.start_conversation` ("the garage door is open,
+want me to close it?") and `assist_satellite.ask_question`, which matches what
+you say against a list of answers you supply. EchoMuse devices never appeared as
+eligible targets for either, so the actions could not be pointed at them at all.
+
+They do now. Both work the same way from your side: the Echo plays the message,
+then its ring lights and it listens, exactly as it does after a wake word. An
+attention chime plays before the message — Home Assistant sends one, and we were
+discarding it. It matters more here than for an ordinary announcement, since an
+unprompted question otherwise arrives with no warning.
+
+Two things worth knowing:
+
+- **The Echo must have a microphone and be connected.** A device Home Assistant
+  cannot reach is not offered as a target.
+- **A muted Echo will not open its microphone**, and nothing in this change
+  weakens that. The question is still spoken; the answer is simply never heard,
+  and the action reports back that it got no answer.
+
+Reported by @pollocluck (#396), with the root cause found by @vbtheory (#335) —
+both halves of it, correctly, before either had been looked at here.
+
 ## 2.22.0-ea.8 (Early Access)
 
 **Adds one setting, for testing echo cancellation.** Nothing else changes, and

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased
+
+**Your Echoes can now be asked a question by Home Assistant, and will listen for
+the answer.** Nothing to do before updating: no database migration, no firmware
+requirement, nothing to change on your devices.
+
+### Announce, then listen
+
+Home Assistant has two actions that speak to a satellite and then wait for a
+spoken reply — `assist_satellite.start_conversation` ("the garage door is open,
+want me to close it?") and `assist_satellite.ask_question`, which matches what
+you say against a list of answers you supply. EchoMuse devices never appeared as
+eligible targets for either, so the actions could not be pointed at them at all.
+
+They do now. Both work the same way from your side: the Echo plays the message,
+then its ring lights and it listens, exactly as it does after a wake word. An
+attention chime plays before the message — Home Assistant sends one, and we were
+discarding it. It matters more here than for an ordinary announcement, since an
+unprompted question otherwise arrives with no warning.
+
+Two things worth knowing:
+
+- **The Echo must have a microphone and be connected.** A device Home Assistant
+  cannot reach is not offered as a target.
+- **A muted Echo will not open its microphone**, and nothing in this change
+  weakens that. The question is still spoken; the answer is simply never heard,
+  and the action reports back that it got no answer.
+
+Reported by @pollocluck (#396), with the root cause found by @vbtheory (#335) —
+both halves of it, correctly, before either had been looked at here.
+
 ## 2.22.0-ea.8 (Early Access)
 
 **Adds one setting, for testing echo cancellation.** Nothing else changes, and

--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -415,6 +415,43 @@ wizard timing out — it would not have: the wizard's connection test does not
 wait on this message, it fires when the device fetches
 `CONNECTION_TEST_URL_BASE`.
 
+**Announce-then-listen is the SAME message with field 4 set** (#335, #396).
+`assist_satellite.start_conversation` and `assist_satellite.ask_question` both
+reach us as `VoiceAssistantAnnounceRequest` with `start_conversation=True`;
+`preannounce_media_id` (field 3) is the attention chime, and both were carried
+by the vendored protobuf and read by nothing. Four rules:
+
+- **HA filters eligible targets on `VoiceAssistantFeature.START_CONVERSATION`**,
+  so without that bit the device does not appear in the action's target picker
+  at all — no error, an empty list. It is advertised **per device**, gated on
+  the `mic` capability (`_voice_assistant_flags`), which is the only reason the
+  rest of `VOICE_ASSISTANT_FLAGS` being a module constant is a gap rather than a
+  bug. That gating works only because `set_device_capabilities` bounces the HA
+  connection when the set changes: the flags ride `DeviceInfoResponse`, a
+  one-shot at connect.
+- **Listen AFTER `AnnounceFinished`, not before.** HA blocks on it for the whole
+  announcement, and `async_internal_ask_question` arms its answer future only
+  once `async_start_conversation` returns.
+- **`ask_question` truncates HA's own pipeline at STT** — it sets
+  `end_stage = STT`, keyed on that future — so the run ends after `STT_END` with
+  **no `INTENT_END` and no TTS**, which the `RUN_END` guard above waits for.
+  Without `_answer_only`, every question was answered correctly and then parked
+  the device on the 30s TTS wait and recorded a timeout. The flag is derived
+  from the trace's own trigger label so it cannot disagree with the stats, and
+  the outcome is `answered`, not `no_tts`: the transcript IS the deliverable.
+- **A muted device runs the turn anyway, and that is deliberate.**
+  `async_internal_ask_question` awaits its answer future with **no timeout**, so
+  a satellite that refuses by staying silent hangs the caller's script for good.
+  The mute is enforced where it always was — the device rejects every
+  `mic_start` while muted and the ADC is muted in hardware — so nothing is
+  captured, the streaming phase gives up at its cap, and HA ends the run with no
+  answer. Refusing controller-side is the change that looks safer and is worse.
+
+The turn is the button turn with a different label (`CONVERSATION_TRIGGER`,
+`preroll_discard=0`, `is_wakeword=False`). It must **not** borrow "button" or a
+"wakeword(…)" label — the dashboard groups wake statistics by it, and
+`wake_word_phrase` is keyed on the prefix.
+
 **`cancel_event` must be cleared by anything that starts playing, not just a
 voice turn.** It is set by a cancel (a button press mid-turn, a mute) and was
 cleared *only* at voice-turn start, so a cancelled turn silently killed every

--- a/controller/em_announce.py
+++ b/controller/em_announce.py
@@ -47,6 +47,7 @@ async def run(
     on_finished: Callable[[bool], None],
     log_name: str = "",
     timeout: float = ANNOUNCE_TIMEOUT_S,
+    preannounce_media_id: str = "",
 ) -> bool:
     """
     Fetch the announcement audio, play it, then report completion exactly once.
@@ -58,6 +59,17 @@ async def run(
     that raise. It is a plain callable rather than a coroutine because the
     caller's job here is a socket write it may also decline to make (a closed
     transport), and awaiting a decision not to send is noise.
+
+    `preannounce_media_id` is the attention chime HA plays BEFORE the message,
+    on `VoiceAssistantAnnounceRequest` field 3. It matters most on
+    `start_conversation`, where an unprompted "the garage door is open" arrives
+    with no warning at all — nobody asked a question, so there is nothing else
+    to tell the listener that the device is about to talk and then listen.
+
+    **A preannounce failure is not an announcement failure.** The chime is a
+    cue for the message; a missing cue is worth a log line, not a swallowed
+    announcement, and `ok` reports the MESSAGE. Both share one timeout budget
+    so a wedged chime cannot extend the whole thing past it.
     """
     ok = False
     try:
@@ -65,7 +77,9 @@ async def run(
             log.warning(f"[{log_name}] AnnounceRequest with no media_id")
         else:
             ok = await asyncio.wait_for(
-                play_media(media_id, fetch, play, log_name), timeout)
+                _preannounce_then_play(
+                    media_id, preannounce_media_id, fetch, play, log_name),
+                timeout)
     except (asyncio.TimeoutError, TimeoutError):
         log.error(f"[{log_name}] Announce timed out after {timeout}s")
     except Exception as e:
@@ -73,6 +87,22 @@ async def run(
     finally:
         on_finished(ok)
     return ok
+
+
+async def _preannounce_then_play(
+    media_id: str,
+    preannounce_media_id: str,
+    fetch: Callable[[str], Awaitable[bytes]],
+    play: Optional[Callable[[bytes], Awaitable[object]]],
+    log_name: str = "",
+) -> bool:
+    """The chime, then the message. Returns whether the MESSAGE played."""
+    if preannounce_media_id:
+        try:
+            await play_media(preannounce_media_id, fetch, play, log_name)
+        except Exception as e:
+            log.warning(f"[{log_name}] Preannounce chime failed: {e}")
+    return await play_media(media_id, fetch, play, log_name)
 
 
 async def play_media(

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -3378,6 +3378,48 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
             await start_timer_alarm(_d)
         async def _stop_alarm(_d=_device_ref) -> None:
             await stop_timer_alarm(_d)
+        async def _start_conversation(_d=_device_ref) -> None:
+            # HA has finished asking; the answer is whatever is said next.
+            # Same shape as the button turn — a deliberate act with no wake
+            # word, so mic_stop/mic_start_turn to get the beam-locked stream,
+            # and preroll_discard 0 because there is no wake-word tail to trim.
+            #
+            # The mute check is here rather than a refusal further up because
+            # of what HA does with a refusal: `async_internal_ask_question`
+            # awaits its answer future with NO timeout, so a satellite that
+            # stays silent hangs the caller's script for good. Running the turn
+            # keeps that bounded — the device rejects every mic_start while
+            # muted (and the ADC is muted in hardware regardless), so nothing
+            # is captured, the streaming phase gives up at its cap and HA ends
+            # the run with no answer. The mute is not weakened by this; the
+            # device is still the one enforcing it.
+            if _d.muted:
+                log.info(
+                    f"[{_d.device_id}] start_conversation while muted — "
+                    f"the microphone stays closed"
+                )
+                db.log_device(
+                    _d.device_id, "info", "controller",
+                    "Home Assistant asked a question while the mic was muted"
+                )
+            _d.cancel_event.clear()
+            _d.oww_paused.set()
+            _d.oww_paused_since = asyncio.get_event_loop().time()
+            try:
+                await _d.mic_stop()
+                await _d.mic_start_turn()
+                await _run_voice_locked(
+                    _d,
+                    trigger_label=esphome.CONVERSATION_TRIGGER,
+                    is_wakeword=False,
+                )
+            finally:
+                # Back to the ch6 omni wake stream, exactly as the button turn
+                # does — and for its reason: a turn that ended without TTS
+                # leaves the beam-locked stream running, and a bare mic_start
+                # would no-op against it.
+                await _d.mic_stop()
+                await _d.mic_start()
         # Capabilities before the servers come up: they decide which HA
         # entities are advertised, and advertising is a one-shot at
         # ListEntities time.
@@ -3389,6 +3431,7 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
             send_volume_set=_send_volume_set,
             ring_alarm=_ring_alarm,
             stop_alarm=_stop_alarm,
+            start_conversation=_start_conversation,
         )
         # The ESPHome server object caches the OWW model from server
         # creation — refresh it from the config we just loaded so HA's

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -283,6 +283,27 @@ VOICE_ASSISTANT_FLAGS = int(
     | VoiceAssistantFeature.TIMERS
 )
 
+# START_CONVERSATION is advertised PER DEVICE, not in the constant above,
+# because it is the one flag whose feature we cannot deliver without hardware:
+# announce-then-listen needs a microphone. HA filters the eligible targets for
+# `assist_satellite.start_conversation` and `assist_satellite.ask_question` on
+# this bit, so a satellite that cannot listen must not carry it — otherwise it
+# appears in the picker and answers every question with silence.
+#
+# Everything else in VOICE_ASSISTANT_FLAGS is still advertised unconditionally,
+# which is a gap rather than a decision: SPEAKER-less hardware would want the
+# same treatment. Doing it for one flag is not the general fix, and the general
+# fix is not free — the flags ride DeviceInfoResponse, a ONE-SHOT at HA connect,
+# so this only works at all because set_device_capabilities bounces the HA
+# connection when the set changes (a device whose server exists before it has
+# registered would otherwise advertise from an empty capability list forever).
+VOICE_ASSISTANT_CONVERSATION_FLAG = int(VoiceAssistantFeature.START_CONVERSATION)
+
+# Trigger label for a turn Home Assistant started with an announcement, rather
+# than one a wake word or a button started. It is neither, and borrowing either
+# label would put HA-initiated turns into the wake-word statistics.
+CONVERSATION_TRIGGER = "start_conversation"
+
 # VoiceAssistantRequest flags=0 means "device already detected wake word,
 # run Assist pipeline from STT onward — do not run HA-side wake word
 # detection on the audio stream."
@@ -374,6 +395,17 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         # send before the turn has actually progressed (observed in practice —
         # see _handle_voice_event's RUN_END branch).
         self._intent_ended      = False
+        # STT_END seen this turn. Only read on an answer-only run, where
+        # INTENT_END structurally never arrives — see _answer_only.
+        self._stt_ended         = False
+        # This turn was started by HA's announce-then-listen, and HA may have
+        # truncated its own pipeline at STT. `assist_satellite.ask_question`
+        # sets `end_stage = STT` (entity.py, keyed on its answer future), so
+        # the run ends after STT_END with no INTENT_END and no TTS — and the
+        # RUN_END guard below waits for INTENT_END. Without this, every
+        # question answered correctly still parked the device on the 30s TTS
+        # wait and recorded the turn as a timeout.
+        self._answer_only       = False
         self._run_started       = False
         # Whether HA has told us this run is over. A run we started
         # that has not finished is still emitting onto this socket,
@@ -469,6 +501,18 @@ class EchoMuseSatellite(SatelliteServerProtocol):
     def _ambient_lux_capable(self) -> bool:
         return self._device_has("ambient_light")
 
+    def _voice_assistant_flags(self) -> int:
+        """
+        Feature flags for DeviceInfoResponse, gated on what the device has.
+
+        See VOICE_ASSISTANT_CONVERSATION_FLAG for why announce-then-listen is
+        the one that is conditional.
+        """
+        flags = VOICE_ASSISTANT_FLAGS
+        if self._device_has("mic"):
+            flags |= VOICE_ASSISTANT_CONVERSATION_FLAG
+        return flags
+
     @property
     def _current_volume(self) -> float:
         """Current volume as HA float (0.0–1.0), read from owning server."""
@@ -498,7 +542,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 # (session handoff finding #1)
                 project_name=f"EchoMuse.{ESPHOME_DEVICE_MODEL}",
                 project_version=ESPHOME_PROJECT_VERSION,
-                voice_assistant_feature_flags=VOICE_ASSISTANT_FLAGS,
+                voice_assistant_feature_flags=self._voice_assistant_flags(),
             )
             return
 
@@ -777,8 +821,22 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             # claiming it buys nothing and costs an exception per announce.
             # Measured on HA 2026.8.3, alongside the setup wizard stalling on
             # SatelliteBusyError.
-            log.info(f"[{self._log_name}] AnnounceRequest: media_id={msg.media_id!r} text={msg.text!r}")
-            asyncio.create_task(self._run_announce(msg.media_id))
+            #
+            # `start_conversation` (field 4) is HA asking us to LISTEN once the
+            # announcement has played — the wire form of both
+            # `assist_satellite.start_conversation` and
+            # `assist_satellite.ask_question`. It rides the same message as a
+            # plain announcement, so the only difference on our side is what
+            # happens after the audio stops.
+            log.info(
+                f"[{self._log_name}] AnnounceRequest: media_id={msg.media_id!r} "
+                f"text={msg.text!r} start_conversation={msg.start_conversation}"
+            )
+            asyncio.create_task(self._run_announce(
+                msg.media_id,
+                preannounce_media_id=msg.preannounce_media_id,
+                start_conversation=msg.start_conversation,
+            ))
             yield api_pb2.MediaPlayerStateResponse(
                 key=MEDIA_PLAYER_KEY,
                 state=MediaPlayerState.PLAYING,
@@ -849,6 +907,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         elif event_type == ET.VOICE_ASSISTANT_STT_END:
             text = data.get("text", "")
             log.info(f"[{self._log_name}] STT result: {text!r}")
+            self._stt_ended = True
             # HA has final text, so no further microphone audio can change
             # this turn — stop feeding it, the same "HA is done" shape the
             # RUN_END-without-RUN_START and ERROR paths already use.
@@ -961,7 +1020,16 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             # spoken response (e.g. a silent light-toggle intent) still passes
             # through INTENT_END first, so this doesn't add a 30s stall for
             # that case — only a premature RUN_END before INTENT_END is held.
-            if self._intent_ended or self._turn_cancelled:
+            #
+            # An answer-only run never reaches INTENT_END, so STT_END is its
+            # terminal marker instead. `assist_satellite.ask_question` sets
+            # `end_stage = STT`, so HA's pipeline is genuinely over: it has the
+            # text it asked for and there is no intent and no TTS to wait on.
+            # Narrow on purpose — only a turn HA started with an announcement,
+            # and only once STT has actually produced a result — because the
+            # premature RUN_END this guard exists for arrives before STT_START.
+            if self._intent_ended or self._turn_cancelled or (
+                    self._answer_only and self._stt_ended):
                 # The genuine terminal RUN_END. Nothing more is coming for
                 # this run, so teardown has nothing left to serialise
                 # against — the overwhelmingly common case.
@@ -1037,10 +1105,15 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         except Exception as e:
             log.error(f"[{self._log_name}] play_media announce failed: {e}")
 
-    async def _run_announce(self, media_id: str) -> None:
+    async def _run_announce(
+        self,
+        media_id: str,
+        preannounce_media_id: str = "",
+        start_conversation: bool = False,
+    ) -> None:
         """
         Background task: fetch TTS audio from HA, play it, then tell HA the
-        announcement is done.
+        announcement is done — and, if HA asked for a conversation, listen.
 
         The sequencing rules and their reasons live in em_announce, which is
         importable by the test suite. This is the adapter: it resolves the
@@ -1080,7 +1153,40 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             play=self._announce_play_cb(),
             on_finished=reply,
             log_name=self._log_name,
+            preannounce_media_id=preannounce_media_id,
         )
+
+        # AFTER the reply, deliberately. HA blocks on AnnounceFinished for the
+        # whole announcement (`_do_announce` awaits it), so a turn started
+        # before it would be listening while HA still believes it is speaking —
+        # and `async_internal_ask_question` only arms its answer future once
+        # `async_start_conversation` returns.
+        if start_conversation:
+            await self._start_conversation_turn()
+
+    async def _start_conversation_turn(self) -> None:
+        """
+        Open a voice turn nobody spoke a wake word for.
+
+        HA asked the question; the answer is the next thing said in the room.
+        Runs the ordinary turn path — the only differences are the trigger
+        label and that `ask_question` truncates HA's pipeline at STT (see the
+        RUN_END branch in _handle_voice_event).
+        """
+        start = getattr(self._owning_server, "_start_conversation", None)
+        if start is None:
+            # The physical Dot is not connected — HA is talking to a satellite
+            # whose device is absent. The announcement already reported that it
+            # did not play; there is nothing to listen with either.
+            log.warning(
+                f"[{self._log_name}] start_conversation with no device "
+                f"connected — nothing to listen with"
+            )
+            return
+        try:
+            await start()
+        except Exception as e:
+            log.error(f"[{self._log_name}] start_conversation turn failed: {e}")
 
     # ── Voice turn (outbound) ────────────────────────────────────────────
 
@@ -1126,6 +1232,18 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self._tts_audio_url         = None
         self._tts_audio_data        = None
         self._intent_ended          = False
+        self._stt_ended             = False
+        # Derived from the trace's own trigger label rather than plumbed
+        # through as a parameter, so the flag and the activity stats can never
+        # disagree about what started this turn.
+        #
+        # A CONTINUATION of one of these turns keeps the label and so keeps the
+        # flag, which is not strictly right — a continuation runs HA's full
+        # pipeline and does reach INTENT_END. It costs nothing: the guard below
+        # is an OR, and INTENT_END satisfies it first on any turn that gets one.
+        self._answer_only           = bool(
+            trace is not None and trace.trigger == CONVERSATION_TRIGGER
+        )
         self._run_started           = False
         self._run_finished          = False
         self._ha_never_started      = False
@@ -1327,6 +1445,14 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     if trace: trace.outcome = why
                 elif pcm_bytes:
                     if trace: trace.outcome = "ok"
+            elif self._answer_only and self._stt_ended:
+                # Not a fault: `ask_question` ends HA's pipeline at STT, so
+                # there was never going to be a spoken reply — the transcript
+                # IS the deliverable, and HA matches it against the caller's
+                # answers. Distinct from "no_tts" so the activity stats do not
+                # read every question answered as a turn that produced nothing.
+                log.info(f"[{self._log_name}] Question answered — no reply expected")
+                if trace: trace.outcome = "answered"
             else:
                 log.info(f"[{self._log_name}] No TTS audio URL received — turn ended without response")
                 if trace: trace.outcome = "no_tts"
@@ -2058,6 +2184,12 @@ class DeviceESPhomeServer:
         # callable() each; None when no device is connected.
         self._ring_alarm = None
         self._stop_alarm = None
+        # Injected by device_connected() — async callable() that runs one
+        # voice turn nobody spoke a wake word for, for HA's announce-then-
+        # listen. In em_controller for _standalone_play's reason: it drives the
+        # mic, the ring and the voice lock. None when no device is connected,
+        # which is the honest answer to "listen now" for an absent device.
+        self._start_conversation = None
         # Live-timer state, driven by HA's VoiceAssistantTimerEventResponse
         # events. On the server (not the satellite) so it survives an HA
         # reconnect that replaces the satellite mid-countdown.
@@ -2797,6 +2929,7 @@ async def device_connected(
     send_volume_set=None,
     ring_alarm=None,
     stop_alarm=None,
+    start_conversation=None,
 ) -> None:
     """
     Called by em_controller.handle_control() when an Echo Dot connects.
@@ -2818,6 +2951,11 @@ async def device_connected(
     ring_alarm / stop_alarm: async callable() — start / stop the timer-alarm
     ring (chime + LED pulse). Provided by the controller as closures over the
     Device object, since ringing drives device speaker/mic/LEDs.
+
+    start_conversation: async callable() — runs one voice turn with no wake
+    word, for HA's announce-then-listen (`assist_satellite.start_conversation`
+    and `ask_question`). Same reasoning: it drives the mic, the ring and the
+    voice lock.
     """
     server = _servers.get(device_id)
     if server is None:
@@ -2836,6 +2974,7 @@ async def device_connected(
     server._send_volume_set = send_volume_set
     server._ring_alarm = ring_alarm
     server._stop_alarm = stop_alarm
+    server._start_conversation = start_conversation
     if server._server is not None:
         log.debug(f"[esphome.{device_id[-8:]}] device_connected: port {server.port} already listening")
         return
@@ -2864,6 +3003,7 @@ async def device_disconnected(device_id: str) -> None:
     server._timers.clear()
     server._ring_alarm = None
     server._stop_alarm = None
+    server._start_conversation = None
     await server.stop()
     log.info(f"[esphome.{device_id[-8:]}] ESPHome port {server.port} down (device disconnected)")
 

--- a/controller/tests/test_start_conversation.py
+++ b/controller/tests/test_start_conversation.py
@@ -1,0 +1,320 @@
+"""
+Announce-then-listen: `assist_satellite.start_conversation` and
+`assist_satellite.ask_question` (#335, #396).
+
+Home Assistant reuses `VoiceAssistantAnnounceRequest` for both, with
+`start_conversation` (field 4) marking the ones that must be followed by a
+listening turn. Two things decide whether the feature exists at all, and
+neither of them shows up in a log:
+
+  * HA filters the eligible targets on `VoiceAssistantFeature.START_CONVERSATION`
+    in `DeviceInfoResponse`, so without that bit the device never appears in the
+    action's target picker — no error, just an empty list;
+  * the flag on the request itself, which we used to read `media_id` and `text`
+    from and drop.
+
+The third thing is invisible even once it works. `ask_question` sets
+`end_stage = STT` on HA's own pipeline (`assist_satellite/entity.py`, keyed on
+its answer future), so the run ends after STT_END with no INTENT_END and no
+TTS — while our RUN_END guard waits for INTENT_END. Questions get answered
+correctly and the device then sits out the 30s TTS wait and records a timeout.
+
+Pure-logic and source-shape only: the suite does not import em_esphome
+(zeroconf, aiohttp, the database), which is why the sequencing that CAN be
+tested lives in em_announce.
+"""
+
+import asyncio
+import re
+from pathlib import Path
+
+import em_announce
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+ESPHOME_SRC = (CONTROLLER / "em_esphome.py").read_text()
+CONTROLLER_SRC = (CONTROLLER / "em_controller.py").read_text()
+
+
+def _strip_py_comments(src: str) -> str:
+    """
+    Comments AND docstrings. A guard that strips only `#` lines matches the
+    prose explaining the rule it is enforcing and passes whatever the code
+    does — this tree has done that three times now.
+    """
+    src = re.sub(r'"""(?:.|\n)*?"""', "", src)
+    src = re.sub(r"'''(?:.|\n)*?'''", "", src)
+    return "\n".join(re.sub(r"#.*$", "", line) for line in src.splitlines())
+
+
+ESPHOME_CODE = _strip_py_comments(ESPHOME_SRC)
+CONTROLLER_CODE = _strip_py_comments(CONTROLLER_SRC)
+
+
+def fetch_returning(pcm):
+    async def _fetch(url):
+        return pcm
+
+    return _fetch
+
+
+class Replies:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, ok):
+        self.calls.append(ok)
+
+
+# ── The preannounce chime ────────────────────────────────────────────────────
+
+
+def test_the_chime_plays_before_the_message():
+    played = []
+
+    async def play(pcm):
+        played.append(pcm)
+
+    async def fetch(url):
+        return url.encode()
+
+    ok = asyncio.run(
+        em_announce.run(
+            "message",
+            fetch=fetch,
+            play=play,
+            on_finished=Replies(),
+            preannounce_media_id="chime",
+        )
+    )
+    assert ok is True
+    assert played == [b"chime", b"message"], (
+        "the attention chime must arrive before the message it announces"
+    )
+
+
+def test_no_chime_is_the_ordinary_case():
+    played = []
+
+    async def play(pcm):
+        played.append(pcm)
+
+    asyncio.run(
+        em_announce.run(
+            "message",
+            fetch=fetch_returning(b"pcm"),
+            play=play,
+            on_finished=Replies(),
+        )
+    )
+    assert played == [b"pcm"]
+
+
+def test_a_failing_chime_still_plays_the_message():
+    """
+    The chime is a cue for the message, not the message. Losing it is worth a
+    log line; swallowing an announcement over it is not — and on
+    `start_conversation` the announcement is a question somebody is waiting to
+    answer.
+    """
+    played = []
+
+    async def fetch(url):
+        if url == "chime":
+            raise RuntimeError("404 from the TTS proxy")
+        return b"pcm"
+
+    async def play(pcm):
+        played.append(pcm)
+
+    replies = Replies()
+    ok = asyncio.run(
+        em_announce.run(
+            "message",
+            fetch=fetch,
+            play=play,
+            on_finished=replies,
+            preannounce_media_id="chime",
+        )
+    )
+    assert played == [b"pcm"]
+    assert ok is True, "the chime failing must not report the message as failed"
+    assert replies.calls == [True]
+
+
+def test_a_wedged_chime_cannot_outlast_the_announcement_cap():
+    """
+    One budget covers both, or a chime that never returns parks HA for its own
+    five minutes holding `_is_announcing`.
+    """
+    replies = Replies()
+
+    async def play(pcm):
+        await asyncio.Event().wait()
+
+    ok = asyncio.run(
+        em_announce.run(
+            "message",
+            fetch=fetch_returning(b"pcm"),
+            play=play,
+            on_finished=replies,
+            timeout=0.05,
+            preannounce_media_id="chime",
+        )
+    )
+    assert ok is False
+    assert replies.calls == [False], "HA must still be answered"
+
+
+# ── The capability HA filters on ─────────────────────────────────────────────
+
+
+def test_start_conversation_is_gated_on_the_microphone():
+    """
+    A satellite that cannot listen must not offer to. It would appear in the
+    action's target picker and answer every question with silence.
+    """
+    assert "VoiceAssistantFeature.START_CONVERSATION" in ESPHOME_CODE, (
+        "the START_CONVERSATION feature bit is not advertised anywhere — HA "
+        "filters announce-then-listen targets on it, so the device will not "
+        "appear as an eligible target"
+    )
+    flags = ESPHOME_CODE[ESPHOME_CODE.index("VOICE_ASSISTANT_FLAGS = int("):]
+    flags = flags[: flags.index(")")]
+    assert "START_CONVERSATION" not in flags, (
+        "START_CONVERSATION is in the unconditional flag constant — it must be "
+        "advertised per device, gated on the mic capability"
+    )
+    gate = ESPHOME_CODE[ESPHOME_CODE.index("def _voice_assistant_flags"):]
+    gate = gate[: gate.index("\n    def ", 10)]
+    assert '_device_has("mic")' in gate
+
+
+def test_device_info_advertises_the_per_device_flags():
+    """
+    The gate is worth nothing if DeviceInfoResponse still sends the constant.
+    """
+    info = ESPHOME_CODE[ESPHOME_CODE.index("DeviceInfoResponse("):]
+    info = info[: info.index(")\n")]
+    assert "voice_assistant_feature_flags=self._voice_assistant_flags()" in info
+
+
+# ── The request field, and what happens after the audio ──────────────────────
+
+
+def test_the_announce_handler_reads_both_dropped_fields():
+    """
+    `start_conversation` and `preannounce_media_id` are fields 4 and 3 of the
+    same message, and both were carried by the vendored protobuf and read by
+    nothing.
+    """
+    handler = ESPHOME_CODE[ESPHOME_CODE.index("def handle_message"):]
+    handler = handler[: handler.index("\n    def ", 10)]
+    assert "msg.start_conversation" in handler
+    assert "msg.preannounce_media_id" in handler
+
+
+def test_listening_starts_after_ha_has_been_told_the_announcement_finished():
+    """
+    HA blocks on AnnounceFinished for the whole announcement, and
+    `async_internal_ask_question` only arms its answer future once
+    `async_start_conversation` returns. Listening first means listening while
+    HA still believes the satellite is speaking.
+    """
+    body = ESPHOME_CODE[ESPHOME_CODE.index("async def _run_announce"):]
+    body = body[: body.index("\n    async def _start_conversation_turn")]
+    assert body.index("em_announce.run(") < body.index("_start_conversation_turn()"), (
+        "the listening turn is started before the announcement is reported "
+        "finished"
+    )
+
+
+def test_an_absent_device_does_not_pretend_to_listen():
+    """
+    No physical Dot means nothing to listen with, and the announcement has
+    already reported that it did not play.
+    """
+    body = ESPHOME_CODE[ESPHOME_CODE.index("async def _start_conversation_turn"):]
+    body = body[: body.index("\n    async def ", 10)]
+    assert "if start is None:" in body
+    assert "return" in body
+
+
+# ── The pipeline HA truncates at STT ─────────────────────────────────────────
+
+
+def test_an_answer_only_run_ends_on_stt_not_intent():
+    """
+    `ask_question` ends HA's pipeline at STT, so INTENT_END structurally never
+    arrives and the RUN_END guard would hold the turn for the full 30s TTS
+    wait — the question answered correctly, the device unresponsive after it,
+    and every one of them recorded as a timeout.
+    """
+    branch = ESPHOME_CODE[ESPHOME_CODE.index("if self._intent_ended or self._turn_cancelled"):]
+    branch = branch[:400]
+    assert "self._answer_only and self._stt_ended" in branch, (
+        "RUN_END is still gated on INTENT_END alone — an answered question "
+        "will park the turn until the TTS wait expires"
+    )
+
+
+def test_the_answer_only_flag_comes_from_the_turns_own_label():
+    """
+    Derived from the trace's trigger rather than plumbed through as a
+    parameter, so the flag and the activity stats cannot disagree about what
+    started the turn.
+    """
+    assert "trace.trigger == CONVERSATION_TRIGGER" in ESPHOME_CODE
+
+
+def test_stt_end_sets_the_marker_it_is_read_by():
+    stt = ESPHOME_CODE[ESPHOME_CODE.index("VOICE_ASSISTANT_STT_END"):]
+    stt = stt[: stt.index("VOICE_ASSISTANT_INTENT_END")]
+    assert "self._stt_ended = True" in stt
+
+
+# ── The turn itself ──────────────────────────────────────────────────────────
+
+
+def test_the_trigger_is_neither_a_wake_word_nor_a_button():
+    """
+    `wake_word_phrase` is keyed on the label starting with "wakeword", and the
+    dashboard's wake statistics are grouped by it. An HA-initiated turn
+    borrowing either label puts turns nobody spoke a wake word for into the
+    wake-word numbers.
+    """
+    label = re.search(r'CONVERSATION_TRIGGER = "([^"]+)"', ESPHOME_CODE)
+    assert label, "CONVERSATION_TRIGGER is not defined"
+    assert not label.group(1).startswith("wakeword")
+    assert label.group(1) != "button"
+
+
+def test_the_conversation_turn_discards_no_preroll():
+    """
+    There is no wake-word tail to trim, so discarding frames here clips the
+    first words of the answer — the bug C3 fixed on the button path.
+    """
+    body = CONTROLLER_CODE[CONTROLLER_CODE.index("async def _start_conversation("):]
+    body = body[: body.index("\n        await esphome.device_connected(")]
+    assert "is_wakeword=False" in body
+    assert "esphome.CONVERSATION_TRIGGER" in body
+
+
+def test_a_muted_device_still_runs_the_turn_rather_than_going_silent():
+    """
+    The mute is enforced on the device — it rejects every `mic_start` while
+    muted and the ADC is muted in hardware — so nothing is captured either way.
+    What the controller must NOT do is refuse by staying silent:
+    `async_internal_ask_question` awaits its answer future with no timeout, so
+    a satellite that never runs a pipeline hangs the caller's script for good.
+    Running the turn bounds it — the streaming phase gives up at its cap and HA
+    ends the run with no answer.
+    """
+    body = CONTROLLER_CODE[CONTROLLER_CODE.index("async def _start_conversation("):]
+    body = body[: body.index("\n        await esphome.device_connected(")]
+    muted = body[body.index("if _d.muted:"):]
+    muted = muted[: muted.index("_d.cancel_event.clear()")]
+    assert "return" not in muted, (
+        "a muted device refuses the conversation by returning — HA's "
+        "ask_question will then wait on its answer future forever"
+    )
+    assert "_run_voice_locked" in body


### PR DESCRIPTION
Closes #396. Root-caused in #335 by @vbtheory — both halves, correctly, before either had been looked at here.

`assist_satellite.start_conversation` and `assist_satellite.ask_question` speak to a satellite and then wait for a spoken reply. EchoMuse devices never appeared as eligible targets for either, so the actions could not be pointed at them at all.

Both arrive as `VoiceAssistantAnnounceRequest` with `start_conversation` (field 4) set. We read `media_id` and `text` and dropped the rest — including `preannounce_media_id` (field 3), the attention chime, which matters more here than for a plain announcement since an unprompted question otherwise arrives with no warning.

## Four things decide whether this works, and three are invisible

**HA filters the targets on the feature bit.** Without `VoiceAssistantFeature.START_CONVERSATION` in `DeviceInfoResponse` the device is simply absent from the action's picker — no error, an empty list. It is advertised **per device**, gated on the `mic` capability: a satellite that cannot listen must not offer to, or it appears as a target and answers every question with silence. That gating works only because `set_device_capabilities` bounces the HA connection when the set changes — the flags ride a one-shot at connect.

**Listen after `AnnounceFinished`, not before.** HA blocks on it for the whole announcement, and `async_internal_ask_question` arms its answer future only once `async_start_conversation` returns.

**`ask_question` truncates HA's own pipeline at STT.** It sets `end_stage = STT`, keyed on that future, so the run ends after `STT_END` with **no `INTENT_END` and no TTS** — which the `RUN_END` guard waits for. This is the one that would otherwise have shipped broken: every question answered correctly, and then the device parked on the 30s TTS wait with the turn recorded as a timeout. The flag is derived from the trace's own trigger label so it cannot disagree with the stats, and the outcome is `answered`, not `no_tts` — the transcript IS the deliverable.

**A muted device runs the turn anyway, deliberately.** This is the opposite of the instinct in #335, for a reason found in HA's source: `async_internal_ask_question` awaits its answer future with **no timeout**, so a satellite that refuses by staying silent hangs the caller's script for good. The mute is enforced where it always was — the device rejects every `mic_start` while muted and the ADC is muted in hardware — so nothing is captured, the streaming phase gives up at its cap, and HA ends the run with no answer. Refusing controller-side is the change that looks safer and is worse.

## The turn

The button turn with a different label (`CONVERSATION_TRIGGER`, `preroll_discard=0`, `is_wakeword=False`). It must not borrow `button` or a `wakeword(…)` label — the dashboard groups wake statistics by it, and `wake_word_phrase` is keyed on the prefix.

The chime sequencing lives in `em_announce` so the suite can reach it, and a chime that fails or wedges cannot swallow the message it announces.

## Testing

Controller-only, no firmware requirement, no migration. 904 tests pass.

**Not yet run against live HA or hardware** — the protocol assumptions come from reading HA's `assist_satellite` source, not from a live call. Worth one `ask_question` at a device before this reaches a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Dd5WjaRg8SUWv8msXjXU6