### PR TITLE
Take the safe half of the dependency bumps, and hold numpy for #224

### DIFF
--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -5,7 +5,7 @@
 #
 # Tested with Python 3.12.
 # WebSocket server (device connections)
-websockets==17.0.1
+websockets==17.1
 # HTTP API + dashboard server
 aiohttp==3.14.3
 # Password hashing
@@ -13,7 +13,7 @@ bcrypt==5.0.0
 # Device-link TLS: CA + server cert generation (em_pki.py). The controller
 # runs fine without it (plain ws only, wss listener disabled) but the
 # published image always ships it.
-cryptography==50.0.0
+cryptography==50.0.1
 # mDNS advertisement (_emcontroller._tcp.local)
 #
 # Held at >=0.149.12 for three advisories against 0.148.0, all unauthenticated
@@ -61,4 +61,4 @@ onnxruntime==1.20.1
 # and round-trips under runtime 7.35.1. The rule only rejects a runtime OLDER
 # than its gencode, so this direction is the safe one — but protobuf's
 # cross-version guarantee is a window, not a promise, so check again at 8.x.
-protobuf>=7.35.1
+protobuf>=7.36.0


### PR DESCRIPTION
Splits dependabot's #398. Three of the four are taken here; numpy is not.

**Taken** — no bearing on audio or inference:
- `websockets` 17.0.1 → 17.1
- `cryptography` 50.0.0 → 50.0.1
- `protobuf` floor 7.35.1 → 7.36.0

**Held: `numpy` 2.4.4 → 2.5.2.** #224 is open specifically to say onnxruntime and numpy move deliberately, with a wake word comparison behind them, and it carries `needs-hardware` for that reason — numpy sits under the mel-spectrogram pipeline, the EQ, the limiter and the bass guard, and a green unit suite says nothing about whether wake word scores moved. Taking it as part of a routine group update is the accident that issue exists to prevent.

Dependabot should recreate #398 with numpy alone, which then belongs to #224 rather than to a rubber stamp.

The protobuf change raises a floor rather than a pin, unchanged in kind from what is already in the file: the gencode-vs-runtime rule only rejects a runtime *older* than its gencode, so upward is the safe direction. The existing note about re-checking at 8.x still stands.

Verification is CI's image build and boot job — the pure-logic suite does not import these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2XSpGJYfYgi3TeqBXeKbW