### PR TITLE
Bring up the codec's DAPM routes, and two device fixes behind them

### DIFF
--- a/device/internal/bindings/codec/routes.go
+++ b/device/internal/bindings/codec/routes.go
@@ -1,0 +1,104 @@
+// Package codec brings up the DAPM routes the audio path needs, instead of
+// inheriting them from Amazon's audio HAL.
+//
+// Until 2026-09-04 nothing here existed, because nothing had to: on FireOS the
+// HAL configures the codec long before our process opens a PCM, so both the
+// microphone array and the speaker worked and we never learned we were relying
+// on it. Running EchoMuse on a device with no Android userspace made the
+// dependency visible in the least helpful way available — capture returned a
+// steady rms≈0.00035 with a perfectly healthy ALSA clock (300.6s of audio over
+// 300.3s of wall, zero stalls), and playback reported
+// "voice stream complete, periods=35 underruns=0" while the room stayed silent.
+//
+// Both halves had the same cause. An ASoC route that is not connected leaves
+// DAPM no reason to power the converter at either end of it, so the hardware is
+// powered DOWN rather than merely misrouted. Read off the codec (i2c 2-0018) on
+// a device with no Android, against a stock FireOS Dot running the same
+// firmware:
+//
+//	          stock   ours     meaning
+//	  0012      85      05     NADC clock divider, bit7 = powered
+//	  0013      83      03     MADC clock divider
+//	  0026      11      00     ADC flags: left+right converting
+//	  003f      d6      16     DAC data path, bit7/6 = left/right powered
+//	  0089      30      00     output driver power
+//	  008c/8d   08      00     HPL/HPR output mixer routing
+//
+// Applying the routes below took every one of those to stock's exact value.
+//
+// This is written unconditionally, on FireOS as well, and that is deliberate:
+// the values are the ones the HAL would set anyway, so a device that still has
+// Android loses nothing, and one that does not gains a working audio path. The
+// point of the project is not to need Amazon's userspace, and inheriting
+// hardware state from it is a dependency whether or not it currently holds.
+package codec
+
+import (
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// Write is one `tinymix -D 0 <ctl> <value>` invocation.
+type Write struct {
+	Ctl   string
+	Value string
+	Name  string // the control's mixer name, for the log line and for grep
+}
+
+// Routes is every DAPM switch that must be closed for audio to flow.
+//
+// Control IDs are positional and specific to this board, like the ones in the
+// speaker package's jack routing — the name is carried alongside so a mismatch
+// is greppable rather than a bare number nobody can check.
+//
+// CAPTURE: the microphone array reaches the codec on the DIFFERENTIAL inputs,
+// not the single-ended ones. Nothing routed DIF1 into any of the four ADCs, so
+// all four sat powered down. Note the neighbouring "ADC_x DIF1_L/R Input Gain"
+// controls are a DIFFERENT thing in the same register block and were the first
+// thing tried; changing them does nothing, and they are not listed here.
+//
+// PLAYBACK: the DAC was not connected to the output mixer, so it powered down
+// with the firmware streaming correctly into it.
+var Routes = []Write{
+	{"170", "1", "ADC_D Right Ip Select ADC_D DIF1_R switch"},
+	{"177", "1", "ADC_D Left Ip Select ADC_D DIF1_L switch"},
+	{"184", "1", "ADC_C Right Ip Select ADC_C DIF1_R switch"},
+	{"191", "1", "ADC_C Left Ip Select ADC_C DIF1_L switch"},
+	{"200", "1", "ADC_B Right Ip Select ADC_B DIF1_R switch"},
+	{"207", "1", "ADC_B Left Ip Select ADC_B DIF1_L switch"},
+	{"216", "1", "ADC_A Right Ip Select ADC_A DIF1_R switch"},
+	{"223", "1", "ADC_A Left Ip Select ADC_A DIF1_L switch"},
+
+	{"234", "1", "HPR Output Mixer R_DAC Switch"},
+	{"237", "1", "HPL Output Mixer L_DAC Switch"},
+}
+
+var once sync.Once
+
+// EnsureRoutes applies Routes exactly once per process.
+//
+// Called from both the microphone and the speaker Init, because either may run
+// first and each needs the routes closed BEFORE it opens its PCM — DAPM decides
+// what to power at stream open. The sync.Once is what makes calling it from
+// both sites free: process spawns are not cheap on this hardware (a heavy shell
+// command was observed inducing mic capture stalls, and the mic pipeline has a
+// hard 160ms deadline), so ten of them must not become twenty.
+func EnsureRoutes() {
+	once.Do(func() {
+		var failed int
+		for _, w := range Routes {
+			out, err := exec.Command("tinymix", "-D", "0", w.Ctl, w.Value).CombinedOutput()
+			if err != nil {
+				failed++
+				log.Printf("[codec] route ctl %s (%s): %v — %s",
+					w.Ctl, w.Name, err, strings.TrimSpace(string(out)))
+			}
+		}
+		if failed > 0 {
+			log.Printf("[codec] %d of %d DAPM routes failed — audio may be silent",
+				failed, len(Routes))
+		}
+	})
+}

--- a/device/internal/bindings/codec/routes_test.go
+++ b/device/internal/bindings/codec/routes_test.go
@@ -1,0 +1,48 @@
+package codec
+
+import "testing"
+
+// The routes are a table of measured control ids, and a typo in one of them is
+// silence rather than an error — the same reason the jack routing table is
+// pinned. Both ends are covered because they failed independently: the capture
+// routes leave the ADCs powered down, the playback routes leave the DAC powered
+// down, and either alone is a device that looks healthy in every log it writes.
+func TestRoutesCoverBothEndsOfTheAudioPath(t *testing.T) {
+	want := map[string]string{
+		// capture: DIF1 into all four ADCs, left and right
+		"170": "ADC_D Right Ip Select ADC_D DIF1_R switch",
+		"177": "ADC_D Left Ip Select ADC_D DIF1_L switch",
+		"184": "ADC_C Right Ip Select ADC_C DIF1_R switch",
+		"191": "ADC_C Left Ip Select ADC_C DIF1_L switch",
+		"200": "ADC_B Right Ip Select ADC_B DIF1_R switch",
+		"207": "ADC_B Left Ip Select ADC_B DIF1_L switch",
+		"216": "ADC_A Right Ip Select ADC_A DIF1_R switch",
+		"223": "ADC_A Left Ip Select ADC_A DIF1_L switch",
+		// playback: DAC into the output mixer
+		"234": "HPR Output Mixer R_DAC Switch",
+		"237": "HPL Output Mixer L_DAC Switch",
+	}
+
+	got := map[string]string{}
+	for _, w := range Routes {
+		if _, dup := got[w.Ctl]; dup {
+			t.Errorf("control %s listed twice", w.Ctl)
+		}
+		if w.Value != "1" {
+			t.Errorf("control %s (%s): value %q, want \"1\" — every route here is a switch to close",
+				w.Ctl, w.Name, w.Value)
+		}
+		got[w.Ctl] = w.Name
+	}
+
+	for ctl, name := range want {
+		if got[ctl] != name {
+			t.Errorf("control %s: name %q, want %q", ctl, got[ctl], name)
+		}
+	}
+	for ctl := range got {
+		if _, ok := want[ctl]; !ok {
+			t.Errorf("unexpected control %s (%s)", ctl, got[ctl])
+		}
+	}
+}

--- a/device/internal/bindings/led/i2c_controller.go
+++ b/device/internal/bindings/led/i2c_controller.go
@@ -18,6 +18,13 @@ const privacyBrightnessPath = "/sys/devices/soc/10010000.keypad/amz_privacy/priv
 // i2C device that controls the actual LEDs
 const ledFrame = "/sys/devices/soc/11007000.i2c/i2c-0/0-003f/frame"
 
+// The is31fl3236 driver animates the ring itself from boot until something
+// clears this. Android's userspace does; ours does not, so on a device running
+// our own init the kernel animation and our frames drive the same LEDs over the
+// same i2C device and the ring visibly glitches. Reads 1 under our userspace and
+// 0 on stock.
+const bootAnimationPath = "/sys/devices/soc/11007000.i2c/i2c-0/0-003f/boot_animation"
+
 // file permission we need to access the i2C device
 const perm = os.FileMode(0644)
 
@@ -30,6 +37,11 @@ type I2CController struct {
 }
 
 func (i *I2CController) Init() error {
+
+	// Stop the kernel's boot animation before the first frame, or it keeps
+	// driving the same LEDs. Best-effort: on stock Android something has
+	// already cleared it, and a board without the attribute is not a failure.
+	_ = os.WriteFile(bootAnimationPath, []byte("0"), perm)
 
 	// Initialize the LED i2C device in order for us to control it
 	ledCurrentPacket := []byte("3")

--- a/device/internal/bindings/mic/pcm_microphone.go
+++ b/device/internal/bindings/mic/pcm_microphone.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/wilbowes/EchoMuse/internal/bindings/codec"
 	pkgmic "github.com/wilbowes/EchoMuse/pkg/mic"
 	"github.com/Binozo/GoTinyAlsa/pkg/pcm"
 	"github.com/Binozo/GoTinyAlsa/pkg/tinyalsa"
@@ -52,6 +53,11 @@ func (p *PcmMicrophone) Init() error {
 	if err := cmd.Run(); err != nil {
 		log.Printf("mic: stop mixer: %v (continuing)", err)
 	}
+	// Route the differential mic inputs into the ADCs before opening the PCM.
+	// Without this the ADCs are powered down and capture returns the I2S bus's
+	// own noise floor — with a perfectly healthy ALSA clock, which is what
+	// makes it so hard to see. See the codec package.
+	codec.EnsureRoutes()
 	go p.readLoop()
 	return nil
 }

--- a/device/internal/bindings/speaker/pcm_speaker.go
+++ b/device/internal/bindings/speaker/pcm_speaker.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/wilbowes/EchoMuse/internal/bindings/codec"
+
 	"github.com/Binozo/GoTinyAlsa/pkg/pcm"
 	"github.com/Binozo/GoTinyAlsa/pkg/tinyalsa"
 )
@@ -154,6 +156,11 @@ func (p *PcmSpeaker) Init() error {
 	// work to do and is only ever in the way.
 	exec.Command("stop", "media").Run()
 	waitForFreePcm(cardNr, deviceNr, pcmFreeTimeout)
+	// Connect the DAC to the output mixer before opening the stream: DAPM
+	// decides what to power at stream open, and an unrouted DAC is powered
+	// down, which presents as a clean "voice stream complete, underruns=0"
+	// into silence. See the codec package.
+	codec.EnsureRoutes()
 	exec.Command("tinymix", "-D", "0", "61", "0", "0").Run() // mute before touching amp or stream
 
 	device := tinyalsa.NewDevice(cardNr, deviceNr, pcm.Config{

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -1017,17 +1017,40 @@ func probeTCP(addr string, timeout time.Duration) bool {
 }
 
 // GetSerialNo reads ro.serialno — stable device identifier matching adb devices output.
+//
+// Falls back to androidboot.serialno on the kernel command line, which is where
+// the value comes from in the first place. The two sources are complementary
+// rather than redundant: Android's init consumes every androidboot.* argument
+// into a property and strips it from /proc/cmdline, so on stock FireOS only
+// getprop answers — while on a device booted without Android's userspace there
+// is no property service and only the cmdline answers. Both yield the identical
+// string, which matters because the whole fleet is keyed on the serial.
 func GetSerialNo() string {
 	out, err := exec.Command("getprop", "ro.serialno").Output()
+	if err == nil {
+		if serial := strings.TrimSpace(string(out)); serial != "" {
+			return serial
+		}
+	}
+	if serial := serialFromCmdline(); serial != "" {
+		return serial
+	}
+	log.Printf("[control] Warning: could not read ro.serialno: %v", err)
+	return "unknown-device"
+}
+
+func serialFromCmdline() string {
+	b, err := os.ReadFile("/proc/cmdline")
 	if err != nil {
-		log.Printf("[control] Warning: could not read ro.serialno: %v", err)
-		return "unknown-device"
+		return ""
 	}
-	serial := strings.TrimSpace(string(out))
-	if serial == "" {
-		return "unknown-device"
+	const key = "androidboot.serialno="
+	for _, field := range strings.Fields(string(b)) {
+		if strings.HasPrefix(field, key) {
+			return strings.TrimPrefix(field, key)
+		}
 	}
-	return serial
+	return ""
 }
 
 func getLocalIP() string {


### PR DESCRIPTION
Three device fixes, split off `codec-dapm-routes` so they can land without waiting on the emOS work behind them. No emOS code here — this is `device/` only, six files.

**The codec change is the substantial one.** Nothing in the firmware ever brought up the codec's DAPM routes, because Amazon's audio HAL always got there first and configured them for us. That was invisible on FireOS and fatal without it: both the microphones and the speaker come up powered down. `internal/bindings/codec` now drives the routes itself rather than inheriting them.

Written to run unconditionally on both platforms rather than behind a build flag. On FireOS it re-applies what the HAL already set, which costs nothing and removes a silent dependency; there is no second artifact to keep in step.

Verified by cold boot on hardware: the registers read `0012:01 0026:00 003f:14` before the firmware starts and `85/11/d6` — stock's exact values — after, with nothing applied by hand.

The other two:

- **`androidboot.serialno` fallback** when there is no property service, which deletes an Android call site.
- **Stop the kernel's `is31fl3236` boot animation** before driving the LED ring, so two writers stop fighting over the same i2c device.

`go vet` and `go test ./internal/... ./pkg/...` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqfxYZdh5gKrBHtwkbcoSo
