### PR TITLE
Refuse to install the firmware a device is already running

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -1432,7 +1432,11 @@ async def _post_device_update(request: web.Request) -> web.Response:
     release = None
 
     if upload_token:
-        binary_override = _pending_uploads.pop(upload_token, None)
+        # PEEKED, not popped. Every refusal below leaves the token usable, so
+        # re-deciding — or forcing — costs nothing. Popping first meant an
+        # 11MB re-upload to get past a check that had just told the operator
+        # something useful.
+        binary_override = _pending_uploads.get(upload_token)
         if binary_override is None:
             return _error("invalid_token", "Upload token not found or expired", 404)
         _embedded = _extract_binary_version(binary_override)
@@ -1455,6 +1459,30 @@ async def _post_device_update(request: web.Request) -> web.Response:
     if device_id in _updates_in_progress or device_id in _updates_queued:
         return _error("update_in_progress", "An update is already in progress", 409)
 
+    # Installing what the device is already running costs a transfer, a
+    # reboot and a slot — and the fleet endpoint has always skipped it for
+    # releases (`already_current`), while this endpoint checked nothing and
+    # the upload path could not check anything, because it labelled every
+    # uploaded binary `local-<timestamp>` instead of reading the version out
+    # of it. So the case most likely to happen by accident was the one case
+    # nothing guarded: an engineering build uploaded by hand, twice.
+    #
+    # Refused rather than silently skipped, because someone pressed a button
+    # here and a no-op reported as success is how they press it again.
+    # `force` exists because re-flashing the SAME version is a real repair —
+    # a corrupt slot is fixed by writing it again — so this must never become
+    # a wall between an operator and their own device.
+    if (release["version"] and row["firmware_ver"] == release["version"]
+            and not body.get("force")):
+        return _error(
+            "already_running",
+            f"This device is already running {release['version']}. "
+            f"Pass force to install it again.",
+            409,
+        )
+
+    if upload_token:
+        _pending_uploads.pop(upload_token, None)
     asyncio.create_task(_run_update(device_id, release, binary_override))
     return _ok({"status": "started", "version": release["version"]}, status=202)
 
@@ -1517,14 +1545,23 @@ async def _post_upload_binary(request: web.Request) -> web.Response:
 
         token = str(_uuid.uuid4())
         _pending_uploads[token] = binary
-        log.info(f"[api] Binary uploaded: {len(binary):,} bytes token={token[:8]}…")
+        version = _extract_binary_version(binary)
+        log.info(f"[api] Binary uploaded: {len(binary):,} bytes "
+                 f"version={version or 'unknown'} token={token[:8]}…")
 
         async def _expire():
             await asyncio.sleep(600)
             _pending_uploads.pop(token, None)
         asyncio.create_task(_expire())
 
-        return _ok({"upload_token": token, "size": len(binary)})
+        # The version rides back so the dashboard can say what was uploaded,
+        # and warn against a device already running it BEFORE the operator
+        # commits. The update endpoint refuses it either way; this is what
+        # makes the refusal something you see coming instead of something you
+        # find out afterwards. None means the binary carries no recognisable
+        # version — shown as unknown rather than guessed at.
+        return _ok({"upload_token": token, "size": len(binary),
+                    "version": version})
     except web.HTTPException:
         # aiohttp's own — HTTPRequestEntityTooLarge above all, raised by the
         # transport before this handler sees a byte. Swallowing it into a 500
@@ -2783,7 +2820,17 @@ async def _post_deploy_all(request: web.Request) -> web.Response:
         binary_override = _pending_uploads.pop(upload_token, None)
         if binary_override is None:
             return _error("invalid_token", "Upload token not found or expired", 404)
-        release = {"version": f"local-{time.strftime('%Y%m%d-%H%M')}", "url": None}
+        # Read the version OUT of the binary, as the single-device path does.
+        # Labelling it `local-<timestamp>` made every uploaded binary look
+        # like a version no device had ever run, so the already_current skip
+        # below could never fire for an upload and the whole fleet re-flashed
+        # what it was already running. The timestamp remains the fallback for
+        # a binary carrying no recognisable version.
+        _embedded = _extract_binary_version(binary_override)
+        release = {
+            "version": _embedded or f"local-{time.strftime('%Y%m%d-%H%M')}",
+            "url": None,
+        }
     else:
         release = await _get_cached_release()
         if release is None:
@@ -2798,7 +2845,12 @@ async def _post_deploy_all(request: web.Request) -> web.Response:
         if row is None or not row["approved"]:
             skipped.append({"device_id": device_id, "reason": "not_approved"})
             continue
-        if not upload_token and row["firmware_ver"] == release["version"]:
+        # No longer `not upload_token and …`: an uploaded binary now carries a
+        # real version, so this skip finally covers the fleet-wide re-flash of
+        # an engineering build too. `force` overrides it for the repair case,
+        # matching the single-device endpoint.
+        if (release["version"] and row["firmware_ver"] == release["version"]
+                and not body.get("force")):
             skipped.append({"device_id": device_id, "reason": "already_current"})
             continue
         if device_id in _updates_in_progress or device_id in _updates_queued:

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1405,8 +1405,25 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
     try {
       const up = await API.upload('/api/releases/upload', localFile);
       setUploading(false);
-      setPushLog(l => [...l, '✓ Upload complete — deploying…']);
-      const res = await API.post(`/api/devices/${device.device_id}/update`, { upload_token: up.upload_token });
+      setPushLog(l => [...l, `✓ Upload complete${up.version ? ` — ${up.version}` : ''}`]);
+
+      // Ask BEFORE spending a reboot and a slot on a binary the device is
+      // already running. The server refuses this too, so declining here is a
+      // convenience rather than the guard; what it buys is being told at the
+      // point of deciding instead of after. Re-flashing the same version is a
+      // real repair for a corrupt slot, so it is a question and not a wall.
+      let force = false;
+      if (up.version && up.version === device.firmware_ver) {
+        if (!confirm(`${device.label || device.device_id} is already running ${up.version}.\n\nInstall it again anyway?`)) {
+          setPushLog(l => [...l, 'Cancelled — device already running this build.']);
+          setPushing(false);
+          return;
+        }
+        force = true;
+      }
+
+      setPushLog(l => [...l, 'Deploying…']);
+      const res = await API.post(`/api/devices/${device.device_id}/update`, { upload_token: up.upload_token, force });
       setPushLog(l => [...l, `Deploying ${res.version} — waiting for reconnect…`]);
       _pollReconnect(res.version, device.firmware_ver);
     } catch(e) {

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -2192,3 +2192,75 @@ def test_the_payload_syncs_tell_a_missing_file_from_a_silent_device():
         assert fn.index("_SHELL_OK not in out") < fn.index("_stream_file_to_device"), (
             f"{name} must check the device answered BEFORE deciding to push"
         )
+
+
+# ─── Installing what a device already runs ────────────────────────────────────
+#
+# Hit by hand on 2026-09-03: the same engineering build uploaded to a device
+# twice, costing a transfer, a reboot and a slot. The fleet endpoint had
+# skipped this for releases since it was written; the single-device endpoint
+# checked nothing, and neither could check an UPLOAD, because an uploaded
+# binary was labelled `local-<timestamp>` rather than being read for its
+# version. So the case most likely to happen by accident was the one case
+# nothing guarded.
+
+def test_the_update_endpoint_refuses_a_version_the_device_already_runs():
+    fn = _strip_prose(_fn_body(
+        (CONTROLLER / "em_api.py").read_text(), "_post_device_update"))
+
+    assert 'row["firmware_ver"] == release["version"]' in fn, (
+        "the update endpoint must compare the target against what the device "
+        "is already running"
+    )
+    assert "already_running" in fn, "the refusal needs a named error code"
+    assert 'body.get("force")' in fn, (
+        "re-flashing the same version repairs a corrupt slot — force must "
+        "exist, or this is a wall between an operator and their own device"
+    )
+
+
+def test_a_refused_update_does_not_consume_the_uploaded_binary():
+    """
+    The token is peeked and only popped once the update is actually started.
+    Popping first meant a refusal cost an 11MB re-upload to act on the very
+    advice the refusal had just given.
+    """
+    fn = _strip_prose(_fn_body(
+        (CONTROLLER / "em_api.py").read_text(), "_post_device_update"))
+
+    assert "_pending_uploads.get(upload_token)" in fn, (
+        "peek the token — every refusal below it must leave it usable"
+    )
+    pop = fn.index("_pending_uploads.pop")
+    run = fn.index("_run_update(")
+    refuse = fn.index("already_running")
+    assert refuse < pop, "the duplicate check must come before the token is consumed"
+    assert pop < run, "consume the token only once the update is committed"
+
+
+def test_the_fleet_endpoint_reads_the_version_out_of_an_uploaded_binary():
+    """
+    While an upload was labelled `local-<timestamp>`, it looked like a version
+    no device had ever run — so `already_current` could never fire for one and
+    a fleet push re-flashed every device with what it was already running.
+    """
+    src = (CONTROLLER / "em_api.py").read_text()
+    fn  = _strip_prose(_fn_body(src, "_post_deploy_all"))
+
+    assert "_extract_binary_version(binary_override)" in fn, (
+        "the fleet path must read the uploaded binary's own version"
+    )
+    assert "not upload_token and" not in fn, (
+        "the already_current skip must no longer exclude uploads"
+    )
+
+
+def test_the_upload_endpoint_reports_what_was_uploaded():
+    """
+    The version rides back so the dashboard can warn at the point of deciding
+    rather than after the operator has committed.
+    """
+    fn = _strip_prose(_fn_body(
+        (CONTROLLER / "em_api.py").read_text(), "_post_upload_binary"))
+    assert "_extract_binary_version(binary)" in fn
+    assert '"version": version' in fn


### PR DESCRIPTION
Hit by hand today: the same engineering build uploaded to a device twice, costing a transfer, a reboot and a slot for nothing.

## The guard existed and could not fire

`_post_deploy_all` has skipped `already_current` since it was written — but gated on `not upload_token`, and it labelled every uploaded binary `local-<timestamp>` rather than reading the version out of it. So an upload always looked like a version no device had ever run, and **a fleet deploy would re-flash every device with exactly what it was already running.**

`_post_device_update` checked nothing at all, on either path.

So the case most likely to happen by accident — an engineering build pushed by hand, twice — was the one case nothing guarded.

## What changes

Both endpoints read the binary's own version via `_extract_binary_version` and compare it against `firmware_ver`.

- **Single device: refuses**, `409 already_running`, naming the version. Not a silent skip — someone pressed a button, and a no-op reported as success is how they press it again.
- **Fleet: keeps skipping**, which is what a fleet operation should do, and the skip now covers uploads.
- **`force` overrides both, and is not optional.** Re-flashing the same version is a real repair — a corrupt slot is fixed by writing it again — so this must never become a wall between an operator and their own device.

## Two things found on the way

- **The upload token was popped before any check ran**, so a refusal consumed the binary and acting on the advice it had just given cost an 11MB re-upload. It is now peeked, and popped only once the update is committed.
- **`/api/releases/upload` now returns the version it extracted**, so the dashboard can warn at the point of deciding rather than after the operator has committed. It sends `force` when the operator says yes.

The dashboard check is a convenience — the server refuses either way — and it uses the existing `confirm()` pattern, so no panel gains a row.

## Tests

929 pass. New deploy-shape guards: the refusal and its `force` escape, the peek-before-pop ordering (refusal before the token is consumed, consumption before the update starts), the fleet path reading the uploaded version, and the upload endpoint reporting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2XSpGJYfYgi3TeqBXeKbW