### PR TITLE
Early Access 2.22.0-ea.9

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.22.0-ea.9 (Early Access)
 
 **Your Echoes can now be asked a question by Home Assistant, and will listen for
 the answer.** Nothing to do before updating: no database migration, no firmware

--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -17,7 +17,7 @@ name: "EchoMuse (Early Access)"
 # derives from the controller-v* tag (controller-v2.18.0 -> 2.18.0). Bump
 # both together: Supervisor pulls `image:version`, so a version with no
 # matching tag on GHCR fails to install.
-version: "2.22.0-ea.8"
+version: "2.22.0-ea.9"
 # Pull the published multi-arch image rather than building on the user's
 # machine. Without this Supervisor builds from this directory's Dockerfile,
 # which downloads a few hundred MB on whatever the user runs Home Assistant

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.22.0-ea.9 (Early Access)
 
 **Your Echoes can now be asked a question by Home Assistant, and will listen for
 the answer.** Nothing to do before updating: no database migration, no firmware


### PR DESCRIPTION
Cuts **EA 2.22.0-ea.9**, carrying #397 — announce-then-listen.

`assist_satellite.start_conversation` and `assist_satellite.ask_question` can now be pointed at an EchoMuse device. The Echo plays the message, then lights its ring and listens, exactly as it does after a wake word. The attention chime Home Assistant sends before the message is played rather than discarded.

Controller-only: no database migration, no firmware requirement, nothing to change on a device.

Version pinned with `sync_channels.py --set-version`; the changelog heading is edited in `controller/` so the generator produces the EA copy. 904 tests pass.

**Still untested against live HA or hardware** — the protocol assumptions come from reading HA's `assist_satellite` source. This EA build is how that gets tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Dd5WjaRg8SUWv8msXjXU6