### PR TITLE
Give the ring to the link state, and stand the buttons down without one

### DIFF
--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/wilbowes/EchoMuse/internal/aec"
 	"github.com/wilbowes/EchoMuse/internal/bindings/als"
-	"github.com/wilbowes/EchoMuse/internal/bindings/jack"
 	internalbuttons "github.com/wilbowes/EchoMuse/internal/bindings/buttons"
+	"github.com/wilbowes/EchoMuse/internal/bindings/jack"
 	"github.com/wilbowes/EchoMuse/internal/bindings/mic"
 	"github.com/wilbowes/EchoMuse/internal/bindings/speaker"
 	"github.com/wilbowes/EchoMuse/internal/bluetooth"
@@ -95,6 +95,13 @@ func main() {
 	srvPtr.Store(s)
 
 	buttonController.SetVolumeCallback(func(direction string) {
+		// Inert without a controller: nothing is playing to be louder or
+		// quieter, and showing the arc would acknowledge a device that
+		// cannot act. The mute button stays live — see Server.SetLinkDown.
+		if s.LinkDown() {
+			log.Println("[cmd] volume button ignored — no controller session")
+			return
+		}
 		if direction == "up" {
 			s.VolumeStepUp()
 		} else {
@@ -157,6 +164,15 @@ func main() {
 	// Button events — forward to controller via control plane
 	_, err = buttonController.SubscribeToButton(func(event pkgbuttons.ButtonClickEvent) {
 		log.Printf("Button event: clickType=%d down=%v", event.ClickType, event.Down)
+		// Inert without a controller session: the dot cannot start a turn
+		// with nothing to send it to, and the ring flash CancelVolumeDisplay
+		// produces would acknowledge a press that achieves nothing. Dropped
+		// here rather than at the binding — the binding is the portable
+		// hardware layer and knows nothing about sessions.
+		if s.LinkDown() {
+			log.Println("[cmd] action button ignored — no controller session")
+			return
+		}
 		// Muted presses are FORWARDED, with the mute state attached, and the
 		// controller decides what the gesture is allowed to do. Dropping them
 		// here was right while the dot button meant only "start a voice turn";
@@ -238,6 +254,10 @@ func main() {
 		pulseCtx, cancel := context.WithCancel(ctx)
 		pulseCancel = cancel
 		pulseKind = "orange"
+		// Ring belongs to the link state from here, and the action/volume
+		// buttons go inert. Set BEFORE the pulse starts, or its first frames
+		// are swallowed by the mute suppression on a muted device.
+		s.SetLinkDown(true)
 		go pulseOrange(pulseCtx, s)
 	})
 
@@ -252,6 +272,10 @@ func main() {
 		pulseCtx, cancel := context.WithCancel(ctx)
 		pulseCancel = cancel
 		pulseKind = "white"
+		// Pending approval is the same condition one step earlier: there is
+		// nothing above this device, so the white pulse owns the ring and the
+		// buttons do nothing.
+		s.SetLinkDown(true)
 		go pulseWhite(pulseCtx, s)
 	})
 
@@ -263,6 +287,9 @@ func main() {
 			pulseCancel = nil
 		}
 		pulseKind = ""
+		// Session restored: the ring goes back to the controller, the mute
+		// ring reasserts below if it applies, and the buttons work again.
+		s.SetLinkDown(false)
 		// Always report mute state on (re)connect — the controller may have
 		// restarted and lost its record of our state. Volume is only
 		// reported once the device holds an authoritative level (seeded

--- a/device/internal/server/link_state_test.go
+++ b/device/internal/server/link_state_test.go
@@ -1,0 +1,55 @@
+package server
+
+import "testing"
+
+// A muted device that lost its controller sat there showing the red mute
+// ring — which does not merely say less than the orange link pulse, it says
+// something false: red means "muted and working". Reported by Wil,
+// 2026-09-02.
+//
+// The reapply half was always present: OnConnected calls RestoreMuteRing
+// with the comment "orange pulse overwrote the red ring — restore it". The
+// pulse never overwrote it, because the paint suppression could not tell a
+// controller frame from the device's own link pulse.
+
+func TestTheLinkPulsePaintsThroughTheMuteRing(t *testing.T) {
+	cases := []struct {
+		name                          string
+		volumeActive, muted, linkDown bool
+		want                          bool
+	}{
+		{"idle and connected", false, false, false, false},
+		{"muted and connected — mute is sovereign", false, true, false, true},
+		{"muted and disconnected — the pulse wins", false, true, true, false},
+		{"unmuted and disconnected", false, false, true, false},
+		// The arc outranks both. It cannot arise while link-down, since the
+		// volume buttons are inert there, but the ordering must not depend
+		// on that being true elsewhere.
+		{"volume arc holds the ring", true, false, false, true},
+		{"volume arc outranks link-down too", true, false, true, true},
+	}
+	for _, c := range cases {
+		if got := suppressPaint(c.volumeActive, c.muted, c.linkDown); got != c.want {
+			t.Errorf("%s: suppressPaint(%v,%v,%v) = %v, want %v",
+				c.name, c.volumeActive, c.muted, c.linkDown, got, c.want)
+		}
+	}
+}
+
+func TestLinkDownDefaultsToConnected(t *testing.T) {
+	// A fresh Server must not start link-down: that would hand the ring away
+	// from mute before any connection callback has run.
+	s := &Server{}
+	if s.LinkDown() {
+		t.Fatal("a fresh Server must not start in link-down")
+	}
+	s.SetLinkDown(true)
+	if !s.LinkDown() {
+		t.Fatal("SetLinkDown(true) not recorded")
+	}
+	s.SetLinkDown(false)
+	if s.LinkDown() {
+		t.Fatal("SetLinkDown(false) not recorded — the ring would never go " +
+			"back to the controller after a reconnect")
+	}
+}

--- a/device/internal/server/server.go
+++ b/device/internal/server/server.go
@@ -48,6 +48,13 @@ type Server struct {
 	// anim owns the device-rendered ring animation (led_anim messages).
 	anim animator
 
+	// linkDown is true while there is no controller session — disconnected
+	// or pending approval. Read on the LED paint path and the button paths,
+	// written from the connection callbacks; atomic rather than mutexed
+	// because it is read per pulse frame (every 50ms) and never in a
+	// compound decision with anything else it guards. See SetLinkDown.
+	linkDown atomic.Bool
+
 	// audioLevel holds the live speaker RMS as float64 bits — written by
 	// the speaker's ALSA pump via SetAudioLevel, read by the meter anim.
 	audioLevel atomic.Uint64
@@ -229,6 +236,40 @@ func (s *Server) RestoreMuteRing() {
 	s.mute.showMuteLEDs()
 }
 
+// SetLinkDown records whether the device currently has a controller session.
+// True while disconnected AND while pending approval — both mean the same
+// thing to everything that reads it: there is nothing above this device.
+//
+// It governs two things:
+//
+//   - The RING belongs to the link state. The mute ring is otherwise
+//     device-sovereign and suppresses every other paint, which made a muted
+//     device that lost its controller sit there showing red — a state that
+//     is not merely less useful than the orange pulse, it is wrong, because
+//     red says "muted and working". The pulse now paints through mute.
+//     RestoreMuteRing on reconnect has always expected exactly this ("orange
+//     pulse overwrote the red ring — restore it"); the suppression it was
+//     written against is what stopped the pulse ever painting.
+//   - The action and volume BUTTONS are inert. Neither can do anything
+//     without a controller — the dot cannot start a turn and volume changes
+//     a level nothing is playing at — so acknowledging them with a ring
+//     flash or an arc invents a working device.
+//
+// The MUTE button stays live, deliberately. It is the one control that
+// works with no controller at all: the ADC mute is hardware and the button
+// LED is a GPIO, neither needs the network. Making it inert would also mean
+// a user who mutes during an outage gets a live mic back when the controller
+// returns, since mute is persisted — a silent privacy surprise, which is
+// worse than a ring showing the wrong colour.
+func (s *Server) SetLinkDown(down bool) {
+	s.linkDown.Store(down)
+}
+
+// LinkDown reports whether the device is without a controller session.
+func (s *Server) LinkDown() bool {
+	return s.linkDown.Load()
+}
+
 func clearLeds(ledController led.Controller) {
 	numLEDs, err := ledController.GetNumLEDs()
 	if err != nil {
@@ -356,6 +397,7 @@ func clampAdd(v uint8, delta int) uint8 {
 //     overlap mute (mic stopped), but mute-terminates-turn (2026-07-10)
 //     means the cancelled turn's LED cleanup arrives after the red ring
 //     is up — it must not clear it. Unmute clears the ring explicitly.
+//
 // listeningHint is the controller's explicit "this frame is the listening
 // ring" flag (nil from pre-scene controllers). When absent, fall back to
 // the historical heuristic — a 12-LED all-green frame — which only works
@@ -384,10 +426,30 @@ func (s *Server) SetLEDs(leds []led.Led, listeningHint *bool) {
 	}
 	s.listeningLEDs = listeningRing
 	s.baseLEDsMu.Unlock()
-	if s.volume.DisplayActive() || s.mute.IsMuted() {
+	if suppressPaint(s.volume.DisplayActive(), s.mute.IsMuted(), s.LinkDown()) {
 		return
 	}
 	s.paintBaseLEDs()
+}
+
+// suppressPaint decides whether a ring paint is held back. Pure, so the
+// truth table can be tested without hardware — the same reason the
+// controller keeps its link-auth and barge decisions out of their callers.
+//
+//   - volumeActive: the arc owns the ring for its 2s window against
+//     animations, which repaint ~every 100ms and would stomp it in one frame.
+//   - muted: the red ring is device-sovereign, so a cancelled turn's LED
+//     cleanup cannot clear it.
+//   - linkDown: ...unless there is no controller, in which case the ring
+//     belongs to the link pulse. Red on a device with nothing above it is
+//     not less informative than orange, it is false — it says "muted and
+//     working". The mute BUTTON's own LED keeps reporting the mic, so
+//     nothing about the mute state stops being visible.
+func suppressPaint(volumeActive, muted, linkDown bool) bool {
+	if volumeActive {
+		return true
+	}
+	return muted && !linkDown
 }
 
 // paintBaseLEDs paints the ring from the stored controller state.


### PR DESCRIPTION
A muted device that disconnects keeps showing the red mute ring. Red there does not say less than the orange pulse, it says something **false** — "muted and working" — on a device with nothing above it.

**The reapply half was already written and has never done anything.** `OnConnected` calls `RestoreMuteRing` with the comment *"orange pulse overwrote the red ring — restore it"*, but the pulse never overwrote it: `SetLEDs` returns early whenever the device is muted. That suppression exists so a cancelled turn's LED cleanup cannot clear the mute ring, and it cannot tell a controller frame from the device's own link pulse. The same bug hid the white pending pulse.

- `linkDown` covers **disconnected and pending** — both mean nothing is above this device.
- The decision is extracted as `suppressPaint`, pure and truth-tabled.
- **Action and volume buttons go inert** without a session; gated at the consumers in `cmd`, not in the evdev binding, which is the portable hardware layer.

**The mute button stays live, deliberately.** It is the one control that works with no controller: the ADC mute is hardware, the button LED is a GPIO. Making it inert would also hand back a live mic on reconnect, since mute is persisted in `state.json` — a silent privacy surprise. So a muted, disconnected Echo pulses orange with a red button: *cannot reach the controller, mic is off.*

Firmware builds in the pinned compiler; `internal/server` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Vp3HFGRGhs5yNfFM2wSWF