### PR TITLE
Drive the whole jack routing, in both directions and at startup

### DIFF
--- a/device/CLAUDE.md
+++ b/device/CLAUDE.md
@@ -172,7 +172,7 @@ The always-on wake stream (`mic_start` without `lock_mic`) is **ungated and AGC-
 | `internal/wakeword/shadow/` | On-device scoring that reports but never acts (see "On-device wake word"). `Push` must never block: inference runs on its own goroutine and drops frames when behind |
 | `internal/wakeword/fixture/` | Shared golden-fixture parser, tolerance policy and `Verify`. Used by both the host test and `tools/oww_probe`, deliberately — the probe's answer is the trusted one because it runs on hardware, so it must be exactly as strict as the test by construction. Tolerances are relative to the **tensor's** scale, not per element: per-element relative error is meaningless for tensors straddling zero |
 | `internal/bindings/als/` | Ambient light (ams **TSL2540** on i2c). Android does not expose it AT ALL — `dumpsys sensorservice` reports an empty list, nothing under `/sys/class/sensors`, no input device; it is visible only on the raw i2c bus, the same shape as the mute LED being on a different GPIO than the vendor HAL believed. Resolved **by name, not address** (`0-0039` is an enumeration accident). **The bus listing is not a hardware inventory**: both ALS names are registered by Amazon's board file, so a `tsl2540` at 0x39 and a `tsl2584tsv` at 0x29 appear on every unit whatever is soldered on (`modalias` is static kernel data). Which one answers differs by batch — ours have the 2540 and nothing at 0x29 (`taos_probe() err = -6`, ENXIO), the `G090LF096` batch has the 2584 instead, reachable only through IIO at `/sys/bus/iio/devices/iio:device0` (#90). A second-sourced part, not a driver fault, so the answer is to read the IIO sensor too, never to loosen the match to a `tsl` prefix. The **boot log is the real inventory** — both drivers probe on every unit and log what replied — but `dmesg` rolls, so it needs reading soon after a reboot. Never `unbind` the driver to experiment: it succeeds, leaves the `als_*` attributes in place, and the next read hangs the device until a power cycle. `Lux()` returns **nil, never 0** — a covered sensor reads a genuine 0. `Watch` reports a step change immediately (25% relative, 10-lux floor, measured noise ±1.5%); the steady value rides the ~30s stats tick. `Report()` says **why** there is no sensor (`ok`/`no_chip`/`no_attribute`/`unknown`, plus every i2c name it saw) and rides the register message as `ambient_light_status` — absence used to be logged only to the device's own stdout, which support bundles do not collect, so two users could not be told apart without a shell session (#90). The whole bus is enumerated **before** matching: returning at the match truncated the list on working devices, which is exactly the side you compare against |
-| `internal/bindings/jack/` | Headphone jack detect (`/sys/class/switch/h2w`, mediatek accdet). Polled, not evented — the ACCDET input node reports no keys on this hardware. Exists for ONE job: accdet mutes `Ext_Speaker_Amp_Switch` on insert (correctly) and **nothing turns it back on**, so the speaker stayed dead until the next boot (#80). Output routing itself is done by the jack's own switch contacts — a response was heard in headphones while the mixer still read `Headphone_Speaker_Mux=Speaker`, so those controls do NOT describe where audio goes and nothing should drive them |
+| `internal/bindings/jack/` | Headphone jack detect (`/sys/class/switch/h2w`, mediatek accdet). Polled, not evented — the ACCDET input node reports no keys on this hardware. `Watch` dispatches the state it STARTS in as well as every change: accdet is edge-triggered and a boot has no edge, so a device booted with a cable in got no correction at all. The callback (`PcmSpeaker.SetJackRouting`) owns both positions — the amp switch, and the `HP Driver Gain Volume` that accdet drops to the floor of its range on insert and nothing used to raise. Output *destination* is still physical, done by the jack's own switch contacts, so no mux layer should be driven — but level is ours |
 | `internal/wifi/` | Safe WiFi network change with auto-rollback (wifi_change/wifi_commit/wifi_scan control messages; pending-marker recovery at startup). Reload path is `svc wifi disable/enable` ONLY — see package comment for the hardware-proven constraints |
 | `internal/bluetooth/` | BLE proxy — raw HCI passive scan over `/dev/stpbt` (single-owner, so Android's Bluedroid is durably `pm disable`d first), parsed into adverts and forwarded to the controller. `emit.go` decides which of them are worth sending; see "The BLE proxy" below, and read it before changing the scan cadence or the filtering |
 | `pkg/led/`, `pkg/mic/`, `pkg/speaker/`, `pkg/buttons/` | Hardware abstractions (interfaces) |
@@ -552,14 +552,45 @@ initialised` never appears.
 `Ext_Speaker_Amp_Switch` on insert, which is correct — the Dot should not also
 play to the room — and nothing ever turned it back on. `Init()` was the only
 thing that set it, which is exactly why a reboot appeared to fix it.
-`internal/bindings/jack` watches `h2w` and re-enables the amp on removal.
-Insert needs nothing from us.
+`internal/bindings/jack` watches `h2w`, and `PcmSpeaker.SetJackRouting` now
+applies BOTH positions rather than only re-enabling the amp on removal.
 
-**Routing is PHYSICAL and needs no code.** The jack's own switch contacts
-divert the signal. A voice response was heard in headphones while the mixer
-still read `Ext_Speaker_Amp_Switch=On`, `Ext_Headphone_Amp_Switch=Off` and
-`Headphone_Speaker_Mux=Speaker` — so those controls do **not** describe where
-audio goes, and driving them would be wrong. Do not build a routing layer.
+**Booting with a plug in was a third instance of the same gap, and it is
+edge-triggering all the way down.** accdet acts on the insert *transition*;
+`jack.Watch` used to seed its baseline from the first reading and dispatch
+nothing; and `Init()` sets the speaker amp **On unconditionally**, because its
+click-free startup order needs the amp brought up onto a DAC already clocking
+silence and it has no idea whether a plug is present. A boot has no transition,
+so nothing corrected it: measured 2026-09-03 with `h2w=1` and
+`Ext_Speaker_Amp_Switch=On`, i.e. the Dot playing to the room with a cable
+connected, and the jack simultaneously at minimum gain. That is why unplugging
+and replugging was the folk remedy — it manufactures the edge the boot never
+had. `Watch` now dispatches the state it starts in, which is why
+`SetJackRouting` must stay idempotent.
+
+**Routing is PHYSICAL and needs no code — but LEVEL is not, and that
+distinction cost three weeks.** The jack's own switch contacts divert the
+signal: a voice response was heard in headphones while the mixer still read
+`Ext_Speaker_Amp_Switch=On`, `Ext_Headphone_Amp_Switch=Off` and
+`Headphone_Speaker_Mux=Speaker`, so those controls do **not** describe where
+audio goes and no mux/destination layer should be built.
+
+That is still true. What it was read as — "the mixer has nothing to do with the
+jack" — is not, and it is why nobody looked at the gain. **`HP Driver Gain
+Volume` (ctl 62) is the jack's output stage**, and accdet drops it to **0, the
+FLOOR of a 0..35 range** on insert. On a stock Dot the audio HAL then raises it
+to 11; we had nothing that did, so the external output sat at minimum gain.
+Measured 2026-09-03 by diffing all 239 mixer controls across an insert on both
+a stock FireOS 5.5.5.4 Dot and ours: writing ctl 62 with music playing took the
+jack from inaudible to audible, while the `ref` loopback tap stayed flat —
+confirming it is a post-DAC analog stage and not something upstream.
+
+Stock changes five controls on insert, we now change two. `Right Channel Only`
+and `Ignore Ramp Up` are deliberately **not** copied: our wire is mono and
+`toStereo` duplicates L into R, so channel selection carries the same samples
+either way (it becomes real the day the wire carries stereo), and the ramp
+control's effect on this hardware has never been measured. Copying a stock
+value whose effect is unknown is not the same as matching stock.
 
 **Unresolved, and it is not only on removal (#117, #141).** A plug in the
 jack degrades the whole audio subsystem for as long as it is present — mic
@@ -580,12 +611,23 @@ live hypothesis is the audio HAL, which we displace by taking `pcm23p`.
 
 Two traps for whoever picks this up:
 
-- **`Ext_Speaker_Amp_Switch` does not gate the internal speaker.** It was
-  `Off` while the internal speaker was audibly playing. accdet also mutes
-  it on insert only *sometimes*. Making that deterministic ourselves looks
-  like an obvious fix and is currently the wrong one: accdet failing to
-  mute is the only reason a user hears anything at all with a plug in, so
-  it would turn "wrong speaker" into "no sound".
+- **`Ext_Speaker_Amp_Switch` was observed `Off` while the internal speaker
+  was audibly playing**, and that observation has NOT been retested since
+  the jack gain was fixed. It matters: if the control does not gate the
+  internal driver, `SetJackRouting` cannot deliver "external only", and the
+  remaining lever is unknown. The test is cheap and specific — cable in the
+  jack with the powered speaker switched OFF, so the mic array can only be
+  hearing the internal driver, then toggle ctl 5 with music playing and
+  watch the `[aec] mic=` level.
+  The older warning attached to this — that making the mute deterministic
+  would turn "wrong speaker" into "no sound" — **no longer applies**. It was
+  conditional on the external path being dead, and it was dead because
+  nothing set ctl 62. Now that it is set, muting the internal driver on
+  insert leaves a working output rather than silence. Note the residual
+  risk this shifts onto volume: a user at a low `PCM Playback Volume` who
+  plugs in now gets a quiet external output instead of a loud internal one,
+  which reads as a fault. Stock avoids this by sitting at unity (127) and
+  attenuating in software; we sit wherever the user left the control.
 - The mic stall log line says "ALSA overrun", which is an interpretation.
   It measures the arrival gap in `readLoop`, and the GoTinyAlsa stream
   channel is 16 batches (2.56s) deep, so a stall of that goroutine looks

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -244,17 +244,20 @@ func main() {
 		controlClient.SendAmbientLight(lux)
 	})
 
-	// Headphone jack — accdet mutes the internal speaker amp on insert and
-	// never restores it on removal, so without this the speaker stays dead
-	// until the next reboot (issue #80, reproduced and fixed on hardware
-	// 2026-08-09). Insert needs nothing from us: accdet already handles the
-	// mute, and the output routing itself is done by the jack's own switch
-	// contacts, not by any mixer control.
+	// Headphone jack. BOTH directions need work from us, and so does the
+	// state the device booted into — accdet acts only on a transition, and
+	// Init leaves the internal amp on regardless of what is plugged in.
+	// SetJackRouting owns the whole mapping (issue #80 for the removal half,
+	// measured against a stock Dot 2026-09-03 for the rest).
 	go jack.Watch(ctx, func(inserted bool) {
-		if !inserted {
-			pcmSpeaker.EnableSpeakerAmp()
-		}
+		pcmSpeaker.SetJackRouting(inserted)
 	})
+	// Android's audio HAL rewrites the codec on every mediaserver restart —
+	// roughly once a minute with a plug inserted — so applying the routing on
+	// the jack edge alone holds for about a minute and then the jack goes
+	// quiet again. Measured 2026-09-03. Nothing can stop mediaserver (the
+	// framework crash-loops without it), so the routing is reconciled instead.
+	go pcmSpeaker.WatchJackRouting(ctx)
 
 	controlClient.OnDisconnected(func() {
 		// Stop any device-local animation: the controller that owned it is

--- a/device/internal/bindings/jack/jack.go
+++ b/device/internal/bindings/jack/jack.go
@@ -78,13 +78,25 @@ func Present() bool {
 	return ok
 }
 
-// Watch polls the jack and calls onChange when the plug state changes.
+// Watch polls the jack and calls onChange for the state it finds, then again
+// on every change.
 //
-// The FIRST reading seeds the baseline and never fires. Init has already put
-// the speaker amp in the right state for the current jack position by the time
-// this starts, so reporting the initial state would only re-do work — and on a
-// device booted WITH a plug in, would wrongly assert the speaker amp on while
-// headphones are connected.
+// The first reading DOES fire, and dropping it is what broke boot-with-a-plug.
+// It used to seed the baseline silently, on the reasoning that "Init has
+// already put the speaker amp in the right state for the current jack
+// position" — which was simply not true: PcmSpeaker.Init sets the amp ON
+// unconditionally, because its
+// click-free startup order needs the amp brought up onto a DAC already
+// clocking silence, and it has no idea whether a plug is present.
+//
+// So a device booted with a cable in got the internal amp asserted by Init and
+// nothing afterwards to correct it — accdet only acts on a transition, and a
+// boot has no transition. Both outputs were wrong at once: the Dot played to
+// the room, and the jack sat at minimum gain. Measured on hardware 2026-09-03
+// (h2w=1, Ext_Speaker_Amp_Switch=On). Unplugging and replugging "fixed" it by
+// manufacturing the edge the boot never had.
+//
+// onChange must therefore be idempotent, which SetJackRouting is.
 //
 // onChange runs on this goroutine. It shells out to tinymix, which takes
 // milliseconds, so there is no handoff here; if it ever grows into anything
@@ -99,6 +111,7 @@ func Watch(ctx context.Context, onChange func(inserted bool)) {
 	log.Printf("[jack] detect switch at %s (state=%d)", statePath, first)
 
 	was := first != 0
+	onChange(was)
 	t := time.NewTicker(PollInterval)
 	defer t.Stop()
 	for {

--- a/device/internal/bindings/jack/jack_test.go
+++ b/device/internal/bindings/jack/jack_test.go
@@ -1,9 +1,11 @@
 package jack
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // State reads a fixed path, so the tests point it at a temp file by swapping
@@ -71,5 +73,65 @@ func TestUnparseableStateIsNotOk(t *testing.T) {
 	withStateFile(t, "banana\n")
 	if _, ok := State(); ok {
 		t.Fatal("unparseable content must report not-ok, not a state")
+	}
+}
+
+// Watch must report the state it STARTS in, not only later changes.
+//
+// A device booted with a cable in gets no accdet transition and no watcher
+// callback, and PcmSpeaker.Init has already asserted the internal amp — so
+// without this dispatch it plays to the room with a speaker plugged in, and
+// the jack sits at minimum gain. Measured on hardware 2026-09-03; this is the
+// regression test for it.
+func TestWatchReportsTheStateItStartsIn(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"booted with a plug in", "1", true},
+		{"booted with the jack empty", "0", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withStateFile(t, tc.content)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			got := make(chan bool, 1)
+			go Watch(ctx, func(inserted bool) {
+				select {
+				case got <- inserted:
+				default:
+				}
+			})
+
+			select {
+			case v := <-got:
+				if v != tc.want {
+					t.Errorf("initial dispatch: got inserted=%v, want %v", v, tc.want)
+				}
+			case <-time.After(2 * time.Second):
+				t.Error("Watch never reported its initial state")
+			}
+			cancel()
+		})
+	}
+}
+
+// A device with no detect switch must stay silent rather than assert a
+// position it cannot know. Reporting "not inserted" here would drive the
+// routing on hardware we know nothing about.
+func TestWatchDispatchesNothingWithoutADetectSwitch(t *testing.T) {
+	withStateFile(t, "0")
+	statePath = filepath.Join(t.TempDir(), "absent")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	called := make(chan bool, 1)
+	go Watch(ctx, func(inserted bool) { called <- inserted })
+
+	select {
+	case <-called:
+		t.Error("dispatched a jack position on a device with no detect switch")
+	case <-time.After(300 * time.Millisecond):
 	}
 }

--- a/device/internal/bindings/speaker/jackrouting.go
+++ b/device/internal/bindings/speaker/jackrouting.go
@@ -1,0 +1,159 @@
+package speaker
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Jack routing: the codec state each plug position needs.
+//
+// Here rather than in pcm_speaker.go because that file is ARM-only (build tag
+// `server`) and the mapping is worth pinning on the host — it is a table of
+// measured values, and a typo in one of them is silence rather than an error.
+//
+// MEASURED 2026-09-03 against a stock FireOS 5.5.5.4 Dot (root, no EchoMuse)
+// driving the same cable, by diffing all 239 mixer controls across an insert
+// on both devices. Stock changed five controls; we changed one.
+
+// Mixer control ids on this board. Named because "62" at a call site is the
+// difference between the internal driver and the jack, and nothing about the
+// number says so.
+const (
+	ctlSpeakerAmp   = "5"  // Ext_Speaker_Amp_Switch — internal driver's amp
+	ctlHPDriverGain = "62" // HP Driver Gain Volume — the jack's output stage
+)
+
+// HP driver gain values, as mixer indices on a 0..35 range that maps to
+// -6dB..+29dB.
+//
+// hpGainInternal is what both a stock Dot and ours sit at with nothing
+// plugged in. hpGainJack is stock's value with a plug in.
+//
+// The gap is the whole bug. Something drops this control to 0 — the FLOOR of
+// the range, -6dB — when a plug goes in, and on a stock device the audio HAL
+// then raises it to 11. We had nothing that did, so the external output sat at
+// minimum gain: measured inaudible at 0, and audible immediately on writing
+// 11 with music playing. It reads as "the jack does not work" rather than as
+// "the jack is quiet", which is why it survived so long.
+//
+// NOT accdet, despite what this project's docs said for a month. Amazon's
+// accdet driver (accdet_amzn.c) only reads a GPIO and calls switch_set_state
+// on /sys/class/switch/h2w — it writes no mixer control and touches no codec
+// register. Everything attributed to it is Android's audio HAL reacting to
+// that switch state, which is also why it keeps happening: see
+// reconcileJackRouting.
+const (
+	hpGainInternal = "6"
+	hpGainJack     = "11"
+)
+
+// mixerWrite is one `tinymix -D 0 <ctl> <args...>` invocation.
+type mixerWrite struct {
+	Ctl  string
+	Args []string
+}
+
+// jackRouting returns the mixer writes that put the codec into the state a
+// given plug position needs.
+//
+// Two controls, deliberately. Stock also clears Right Channel Only and sets
+// Ignore Ramp Up on insert, and NEITHER is copied here:
+//
+//   - Right Channel Only selects which codec channel carries the signal, and
+//     our wire is mono — toStereo duplicates L into R — so both channels carry
+//     the same samples whichever way it is set. It becomes real the day the
+//     wire carries stereo, and not before.
+//   - Ignore Ramp Up has not been measured on this hardware at all. Copying a
+//     stock value whose effect is unknown is how you ship a change that cannot
+//     be defended when it turns out to do something else.
+//
+// The order within a position does not matter: these are independent controls
+// on a codec that is already clocking, not a sequence.
+func jackRouting(inserted bool) []mixerWrite {
+	if inserted {
+		// Something is in the jack, so the internal driver must be silent —
+		// otherwise the Dot plays to the room while the cable carries the
+		// same audio somewhere else.
+		return []mixerWrite{
+			{Ctl: ctlSpeakerAmp, Args: []string{"Off"}},
+			{Ctl: ctlHPDriverGain, Args: []string{hpGainJack, hpGainJack}},
+		}
+	}
+	// Nothing in the jack: the internal driver is the only output there is.
+	return []mixerWrite{
+		{Ctl: ctlSpeakerAmp, Args: []string{"On"}},
+		{Ctl: ctlHPDriverGain, Args: []string{hpGainInternal, hpGainInternal}},
+	}
+}
+
+// ── Drift ────────────────────────────────────────────────────────────────────
+//
+// Applying the routing once on a jack edge is not enough, and this is measured
+// rather than anticipated. Android's audio HAL rewrites the codec whenever
+// mediaserver restarts, which on a device holding pcm23p with a plug inserted
+// is roughly every 60-90 seconds. Observed directly on 2026-09-03: HP Driver
+// Gain set to 11 came back as 0 within a minute, every minute, and each revert
+// coincided exactly with mediaserver taking a new pid. So the jack works for
+// about a minute after a plug event and then goes quiet again.
+//
+// We cannot stop it — mediaserver publishes AudioFlinger and AudioPolicyService
+// and system_server crash-loops without them, taking WiFi down with it (tested,
+// 2026-09-03). So the routing is reconciled instead: read the controls back,
+// and rewrite only the ones that moved.
+
+// tinymixValue extracts the CURRENT value from one `tinymix -D 0 <ctl>` line.
+//
+// Two shapes, because the tool prints enums and integers differently:
+//
+//	Ext_Speaker_Amp_Switch:  >Off  On          → enum, ">" marks current
+//	HP Driver Gain Volume: 11 11 (range 0->35) → int, first field after ":"
+//
+// The enum form is the awkward one: the current value is marked in place
+// rather than printed on its own, so a naive "first token after the colon"
+// reads the wrong entry whenever the current value is not the first option.
+// Returns ok=false for anything unrecognised — a control we cannot READ is not
+// a control we should assume has drifted, since that would rewrite it forever.
+func tinymixValue(out string) (string, bool) {
+	i := strings.Index(out, ":")
+	if i < 0 {
+		return "", false
+	}
+	fields := strings.Fields(out[i+1:])
+	for _, f := range fields {
+		if strings.HasPrefix(f, ">") {
+			return strings.TrimPrefix(f, ">"), true // enum
+		}
+	}
+	if len(fields) > 0 && fields[0] != "" {
+		// Integer form. Only the first channel is compared: both are always
+		// written to the same value, so a difference between them would mean
+		// something outside this file is writing one channel on its own.
+		if _, err := strconv.Atoi(fields[0]); err == nil {
+			return fields[0], true
+		}
+	}
+	return "", false
+}
+
+// jackRoutingDrift returns the writes needed to bring the codec back to the
+// state `inserted` requires, given what the controls currently read.
+//
+// `current` maps control id to the value read back. A control MISSING from the
+// map is skipped rather than rewritten: an unreadable control means the read
+// failed, and "failure to look is not evidence of absence" applies here exactly
+// as it does to the controller's asset reconcile — rewriting on a failed read
+// would spawn two tinymix processes every interval forever on any device whose
+// output we cannot parse.
+func jackRoutingDrift(inserted bool, current map[string]string) []mixerWrite {
+	var out []mixerWrite
+	for _, w := range jackRouting(inserted) {
+		got, ok := current[w.Ctl]
+		if !ok {
+			continue
+		}
+		if got != w.Args[0] {
+			out = append(out, w)
+		}
+	}
+	return out
+}

--- a/device/internal/bindings/speaker/jackrouting_test.go
+++ b/device/internal/bindings/speaker/jackrouting_test.go
@@ -1,0 +1,147 @@
+package speaker
+
+import "testing"
+
+// The values here are measurements off a stock FireOS Dot, not preferences.
+// Pinning them means a later edit has to disagree with the hardware on
+// purpose rather than by accident.
+
+func TestJackRoutingMutesInternalDriverWhenSomethingIsPluggedIn(t *testing.T) {
+	got := jackRouting(true)
+	if len(got) != 2 {
+		t.Fatalf("want 2 writes, got %d: %+v", len(got), got)
+	}
+	if got[0].Ctl != ctlSpeakerAmp || got[0].Args[0] != "Off" {
+		t.Errorf("internal amp must be Off with a plug in, got ctl %s = %v", got[0].Ctl, got[0].Args)
+	}
+}
+
+func TestJackRoutingEnablesInternalDriverWhenNothingIsPluggedIn(t *testing.T) {
+	got := jackRouting(false)
+	if got[0].Ctl != ctlSpeakerAmp || got[0].Args[0] != "On" {
+		t.Errorf("internal amp must be On with the jack empty, got ctl %s = %v", got[0].Ctl, got[0].Args)
+	}
+}
+
+// The regression this whole change exists for: accdet leaves the jack's
+// output stage at the floor of its range on insert, and nothing of ours used
+// to raise it. A gain that is not set, or set to 0, is silence.
+func TestJackRoutingRaisesTheJackOutputStageOnInsert(t *testing.T) {
+	in := jackRouting(true)
+	out := jackRouting(false)
+
+	find := func(ws []mixerWrite) *mixerWrite {
+		for i := range ws {
+			if ws[i].Ctl == ctlHPDriverGain {
+				return &ws[i]
+			}
+		}
+		return nil
+	}
+
+	gi, go_ := find(in), find(out)
+	if gi == nil || go_ == nil {
+		t.Fatal("HP driver gain must be set for BOTH positions — leaving it unset on either side is how the jack went silent")
+	}
+	if gi.Args[0] != hpGainJack {
+		t.Errorf("plug in: want gain %s (stock's value), got %s", hpGainJack, gi.Args[0])
+	}
+	if go_.Args[0] != hpGainInternal {
+		t.Errorf("plug out: want gain %s restored, got %s", hpGainInternal, go_.Args[0])
+	}
+	if gi.Args[0] == "0" {
+		t.Error("gain 0 is the FLOOR of the 0..35 range, which is the bug, not a setting")
+	}
+}
+
+// Both channels take the same value: the control is a pair (L, R) and
+// tinymix writes it as two arguments. One argument sets only the left.
+func TestJackRoutingWritesBothChannelsOfTheGainPair(t *testing.T) {
+	for _, inserted := range []bool{true, false} {
+		for _, w := range jackRouting(inserted) {
+			if w.Ctl != ctlHPDriverGain {
+				continue
+			}
+			if len(w.Args) != 2 || w.Args[0] != w.Args[1] {
+				t.Errorf("inserted=%v: gain needs two equal args, got %v", inserted, w.Args)
+			}
+		}
+	}
+}
+
+// Watch dispatches the state it booted into, so every write runs twice in a
+// row on an ordinary device. Nothing here may depend on the previous state.
+func TestJackRoutingIsIdempotent(t *testing.T) {
+	for _, inserted := range []bool{true, false} {
+		a, b := jackRouting(inserted), jackRouting(inserted)
+		if len(a) != len(b) {
+			t.Fatalf("inserted=%v: not deterministic", inserted)
+		}
+		for i := range a {
+			if a[i].Ctl != b[i].Ctl || len(a[i].Args) != len(b[i].Args) {
+				t.Errorf("inserted=%v: write %d differs between calls", inserted, i)
+			}
+		}
+	}
+}
+
+// tinymix prints enums and integers differently, and the enum form marks the
+// current value in place rather than printing it alone — so a parser that
+// takes "the first token after the colon" reads the wrong entry whenever the
+// current value is not listed first. These are real lines off a device.
+func TestTinymixValueReadsTheCurrentEntry(t *testing.T) {
+	for _, tc := range []struct {
+		name, line, want string
+		ok               bool
+	}{
+		{"enum, current is first", "Ext_Speaker_Amp_Switch:\t>Off\tOn", "Off", true},
+		{"enum, current is NOT first", "Ext_Speaker_Amp_Switch:\tOff\t>On", "On", true},
+		{"enum, three options", "Board Channel Config:\tStereo\tMonoLeft\t>MonoRight", "MonoRight", true},
+		{"int pair with range", "HP Driver Gain Volume: 11 11 (range 0->35)", "11", true},
+		{"int at the floor", "HP Driver Gain Volume: 0 0 (range 0->35)", "0", true},
+		{"no colon", "tinymix: no such control", "", false},
+		{"empty value", "Some Control:", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := tinymixValue(tc.line)
+			if ok != tc.ok || got != tc.want {
+				t.Errorf("got (%q,%v), want (%q,%v)", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestJackRoutingDriftRewritesOnlyWhatMoved(t *testing.T) {
+	// Gain clobbered back to the floor, amp still correct — the exact state
+	// measured after a mediaserver restart with a plug in.
+	drift := jackRoutingDrift(true, map[string]string{
+		ctlSpeakerAmp:   "Off",
+		ctlHPDriverGain: "0",
+	})
+	if len(drift) != 1 || drift[0].Ctl != ctlHPDriverGain {
+		t.Fatalf("want only the gain rewritten, got %+v", drift)
+	}
+}
+
+func TestJackRoutingDriftIsSilentWhenNothingMoved(t *testing.T) {
+	if d := jackRoutingDrift(true, map[string]string{
+		ctlSpeakerAmp:   "Off",
+		ctlHPDriverGain: hpGainJack,
+	}); len(d) != 0 {
+		t.Errorf("want no writes on a correct codec, got %+v", d)
+	}
+}
+
+// A control we could not READ must not be treated as drifted. Rewriting on a
+// failed read would spawn tinymix every interval forever on any device whose
+// output we cannot parse — the same "failure to look is not evidence of
+// absence" rule the controller's asset reconcile follows.
+func TestJackRoutingDriftSkipsUnreadableControls(t *testing.T) {
+	if d := jackRoutingDrift(true, map[string]string{}); len(d) != 0 {
+		t.Errorf("want no writes when nothing could be read, got %+v", d)
+	}
+	d := jackRoutingDrift(true, map[string]string{ctlHPDriverGain: "0"})
+	if len(d) != 1 || d[0].Ctl != ctlHPDriverGain {
+		t.Errorf("want only the readable, drifted control, got %+v", d)
+	}
+}

--- a/device/internal/bindings/speaker/pcm_speaker.go
+++ b/device/internal/bindings/speaker/pcm_speaker.go
@@ -3,6 +3,7 @@
 package speaker
 
 import (
+	"context"
 	"log"
 	"math"
 	"os"
@@ -50,6 +51,13 @@ var silencePeriod = make([]byte, periodBytes)
 type PcmSpeaker struct {
 	session *tinyalsa.AudioSession
 	stopCh  chan struct{}
+	// jackInserted is the plug position last applied by SetJackRouting, and
+	// jackKnown says whether one has been applied at all. The reconcile loop
+	// needs a DESIRED state to compare against, and before jack.Watch has run
+	// there is none — acting on a default would fight whatever Init set up.
+	jackMu       sync.Mutex
+	jackInserted bool
+	jackKnown    bool
 	// deadCh is closed by silenceLoop on any exit so a pump call can return
 	// an error rather than block indefinitely waiting for a dead consumer.
 	deadCh chan struct{}
@@ -215,22 +223,115 @@ func waitForFreePcm(card, device int, timeout time.Duration) {
 		pcmOwner(string(b)), timeout)
 }
 
-// EnableSpeakerAmp switches the internal speaker amplifier back on.
+// SetJackRouting puts the codec into the state the current plug position
+// needs. Safe to call repeatedly with the same position — every write is
+// idempotent, which is what lets Watch dispatch the state it booted into
+// without special-casing it.
 //
-// accdet turns it off when a plug is inserted (correctly — the Dot should not
-// play to the room while headphones are connected) and NOTHING turns it back
-// on when the plug is removed. Init is otherwise the only thing that ever sets
-// it, which is why the speaker stayed silent until the next reboot (#80).
+// It replaces EnableSpeakerAmp, which acted only on REMOVAL and only on the
+// amp switch. Both halves of that were wrong, and each hid a symptom:
 //
-// Note this is the ONLY control involved: output routing is done in hardware
-// by the jack's switch contacts, so there is no mux or headphone-amp control
-// to drive alongside it.
-func (p *PcmSpeaker) EnableSpeakerAmp() {
-	if out, err := exec.Command("tinymix", "-D", "0", "5", "On").CombinedOutput(); err != nil {
-		log.Printf("[speaker] could not re-enable speaker amp: %v — %s", err, strings.TrimSpace(string(out)))
-		return
+//   - Insert was left entirely to accdet. accdet does mute the internal amp
+//     on the insert transition, but it also drops HP Driver Gain to the floor
+//     of its range, and on a stock Dot the audio HAL raises it back. Nothing
+//     of ours did, so the external output was inaudible — not quiet, silent —
+//     and the old comment here asserting the amp switch was "the ONLY control
+//     involved" is what stopped anyone looking (falsified 2026-09-03: writing
+//     ctl 62 with music playing took the jack from silent to audible, with the
+//     loopback tap `ref` unchanged, so it is a post-DAC analog stage).
+//   - Neither accdet nor the old code ran at BOOT, because both are
+//     edge-triggered and a boot has no edge. Init unconditionally sets the amp
+//     ON, so a device booted with a cable in played out its internal speaker
+//     until someone unplugged and replugged — which is exactly why replugging
+//     was the folk remedy. It manufactures the edge the boot never had.
+func (p *PcmSpeaker) SetJackRouting(inserted bool) {
+	p.jackMu.Lock()
+	p.jackInserted = inserted
+	p.jackKnown = true
+	p.jackMu.Unlock()
+
+	p.applyJackWrites(jackRouting(inserted))
+	log.Printf("[speaker] jack routing applied (%s)",
+		map[bool]string{true: "external", false: "internal"}[inserted])
+}
+
+func (p *PcmSpeaker) applyJackWrites(ws []mixerWrite) {
+	for _, w := range ws {
+		args := append([]string{"-D", "0", w.Ctl}, w.Args...)
+		if out, err := exec.Command("tinymix", args...).CombinedOutput(); err != nil {
+			log.Printf("[speaker] jack routing: ctl %s: %v — %s", w.Ctl, err, strings.TrimSpace(string(out)))
+		}
 	}
-	log.Println("[speaker] speaker amp re-enabled")
+}
+
+// JackReconcileInterval bounds how long the jack can sit at the wrong gain
+// after Android's HAL has rewritten it.
+//
+// 30s is a compromise, not a measurement. Shorter closes the window of silence
+// after each mediaserver restart; longer costs fewer process spawns, and spawns
+// are not free on this hardware — a heavy shell command was observed inducing
+// mic capture stalls on 2026-09-03, and the mic pipeline has a hard 160ms
+// deadline. Two short-lived reads per 30s sits well below what caused that,
+// and the reverts themselves only arrive every 60-90s.
+const JackReconcileInterval = 30 * time.Second
+
+// ReconcileJackRouting reads the routing controls back and rewrites only the
+// ones that have moved. Returns the number of controls it had to correct, so a
+// caller can tell "the HAL is fighting us" from "nothing is happening" — which
+// are identical from the outside and want opposite investigations.
+//
+// Does nothing until a jack position has actually been observed: before
+// jack.Watch has run there is no desired state, and guessing one would fight
+// whatever Init established.
+func (p *PcmSpeaker) ReconcileJackRouting() int {
+	p.jackMu.Lock()
+	inserted, known := p.jackInserted, p.jackKnown
+	p.jackMu.Unlock()
+	if !known {
+		return 0
+	}
+
+	current := map[string]string{}
+	for _, ctl := range []string{ctlSpeakerAmp, ctlHPDriverGain} {
+		out, err := exec.Command("tinymix", "-D", "0", ctl).CombinedOutput()
+		if err != nil {
+			continue // a failed read is not evidence of drift
+		}
+		if v, ok := tinymixValue(string(out)); ok {
+			current[ctl] = v
+		}
+	}
+
+	drift := jackRoutingDrift(inserted, current)
+	if len(drift) == 0 {
+		return 0
+	}
+	p.applyJackWrites(drift)
+	return len(drift)
+}
+
+// WatchJackRouting re-applies the routing for as long as ctx lives.
+//
+// Runs regardless of plug position: the HAL's rewrite is not specific to the
+// jack, and a gain left at the floor is just as wrong for the internal driver.
+func (p *PcmSpeaker) WatchJackRouting(ctx context.Context) {
+	t := time.NewTicker(JackReconcileInterval)
+	defer t.Stop()
+	var corrected int
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if n := p.ReconcileJackRouting(); n > 0 {
+				corrected += n
+				// Logged per event rather than counted silently: the RATE is
+				// the diagnostic, and it is the only place the HAL's
+				// interference is visible at all.
+				log.Printf("[speaker] jack routing drifted — %d control(s) rewritten (total %d)", n, corrected)
+			}
+		}
+	}
 }
 
 // silenceLoop is the ALSA write path: every period, take what each plane has


### PR DESCRIPTION
The external jack was silent, and a Dot booted with a cable in played out its
internal speaker. Both were the same omission seen from two sides: we treated
jack handling as one control, changed on one edge.

## What was actually wrong

`HP Driver Gain Volume` (ctl 62) is the jack's output stage. Something drops it
to **0 — the floor of a 0..35 range, −6dB** — when a plug goes in, and on a
stock Dot the audio HAL raises it to 11. We had nothing that did, so the
external output sat at minimum gain. That reads as "the jack does not work"
rather than "the jack is quiet", which is why it survived so long.

Measured by diffing all 239 mixer controls across an insert on ours and on a
stock rooted Dot, and confirmed by writing ctl 62 with music playing: the jack
went from inaudible to audible while the loopback tap stayed flat, so it is a
post-DAC analog stage.

Not accdet, despite what our docs said for a month. `accdet_amzn.c` reads a
GPIO and calls `switch_set_state` on `/sys/class/switch/h2w` — no codec
register, no mixer control. Everything attributed to it is Android's audio HAL
reacting to that switch state.

## Changes

- **`SetJackRouting` replaces `EnableSpeakerAmp`** and owns both controls in
  both directions, idempotently. The old comment asserting the amp switch was
  "the ONLY control involved" is what stopped anyone looking. Routing being
  physical is true; "therefore the mixer is irrelevant" was the wrong inference.

- **`jack.Watch` dispatches the state it finds** instead of silently seeding a
  baseline. `Init` sets the amp ON unconditionally — its click-free startup
  needs the amp brought up onto a DAC already clocking silence, and it cannot
  know whether a plug is present — and accdet only acts on a transition, so a
  boot had nothing to correct it. Unplugging and replugging "fixed" it by
  manufacturing the edge the boot never had. **This covers a server restart as
  well as a device boot: both start with no edge.**

- **`WatchJackRouting` reconciles every 30s.** The HAL rewrites the codec on
  every mediaserver restart, roughly once a minute with a plug inserted, so
  applying on the edge alone holds for about a minute. Nothing can stop
  mediaserver (holding it down crash-loops `system_server`, which owns
  `WifiService`), so the routing is reconciled rather than defended. It reads
  before writing and counts corrections, because that count is the only
  visibility we have into how often the HAL interferes.

`Right Channel Only` and `Ignore Ramp Up` are deliberately **not** copied from
stock: our wire is mono (`toStereo` duplicates L=R) so channel selection is a
no-op until stereo, and the ramp control has never been measured here.

The routing table lives in `jackrouting.go`, untagged so it is host-testable,
following the `pcmstatus.go` precedent. A typo in a measured mixer value is
silence, not a compile error, which is worth a test.

## Verification

`go vet` clean, all 13 packages pass, ARM build confirmed.

On hardware: C95 has held ctl 62 at 11 with the internal amp off for **13.8
hours with a plug in**, across no server restarts. The drift counter itself is
still unexercised — it needs mediaserver actually churning, which means a
boot-with-plug-in.

— Team EchoMuse (powered by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPdF3CTSCnbWmpuHEqERoX