### PR TITLE
Serialise firmware updates across the controller, not per device

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -187,6 +187,12 @@ _updates_in_progress: set[str] = set()
 # rest of a fleet update behind it.
 _ota_lock = asyncio.Lock()
 
+# Longest one device may hold the OTA queue. A real update is a ~10MB transfer,
+# a reboot and a 90s reconnect watch, so this is a deadlock cap rather than a
+# performance budget: it exists because serialising made one wedged device able
+# to block the whole fleet's updates until the controller restarted.
+OTA_MAX_HOLD_S = 300.0
+
 # Devices waiting on `_ota_lock`. Reported separately from
 # `update_in_progress` so the dashboard says "queued" rather than claiming
 # work that has not started — the same rule as everywhere else here: a control
@@ -1713,6 +1719,41 @@ async def _run_update(device_id: str, release: dict,
         _updates_queued.discard(device_id)
 
     _updates_in_progress.add(device_id)
+    try:
+        # Bounded, because serialising turned a device-local stall into a
+        # fleet-wide one. Every `recv` in the transfer is wait_for-bounded but
+        # `await ws.send(line)` in the base64 loop is not: a device that stops
+        # reading applies backpressure and can hang there. Before the lock that
+        # stalled one device; now it would hold the queue and NOTHING could be
+        # updated until the controller restarted.
+        #
+        # Generous on purpose — a real update is a ~10MB transfer plus a reboot
+        # and a 90s reconnect watch, so this is a deadlock cap, not a
+        # performance budget. A device that trips it has failed anyway.
+        await asyncio.wait_for(
+            _run_update_locked(device_id, release, binary_override),
+            timeout=OTA_MAX_HOLD_S,
+        )
+    except asyncio.TimeoutError:
+        await _update_failed(
+            device_id,
+            f"Update abandoned after {OTA_MAX_HOLD_S:.0f}s so the queue "
+            f"could continue — the device may still be mid-update",
+        )
+    finally:
+        _updates_in_progress.discard(device_id)
+        # Release LAST, so the next queued device does not start its transfer
+        # while this one is still being cleaned up.
+        _ota_lock.release()
+
+
+async def _run_update_locked(device_id: str, release: dict,
+                             binary_override: bytes | None = None) -> None:
+    """
+    The update itself, run with `_ota_lock` already held. Split from
+    `_run_update` so the whole of it can sit under one timeout — the queue is
+    only as safe as its slowest member.
+    """
     loop = asyncio.get_event_loop()
     version = release["version"]
 
@@ -1895,11 +1936,6 @@ async def _run_update(device_id: str, release: dict,
     except Exception as e:
         log.exception(f"[api] OTA update error for {device_id}: {e}")
         await _update_failed(device_id, f"OTA exception: {e}")
-    finally:
-        _updates_in_progress.discard(device_id)
-        # Release LAST, so the next queued device does not start its transfer
-        # while this one is still being cleaned up.
-        _ota_lock.release()
 
 
 async def _run_rollback(device_id: str, target_version: str) -> None:

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -169,6 +169,30 @@ _event_clients: set[web.WebSocketResponse] = set()
 # Track in-progress OTA updates per device_id to enforce one-at-a-time.
 _updates_in_progress: set[str] = set()
 
+# Firmware updates are SERIALISED across the whole controller, not just per
+# device. Three concurrent OTAs stalled the event loop for 11.1 seconds on
+# 2026-09-02 — measured, in the `[loop] event loop stalled` warnings — and
+# that loop is what sends speaker periods and LED frames, so a device mid
+# response pays for a device being updated. The transfer is base64 over the
+# shell plane and CPU-bound in this process; the fix is to stop doing several
+# at once, not to make one cheaper.
+#
+# A device-level guard cannot do this: `_updates_in_progress` stops one device
+# being updated twice, and says nothing about two devices being updated at
+# once. So the lock is global and BOTH entry points go through it — the fleet
+# deploy and a hand-clicked single update, which collide identically.
+#
+# A failure does NOT stop the queue. Wil's call, 2026-09-02: mark it, carry on,
+# report at the end — one device that will not come back should not strand the
+# rest of a fleet update behind it.
+_ota_lock = asyncio.Lock()
+
+# Devices waiting on `_ota_lock`. Reported separately from
+# `update_in_progress` so the dashboard says "queued" rather than claiming
+# work that has not started — the same rule as everywhere else here: a control
+# that cannot act must say so rather than appear to work.
+_updates_queued: set[str] = set()
+
 # Last OTA failure per device, surfaced as `update_error` in /api/devices so
 # the dashboard (fleet deploy modal + per-device update log) can show *why* a
 # tile stopped progressing instead of sitting at "updating…" forever. Set by
@@ -1418,7 +1442,7 @@ async def _post_device_update(request: web.Request) -> web.Response:
     if live is None:
         return _error("device_offline", "Device is not connected", 409)
 
-    if device_id in _updates_in_progress:
+    if device_id in _updates_in_progress or device_id in _updates_queued:
         return _error("update_in_progress", "An update is already in progress", 409)
 
     asyncio.create_task(_run_update(device_id, release, binary_override))
@@ -1448,7 +1472,7 @@ async def _post_device_rollback(request: web.Request) -> web.Response:
     if live is None:
         return _error("device_offline", "Device is not connected", 409)
 
-    if device_id in _updates_in_progress:
+    if device_id in _updates_in_progress or device_id in _updates_queued:
         return _error("update_in_progress", "An update is already in progress", 409)
 
     asyncio.create_task(_run_rollback(device_id, row["firmware_previous"]))
@@ -1676,8 +1700,19 @@ async def _run_update(device_id: str, release: dict,
     5. Restart service and monitor reconnect.
     6. Detect auto-rollback (start_server.sh retry exhausted).
     """
-    _updates_in_progress.add(device_id)
     _update_errors.pop(device_id, None)  # fresh attempt clears the last failure
+
+    # Wait for any other device's update to finish before touching this one.
+    # Queued state is visible while waiting (see `_updates_queued`), and the
+    # binary is fetched INSIDE the lock so a queued device is holding nothing
+    # but its place in line.
+    _updates_queued.add(device_id)
+    try:
+        await _ota_lock.acquire()
+    finally:
+        _updates_queued.discard(device_id)
+
+    _updates_in_progress.add(device_id)
     loop = asyncio.get_event_loop()
     version = release["version"]
 
@@ -1862,6 +1897,9 @@ async def _run_update(device_id: str, release: dict,
         await _update_failed(device_id, f"OTA exception: {e}")
     finally:
         _updates_in_progress.discard(device_id)
+        # Release LAST, so the next queued device does not start its transfer
+        # while this one is still being cleaned up.
+        _ota_lock.release()
 
 
 async def _run_rollback(device_id: str, target_version: str) -> None:
@@ -2696,7 +2734,7 @@ async def _post_deploy_all(request: web.Request) -> web.Response:
         if not upload_token and row["firmware_ver"] == release["version"]:
             skipped.append({"device_id": device_id, "reason": "already_current"})
             continue
-        if device_id in _updates_in_progress:
+        if device_id in _updates_in_progress or device_id in _updates_queued:
             skipped.append({"device_id": device_id, "reason": "update_in_progress"})
             continue
 
@@ -4742,6 +4780,10 @@ def _merge_device(row) -> dict:
         "wifi":             wifi_state(device_id),
         # Update state
         "update_in_progress": device_id in _updates_in_progress,
+        # Waiting on the global OTA lock — started, but nothing has been sent
+        # to this device yet. Distinct from update_in_progress so the panel
+        # does not report a transfer that has not begun.
+        "update_queued":      device_id in _updates_queued,
         # Last OTA/rollback failure (None when the last attempt succeeded or
         # none was made) — lets the dashboard show a terminal ✗ state instead
         # of "updating…" forever when an update aborts.

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5664,6 +5664,10 @@ function DeployAllModal({ release, devices, deployState, onStarted, onDismiss, o
     // A recorded failure is terminal — without this the row (and the header
     // progress pill) sat at "updating…" forever after an aborted update.
     if (d.update_error)                  return { text: `✗ ${d.update_error}`, color: 'var(--error)' };
+    // Queued outranks "rebooting…": a device waiting its turn has had nothing
+    // sent to it, and a disconnected one in the queue is offline for its own
+    // reasons, not because we restarted it.
+    if (d.update_queued)                 return { text: 'queued',       color: 'var(--muted)' };
     if (!d.connected)                    return { text: 'rebooting…',   color: 'var(--warn)' };
     return { text: 'updating…', color: 'var(--accent)' };
   }

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -691,9 +691,10 @@ def test_a_failed_update_asks_for_the_supervisor_log():
     from pathlib import Path
     api = (Path(__file__).resolve().parent.parent / "em_api.py").read_text()
 
-    # The failure paths live in _run_update, which is what awaits
-    # _monitor_reconnect and decides what its result means.
-    monitor = api[api.index("async def _run_update"):]
+    # The failure paths live in _run_update_locked, which is what awaits
+    # _monitor_reconnect and decides what its result means. (_run_update is
+    # now the queue wrapper in front of it.)
+    monitor = api[api.index("async def _run_update_locked"):]
     monitor = monitor[:monitor.index("\nasync def ", 1)]
     assert monitor.count("_supervisor_log_wanted.add") >= 2, (
         "both update-failure paths (auto-rollback and timeout) must request "
@@ -1921,11 +1922,27 @@ def test_firmware_updates_are_serialised_across_the_whole_controller():
     assert "_ota_lock.release()" in body, "the lock must be released"
 
     # Nothing may reach the device before the lock is held, or the serialising
-    # is decorative: the transfer is the expensive part.
-    acquire  = body.index("_ota_lock.acquire()")
-    transfer = body.index("_stream_binary_to_slot")
-    assert acquire < transfer, (
-        "the lock must be acquired BEFORE the binary transfer starts"
+    # is decorative: the transfer is the expensive part, and it all lives
+    # inside _run_update_locked.
+    acquire = body.index("_ota_lock.acquire()")
+    work    = body.index("_run_update_locked")
+    assert acquire < work, (
+        "the lock must be acquired BEFORE the update work starts"
+    )
+    inner = _strip_prose(_fn_body(src, "_run_update_locked"))
+    assert "_stream_binary_to_slot" in inner, (
+        "the transfer must live inside the locked half"
+    )
+    assert "_ota_lock" not in inner, (
+        "the locked half must not touch the lock — one owner, or a release "
+        "on a path that never acquired frees somebody else's turn"
+    )
+
+    # Bounded, or one wedged device holds the whole fleet's queue: the base64
+    # send loop has no timeout of its own.
+    assert "OTA_MAX_HOLD_S" in body and "wait_for" in body, (
+        "the locked half must run under a timeout — serialising turns a "
+        "device-local stall into a fleet-wide one"
     )
 
     # Released in the finally, not on the success path — an update that raises

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1883,3 +1883,83 @@ def test_every_outcome_cue_names_a_scene_key_that_exists():
     scene = em_scenes.resolve({})
     for key in keys:
         assert key in scene, f"_OUTCOME_ANIM names {key}, which no scene defines"
+
+
+def _strip_prose(src: str) -> str:
+    """
+    Drop comments and string literals from a source slice.
+
+    A guard that greps for the thing it forbids finds the comment explaining
+    it and passes anyway — three separate tests in this tree have done exactly
+    that. The prose below this function's subject is unusually chatty about
+    locks, so strip it before asserting on code.
+    """
+    src = re.sub(r'""".*?"""', "", src, flags=re.S)
+    src = re.sub(r"#.*", "", src)
+    return src
+
+
+def test_firmware_updates_are_serialised_across_the_whole_controller():
+    """
+    Three concurrent OTAs stalled the event loop for 11.1 seconds (measured
+    2026-09-02, `[loop] event loop stalled` in the GA log) — and that loop is
+    what sends speaker periods and LED frames, so a device answering someone
+    pays for a device being updated.
+
+    `_updates_in_progress` cannot prevent it: it stops ONE device being
+    updated twice and says nothing about two devices at once. The serialiser
+    has to be a global lock taken inside `_run_update`, so both entry points —
+    the fleet deploy and a hand-clicked single update — go through it.
+    """
+    src  = (CONTROLLER / "em_api.py").read_text()
+    body = _strip_prose(_fn_body(src, "_run_update"))
+
+    assert "_ota_lock.acquire()" in body, (
+        "_run_update must take the global OTA lock — a per-device guard does "
+        "not stop two devices updating at once"
+    )
+    assert "_ota_lock.release()" in body, "the lock must be released"
+
+    # Nothing may reach the device before the lock is held, or the serialising
+    # is decorative: the transfer is the expensive part.
+    acquire  = body.index("_ota_lock.acquire()")
+    transfer = body.index("_stream_binary_to_slot")
+    assert acquire < transfer, (
+        "the lock must be acquired BEFORE the binary transfer starts"
+    )
+
+    # Released in the finally, not on the success path — an update that raises
+    # would otherwise hold the lock for the life of the process and no device
+    # could ever be updated again without a restart.
+    tail = body[body.rindex("finally:"):]
+    assert "_ota_lock.release()" in tail, (
+        "release the lock in the finally — a failed update must not strand "
+        "every later one behind it"
+    )
+
+
+def test_a_queued_update_is_reported_as_queued_not_as_in_progress():
+    """
+    Serialising means a device can be started and not yet touched. Reporting
+    that as `update_in_progress` claims a transfer that has not begun, which
+    is the same failure as any control that appears to work and does not.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+    assert '"update_queued":' in src, (
+        "/api/devices must expose update_queued, or the dashboard cannot tell "
+        "waiting from working"
+    )
+
+    body = _strip_prose(_fn_body(src, "_run_update"))
+    add     = body.index("_updates_queued.add")
+    acquire = body.index("_ota_lock.acquire()")
+    assert add < acquire, "a device must be marked queued BEFORE it waits"
+    assert "_updates_queued.discard" in body, (
+        "queued state must be cleared once the lock is held, or a device "
+        "reads as queued for the whole of its own update"
+    )
+
+    jsx = (CONTROLLER / "static" / "dashboard.jsx").read_text()
+    assert "update_queued" in jsx, (
+        "the fleet deploy modal must render the queued state it is sent"
+    )


### PR DESCRIPTION
Three concurrent OTAs stalled the event loop for **11.1 seconds** on the GA controller today, updating three devices to v2.14.0. That loop sends speaker periods and LED frames, so a device answering someone pays for a device being updated.

`_updates_in_progress` stops one device being updated twice and says nothing about two devices at once, so the serialiser is a global `_ota_lock` inside `_run_update` — which puts the fleet deploy and a hand-clicked single update through the same gate.

- The binary is fetched inside the lock; a queued device holds only its place in line.
- Released in the `finally`, or a raised update strands every later one until a restart.
- **A failure does not stop the queue** — mark it, carry on, report at the end.
- `update_queued` is reported and rendered separately from `update_in_progress`, so the panel does not claim a transfer that has not started.

Both guards verified by reintroducing the bug. 909 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Vp3HFGRGhs5yNfFM2wSWF