### PR TITLE
Take the Echo ref row back off the Status tab

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1748,17 +1748,6 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
                          : (s?.volumePct != null ? `${s.volumePct}%` : '—'))}
                     {row('Link', device.connected ? (device.linkTls ? 'wss (TLS)' : 'plain ws') : '—',
                          device.connected ? (device.linkTls ? 'var(--ok)' : 'var(--warn)') : undefined)}
-                    {/* Which far-end reference the AEC found. Shown only
-                        while cancellation is running: "off" is already
-                        readable from the AEC toggle, and a row repeating it
-                        earns nothing. Absent on firmware that cannot say,
-                        which must not read as the software tap. */}
-                    {device.connected && (device.aecRef === 'hw' || device.aecRef === 'sw') &&
-                      row('Echo ref',
-                          device.aecRef === 'hw'
-                            ? 'hardware (frame-aligned)'
-                            : 'software tap (delay-compensated)',
-                          device.aecRef === 'hw' ? 'var(--ok)' : undefined)}
                     {row('Config', (() => {
                       const n = (device.config_sections ?? []).length;
                       const total = Object.keys(CONFIG_SECTIONS).length;


### PR DESCRIPTION
Removes the "Echo ref" row I added to the Status tab with the hardware AEC work (#385).

It should not have gone in — adding a row to an existing dashboard panel as a side effect of a feature is a layout decision, and that was made explicit on 2026-08-31 after the same thing happened.

It is worse than a spare row because it is **conditional**: it renders only while `aecRef` is `hw` or `sw`, so a fleet with one device on hardware-reference firmware and one without gets device panels of different heights, and everything below them stops lining up.

## Nothing is lost

The AEC reference-source control on the Microphones tab still reads the runtime value via `hwEchoRef` (`dashboard.jsx:1927`), which is what CLAUDE.md asks for — gate the UI on the runtime value, since the delay control is meaningless on a frame-aligned reference. That call site is untouched.

## Verification

- `test_design_tokens.py`, `test_config_sections.py`, `test_deploy.py`, `test_channels.py` — 115 passed
- JSX compiles under the same esbuild 0.20.2 the image uses
- `sync_channels.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxWstDAU3QMh64ymTeduvY
