### PR TITLE
Move the base OS onto the register message, where its consumer can see it

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -369,6 +369,11 @@ class Device:
         self.control_ws   = control_ws
         # Set from the register message; None on firmware that predates it.
         self.ambient_light_status: dict | None = None
+        # Which userspace the device booted, from its register message.
+        # None until a device registers, and None forever for firmware too
+        # old to say — which em_platform resolves to Android, leaving the
+        # existing fleet exactly as it was.
+        self._base_os: str | None = None
 
         self.data_ws: WebSocketServerProtocol | None = None
         # Remaining reconnect grace for the speaker stream in flight. Armed by
@@ -903,8 +908,15 @@ class Device:
         distinction is the whole point of the field: `android_userspace`
         below acts on it, and reading absence as Android would keep pushing
         the debloat payload at an emOS device that has no package manager.
+
+        Set from the REGISTER message, not the stats tick. It rode the stats
+        report for exactly one commit, which put it 30 seconds too late for
+        its only consumer — the payload reconcile runs on connect, so it read
+        None, pushed the Magisk service.d script at an emOS device, and each
+        attempt sat out the full 120s transfer timeout waiting for a
+        TRANSFER_OK that could never come.
         """
-        return (self.stats or {}).get(em_platform.STATS_KEY)
+        return self._base_os
 
     @property
     def android_userspace(self) -> bool:
@@ -3376,6 +3388,10 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
         # to tell them apart. Absent on firmware that does not send it, which
         # reads as "not reported" rather than as a fault.
         device.ambient_light_status = msg.get("ambient_light_status")
+        # Static property of the boot, so it arrives with registration
+        # rather than on the stats tick — reconcile_on_connect asks for it
+        # immediately and a stats-borne value is ~30s too late.
+        device._base_os = msg.get(em_platform.REGISTER_KEY)
         # Link-security telemetry for the dashboard: True when this control
         # connection arrived over the TLS listener.
         device.secure = secure
@@ -3724,11 +3740,6 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                             # allowlist: it is a state, not a metric, and
                             # the hourly rollup averages numbers.
                             "aecRef":        msg.get("aecRef"),
-                            # Which userspace the device booted: "emos",
-                            # "fireos", or absent from firmware too old to
-                            # say. A state like aecRef, and kept out of
-                            # record_device_stats for the same reason.
-                            "baseOs":        msg.get("baseOs"),
                         }
                         # Shadow summary → hourly rollup. Present only while the
                         # device is scoring, so its presence is also the "was it

--- a/controller/em_platform.py
+++ b/controller/em_platform.py
@@ -21,8 +21,10 @@ EMOS = "emos"
 FIREOS = "fireos"
 UNKNOWN = "unknown"
 
-# The wire key on the stats message.
-STATS_KEY = "baseOs"
+# The wire key on the REGISTER message. Snake case, matching its neighbours
+# there (`ambient_light_status`, `firmware_ver`) rather than the camelCase of
+# the stats report it briefly rode on.
+REGISTER_KEY = "base_os"
 
 
 def android_userspace(base_os) -> bool:

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1424,6 +1424,13 @@ function Detail({ device, token, onClose, onApprove, isAdmin, globalConfig, onDe
 
       setPushLog(l => [...l, 'Deploying…']);
       const res = await API.post(`/api/devices/${device.device_id}/update`, { upload_token: up.upload_token, force });
+      // The picker has done its job — the bytes are on the controller and the
+      // deploy is running from the upload token, not from this File handle.
+      // Leaving the filename sitting there invites a second Deploy click on a
+      // build that is already installing, and the panel then reads as though
+      // something is still pending when nothing is.
+      setLocalFile(null);
+      if (fileInputRef.current) fileInputRef.current.value = '';
       setPushLog(l => [...l, `Deploying ${res.version} — waiting for reconnect…`]);
       _pollReconnect(res.version, device.firmware_ver);
     } catch(e) {

--- a/controller/tests/test_platform.py
+++ b/controller/tests/test_platform.py
@@ -20,7 +20,7 @@ import em_platform  # noqa: E402
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 PLATFORM_GO = ROOT / "device" / "internal" / "platform" / "platform.go"
-STATS_GO = ROOT / "device" / "internal" / "client" / "stats.go"
+CONTROL_GO = ROOT / "device" / "internal" / "client" / "control.go"
 
 
 def _strip_comments(src: str) -> str:
@@ -104,41 +104,32 @@ def test_values_match_the_firmware():
 
 def test_wire_key_matches_the_firmware():
     """
-    The stats field is named the same at both ends.
+    The register field is named the same at both ends.
 
     A mismatch here is invisible: the controller reads a key nothing sends,
     every device reports None, and None correctly degrades to Android — so
     the fleet keeps working and the feature simply never activates.
     """
-    src = _strip_comments(STATS_GO.read_text())
-    m = re.search(r'BaseOs\s+string\s+`json:"([^"]+)"`', src)
-    assert m, "BaseOs field not found in stats.go"
-    assert m.group(1) == em_platform.STATS_KEY
+    src = _strip_comments(CONTROL_GO.read_text())
+    assert re.search(r'"%s":\s*platform\.Base\(\)' % em_platform.REGISTER_KEY, src), \
+        "the register message does not carry the base OS"
 
 
-def test_base_os_is_not_omitempty():
+def test_base_os_rides_registration_not_stats():
     """
-    `baseOs` must be sent even when empty.
+    It must arrive with REGISTRATION, not on the stats tick.
 
-    With omitempty, a device that could not determine its base would send
-    nothing, which is indistinguishable from firmware too old to have the
-    field. Those are different facts: one device was asked and could not
-    answer, the other was never able to be asked. Same reasoning as aecRef,
-    which carries the identical comment.
+    This is the whole bug that PR #427 shipped and #428 fixed. The only
+    consumer is the payload reconcile, which runs the instant a device
+    connects — roughly 30 seconds before the first stats report. Riding the
+    tick meant the field read as unknown exactly when it was asked, so an
+    emOS device was sent the Magisk service.d script and each attempt sat out
+    the full 120s transfer timeout. Measured on EFF, 2026-09-04: 240s.
     """
-    src = _strip_comments(STATS_GO.read_text())
-    m = re.search(r'BaseOs\s+string\s+`json:"([^"]+)"`', src)
-    assert m and "omitempty" not in m.group(1)
-
-
-def test_sendstats_actually_puts_it_on_the_wire():
-    """
-    The struct field is populated into the outgoing message.
-
-    DeviceStats is assembled in one place and marshalled by hand in another,
-    so a field can exist, be set, and never be sent — which would look exactly
-    like firmware too old to report it.
-    """
-    src = _strip_comments(STATS_GO.read_text())
-    assert re.search(r'"%s":\s*\w+\.BaseOs' % em_platform.STATS_KEY, src), \
-        "SendStats does not send BaseOs"
+    stats_src = _strip_comments(
+        (ROOT / "device" / "internal" / "client" / "stats.go").read_text())
+    assert "BaseOs" not in stats_src, \
+        "the base OS is back on the stats message, where it is 30s too late"
+    assert em_platform.REGISTER_KEY not in stats_src
+    assert not hasattr(em_platform, "STATS_KEY"), \
+        "STATS_KEY implies a stats-borne value; the field rides registration"

--- a/device/cmd/server.go
+++ b/device/cmd/server.go
@@ -30,7 +30,6 @@ import (
 	"github.com/wilbowes/EchoMuse/internal/bluetooth"
 	"github.com/wilbowes/EchoMuse/internal/client"
 	"github.com/wilbowes/EchoMuse/internal/config"
-	"github.com/wilbowes/EchoMuse/internal/platform"
 	"github.com/wilbowes/EchoMuse/internal/server"
 	"github.com/wilbowes/EchoMuse/internal/wakeword/shadow"
 	"github.com/wilbowes/EchoMuse/internal/wifi"
@@ -632,7 +631,6 @@ func collectStats() client.DeviceStats {
 	speed, freq, bssid := linkInfo()
 	cpuC, maxC, coreLimit := thermals()
 	return client.DeviceStats{
-		BaseOs:           platform.Base(),
 		AmbientLux:       als.Lux(),
 		CPUTempC:         cpuC,
 		MaxTempC:         maxC,

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -20,6 +20,7 @@ import (
 	"github.com/wilbowes/EchoMuse/internal/bindings/als"
 	"github.com/wilbowes/EchoMuse/internal/config"
 	"github.com/wilbowes/EchoMuse/internal/discovery"
+	"github.com/wilbowes/EchoMuse/internal/platform"
 	"github.com/wilbowes/EchoMuse/pkg/buttons"
 	"github.com/wilbowes/EchoMuse/pkg/led"
 )
@@ -287,6 +288,21 @@ func (c *ControlClient) connect(ctx context.Context, server *discovery.ServerInf
 		// the support bundle does not collect. Costs one small object per
 		// registration.
 		"ambient_light_status": als.Report(),
+		// Which userspace this firmware booted on — see internal/platform.
+		//
+		// On REGISTRATION and not the stats tick, which is where it was first
+		// put and where it was useless: its consumer is the payload reconcile,
+		// which runs the moment a device connects, ~30s before the first stats
+		// report. So the field resolved to "unknown" exactly when it was
+		// asked, the controller pushed Android payloads at an emOS device, and
+		// each one sat for the full 120s transfer timeout waiting for a
+		// TRANSFER_OK that a write into Magisk's absent overlay can never
+		// send. Measured on EFF, 2026-09-04: 240s across two attempts.
+		//
+		// It belongs here anyway. This is a static property of the boot, known
+		// before the network is up, exactly like ambient_light_status above —
+		// nothing about it needs re-reporting every 30 seconds.
+		"base_os": platform.Base(),
 	}
 	// Resolved fresh per registration: a cached-at-startup value goes stale
 	// after a WiFi change, and if the process started while the network was

--- a/device/internal/client/stats.go
+++ b/device/internal/client/stats.go
@@ -64,17 +64,10 @@ type DeviceStats struct {
 	// old to report it", and "off" collapsing into that would tell the
 	// dashboard a disarmed AEC is an unknown one.
 	AecRef string `json:"aecRef"`
-	// BaseOs is which userspace the firmware booted on: "emos", "fireos" or
-	// "unknown" (see internal/platform). The controller needs it because it
-	// distributes payloads that only mean anything under Android — the debloat
-	// script and the pm-hide list — and a device running emOS has no package
-	// manager to hide anything from.
-	//
-	// Not omitempty, for AecRef's reason and with more at stake: absent means
-	// "firmware too old to say", which the controller must treat as unknown
-	// rather than as FireOS. Reading absence as Android is how a device gets
-	// sent payloads it cannot use.
-	BaseOs string `json:"baseOs"`
+	// The base OS deliberately does NOT ride this message — it is a static
+	// property of the boot and goes out once, on registration (control.go).
+	// It was here first and that was the bug: the payload reconcile asks for
+	// it the instant a device connects, ~30s before the first stats tick.
 }
 
 // SendStats sends a stats message to the controller.
@@ -106,6 +99,5 @@ func (c *ControlClient) SendStats(s DeviceStats) {
 		"coresTotal":       s.CoresTotal,
 		"thermalCoreLimit": s.ThermalCoreLimit,
 		"aecRef":           s.AecRef,
-		"baseOs":           s.BaseOs,
 	})
 }


### PR DESCRIPTION
#427 put the field on the stats tick, which is about 30 seconds too late for the only thing that reads it. `reconcile_on_connect` runs the instant a device connects, so `base_os` was `None` exactly when it was asked, `android_userspace` correctly degraded to Android, and the controller pushed the Magisk `service.d` script at an emOS device.

That is not a wasted round trip. The write lands in `/sbin/.core`, which emOS has no magiskd to create, so it fails and `TRANSFER_OK` is never echoed — and the transfer sits out the full 120s timeout.

**Measured on EFF while updating it to `v2.14.0-15-gb40ecc5`: 240 seconds across two attempts**, once before the update and once when the reconcile fired again on reconnect. The OTA itself was healthy throughout — 10.7MB in 27s, md5 confirmed — so this presented as "the update timed out" when nothing about the update had.

The field belongs on registration regardless of the bug: it is a static property of the boot, known before the network is up, exactly like `ambient_light_status` beside it. Moved rather than duplicated, because two sources for one fact is one that can disagree with the other. The key is renamed `STATS_KEY` → `REGISTER_KEY` and spelled `base_os`, matching the snake_case of its neighbours on that message.

A test pins that it does **not** ride the stats message — putting it back restores a fault whose only symptom is a slow update.

Also in here: the Local Build picker clears once a deploy has started. The bytes are on the controller by then and the deploy runs from the upload token, so a filename left sitting there invites a second Deploy click on a build that is already installing. The input's `value` is cleared too, or re-selecting the same file fires no change event.

`go vet`, the device suite, 938 controller tests and the dashboard tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqfxYZdh5gKrBHtwkbcoSo
