### PR TITLE
The controller tells the device what time it is

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -56,6 +56,7 @@ import logging
 import os
 import socket
 import struct
+import time
 
 import numpy as np
 from aiohttp import web
@@ -3419,6 +3420,21 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
             "type": "ack",
             "device_id": device_id,
             "features": CONTROLLER_FEATURES,
+            # The device's wall clock. An Echo has no RTC that survives a
+            # power cut and boots reading 2010; under emOS nothing ever
+            # corrects it, because bionic resolves through Android's property
+            # service so no bionic-linked binary there has DNS for an NTP
+            # pool. Telling it over the link it already trusts costs one
+            # integer on a message that already flows — against an NTP server
+            # here, which would mean a listening socket, a second way for the
+            # device to find us, and a daemon to supervise, for an accuracy
+            # nothing in this system reads. Every measurement we take is
+            # monotonic and the device never sends a timestamp.
+            #
+            # Not negotiated, and does not need to be: adding a field is safe
+            # unnegotiated, older firmware ignores it, and a device that gets
+            # no field leaves its clock alone.
+            "time_ms": int(time.time() * 1000),
         })
 
         config = await loop.run_in_executor(

--- a/device/internal/client/control.go
+++ b/device/internal/client/control.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/wilbowes/EchoMuse/internal/bindings/als"
+	"github.com/wilbowes/EchoMuse/internal/clock"
 	"github.com/wilbowes/EchoMuse/internal/config"
 	"github.com/wilbowes/EchoMuse/internal/discovery"
 	"github.com/wilbowes/EchoMuse/internal/platform"
@@ -45,6 +46,13 @@ type controlMessage struct {
 	// never by version string. Absent on older controllers, which is
 	// exactly how absence should read — as "does not do this".
 	Features []string `json:"features,omitempty"`
+	// TimeMs is the controller's wall clock in unix milliseconds, sent on the
+	// ack. An Echo has no RTC that survives a power cut and boots reading
+	// 2010; under emOS nothing ever corrects that, because bionic resolves
+	// through Android's property service and so no bionic-linked binary there
+	// has DNS for an NTP pool. Absent from older controllers, which correctly
+	// reads as "no opinion" — see clock.ShouldStep.
+	TimeMs int64 `json:"time_ms,omitempty"`
 }
 
 // ─── Callbacks ────────────────────────────────────────────────────────────────
@@ -334,6 +342,24 @@ func (c *ControlClient) connect(ctx context.Context, server *discovery.ServerInf
 		// is published, so a caller reading it can never see a stale set
 		// from the previous connection.
 		c.setFeatures(first.Features)
+		// ...and what time it is. Deliberately AFTER the connection exists,
+		// so nothing a connection depends on can depend on this: TLS keeps
+		// verifying against the build-time clamp, which is there precisely
+		// because the clock cannot be trusted at dial time.
+		//
+		// Every reconnect is the refresh. Once the clock is right the
+		// threshold makes this a no-op, so it costs a comparison.
+		if clock.ShouldStep(time.Now(), first.TimeMs) {
+			if err := clock.Step(first.TimeMs); err != nil {
+				// Not fatal, and not retried: a device that cannot set its
+				// own clock still does everything else, and the only cost is
+				// log lines that do not line up with the controller's.
+				log.Printf("[clock] could not set the clock from the controller: %v", err)
+			} else {
+				log.Printf("[clock] stepped to %s (from the controller)",
+					time.Now().Format(time.RFC3339))
+			}
+		}
 	default:
 		return fmt.Errorf("unexpected first message: %s", first.Type)
 	}

--- a/device/internal/clock/clock.go
+++ b/device/internal/clock/clock.go
@@ -1,0 +1,77 @@
+// Package clock sets the device's wall clock from the controller.
+//
+// An Echo has no RTC that survives a power cut and boots reading 2010. Under
+// FireOS Android's own time service eventually fixes that when it has
+// internet; under emOS nothing does, and it cannot: bionic resolves hostnames
+// through Android's property service rather than /etc/resolv.conf, so no
+// bionic-linked binary on that system has DNS at all, and `ntpd` cannot look
+// up a pool server. Pointing it at the gateway works only on networks whose
+// router happens to serve NTP.
+//
+// So the controller tells us instead, over the authenticated outbound link the
+// device already trusts. No DNS, no listening socket, no dependency on
+// anything outside the user's own network — the same properties that make the
+// shell plane acceptable.
+//
+// **This does not affect any of the project's timing instrumentation, and must
+// not.** The firmware never sends a timestamp: RTT, wake-crossing ages and
+// stall gaps are all measured with time.Since against Go's monotonic clock,
+// which settimeofday does not perturb — a time.Time from time.Now() carries a
+// monotonic reading and Sub uses it. Fixing the wall clock makes log lines
+// correlatable with the controller's; it changes no measurement.
+//
+// It also does not affect TLS. The device clamps its verification clock to the
+// firmware build time precisely because it cannot trust its own clock at dial
+// time, and that clamp stays: this runs after a connection exists, so it can
+// never be what a connection depends on.
+package clock
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// StepThreshold is how wrong the clock has to be before we touch it.
+//
+// Sized against the link, not against ambition. The ack crosses a network
+// measured at 1-2s RTT excursions on this fleet and carries no delay
+// compensation, so the answer is good to about a second and no better —
+// stepping for a sub-second disagreement would be churn that cannot even be
+// verified. It is also comfortably below the fault this exists for, which is a
+// clock reading fifteen years out.
+//
+// The generous threshold has a second job on FireOS, where Android's own time
+// service is also setting the clock: two setters an hour apart is fine, two
+// setters fighting over half a second is not.
+const StepThreshold = 30 * time.Second
+
+// ShouldStep says whether `serverUnixMs` is far enough from the device's own
+// clock to be worth applying. Pure, so the rule is testable without root.
+//
+// A zero or negative server time means the controller did not send one — an
+// older controller, or a field that did not survive a round trip. That is
+// "no opinion", never "the epoch", and must leave the clock alone: setting a
+// device to 1970 is strictly worse than leaving it in 2010, because it is a
+// value that looks deliberate.
+func ShouldStep(deviceNow time.Time, serverUnixMs int64) bool {
+	if serverUnixMs <= 0 {
+		return false
+	}
+	drift := time.UnixMilli(serverUnixMs).Sub(deviceNow)
+	if drift < 0 {
+		drift = -drift
+	}
+	return drift >= StepThreshold
+}
+
+// Step sets CLOCK_REALTIME to serverUnixMs.
+//
+// clock_settime rather than settimeofday: arm64 is a 64-bit-time-only
+// architecture and does not implement the settimeofday syscall at all, so the
+// obvious call is one that compiles everywhere and fails on the hardware we
+// ship to.
+func Step(serverUnixMs int64) error {
+	ts := unix.NsecToTimespec(serverUnixMs * int64(time.Millisecond))
+	return unix.ClockSettime(unix.CLOCK_REALTIME, &ts)
+}

--- a/device/internal/clock/clock_test.go
+++ b/device/internal/clock/clock_test.go
@@ -1,0 +1,92 @@
+package clock
+
+import (
+	"testing"
+	"time"
+)
+
+func ms(t time.Time) int64 { return t.UnixMilli() }
+
+func TestShouldStep(t *testing.T) {
+	// A fixed "now" so the test says nothing about how long it took to run.
+	now := time.Date(2026, 9, 4, 21, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name   string
+		server int64
+		want   bool
+	}{
+		{
+			// The fault this exists for: an Echo with no RTC boots in 2010,
+			// so the controller is sixteen years ahead of it.
+			name:   "device is sixteen years behind the controller",
+			server: ms(now.AddDate(16, 0, 0)),
+			want:   true,
+		},
+		{
+			name:   "agreed to the second",
+			server: ms(now.Add(400 * time.Millisecond)),
+			want:   false,
+		},
+		{
+			// Within the link's own jitter. Stepping here would be churn we
+			// could not even verify, and on FireOS it would mean fighting
+			// Android's time service over fractions of a second.
+			name:   "inside the link's RTT excursions",
+			server: ms(now.Add(2 * time.Second)),
+			want:   false,
+		},
+		{
+			name:   "just under the threshold",
+			server: ms(now.Add(StepThreshold - time.Second)),
+			want:   false,
+		},
+		{
+			name:   "at the threshold",
+			server: ms(now.Add(StepThreshold)),
+			want:   true,
+		},
+		{
+			// Symmetric: a device running fast is as wrong as one running
+			// slow, and the correction is the same act.
+			name:   "device is ahead of the controller",
+			server: ms(now.Add(-2 * time.Hour)),
+			want:   true,
+		},
+		{
+			// No field on the message — an older controller, or one that does
+			// not send it. "No opinion", never "the epoch": setting a device
+			// to 1970 is worse than leaving it in 2010, because 1970 looks
+			// like a value somebody chose.
+			name:   "controller sent nothing",
+			server: 0,
+			want:   false,
+		},
+		{
+			name:   "controller sent something nonsensical",
+			server: -1,
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ShouldStep(now, tc.server); got != tc.want {
+				t.Errorf("ShouldStep(%d) = %v, want %v", tc.server, got, tc.want)
+			}
+		})
+	}
+}
+
+// The device boots in 2010 and the controller is correct: the whole point.
+func TestBootClockIsStepped(t *testing.T) {
+	boot := time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)
+	real := time.Date(2026, 9, 4, 21, 0, 0, 0, time.UTC)
+	if !ShouldStep(boot, ms(real)) {
+		t.Fatal("a device reading 2010 must be corrected")
+	}
+	// ...and once corrected, the next ack must leave it alone.
+	if ShouldStep(real, ms(real)) {
+		t.Fatal("a correct clock must not be stepped again")
+	}
+}


### PR DESCRIPTION
An Echo has no RTC that survives a power cut and boots reading 2010. Under FireOS, Android's time service eventually fixes that given internet; under emOS nothing does and nothing can — bionic resolves hostnames through Android's property service rather than `/etc/resolv.conf`, so no bionic-linked binary there has DNS, and `ntpd` cannot look up a pool server. Pointing it at the gateway works only on networks whose router serves NTP, and this one does not.

So the controller sends its own clock on the `ack` and the device steps to it. One integer on a message that already flows.

### Why not run NTP on the controller

That costs a listening socket on the user's LAN, a second way for the device to learn where the controller is — free to go stale, and the shape of #169 — and another daemon in init's service table. It buys accuracy nothing in this system reads: every measurement here is monotonic by design and the device never sends a timestamp, so the wall clock's only jobs are making log lines correlatable and keeping TLS sane. One second is ample for both, and the ack crosses a link measured at 1–2s RTT excursions, so one second is about what this gives.

### Three things it deliberately does not do

- **It does not touch timing instrumentation.** `time.Since` works on Go's monotonic reading, which `settimeofday` does not perturb, so RTT, wake-crossing ages and stall gaps are unaffected. Fixing the wall clock changes what a log line says, not what any measurement means.
- **It does not touch TLS.** The step runs *after* a connection exists, so nothing a connection depends on can depend on it. The build-time clamp stays exactly as it is — it exists because the clock cannot be trusted at dial time, which is still true.
- **It does not step small differences.** 30s is comfortably above the link's own jitter and far below the fault this exists for. On FireOS it also keeps us from fighting Android's time service over fractions of a second.

An absent field reads as "no opinion", never as the epoch: an older controller sends nothing, and setting a device to 1970 would be worse than leaving it in 2010, because 1970 looks like a value somebody chose.

`clock_settime`, not `settimeofday` — arm64 does not implement the `settimeofday` syscall at all, so the obvious call is one that compiles everywhere and fails on the hardware we ship to. Verified by building for arm64.

One near-miss worth recording: `em_controller.py` does not import `time`. That is the exact NameError that once killed the wake word listener fleet-wide and the reason the pyflakes job exists — caught locally this time.

`go vet`, the device suite, 942 controller tests and the dashboard tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqfxYZdh5gKrBHtwkbcoSo
