### PR TITLE
Early Access 2.22.0-ea.10

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2.22.0-ea.10 (Early Access)
+
+**A fix for interrupting your Echo mid-response.** Nothing to do before
+updating: no database migration, no firmware requirement, nothing to change on
+your devices.
+
+### Talking over a response cleaned up badly
+
+When you interrupt an Echo while it is speaking, the controller stops decoding
+the rest of the response and tears down the audio pipeline. It was doing that
+in the wrong order, and two things followed.
+
+The visible one was noise in the log: an unhandled error with a full traceback,
+printed on every interruption. Harmless in itself, but it sat next to whatever
+someone was actually investigating and cost them time — and it goes into support
+bundles.
+
+The other was not visible and matters more. In the right conditions the teardown
+could stop making progress rather than finish, holding the turn open. We have
+not seen this happen on a real device, so this is a fault found by measurement
+rather than one reported from the field; the fix removes the possibility either
+way.
+
+Nothing about interrupting changes from your side — it behaves as it did, minus
+the error.
+
 ## 2.22.0-ea.9 (Early Access)
 
 **Your Echoes can now be asked a question by Home Assistant, and will listen for

--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -17,7 +17,7 @@ name: "EchoMuse (Early Access)"
 # derives from the controller-v* tag (controller-v2.18.0 -> 2.18.0). Bump
 # both together: Supervisor pulls `image:version`, so a version with no
 # matching tag on GHCR fails to install.
-version: "2.22.0-ea.9"
+version: "2.22.0-ea.10"
 # Pull the published multi-arch image rather than building on the user's
 # machine. Without this Supervisor builds from this directory's Dockerfile,
 # which downloads a few hundred MB on whatever the user runs Home Assistant

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2.22.0-ea.10 (Early Access)
+
+**A fix for interrupting your Echo mid-response.** Nothing to do before
+updating: no database migration, no firmware requirement, nothing to change on
+your devices.
+
+### Talking over a response cleaned up badly
+
+When you interrupt an Echo while it is speaking, the controller stops decoding
+the rest of the response and tears down the audio pipeline. It was doing that
+in the wrong order, and two things followed.
+
+The visible one was noise in the log: an unhandled error with a full traceback,
+printed on every interruption. Harmless in itself, but it sat next to whatever
+someone was actually investigating and cost them time — and it goes into support
+bundles.
+
+The other was not visible and matters more. In the right conditions the teardown
+could stop making progress rather than finish, holding the turn open. We have
+not seen this happen on a real device, so this is a fault found by measurement
+rather than one reported from the field; the fix removes the possibility either
+way.
+
+Nothing about interrupting changes from your side — it behaves as it did, minus
+the error.
+
 ## 2.22.0-ea.9 (Early Access)
 
 **Your Echoes can now be asked a question by Home Assistant, and will listen for


### PR DESCRIPTION
Cuts Early Access **2.22.0-ea.10**.

Carries one change on top of ea.9: the streaming teardown fix from #402, closing #252.

`_stream_tts_audio_once` killed ffmpeg *after* cancelling its feeder task and awaiting the gather. On a barge-in nobody drains ffmpeg's stdout, so ffmpeg blocks on write and stops reading stdin; the feeder's own `finally` then awaits a `stdin.wait_closed()` flush that can never complete, and the kill on the next line is never reached. Killing first breaks both pipes.

Controller-only — no database migration, no firmware requirement, nothing to change on devices.

## What to watch on the soak

The directly observable half is the `InvalidStateError` traceback disappearing from the log on barge-in. The hang has never been seen on a real device — it was found by measurement — so its absence is not strong evidence either way.

## Release order

`Controller Build (main)` must be green on the merge commit before the `controller-ea-v2.22.0-ea.10` tag is pushed, or the release job fails looking for `:sha-<short>`.

Full suite: 907 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxWstDAU3QMh64ymTeduvY
