### PR TITLE
Don't wait 120s for an Android service that emOS will never have

### DIFF
--- a/controller/device_payloads/start_server.sh
+++ b/controller/device_payloads/start_server.sh
@@ -13,17 +13,32 @@
 MAX_ATTEMPTS=3
 MIN_RUNTIME=15   # seconds below which an exit is treated as a failed start
 
-# ── Wait for echoaudioservice (up to 4 minutes) ──────────────────────────────
-i=0
-while [ $i -lt 120 ]; do
-    pid=$(ps | grep echoaudio | grep -v grep)
-    if [ -n "$pid" ]; then
-        sleep 5
-        break
-    fi
-    sleep 2
-    i=$((i + 2))
-done
+# ── Wait for echoaudioservice, but only where Android exists ─────────────────
+#
+# This wait is for Amazon's audio service to bring the codec up before we take
+# it. On emOS there is no Android userspace and no echoaudioservice, so the
+# loop can never succeed and always runs its full 120 seconds — measured as a
+# 126s delay from boot to a working assistant, every boot, for a service that
+# will never appear. The firmware configures the codec's DAPM routes itself
+# now (internal/bindings/codec), so there is nothing to wait for there either.
+#
+# The test is whether ANDROID is running, not whether this is emOS: the same
+# script has to be correct on both for as long as both are supported, and a
+# build flag would mean two artifacts to keep in step. /dev/__properties__ is
+# Android's property service — present on FireOS, absent without it — so it
+# tests the thing the wait actually depends on.
+if [ -e /dev/__properties__ ]; then
+    i=0
+    while [ $i -lt 120 ]; do
+        pid=$(ps | grep echoaudio | grep -v grep)
+        if [ -n "$pid" ]; then
+            sleep 5
+            break
+        fi
+        sleep 2
+        i=$((i + 2))
+    done
+fi
 
 # ── Hardware init ─────────────────────────────────────────────────────────────
 ip link set p2p0 down


### PR DESCRIPTION
**EchoMuse starts 122 seconds earlier on emOS.** Measured on EFF today: `up=157s` before, `up=35s` after.

`start_server.sh` polls for Amazon's `echoaudioservice` before starting the server, so the codec is up before we take it. On emOS that service can never appear, so the loop always ran its full 120s timeout. The supervisor log showed EchoMuse starting at `up=157s` on every boot, within a second of the same figure each time — a fixed timeout rather than a retry.

Three things worth knowing:

- **The test is whether Android is running, not whether this is emOS.** `/dev/__properties__` is Android's property service — present on FireOS, absent without it — so it tests the thing the wait actually depends on. One script deciding at runtime beats a build flag and two artifacts to keep in step.
- **The wait is unnecessary on either platform now**, since the firmware configures the codec's DAPM routes itself rather than relying on the HAL having got there first.
- **This is split out of the emOS branch on purpose.** The controller distributes this payload from its own checkout and Supervisor clones the *default* branch, so a fix living only on a feature branch can never reach a device — EFF has been served the old script all along, and reconnecting would have pushed it back. Nothing here depends on the rest of that branch.

Verified on hardware: flashed, rebooted, and the delay is gone. `tests/test_deploy.py` passes (88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGe8ESz9J3hMmDZBi8inuM