### PR TITLE
Stop treating a rotating BLE address as an arrival

### DIFF
--- a/device/internal/bluetooth/emit.go
+++ b/device/internal/bluetooth/emit.go
@@ -61,24 +61,43 @@ type emitEntry struct {
 // that alternates payloads — ADV_IND against a scan response, or a sensor
 // rotating service data — keeps a separate floor for each rather than
 // reading as a change on every broadcast.
+//
+// `addrs` tracks addresses independently of payload, and exists for one
+// reason: **BLE privacy addresses rotate**, roughly every 15 minutes on
+// phones and watches. A never-before-seen address is therefore NOT evidence
+// that anything arrived — most of the time it is a device already in the
+// room wearing a new name. Resolving that properly needs the IRK, which is
+// Home Assistant's job and not something to attempt here.
 type emitGate struct {
 	mu      sync.Mutex
 	entries map[string]emitEntry
+	addrs   map[string]time.Time
 	lastAny time.Time
 	dropped uint64
 }
 
 func newEmitGate() *emitGate {
-	return &emitGate{entries: make(map[string]emitEntry)}
+	return &emitGate{
+		entries: make(map[string]emitEntry),
+		addrs:   make(map[string]time.Time),
+	}
 }
 
 // admit filters one batch of parsed advertisements.
 //
 // It returns the advertisements to forward and whether any of them is
-// URGENT — a payload this address has not broadcast before, which is the
-// case latency actually matters for: a new device arriving, a button press,
-// a sensor reading changing. Those bypass the batch tick; routine RSSI
-// refreshes ride it.
+// URGENT — a KNOWN address whose payload changed, which is the case latency
+// actually matters for: a button press, a sensor reading, a beacon changing
+// state. Those cut the batch tick short; everything else rides it.
+//
+// A first sighting of an address is deliberately NOT urgent, however new it
+// looks. Privacy addresses rotate, so in a room with a few phones the
+// "never seen this address" branch fires continuously — the first version of
+// this treated each rotation as an arrival and flushed on it, which made the
+// gate emit MORE small writes than the plain 250ms batching it replaced, on
+// the same goroutine that reads HCI. Exactly backwards. A genuine arrival
+// waits at most one tick, which nothing downstream can perceive: Home
+// Assistant tolerates 195s.
 func (g *emitGate) admit(adverts []Advert, now time.Time) (keep []Advert, urgent bool) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -90,12 +109,19 @@ func (g *emitGate) admit(adverts []Advert, now time.Time) (keep []Advert, urgent
 	for _, a := range adverts {
 		key := batchKey(a)
 		prev, seen := g.entries[key]
+		_, knownAddr := g.addrs[a.Addr]
+		g.addrs[a.Addr] = now
 
 		emit := false
 		switch {
 		case !seen:
-			// New address, or a payload this address has not sent before.
-			emit, urgent = true, true
+			// A payload this address has not sent before. Urgent only if we
+			// already knew the address — otherwise this is a first sighting,
+			// which is as likely to be an address rotation as an arrival.
+			emit = true
+			if knownAddr {
+				urgent = true
+			}
 		case now.Sub(prev.sent) >= emitMaxSilence:
 			emit = true
 		case abs(a.Rssi-prev.rssi) >= emitRssiDeltaDb &&
@@ -136,6 +162,14 @@ func (g *emitGate) prune(now time.Time) {
 	for k, e := range g.entries {
 		if now.Sub(e.seen) > emitEntryTTL {
 			delete(g.entries, k)
+		}
+	}
+	// Rotating addresses are the reason this map needs sweeping at all —
+	// without it, a room with a few phones adds a permanent entry every
+	// ~15 minutes for the life of the process.
+	for a, seen := range g.addrs {
+		if now.Sub(seen) > emitEntryTTL {
+			delete(g.addrs, a)
 		}
 	}
 }

--- a/device/internal/bluetooth/emit_test.go
+++ b/device/internal/bluetooth/emit_test.go
@@ -13,7 +13,7 @@ func adv(addr string, rssi int, data ...byte) Advert {
 	return Advert{Addr: addr, Rssi: rssi, Data: data}
 }
 
-func TestFirstSightingOfAPayloadIsForwardedAndUrgent(t *testing.T) {
+func TestFirstSightingIsForwardedButNotUrgent(t *testing.T) {
 	g := newEmitGate()
 	now := time.Now()
 
@@ -22,8 +22,31 @@ func TestFirstSightingOfAPayloadIsForwardedAndUrgent(t *testing.T) {
 	if len(keep) != 1 {
 		t.Fatalf("a device never seen before must be forwarded, got %d", len(keep))
 	}
-	if !urgent {
-		t.Fatal("a new device must bypass the batch tick — that is the arrival latency case")
+	if urgent {
+		t.Fatal("a first sighting must NOT cut the tick short — privacy addresses " +
+			"rotate, so an unseen address is as likely to be a rename as an arrival")
+	}
+}
+
+// The defect this test exists for: BLE privacy addresses rotate roughly every
+// 15 minutes, so treating an unseen address as an arrival makes the urgent
+// path fire continuously in any room with phones in it — emitting more small
+// writes than the plain batching it replaced, on the goroutine that reads HCI.
+func TestRotatingPrivacyAddressesNeverCutTheTickShort(t *testing.T) {
+	g := newEmitGate()
+	start := time.Now()
+
+	urgentCount := 0
+	for i := 0; i < 200; i++ {
+		// A phone re-randomising its address on every broadcast: the
+		// pathological case, and the shape of the real one.
+		a := adv(fmt.Sprintf("7A:BB:CC:DD:%02X:%02X", i/256, i%256), -60)
+		if _, urgent := g.admit([]Advert{a}, start.Add(time.Duration(i)*100*time.Millisecond)); urgent {
+			urgentCount++
+		}
+	}
+	if urgentCount != 0 {
+		t.Fatalf("rotating addresses triggered %d urgent flushes; must be 0", urgentCount)
 	}
 }
 
@@ -49,7 +72,8 @@ func TestAChangedPayloadIsForwardedImmediately(t *testing.T) {
 	g.admit([]Advert{adv("AA:BB:CC:DD:EE:01", -60, 0x02, 0x01, 0x06)}, now)
 
 	// Same address, different payload 10ms later — a button press or a
-	// sensor reading. This is the case the whole design is for.
+	// sensor reading. A KNOWN address changing what it says is the one case
+	// latency genuinely matters for, and the only thing that cuts the tick.
 	keep, urgent := g.admit(
 		[]Advert{adv("AA:BB:CC:DD:EE:01", -60, 0x02, 0x01, 0x1A)},
 		now.Add(10*time.Millisecond),
@@ -59,7 +83,7 @@ func TestAChangedPayloadIsForwardedImmediately(t *testing.T) {
 		t.Fatal("a changed payload must be forwarded, whatever the floor")
 	}
 	if !urgent {
-		t.Fatal("a changed payload must bypass the batch tick")
+		t.Fatal("a known address changing payload must cut the batch tick short")
 	}
 }
 

--- a/device/internal/bluetooth/scanner.go
+++ b/device/internal/bluetooth/scanner.go
@@ -285,7 +285,10 @@ func (s *Scanner) session(stopCh chan struct{}) error {
 			}
 			watchdog.Reset(watchdogQuiet)
 			if adverts := parseAdvReports(pkt); len(adverts) > 0 {
-				s.ingest(adverts)
+				if s.ingest(adverts) {
+					// Keep the total flush rate at or below the plain tick.
+					flushTicker.Reset(flushInterval)
+				}
 			}
 		case <-flushTicker.C:
 			s.flush()
@@ -304,7 +307,9 @@ func (s *Scanner) session(stopCh chan struct{}) error {
 	}
 }
 
-func (s *Scanner) ingest(adverts []Advert) {
+// ingest filters, batches and (when warranted) flushes one parsed batch.
+// Returns true if it flushed early, so the caller can reset the flush tick.
+func (s *Scanner) ingest(adverts []Advert) bool {
 	s.advertsSeen.Add(uint64(len(adverts)))
 	now := time.Now()
 	s.uniqueMu.Lock()
@@ -319,7 +324,7 @@ func (s *Scanner) ingest(adverts []Advert) {
 	// keepalive pong. See emit.go for what the constants are derived from.
 	keep, urgent := s.gate.admit(adverts, now)
 	if len(keep) == 0 {
-		return
+		return false
 	}
 
 	s.batchMu.Lock()
@@ -329,13 +334,20 @@ func (s *Scanner) ingest(adverts []Advert) {
 	full := len(s.pending) >= flushCount
 	s.batchMu.Unlock()
 
-	// A payload never broadcast before is the case latency matters for — a
-	// device arriving, a button press, a sensor changing. Those go now
-	// rather than waiting up to flushInterval to be amortised against
-	// beacons repeating themselves; routine RSSI refreshes ride the tick.
+	// A known device whose payload changed — a button press, a sensor
+	// reading — goes now rather than waiting up to flushInterval to be
+	// amortised against beacons repeating themselves. Routine RSSI
+	// refreshes ride the tick.
+	//
+	// Reported back so the caller can RESET the tick: an early flush then
+	// moves a write earlier without adding one. That bound is the point —
+	// it holds the flush rate no higher than the plain 250ms batching this
+	// replaced, whatever the room does, on a goroutine that also reads HCI.
 	if full || urgent {
 		s.flush()
+		return true
 	}
+	return false
 }
 
 func (s *Scanner) flush() {


### PR DESCRIPTION
Fixes a defect in #405, found the same evening it shipped.

## The defect

The urgent path — which cuts the batch tick short so a latency-sensitive advert goes immediately — fired on any `(address, payload)` pair the gate had not seen.

**BLE privacy addresses rotate**, roughly every 15 minutes on phones and watches, and a rotated address arrives with a payload under a name we have never seen. So in any room with phones in it the urgent branch fires continuously — and `flush()` runs synchronously on the goroutine that reads HCI, taking `connMu` and doing a deadlined network write each time.

The gate exists to *reduce* control-plane writes. In a busy room that branch could produce **more** small writes than the plain 250ms batching it replaced. Exactly backwards, and on the worst possible goroutine.

## Two changes

**1. Urgency requires a known address whose payload changed.** That is the case latency genuinely matters for — a button press, a sensor reading. A first sighting is as likely to be a rename as an arrival, and telling them apart needs the IRK, which is Home Assistant's job. A genuine arrival now waits at most one tick; nothing downstream can perceive 250ms when HA tolerates 195s.

**2. An early flush resets the flush ticker.** This is the half that bounds it: an early flush now moves a write *earlier* rather than *adding* one, so the flush rate is no higher than the plain batching this replaced, whatever the room does. `ingest` reports back rather than owning the ticker, since it already runs on the loop goroutine that has it.

`addrs` is swept on the same TTL as the payload table, or rotation would add a permanent entry every ~15 minutes for the life of the process.

## Tests

New: `TestRotatingPrivacyAddressesNeverCutTheTickShort` drives 200 consecutive never-before-seen addresses (the pathological case, and the shape of the real one) and asserts zero urgent flushes. `TestFirstSightingOfAPayloadIsForwardedAndUrgent` is inverted and renamed — it asserted the defect.

All 11 gate cases plus the existing HCI tests pass; `go vet` clean; ARM firmware builds.

## Relationship to tonight's HCI reset

**Not known to be the cause.** The transport reset on C95 is a read-path failure in code this does not touch, and the log ordering shows the WiFi link failing *before* our reopen rather than after. This is a defect on its own merits, found by re-reading the change rather than by chasing that event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxWstDAU3QMh64ymTeduvY
