### PR TITLE
Report which userspace the device booted, and stop debloating emOS

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -90,6 +90,7 @@ COPY em_hostip.py .
 COPY em_ingressauth.py .
 COPY em_linkauth.py .
 COPY em_pacing.py .
+COPY em_platform.py .
 COPY em_wsclose.py .
 COPY em_rttlog.py .
 COPY em_esphome.py .

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -4033,11 +4033,18 @@ async def reconcile_on_connect(device_id: str, live) -> None:
 
     # Held as callables, not coroutines: building all three up front and
     # abandoning two of them leaves un-awaited coroutines to warn about later.
-    steps = (
+    steps = [
         ("oww assets", lambda: reconcile_oww_assets(device_id, live)),
         ("start script", lambda: _sync_start_script(live, device_id)),
-        ("debloat", lambda: _sync_debloat(live, device_id)),
-    )
+    ]
+    # The debloat payload is Android-only: a pm-hide list and a Magisk
+    # service.d script. emOS has neither a package manager nor Magisk, so
+    # pushing it there spends a shell round trip to run `pm hide` against
+    # nothing and leave a boot script no init will read. Gated on the device
+    # having POSITIVELY said it is on emOS — see Device.android_userspace for
+    # why absence keeps today's behaviour.
+    if live.android_userspace:
+        steps.append(("debloat", lambda: _sync_debloat(live, device_id)))
     for name, make in steps:
         # Re-read each time, and compare IDENTITY rather than presence: these
         # take seconds, and a device that dropped and redialled part-way
@@ -4996,6 +5003,11 @@ def _merge_device(row) -> dict:
         # capable and still be running on the software tap.
         "aecHwRefCapable": getattr(live, "aec_hw_ref_capable", False) if live else False,
         "aecRef":          getattr(live, "aec_ref", None) if live else None,
+        # Which userspace the device booted: "emos", "fireos", or null from
+        # firmware that cannot say. Null is not FireOS — the wizard, the
+        # support bundle and the payload reconcile all need to tell "Android"
+        # apart from "not asked".
+        "baseOs":          getattr(live, "base_os", None) if live else None,
         # Gates the tap-as-event toggle — see em_button.decide.
         "buttonHoldCapable": getattr(live, "button_hold_capable", False) if live else False,
         # Whether the device found its ambient light sensor. Reported so the

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -72,6 +72,7 @@ import em_pki
 import em_hostip
 import em_linkauth
 import em_pacing
+import em_platform
 import em_wsclose
 import em_rttlog
 import em_eq
@@ -892,6 +893,28 @@ class Device:
         playback_stats stores NULL rather than zero.
         """
         return (self.stats or {}).get("aecRef")
+
+    @property
+    def base_os(self):
+        """
+        The userspace the device booted: "emos", "fireos", or None.
+
+        None means the firmware is too old to report it, NOT FireOS. The
+        distinction is the whole point of the field: `android_userspace`
+        below acts on it, and reading absence as Android would keep pushing
+        the debloat payload at an emOS device that has no package manager.
+        """
+        return (self.stats or {}).get(em_platform.STATS_KEY)
+
+    @property
+    def android_userspace(self) -> bool:
+        """
+        Whether Android-only payloads mean anything on this device.
+
+        The rule and its asymmetry live in em_platform, where a test can
+        reach them without aiohttp.
+        """
+        return em_platform.android_userspace(self.base_os)
 
     async def send_led_anim(self, anim: dict):
         """
@@ -3701,6 +3724,11 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                             # allowlist: it is a state, not a metric, and
                             # the hourly rollup averages numbers.
                             "aecRef":        msg.get("aecRef"),
+                            # Which userspace the device booted: "emos",
+                            # "fireos", or absent from firmware too old to
+                            # say. A state like aecRef, and kept out of
+                            # record_device_stats for the same reason.
+                            "baseOs":        msg.get("baseOs"),
                         }
                         # Shadow summary → hourly rollup. Present only while the
                         # device is scoring, so its presence is also the "was it

--- a/controller/em_platform.py
+++ b/controller/em_platform.py
@@ -1,0 +1,65 @@
+"""
+Which userspace a device booted on, and what follows from it.
+
+The firmware runs on two bases and will for as long as the fleet runs FireOS:
+Amazon's Android 5.1 userspace, and emOS, which replaces it with our own init
+on the same kernel. The device reports which one it booted as `baseOs` on the
+stats message (device/internal/platform), and this module holds the decisions
+the controller makes off the back of it.
+
+Pure and dependency-free, for the reason `em_linkauth.decide` and
+`em_button.decide` are: the rule below is one comparison and getting it
+backwards is silent, so it belongs somewhere a test can reach without
+aiohttp.
+"""
+
+# The three answers the device can give. Mirrored from
+# device/internal/platform/platform.go and pinned by test — a typo here makes
+# every device look like Android forever, which is exactly the failure the
+# capability-string mirroring exists to prevent.
+EMOS = "emos"
+FIREOS = "fireos"
+UNKNOWN = "unknown"
+
+# The wire key on the stats message.
+STATS_KEY = "baseOs"
+
+
+def android_userspace(base_os) -> bool:
+    """
+    Whether Android-only payloads mean anything on this device.
+
+    True for everything except a device that has POSITIVELY said `emos`.
+    Firmware too old to report the field, a device that has not sent stats
+    yet, and any value we do not recognise all keep today's behaviour.
+
+    That asymmetry is deliberate and is the whole content of this function.
+    The project's rule is to degrade to old behaviour rather than to a wrong
+    answer, and the two ways of being wrong here are not equal:
+
+    - Treating an Android device as emOS skips the debloat, leaving a device
+      slightly fatter than intended. Recoverable, invisible, cheap.
+    - Treating an emOS device as Android runs `pm hide` against a system with
+      no package manager and writes a Magisk service.d script no init will
+      ever read. It wastes a shell round trip per reconnect and reports
+      success at having done nothing.
+
+    So absence resolves toward Android, which is where every device was
+    before emOS existed.
+    """
+    return base_os != EMOS
+
+
+def label(base_os) -> str:
+    """
+    How to name the base in something a person reads.
+
+    None becomes "unknown" rather than an empty string or "FireOS": a device
+    whose firmware predates the field has not told us it is on Android, and a
+    panel that says FireOS anyway is stating a fact nobody established.
+    """
+    if base_os == EMOS:
+        return "emOS"
+    if base_os == FIREOS:
+        return "FireOS"
+    return "unknown"

--- a/controller/tests/test_platform.py
+++ b/controller/tests/test_platform.py
@@ -1,0 +1,144 @@
+"""
+The base OS a device booted is a runtime VALUE, and absence is not FireOS.
+
+Two things are guarded here. The decision itself — which payloads mean
+anything on which base — and the strings, which are spelled in Go on the
+device and in Python on the controller and must match exactly. A typo in
+either place makes every device read as Android forever: the debloat keeps
+being pushed at emOS devices, `pm hide` keeps running against nothing, and
+nothing anywhere reports a problem. That is the same silent-typo failure
+test_capabilities.py exists to prevent, so it is checked the same way.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import em_platform  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+PLATFORM_GO = ROOT / "device" / "internal" / "platform" / "platform.go"
+STATS_GO = ROOT / "device" / "internal" / "client" / "stats.go"
+
+
+def _strip_comments(src: str) -> str:
+    """
+    Drop // comments and block comments before matching.
+
+    Source guards that grep raw text find the comment explaining the rule and
+    pass on it — that has happened three times in this repo. Everything below
+    matches against code only.
+    """
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+    return "\n".join(re.sub(r"//.*$", "", line) for line in src.split("\n"))
+
+
+# ─── The decision ─────────────────────────────────────────────────────────────
+
+def test_emos_is_not_android():
+    """A device that said emos gets no Android payloads."""
+    assert em_platform.android_userspace("emos") is False
+
+
+def test_fireos_is_android():
+    assert em_platform.android_userspace("fireos") is True
+
+
+def test_absence_keeps_todays_behaviour():
+    """
+    Firmware too old to report the field, and a device that has not sent
+    stats yet, must both behave exactly as they did before this existed.
+
+    This is the degrade-to-old-behaviour rule. Reading None as emOS would
+    silently stop debloating the entire existing fleet.
+    """
+    assert em_platform.android_userspace(None) is True
+
+
+def test_unknown_values_are_android():
+    """
+    An unrecognised value resolves toward Android, not toward emOS.
+
+    A future base we have not heard of, or a corrupted field, must not be
+    treated as "definitely emOS" — the positive claim is the only thing that
+    turns Android payloads off.
+    """
+    for value in ("unknown", "", "linux", "EMOS", " emos", "emosaic"):
+        assert em_platform.android_userspace(value) is True, value
+
+
+def test_label_never_invents_fireos():
+    """
+    A device that has not said what it runs is reported as unknown.
+
+    Naming it FireOS in a panel states a fact nobody established — the same
+    reason aec_ref returns None rather than "sw".
+    """
+    assert em_platform.label("emos") == "emOS"
+    assert em_platform.label("fireos") == "FireOS"
+    assert em_platform.label(None) == "unknown"
+    assert em_platform.label("something else") == "unknown"
+
+
+# ─── The strings, mirrored across the two languages ──────────────────────────
+
+def test_values_match_the_firmware():
+    """
+    The three answers are spelled identically in Go and Python.
+
+    Read out of the Go constant block rather than hardcoded here, so this
+    fails if the firmware renames one rather than passing on a stale copy.
+    """
+    src = _strip_comments(PLATFORM_GO.read_text())
+    block = re.search(r"const \(\s*(.*?)\s*\)", src, re.S)
+    assert block, "could not find the const block in platform.go"
+    go_values = dict(re.findall(r'(\w+)\s*=\s*"([^"]+)"', block.group(1)))
+    assert go_values == {
+        "EmOS": em_platform.EMOS,
+        "FireOS": em_platform.FIREOS,
+        "Unknown": em_platform.UNKNOWN,
+    }, f"Go and Python disagree about the base OS values: {go_values}"
+
+
+def test_wire_key_matches_the_firmware():
+    """
+    The stats field is named the same at both ends.
+
+    A mismatch here is invisible: the controller reads a key nothing sends,
+    every device reports None, and None correctly degrades to Android — so
+    the fleet keeps working and the feature simply never activates.
+    """
+    src = _strip_comments(STATS_GO.read_text())
+    m = re.search(r'BaseOs\s+string\s+`json:"([^"]+)"`', src)
+    assert m, "BaseOs field not found in stats.go"
+    assert m.group(1) == em_platform.STATS_KEY
+
+
+def test_base_os_is_not_omitempty():
+    """
+    `baseOs` must be sent even when empty.
+
+    With omitempty, a device that could not determine its base would send
+    nothing, which is indistinguishable from firmware too old to have the
+    field. Those are different facts: one device was asked and could not
+    answer, the other was never able to be asked. Same reasoning as aecRef,
+    which carries the identical comment.
+    """
+    src = _strip_comments(STATS_GO.read_text())
+    m = re.search(r'BaseOs\s+string\s+`json:"([^"]+)"`', src)
+    assert m and "omitempty" not in m.group(1)
+
+
+def test_sendstats_actually_puts_it_on_the_wire():
+    """
+    The struct field is populated into the outgoing message.
+
+    DeviceStats is assembled in one place and marshalled by hand in another,
+    so a field can exist, be set, and never be sent — which would look exactly
+    like firmware too old to report it.
+    """
+    src = _strip_comments(STATS_GO.read_text())
+    assert re.search(r'"%s":\s*\w+\.BaseOs' % em_platform.STATS_KEY, src), \
+        "SendStats does not send BaseOs"

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/wilbowes/EchoMuse/internal/bluetooth"
 	"github.com/wilbowes/EchoMuse/internal/client"
 	"github.com/wilbowes/EchoMuse/internal/config"
+	"github.com/wilbowes/EchoMuse/internal/platform"
 	"github.com/wilbowes/EchoMuse/internal/server"
 	"github.com/wilbowes/EchoMuse/internal/wakeword/shadow"
 	"github.com/wilbowes/EchoMuse/internal/wifi"
@@ -631,6 +632,7 @@ func collectStats() client.DeviceStats {
 	speed, freq, bssid := linkInfo()
 	cpuC, maxC, coreLimit := thermals()
 	return client.DeviceStats{
+		BaseOs:           platform.Base(),
 		AmbientLux:       als.Lux(),
 		CPUTempC:         cpuC,
 		MaxTempC:         maxC,

--- a/device/internal/client/stats.go
+++ b/device/internal/client/stats.go
@@ -64,6 +64,17 @@ type DeviceStats struct {
 	// old to report it", and "off" collapsing into that would tell the
 	// dashboard a disarmed AEC is an unknown one.
 	AecRef string `json:"aecRef"`
+	// BaseOs is which userspace the firmware booted on: "emos", "fireos" or
+	// "unknown" (see internal/platform). The controller needs it because it
+	// distributes payloads that only mean anything under Android — the debloat
+	// script and the pm-hide list — and a device running emOS has no package
+	// manager to hide anything from.
+	//
+	// Not omitempty, for AecRef's reason and with more at stake: absent means
+	// "firmware too old to say", which the controller must treat as unknown
+	// rather than as FireOS. Reading absence as Android is how a device gets
+	// sent payloads it cannot use.
+	BaseOs string `json:"baseOs"`
 }
 
 // SendStats sends a stats message to the controller.
@@ -95,5 +106,6 @@ func (c *ControlClient) SendStats(s DeviceStats) {
 		"coresTotal":       s.CoresTotal,
 		"thermalCoreLimit": s.ThermalCoreLimit,
 		"aecRef":           s.AecRef,
+		"baseOs":           s.BaseOs,
 	})
 }

--- a/device/internal/platform/platform.go
+++ b/device/internal/platform/platform.go
@@ -1,0 +1,75 @@
+// Package platform answers which base operating system the firmware booted on.
+//
+// The firmware runs on two bases and will for as long as the fleet runs FireOS:
+// Amazon's Android 5.1 userspace, and emOS (see emos/README.md), which replaces
+// it with our own init on the same kernel. Almost nothing in the firmware needs
+// to care — the hardware is reached through ALSA, i2c, evdev and sysfs either
+// way, which is the whole reason emOS was possible. What DOES need to care is
+// the controller: it distributes payloads that only mean something under
+// Android (the debloat script, the pm-hide list) and would otherwise keep
+// pushing them at a device with no package manager to hide anything from.
+//
+// This is a runtime VALUE, not a capability. The capability question — "can
+// this firmware run on emOS" — is answered yes by every build that contains
+// this file, so announcing it would tell the controller nothing. The useful
+// question is which base the device actually booted, and that is the same
+// "could it" vs "is it" split as aec_hw_ref against the aecRef stats field.
+package platform
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// The three answers. Unknown is not a failure: firmware older than this field
+// reports nothing at all, and the controller must read that as "not asked"
+// rather than as FireOS. Guessing a base is how a device gets sent payloads it
+// cannot use, which is the fault this exists to prevent.
+const (
+	EmOS    = "emos"
+	FireOS  = "fireos"
+	Unknown = "unknown"
+)
+
+// Detect resolves the base OS beneath root. Split from Base for testing —
+// the whole point is to exercise both platforms from a host that is neither.
+//
+// Order is belt and braces rather than precedence: the two markers are
+// mutually exclusive in practice, since emOS has no property service and
+// FireOS does not stamp our os-release.
+func Detect(root string) string {
+	// emOS stamps /etc/os-release at BUILD time, so the file describes the
+	// image rather than something a running system can drift from. init
+	// creates it in the ramdisk before building the /etc symlink farm, and
+	// symlinking over an existing name simply fails — so on emOS this is
+	// always our file, never Amazon's /system/etc.
+	if b, err := os.ReadFile(root + "/etc/os-release"); err == nil {
+		for _, line := range strings.Split(string(b), "\n") {
+			if strings.TrimSpace(line) == "ID="+EmOS {
+				return EmOS
+			}
+		}
+	}
+	// Android's property service. The same marker start_server.sh gates on,
+	// deliberately: one runtime test, used identically in both places, beats
+	// a build flag and the two artifacts that come with it.
+	if _, err := os.Stat(root + "/dev/__properties__"); err == nil {
+		return FireOS
+	}
+	return Unknown
+}
+
+var (
+	once   sync.Once
+	cached string
+)
+
+// Base returns the detected base OS, resolved once. It cannot change without a
+// reboot, and caching also means the value reported on the first stats tick is
+// the value reported on every later one — a field that flapped would be read as
+// a device changing platform underneath the controller.
+func Base() string {
+	once.Do(func() { cached = Detect("") })
+	return cached
+}

--- a/device/internal/platform/platform_test.go
+++ b/device/internal/platform/platform_test.go
@@ -1,0 +1,117 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mkroot builds a fake filesystem root. Files are given as path → contents;
+// an empty content string makes a directory instead, which is what
+// /dev/__properties__ is on a real device.
+func mkroot(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for p, content := range files {
+		full := filepath.Join(root, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if content == "" {
+			if err := os.MkdirAll(full, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// The os-release emOS actually writes, from emos/build.sh. Kept verbatim so
+// this test fails if that format changes shape.
+const emosRelease = `NAME="emOS"
+ID=emos
+PRETTY_NAME="emOS 0.1.3"
+VERSION="0.1.3"
+VERSION_ID="0.1.3"
+BUILD_ID="20260904T071342Z"
+`
+
+func TestDetect(t *testing.T) {
+	cases := []struct {
+		name  string
+		files map[string]string
+		want  string
+	}{
+		{
+			name:  "emOS: os-release stamped at build time",
+			files: map[string]string{"etc/os-release": emosRelease},
+			want:  EmOS,
+		},
+		{
+			name:  "FireOS: Android's property service",
+			files: map[string]string{"dev/__properties__": ""},
+			want:  FireOS,
+		},
+		{
+			// Neither marker. Must NOT guess: a wrong answer here sends a
+			// device payloads it cannot use.
+			name:  "neither marker present",
+			files: map[string]string{},
+			want:  Unknown,
+		},
+		{
+			// Some other distribution's os-release must not read as emOS.
+			name:  "os-release from something else",
+			files: map[string]string{"etc/os-release": "NAME=\"Debian\"\nID=debian\n"},
+			want:  Unknown,
+		},
+		{
+			// ID=emos wins over the property service. They are mutually
+			// exclusive on real hardware, so this only fires if something has
+			// gone strange — and claiming emOS is the safe half, since the
+			// consequence is skipping Android payloads rather than pushing
+			// Android payloads at a device with no package manager.
+			name: "both markers: emOS wins",
+			files: map[string]string{
+				"etc/os-release":     emosRelease,
+				"dev/__properties__": "",
+			},
+			want: EmOS,
+		},
+		{
+			// The ID must be the whole value, not a prefix match — an
+			// "emosaic" distribution is not ours.
+			name:  "ID that merely starts with emos",
+			files: map[string]string{"etc/os-release": "ID=emosaic\n"},
+			want:  Unknown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Detect(mkroot(t, tc.files)); got != tc.want {
+				t.Errorf("Detect() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Base caches, and the value must be stable for the life of the process: a
+// field that flapped would read as a device changing platform underneath the
+// controller.
+func TestBaseIsStable(t *testing.T) {
+	first := Base()
+	for i := 0; i < 3; i++ {
+		if got := Base(); got != first {
+			t.Fatalf("Base() returned %q then %q", first, got)
+		}
+	}
+	switch first {
+	case EmOS, FireOS, Unknown:
+	default:
+		t.Errorf("Base() = %q, not one of the three defined answers", first)
+	}
+}


### PR DESCRIPTION
The controller could not tell which userspace a device booted, which blocks the wizard installing emOS. The payload reconcile pushes a pm-hide list and a Magisk `service.d` script on every connect; on emOS there is no package manager and no Magisk, so that spends a shell round trip running `pm hide` against nothing and leaving a boot script no init will read — then reports success.

The device now reports `baseOs` on the stats message: `emos`, `fireos` or `unknown`.

**A runtime value, not a capability.** "Can this firmware run on emOS" is answered yes by every build containing this PR, so announcing it would tell the controller nothing. The useful question is which base the device actually booted — the same "could it" versus "is it" split as `aec_hw_ref` against the `aecRef` stats field.

**Absence is not FireOS.** Firmware too old to report the field, a device that has not sent stats yet, and any unrecognised value all keep today's behaviour. Only a positive `emos` turns the Android payloads off, because the two ways of being wrong are not equal: treating Android as emOS leaves a device slightly fatter, while treating emOS as Android is the wasted round trip above.

Detection is `ID=emos` in `/etc/os-release`, then `/dev/__properties__` — the same marker `start_server.sh` already gates on, so there is one runtime test rather than a build flag and two artifacts to keep in step.

The decision sits in `em_platform` rather than on `Device` so the suite can reach it without aiohttp, as with `em_linkauth.decide`. The strings are pinned across Go and Python by test, the way capability strings are — a typo there makes every device read as Android forever and nothing reports it.

`go vet`, the device suite and all 939 controller tests pass. `test_deploy` caught the missing Dockerfile `COPY`, which is the crash-loop it exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqfxYZdh5gKrBHtwkbcoSo
