### PR TITLE
Forward the BLE adverts Home Assistant reads, not every broadcast

### DIFF
--- a/device/internal/bluetooth/emit.go
+++ b/device/internal/bluetooth/emit.go
@@ -1,0 +1,164 @@
+package bluetooth
+
+import (
+	"sync"
+	"time"
+)
+
+// Emission policy for scanned advertisements (#404).
+//
+// Passive scanning with duplicate filtering off produces one HCI event per
+// broadcast, and a beacon typically broadcasts every 100-500ms. Forwarding
+// all of it costs the device far more than anything downstream reads:
+//
+//   - Home Assistant's habluetooth tolerates 195s (connectable) to 900s
+//     between advertisements per device before considering one stale, and
+//     declares a SCANNER dead only after 90s of total silence.
+//   - It smooths RSSI itself (EWMA alpha=0.3) and switches which proxy owns
+//     a device on a 16dB difference with a 6dB deadband, so resolution finer
+//     than a few dB changes no decision it makes.
+//   - Bermuda re-decides which area a device is in every second.
+//
+// So the binding requirement is roughly one advertisement per device per
+// second, and everything past that is waste — waste that lands on the
+// control WebSocket, contending with the keepalive pong and the RTT echo.
+//
+// The gate is deliberately NOT the chip's duplicate filter
+// (filter_duplicates=1), which suppresses identical advertisements: RSSI is
+// the field that varies and the field Bermuda consumes, so the chip filter
+// discards the signal and keeps the noise. Filtering here can be RSSI-aware
+// in a way the chip cannot.
+const (
+	// A change worth forwarding. Below this is inside this hardware's RSSI
+	// noise and inside HA's own smoothing.
+	emitRssiDeltaDb = 3
+
+	// Floor between RSSI-triggered emissions for one payload, so a device
+	// whose signal is fluctuating cannot restore the firehose on its own.
+	emitMinInterval = 250 * time.Millisecond
+
+	// Ceiling on silence per payload — keeps Bermuda's per-second area
+	// decision fed even for a beacon sitting perfectly still.
+	emitMaxSilence = 1000 * time.Millisecond
+
+	// Ceiling on silence for the scanner as a whole. HA's
+	// SCANNER_WATCHDOG_TIMEOUT is 90s; this leaves 3x margin.
+	emitGlobalMaxSilence = 30 * time.Second
+
+	// Entries not seen for this long are dropped, so the table tracks the
+	// devices in range rather than every device ever seen.
+	emitEntryTTL = 5 * time.Minute
+)
+
+type emitEntry struct {
+	rssi int
+	sent time.Time
+	seen time.Time
+}
+
+// emitGate decides which scanned advertisements are worth forwarding.
+// Keyed per (address, payload) exactly as batchKey coalesces, so a device
+// that alternates payloads — ADV_IND against a scan response, or a sensor
+// rotating service data — keeps a separate floor for each rather than
+// reading as a change on every broadcast.
+type emitGate struct {
+	mu      sync.Mutex
+	entries map[string]emitEntry
+	lastAny time.Time
+	dropped uint64
+}
+
+func newEmitGate() *emitGate {
+	return &emitGate{entries: make(map[string]emitEntry)}
+}
+
+// admit filters one batch of parsed advertisements.
+//
+// It returns the advertisements to forward and whether any of them is
+// URGENT — a payload this address has not broadcast before, which is the
+// case latency actually matters for: a new device arriving, a button press,
+// a sensor reading changing. Those bypass the batch tick; routine RSSI
+// refreshes ride it.
+func (g *emitGate) admit(adverts []Advert, now time.Time) (keep []Advert, urgent bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	// The scanner as a whole must not go quiet, or HA's watchdog retires it.
+	// Checked before the loop so one advert can satisfy it.
+	forceOne := !g.lastAny.IsZero() && now.Sub(g.lastAny) >= emitGlobalMaxSilence
+
+	for _, a := range adverts {
+		key := batchKey(a)
+		prev, seen := g.entries[key]
+
+		emit := false
+		switch {
+		case !seen:
+			// New address, or a payload this address has not sent before.
+			emit, urgent = true, true
+		case now.Sub(prev.sent) >= emitMaxSilence:
+			emit = true
+		case abs(a.Rssi-prev.rssi) >= emitRssiDeltaDb &&
+			now.Sub(prev.sent) >= emitMinInterval:
+			emit = true
+		case forceOne:
+			emit = true
+		}
+
+		if !emit {
+			// Still record the sighting, or the TTL sweep would retire a
+			// device that is broadcasting steadily and being filtered.
+			prev.seen = now
+			g.entries[key] = prev
+			g.dropped++
+			continue
+		}
+
+		forceOne = false
+		g.entries[key] = emitEntry{rssi: a.Rssi, sent: now, seen: now}
+		g.lastAny = now
+		keep = append(keep, a)
+	}
+
+	// Seed the global clock on the first batch, so a scanner that has never
+	// forwarded anything does not read as 30s overdue.
+	if g.lastAny.IsZero() {
+		g.lastAny = now
+	}
+	return keep, urgent
+}
+
+// prune drops entries for devices that have left. Called from the flush
+// ticker rather than per advertisement — this is the cold path.
+func (g *emitGate) prune(now time.Time) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for k, e := range g.entries {
+		if now.Sub(e.seen) > emitEntryTTL {
+			delete(g.entries, k)
+		}
+	}
+}
+
+// droppedCount reports advertisements filtered since start, for diagnostics.
+// The useful figure is against Stats.AdvertsSeen — their ratio is the
+// reduction this gate is achieving in the room it is actually in.
+func (g *emitGate) droppedCount() uint64 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.dropped
+}
+
+// tracked reports the current table size, for the same reason.
+func (g *emitGate) tracked() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.entries)
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/device/internal/bluetooth/emit_test.go
+++ b/device/internal/bluetooth/emit_test.go
@@ -1,0 +1,240 @@
+package bluetooth
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func adv(addr string, rssi int, data ...byte) Advert {
+	if len(data) == 0 {
+		data = []byte{0x02, 0x01, 0x06}
+	}
+	return Advert{Addr: addr, Rssi: rssi, Data: data}
+}
+
+func TestFirstSightingOfAPayloadIsForwardedAndUrgent(t *testing.T) {
+	g := newEmitGate()
+	now := time.Now()
+
+	keep, urgent := g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60)}, now)
+
+	if len(keep) != 1 {
+		t.Fatalf("a device never seen before must be forwarded, got %d", len(keep))
+	}
+	if !urgent {
+		t.Fatal("a new device must bypass the batch tick — that is the arrival latency case")
+	}
+}
+
+func TestARepeatedIdenticalBroadcastIsDropped(t *testing.T) {
+	g := newEmitGate()
+	now := time.Now()
+	g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60)}, now)
+
+	// A beacon repeating itself 100ms later at the same signal level.
+	keep, urgent := g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60)}, now.Add(100*time.Millisecond))
+
+	if len(keep) != 0 {
+		t.Fatalf("an unchanged repeat inside the floor must be dropped, got %d", len(keep))
+	}
+	if urgent {
+		t.Fatal("a dropped advert must not force a flush")
+	}
+}
+
+func TestAChangedPayloadIsForwardedImmediately(t *testing.T) {
+	g := newEmitGate()
+	now := time.Now()
+	g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60, 0x02, 0x01, 0x06)}, now)
+
+	// Same address, different payload 10ms later — a button press or a
+	// sensor reading. This is the case the whole design is for.
+	keep, urgent := g.admit(
+		[]Advert{adv("AA:BB:CC:DD:EE:01", -60, 0x02, 0x01, 0x1A)},
+		now.Add(10*time.Millisecond),
+	)
+
+	if len(keep) != 1 {
+		t.Fatal("a changed payload must be forwarded, whatever the floor")
+	}
+	if !urgent {
+		t.Fatal("a changed payload must bypass the batch tick")
+	}
+}
+
+func TestRssiMustMoveByTheThresholdAndClearTheFloor(t *testing.T) {
+	g := newEmitGate()
+	now := time.Now()
+	g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60)}, now)
+
+	// Inside HA's own smoothing, past the floor: not worth the control plane.
+	if keep, _ := g.admit(
+		[]Advert{adv("AA:BB:CC:DD:EE:01", -62)},
+		now.Add(300*time.Millisecond),
+	); len(keep) != 0 {
+		t.Fatalf("a %ddB move is below the %ddB threshold and must be dropped",
+			2, emitRssiDeltaDb)
+	}
+
+	// A real move, but inside the floor: rate-limited, or a fluctuating
+	// signal restores the firehose on its own.
+	if keep, _ := g.admit(
+		[]Advert{adv("AA:BB:CC:DD:EE:01", -70)},
+		now.Add(50*time.Millisecond),
+	); len(keep) != 0 {
+		t.Fatal("an RSSI move inside emitMinInterval must be rate-limited")
+	}
+
+	// A real move, past the floor.
+	if keep, _ := g.admit(
+		[]Advert{adv("AA:BB:CC:DD:EE:01", -70)},
+		now.Add(300*time.Millisecond),
+	); len(keep) != 1 {
+		t.Fatalf("a %ddB move past the floor must be forwarded", 10)
+	}
+}
+
+func TestASilentBeaconIsRefreshedOncePerSecond(t *testing.T) {
+	g := newEmitGate()
+	now := time.Now()
+	g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60)}, now)
+
+	// Bermuda re-decides area every second, so a perfectly stationary
+	// beacon still has to be refreshed at that cadence.
+	if keep, _ := g.admit(
+		[]Advert{adv("AA:BB:CC:DD:EE:01", -60)},
+		now.Add(emitMaxSilence),
+	); len(keep) != 1 {
+		t.Fatal("a stationary beacon must still be refreshed at emitMaxSilence")
+	}
+}
+
+func TestTheScannerNeverGoesSilentPastTheGlobalCeiling(t *testing.T) {
+	g := newEmitGate()
+	now := time.Now()
+	g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60)}, now)
+
+	// Contrived but the case that matters: a device whose payload and
+	// signal never change, and nothing else in range. HA retires a scanner
+	// that says nothing for SCANNER_WATCHDOG_TIMEOUT (90s), so something
+	// has to go out well before then.
+	late := now.Add(emitGlobalMaxSilence)
+	keep, _ := g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60)}, late)
+	if len(keep) == 0 {
+		t.Fatal("the gate must forward something rather than let HA retire the scanner")
+	}
+	if emitGlobalMaxSilence >= 90*time.Second {
+		t.Fatalf("emitGlobalMaxSilence %s leaves no margin on HA's 90s scanner watchdog",
+			emitGlobalMaxSilence)
+	}
+}
+
+func TestAlternatingPayloadsKeepSeparateFloors(t *testing.T) {
+	g := newEmitGate()
+	now := time.Now()
+	a := adv("AA:BB:CC:DD:EE:01", -60, 0x02, 0x01, 0x06)
+	b := adv("AA:BB:CC:DD:EE:01", -60, 0x03, 0x02, 0x0A)
+
+	g.admit([]Advert{a}, now)
+	g.admit([]Advert{b}, now.Add(10*time.Millisecond))
+
+	// Both payloads are now known. Alternating between them must not read
+	// as "changed" every time, or a device that rotates service data
+	// bypasses the gate completely.
+	total := 0
+	for i := 0; i < 10; i++ {
+		at := now.Add(time.Duration(20+i*20) * time.Millisecond)
+		next := a
+		if i%2 == 1 {
+			next = b
+		}
+		keep, _ := g.admit([]Advert{next}, at)
+		total += len(keep)
+	}
+	if total != 0 {
+		t.Fatalf("alternating known payloads inside the floor must be dropped, forwarded %d", total)
+	}
+}
+
+func TestTheTableTracksDevicesInRangeNotEveryDeviceEverSeen(t *testing.T) {
+	g := newEmitGate()
+	now := time.Now()
+
+	g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60)}, now)
+	if g.tracked() != 1 {
+		t.Fatalf("expected 1 tracked entry, got %d", g.tracked())
+	}
+
+	// A device that has left. Pruning is what stops the table growing for
+	// the life of the process in a place with passing phones.
+	g.prune(now.Add(emitEntryTTL + time.Second))
+	if g.tracked() != 0 {
+		t.Fatalf("a device gone for longer than the TTL must be dropped, %d left", g.tracked())
+	}
+}
+
+func TestASteadilyBroadcastingDeviceIsNotPrunedWhileBeingFiltered(t *testing.T) {
+	g := newEmitGate()
+	now := time.Now()
+	g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60)}, now)
+
+	// Seen constantly, forwarded rarely. If `seen` only advanced on
+	// emission the sweep would retire it, and it would then re-enter as a
+	// "new device" — an arrival event for something that never left.
+	at := now
+	for i := 0; i < 60; i++ {
+		at = at.Add(10 * time.Second)
+		g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60)}, at)
+		g.prune(at)
+	}
+	if g.tracked() != 1 {
+		t.Fatal("a device broadcasting throughout must stay tracked, not re-arrive")
+	}
+}
+
+// The property this exists for: output rate is bounded by the number of
+// devices in range, NOT by how fast they broadcast.
+//
+// That is what makes the saving scale — a beacon at 100ms costs the same as
+// one at 500ms, so the busier the room the more the gate removes. Asserting
+// a fixed reduction ratio instead would be asserting a property of the test's
+// chosen beacon interval.
+func TestOutputScalesWithDevicesNotWithBroadcastRate(t *testing.T) {
+	const (
+		devices  = 20
+		duration = 60 * time.Second
+	)
+
+	run := func(everyMs int) (seen, sent int) {
+		g := newEmitGate()
+		start := time.Now()
+		for t0 := time.Duration(0); t0 < duration; t0 += time.Duration(everyMs) * time.Millisecond {
+			batch := make([]Advert, 0, devices)
+			for d := 0; d < devices; d++ {
+				// Stationary, RSSI dithering by 1dB — inside the threshold
+				// and inside HA's own smoothing, which is the point.
+				rssi := -60 - (int(t0/time.Second)+d)%2
+				batch = append(batch, adv(fmt.Sprintf("AA:BB:CC:DD:EE:%02X", d), rssi))
+			}
+			seen += len(batch)
+			keep, _ := g.admit(batch, start.Add(t0))
+			sent += len(keep)
+		}
+		return seen, sent
+	}
+
+	// One per device per second is the requirement Bermuda's per-second area
+	// decision sets. Allow a little slack for the first-sighting emission.
+	expected := devices * int(duration/emitMaxSilence)
+
+	for _, everyMs := range []int{100, 200, 500} {
+		seen, sent := run(everyMs)
+		if sent < expected || sent > expected+devices {
+			t.Errorf("at %dms intervals: forwarded %d, expected ~%d (one per device per second)",
+				everyMs, sent, expected)
+		}
+		t.Logf("%3dms intervals: forwarded %4d of %5d (%.1f%%, %.1fx reduction)",
+			everyMs, sent, seen, 100*float64(sent)/float64(seen), float64(seen)/float64(sent))
+	}
+}

--- a/device/internal/bluetooth/scanner.go
+++ b/device/internal/bluetooth/scanner.go
@@ -81,6 +81,9 @@ type Scanner struct {
 	uniqueMu    sync.Mutex
 	unique      map[string]time.Time
 
+	// gate decides which adverts are worth the control plane (#404)
+	gate *emitGate
+
 	bluedroidDisabled bool
 }
 
@@ -89,6 +92,7 @@ func NewScanner(onBatch BatchCallback) *Scanner {
 		onBatch: onBatch,
 		unique:  make(map[string]time.Time),
 		pending: make(map[string]Advert),
+		gate:    newEmitGate(),
 	}
 }
 
@@ -265,6 +269,10 @@ func (s *Scanner) session(stopCh chan struct{}) error {
 
 	flushTicker := time.NewTicker(flushInterval)
 	defer flushTicker.Stop()
+	// The gate's table is swept on its own slow ticker — it is the cold
+	// path, and walking it at flushInterval would be its own small tax.
+	pruneTicker := time.NewTicker(emitEntryTTL / 5)
+	defer pruneTicker.Stop()
 	defer s.flush()
 	watchdog := time.NewTimer(watchdogQuiet)
 	defer watchdog.Stop()
@@ -281,6 +289,8 @@ func (s *Scanner) session(stopCh chan struct{}) error {
 			}
 		case <-flushTicker.C:
 			s.flush()
+		case <-pruneTicker.C:
+			s.gate.prune(time.Now())
 		case <-watchdog.C:
 			return fmt.Errorf("watchdog: no HCI events for %s — re-initialising", watchdogQuiet)
 		case err := <-readErr:
@@ -302,13 +312,28 @@ func (s *Scanner) ingest(adverts []Advert) {
 		s.unique[a.Addr] = now
 	}
 	s.uniqueMu.Unlock()
+
+	// Filter before batching (#404). Everything admitted here is something
+	// Home Assistant or Bermuda actually reads; the rest is a beacon
+	// repeating itself at 100-500ms into a control channel shared with the
+	// keepalive pong. See emit.go for what the constants are derived from.
+	keep, urgent := s.gate.admit(adverts, now)
+	if len(keep) == 0 {
+		return
+	}
+
 	s.batchMu.Lock()
-	for _, a := range adverts {
+	for _, a := range keep {
 		s.pending[batchKey(a)] = a
 	}
 	full := len(s.pending) >= flushCount
 	s.batchMu.Unlock()
-	if full {
+
+	// A payload never broadcast before is the case latency matters for — a
+	// device arriving, a button press, a sensor changing. Those go now
+	// rather than waiting up to flushInterval to be amortised against
+	// beacons repeating themselves; routine RSSI refreshes ride the tick.
+	if full || urgent {
 		s.flush()
 	}
 }


### PR DESCRIPTION
First half of #404 — the device-local half, which is what cuts the volume. No protocol change, no capability negotiation, any controller pairing unaffected.

## What it does

`emitGate` keeps a table per (address, payload) and forwards on:

| condition | why |
|---|---|
| payload this address has not broadcast before | a device arriving, a button press, a sensor reading — **bypasses the batch tick** |
| RSSI moved >= 3dB, max once per 250ms | HA smooths at alpha=0.3 and switches source on 16dB/6dB deadband; finer changes no decision, and sits inside this hardware's noise |
| nothing sent for that payload in 1s | Bermuda re-decides area every second |
| nothing sent at all for 30s | HA retires a scanner after 90s (`SCANNER_WATCHDOG_TIMEOUT`) — 3x margin |

Entries unseen for 5 minutes are swept, on their own slow ticker rather than the 250ms flush path.

## The property under test

Output is bounded by **devices in range**, not by how fast they broadcast — which is what makes the saving scale with how busy the room is. At 20 devices over 60s:

```
100ms intervals: forwarded 1200 of 12000 (10.0%, 10.0x reduction)
200ms intervals: forwarded 1200 of  6000 (20.0%,  5.0x reduction)
500ms intervals: forwarded 1200 of  2400 (50.0%,  2.0x reduction)
```

1200 = 20 devices x 60 seconds, in every case.

The first version of that test asserted a fixed reduction ratio and failed at 5x — correctly, because the ratio is a property of the beacon interval, not of the gate. It now asserts the invariant instead.

## It also gets faster

The 250ms flush tick put a floor under everything, delaying a genuinely new device or a changed payload in order to amortise beacons repeating themselves. First-seen payloads now bypass it; routine RSSI refreshes still ride it.

## Rejected, on the reading

- **Lowering the scan duty cycle.** 320ms/30ms is exactly `esp32_ble_tracker`'s default, which is what Bermuda deployments are tuned against. Fine as a diagnostic, wrong as a fix.
- **`filter_duplicates=1` at the chip.** It suppresses identical adverts, but RSSI is the field that varies and the field Bermuda consumes — the chip filter discards the signal and keeps the noise. Filtering on the device can be RSSI-aware; the chip cannot.

## Verification

- `go test ./internal/bluetooth/` — 10 new cases, all pass, plus the existing HCI tests.
- `./compile.sh` — ARM firmware builds.
- Not yet run on hardware. The check that matters after deploy is `advertsSent` against `advertsSeen` in the BLE stats, and a Bermuda distance sensor still tracking across the change.

## Still open in #404

Moving adverts off the control plane onto the data plane. That is the structural half — it removes the coupling permanently rather than reducing what flows through it — and it needs capability negotiation plus an interface-doc update, so it is left to its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxWstDAU3QMh64ymTeduvY
