### PR TITLE
Early Access 2.23.0-ea.1

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## 2.23.0-ea.1 (Early Access)
+
+**The Bluetooth proxy stops crowding out the device it runs on, and the
+controller stops trusting a device to be up to date.** Nothing to do before
+updating: no database migration, nothing to change on your devices. Two of the
+changes below need firmware newer than v2.14.0 and do nothing until you have
+it — they are harmless without it.
+
+### The Bluetooth proxy no longer competes with its own device's health
+
+An Echo running the Bluetooth proxy sent every advertisement it heard over the
+same connection the controller uses to check the device is alive. Bulk
+telemetry and the liveness check took turns on one channel, so a busy room made
+the device look unwell — measured at 3615 round-trip delays in a day against 2
+on the Echo beside it, and the fault followed the proxy when it was moved.
+
+Advertisements now ride the data connection instead. **This needs firmware past
+v2.14.0 at both ends**, and the two halves agree before either uses the new
+path, so an older device keeps working exactly as before rather than silently
+dropping advertisements.
+
+### Firmware updates no longer slow down whoever is talking
+
+Updating several Echoes at once stalled the controller for as long as eleven
+seconds, and that is the same loop that sends audio and ring animations — so an
+Echo answering someone paid for an Echo being updated. Updates now run one at a
+time across the whole controller, queued rather than refused.
+
+### Only one Echo answers when you interrupt
+
+Interrupting a response in a room with more than one Echo could start a turn on
+each of them. The same arbitration that already decides which Echo answers a
+wake word now decides which one takes an interruption.
+
+### The ring shows whether the Echo can reach the controller
+
+An Echo that has lost the controller now says so on its ring rather than
+looking idle, and its buttons stand down instead of appearing to work. **Needs
+firmware past v2.14.0.**
+
+### Devices are checked against what they actually have
+
+The controller assumed a device already held its wake word models, its startup
+script and its debloat list, and only ever verified the first — and only when
+the device was scoring wake words itself. One of our own Echoes ran for a
+fortnight missing three of its four wake word models while every panel called
+it healthy. All three are now checked when a device connects.
+
+### Installing firmware an Echo already has
+
+Pushing a build an Echo is already running cost it a reboot and a slot for no
+change, and nothing stopped it. Updating one Echo now says so and refuses;
+updating the whole fleet skips the ones already on that version, which it did
+for published releases but never for a binary you uploaded yourself. You can
+still force it — writing the same version again is how a damaged slot gets
+repaired.
+
+### Smaller things
+
+Request logging is quiet by default, so the log is about your devices rather
+than about the dashboard polling itself — thank you to @DennisGaida. Security
+and dependency updates for websockets, cryptography and protobuf.
+
 ## 2.22.0
 
 **Timers, and your Echoes can now be asked a question.** Everything from the ten

--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -17,7 +17,7 @@ name: "EchoMuse (Early Access)"
 # derives from the controller-v* tag (controller-v2.18.0 -> 2.18.0). Bump
 # both together: Supervisor pulls `image:version`, so a version with no
 # matching tag on GHCR fails to install.
-version: "2.22.0-ea.10"
+version: "2.23.0-ea.1"
 # Pull the published multi-arch image rather than building on the user's
 # machine. Without this Supervisor builds from this directory's Dockerfile,
 # which downloads a few hundred MB on whatever the user runs Home Assistant

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## 2.23.0-ea.1 (Early Access)
+
+**The Bluetooth proxy stops crowding out the device it runs on, and the
+controller stops trusting a device to be up to date.** Nothing to do before
+updating: no database migration, nothing to change on your devices. Two of the
+changes below need firmware newer than v2.14.0 and do nothing until you have
+it — they are harmless without it.
+
+### The Bluetooth proxy no longer competes with its own device's health
+
+An Echo running the Bluetooth proxy sent every advertisement it heard over the
+same connection the controller uses to check the device is alive. Bulk
+telemetry and the liveness check took turns on one channel, so a busy room made
+the device look unwell — measured at 3615 round-trip delays in a day against 2
+on the Echo beside it, and the fault followed the proxy when it was moved.
+
+Advertisements now ride the data connection instead. **This needs firmware past
+v2.14.0 at both ends**, and the two halves agree before either uses the new
+path, so an older device keeps working exactly as before rather than silently
+dropping advertisements.
+
+### Firmware updates no longer slow down whoever is talking
+
+Updating several Echoes at once stalled the controller for as long as eleven
+seconds, and that is the same loop that sends audio and ring animations — so an
+Echo answering someone paid for an Echo being updated. Updates now run one at a
+time across the whole controller, queued rather than refused.
+
+### Only one Echo answers when you interrupt
+
+Interrupting a response in a room with more than one Echo could start a turn on
+each of them. The same arbitration that already decides which Echo answers a
+wake word now decides which one takes an interruption.
+
+### The ring shows whether the Echo can reach the controller
+
+An Echo that has lost the controller now says so on its ring rather than
+looking idle, and its buttons stand down instead of appearing to work. **Needs
+firmware past v2.14.0.**
+
+### Devices are checked against what they actually have
+
+The controller assumed a device already held its wake word models, its startup
+script and its debloat list, and only ever verified the first — and only when
+the device was scoring wake words itself. One of our own Echoes ran for a
+fortnight missing three of its four wake word models while every panel called
+it healthy. All three are now checked when a device connects.
+
+### Installing firmware an Echo already has
+
+Pushing a build an Echo is already running cost it a reboot and a slot for no
+change, and nothing stopped it. Updating one Echo now says so and refuses;
+updating the whole fleet skips the ones already on that version, which it did
+for published releases but never for a binary you uploaded yourself. You can
+still force it — writing the same version again is how a damaged slot gets
+repaired.
+
+### Smaller things
+
+Request logging is quiet by default, so the log is about your devices rather
+than about the dashboard polling itself — thank you to @DennisGaida. Security
+and dependency updates for websockets, cryptography and protobuf.
+
 ## 2.22.0
 
 **Timers, and your Echoes can now be asked a question.** Everything from the ten


### PR DESCRIPTION
First EA of the line that follows GA 2.22.0. Ten commits beyond it.

**Behavioural:** adverts off the control plane (#413), OTA serialisation (#412), barge arbitration (#414), the link-state ring (#415), the duplicate-firmware guard (#422). **Plus:** the connect-time payload reconcile (#419), @DennisGaida's `aiohttp.access` quieting (#376), and the safe half of the dependency bumps (#420).

## Why 2.23.0-ea.1 and not 2.22.0-ea.11

That line previewed GA 2.22.0 and ended when it shipped. This build contains strictly more than GA, and `version.parse` does not order prereleases — so `2.22.0-ea.11` would parse **equal** to the shipped GA and read as behind what users already have.

## What this release does and does not prove

#413 and #415 need firmware past v2.14.0 and do nothing without it. #413 needs **both** halves, and its negotiation has not yet met hardware — a device that has not negotiated the new path keeps using the control plane, which is exactly the point of negotiating it, but it means this release is what makes the #404 measurement *possible* rather than what proves the fix.

## Changelog

Written for someone deciding whether to take the update: what changes from their side, and what needs firmware. Supervisor shows `CHANGELOG.md` in its update dialog, so the entry lands in the GA file and `sync_channels.py` copies it — the convention every previous EA entry follows.

## Release sequence after merge

Merge → **wait for `Controller Build (main)` to go green on the merge commit** → then push `controller-ea-v2.23.0-ea.1` annotated, with `--cleanup=verbatim`. The release workflow does not build; it re-tags the image that main build publishes, so a tag pushed early fails on a race rather than on anything being wrong.

929 tests pass; `test_channels.py` confirms the generated channel matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2XSpGJYfYgi3TeqBXeKbW