### PR TITLE
emOS 0.1: an Echo Dot that runs EchoMuse with no Amazon userspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
         run: docker rm -f em-ci 2>/dev/null || true
 
   device-firmware-build:
-    name: Device firmware builds (pinned compiler)
+    name: Device and emOS builds (pinned compiler)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -421,6 +421,125 @@ jobs:
           file device/build/server
           file device/build/server | grep -q "ARM" || {
             echo "::error::firmware is not an ARM binary"; exit 1; }
+      # emOS's init rides in this job rather than its own because the compiler
+      # it needs is already here: the NDK inside this image is the toolchain
+      # emos/build.sh reaches for, and building the image is minutes where the
+      # compile below is seconds. A second job would pay that cost twice for
+      # one clang invocation.
+      #
+      # It is AARCH64 while the firmware beside it is armv7a, and that is not a
+      # mistake in either. biscuit boots an ARM64 kernel — the fact that cost
+      # five flashed images of a 32-bit kernel that never executed an
+      # instruction (see the LibreEcho notes) — while the server binary is
+      # built for the Android userspace it has always run under.
+      #
+      # -static is the part that has to keep working. Three boots with a
+      # busybox script init produced no output at all, which is
+      # indistinguishable from a kernel that never started; there is no
+      # dynamic loader at PID 1 time, so a link that quietly picks up a shared
+      # object is a device that has to be recovered by hand to diagnose.
+      - name: Build the emOS init (aarch64, static)
+        run: |
+          mkdir -p emos/build
+          docker run --rm -v "$PWD/emos":/emos -w /emos echomuse-compiler bash -lc \
+            '/opt/android/ndk/21.4.7075529/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang \
+               -static -O2 -Wall -o build/init init/init.c'
+      - name: Check it is a static aarch64 binary
+        # Same reasoning as the firmware check above, plus the static half:
+        # both properties are silent when wrong and fatal on the device.
+        run: |
+          file emos/build/init
+          file emos/build/init | grep -q "ARM aarch64" || {
+            echo "::error::emOS init is not an aarch64 binary"; exit 1; }
+          file emos/build/init | grep -q "statically linked" || {
+            echo "::error::emOS init is not statically linked"; exit 1; }
+
+  emos-checks:
+    name: emOS init checks (ring and password)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # WHY THIS EXISTS: emos/ is ~1,900 lines of C that until now nothing in
+      # CI compiled, let alone ran. It is also the code with the longest
+      # feedback loop in the project — a change reaches a verdict only by
+      # flashing a boot partition and watching the device, so a mistake that a
+      # compiler or a simulator could have caught costs a reflash instead.
+      #
+      # Both tools below already existed for exactly this and were run by
+      # hand. Running them here is the whole change; neither reimplements
+      # anything, because both #include init.c whole and drive the real
+      # functions.
+      #
+      # Host cc, not the NDK: these are the OFF-TARGET tools, and their value
+      # is the behaviour they check rather than the code generation. The
+      # target build lives in the pinned-compiler job above, where the NDK is.
+      - name: The boot ring holds its invariants
+        # Only the clean boot is asserted. `ringsim --check <stage>` also
+        # renders the failure display, but that path deliberately ends with
+        # the ring LIT — it is an error indication — so it fails the
+        # handed-back-dark check by design and is not a scenario to assert
+        # here without a second invariant set.
+        run: |
+          cc -O2 -Wall -o /tmp/ringsim emos/init/ringsim.c -lm
+          /tmp/ringsim --check
+      # The C hashes a password by hand — init is a static binary with no
+      # crypto library — and the controller hashes it in Python. Nothing but
+      # equal output proves they agree, and the failure mode is a device
+      # refusing the password the dashboard just accepted, discovered over
+      # USB on hardware.
+      #
+      # The vectors are NOT restated here. pwcheck prints the password that
+      # produced each record, so this recomputes from the C's own inputs with
+      # nothing but hashlib; a third copy of the table would be the drift the
+      # check is for. It also needs no controller module, so it stands whether
+      # or not the console-password work is in the tree beside it.
+      - name: The C password hash agrees with Python's
+        run: |
+          cc -O2 -o /tmp/pwcheck emos/init/pwcheck.c
+          /tmp/pwcheck | tee /tmp/vectors.txt
+          # The vectors go in as an ARGUMENT, not on stdin: the heredoc below
+          # is already stdin, so a redirect here would be overridden and the
+          # loop would read the script's own source and find no records.
+          python3 - /tmp/vectors.txt <<'PY'
+          import hashlib, sys
+
+          n = 0
+          for line in open(sys.argv[1]):
+              line = line.rstrip("\n")
+              if not line:
+                  continue
+              pw, record = line.split("\t", 1)
+              iters, salthex, got = record.split(":")
+              h = hashlib.sha256(bytes.fromhex(salthex) + pw.encode()).digest()
+              for _ in range(int(iters) - 1):
+                  h = hashlib.sha256(h).digest()
+              if h.hex() != got:
+                  print(f"::error::{iters} rounds of {pw!r}: "
+                        f"C says {got}, Python says {h.hex()}")
+                  sys.exit(1)
+              n += 1
+          # A pwcheck that emitted nothing would otherwise pass this silently,
+          # which is the shape of bug ringsim's own frame count exists to catch.
+          if n < 4:
+              print(f"::error::pwcheck emitted {n} vectors, expected at least 4")
+              sys.exit(1)
+          print(f"{n} vectors agree")
+          PY
+      # mkboot.py cannot be exercised without a reference boot image, which is
+      # the one input we never ship — it comes off the user's own device. So
+      # this is the same undefined-name check the controller gets, for the
+      # same reason: it is the failure that is silent until the line runs, and
+      # the line here runs while somebody is writing to a boot partition.
+      - name: Check the packer for undefined names
+        run: |
+          pip install pyflakes
+          out=$(python -m pyflakes emos/mkboot.py 2>&1 | grep -i "undefined name" || true)
+          if [ -n "$out" ]; then
+            echo "$out"
+            echo "::error::pyflakes found undefined name(s) in mkboot.py"
+            exit 1
+          fi
+          echo "No undefined names."
 
   device-vet:
     name: Device go vet

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 __pycache__
 /device/build/
+/emos/build/
 controller/.env
 controller/.venv/
 controller/data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,9 +199,19 @@ git submodule update --init          # GoTinyAlsa fork — see device/CLAUDE.md
 cd device && ./compile.sh            # needs the echomuse-compiler image
 cd device && go test ./...
 cd controller && python -m pytest tests/   # needs: pytest numpy scipy pyyaml
+cd emos/init && cc -O2 -o /tmp/ringsim ringsim.c -lm && /tmp/ringsim --check
+cd emos/init && cc -O2 -o /tmp/pwcheck pwcheck.c && /tmp/pwcheck
 ```
 
 Both suites plus `go vet` run in CI on every push/PR
 (`.github/workflows/ci.yml`). Controller tests deliberately cover the
 pure-logic modules only — see `controller/CLAUDE.md` before adding one that
 needs openwakeword or aiohttp.
+
+**emOS is C with no test framework, so its two off-target tools ARE its
+suite** — `ringsim --check` for the boot ring's invariants and `pwcheck` for
+the password hash the controller has to agree with. Both `#include init.c`
+whole and drive the real functions, so neither can drift from the device.
+CI runs both, builds the init for aarch64 in the pinned compiler image, and
+asserts the result is static — a dynamically linked PID 1 produces no output
+at all, which is indistinguishable from a kernel that never started.

--- a/emos/README.md
+++ b/emos/README.md
@@ -193,14 +193,82 @@ busybox, no bionic. Not legal advice; and never ship Amazon marks or branding.
 
 ## How it boots, and what the ring tells you
 
-Twelve stages, twelve LEDs. The ring is claimed before the first step that can
-fail, fills blue one LED per stage, goes fully green when the network is up and
-then fades out — handing the LEDs to the firmware, so anything shown afterwards
-is EchoMuse's to explain. **A stage that fails leaves the ring RED at the point
-it reached**, so a device that dies says where without a cable.
+The ring passes through three owners on the way up, and only the last is ours.
+Knowing which one you are looking at is most of the diagnosis:
+
+| what you see | who is driving it | what it means |
+|---|---|---|
+| solid dark blue | the bootloader | powered, before Linux. We have not confirmed whether this is the preloader or LK |
+| dark blue ring, one lighter segment orbiting | the **kernel**, via the `is31fl3236` driver's `boot_animation` | the kernel is up and **our init has not run**. It keeps orbiting until userspace claims the ring, so an orbit that never becomes a progress head means PID 1 never started or died before its first instruction |
+| dark blue trail behind a lighter blue head | emOS init | booting, and the head's position is how far |
+| both sides filling bottom to top, brightening, fading | emOS init | up, on the network, ring handed back |
+| red head, stopped | emOS init | that stage failed |
+| solid amber | emOS init | rolling back to the known-good image |
+
+Ours is deliberately a continuation of the kernel's orbit rather than a
+different display — same two blues, same direction, a lighter head leading a
+dark blue trail — because the user should see one object making progress, not
+three unrelated lights.
+
+**The head moves continuously, not in twelve jumps.** Stages are nothing like
+evenly spaced in time, so a head that advanced only on completion would sit
+motionless through `fsck` and WiFi association — the two longest stages, and
+precisely the ones someone reads as a hang. It eases towards the next stage and
+decelerates as it approaches, never arriving until that stage actually
+completes; a completed stage gives it a visible kick forward. It never claims
+progress that has not happened, and it is never still.
+
+Twelve stages, twelve LEDs:
+
+| # | reached when |
+|---|---|
+| 1 | `proc`/`sys`/`devpts` mounted and every device node created |
+| 2 | `/system` mounted read-only |
+| 3 | `e2fsck -p` on `/data` finished |
+| 4 | `/data` mounted read-write |
+| 5 | the `/etc` symlink farm is built |
+| 6 | the previous boot's kernel log is preserved |
+| 7 | busybox applets linked |
+| 8 | the USB gadget is up |
+| 9 | `/dev/ttyGS0` exists — the console is open |
+| 10 | `wlan0` exists |
+| 11 | associating |
+| 12 | carrier and an address — the boot is confirmed |
+
+Stage 10 did not exist until 2026-09-05: both the wlan0 and associating steps
+pinned the same number, so one LED never lit and the two states were the same
+picture. Harmless on a bar that fills; a visible stumble once the head travels.
 
 **Amber means a rollback is in progress** (see below). Cold boot to a working
 voice assistant is about 35 seconds.
+
+### Judging it without a device
+
+`init/ringsim.c` includes `init.c` whole and drives the real animation
+functions against a simulated clock, so the ring can be watched as text and its
+invariants checked without flashing anything:
+
+```sh
+cd init && cc -O2 -o /tmp/ringsim ringsim.c -lm
+/tmp/ringsim            # every frame, as a brightness ramp
+/tmp/ringsim --check    # the invariants
+/tmp/ringsim x 3        # what a failure at stage 3 looks like
+```
+
+Nothing is reimplemented there, so it cannot drift from what the device runs.
+It checks that the ring is never still for 400ms, that the head never travels
+backwards, that nothing lights ahead of it, and that the ring is handed back
+dark. Note the display is gamma-corrected: rendered linearly the dark blue
+trail reads as blank, which is a property of the ramp and not of the ring.
+
+**Three constants in `init.c` are still guesses** and are gathered under "Four
+numbers nobody has measured yet": the two blues, and which way round the index
+runs. `ORBIT_PROBE` reads the kernel's own frames back out of `frame` — it is a
+read/write attribute, so the driver hands back exactly what it is displaying —
+and writes them to the boot trail, which gives the palette exactly rather than
+by eye, plus the orbit's direction and period. One boot answers all three. The
+bottom LED is settled: position 0 is the one just left of bottom centre, where
+the ring's fill has always started.
 
 ## Services
 

--- a/emos/README.md
+++ b/emos/README.md
@@ -59,9 +59,10 @@ Once emOS is running and on the network, flashing no longer needs TWRP:
 
 `init/init.c` is a static AArch64 binary, PID 1, ~500 lines. In order: mount
 `proc`/`sys`/`devpts`; create every device node by hand; mount `/system`
-read-only and `/data` read-write; symlink `/etc` and `/vendor`; link busybox's
-applets; bring up the USB serial console; fork the WiFi stage; then supervise a
-shell on the console.
+read-only and `/data` read-write; build the `/etc` symlink farm; link busybox's
+applets; preserve the previous boot's kernel log; bring up the USB serial
+console; then supervise the service table below. `/data` is checked with
+`e2fsck -p` before it is mounted.
 
 Five things in there each failed *silently* before they were understood, and
 every one of them is a comment in the source rather than folklore:
@@ -83,10 +84,12 @@ every one of them is a comment in the source rather than folklore:
 4. **`f_acm`, not adbd.** adbd needs functionfs descriptors and Android's
    property service. `f_acm` needs no daemon: the kernel exposes `/dev/ttyGS0`
    and init puts a shell on it.
-5. **`/etc` must be a symlink to `/system/etc`.** The kernel firmware loader
+5. **`/etc` must resolve to `/system/etc`.** The kernel firmware loader
    searches `/etc/firmware` for the WiFi blob, so without it the combo chip
    powers on, reports success, and no `wlan0` is ever created. Nothing in the
-   failure mentions `/etc`.
+   failure mentions `/etc`. It is a real DIRECTORY of symlinks rather than a
+   symlink to `/system/etc`, because `/system` is read-only and a symlink
+   would mean the device could never have a writable `resolv.conf`.
 
 ### WiFi
 
@@ -104,9 +107,9 @@ Cold boot to on-the-network is about 32 seconds.
 
 ## Diagnostics
 
-There is no UART without opening the case, and the LED ring is the kernel's
-own `is31fl3236` boot animation, so it says nothing about our progress. Two
-channels exist instead:
+There is no UART without opening the case. Three channels exist instead — and
+the LED ring is the first of them, since init takes it off the kernel's own
+`is31fl3236` boot animation and drives it as a progress bar (above):
 
 - **The progress trail.** init writes a marker at offset 0 of the cache
   partition, `/proc/version` at 512, and an append-only trail at 1024, flushed
@@ -137,27 +140,139 @@ Leaning on `/system` is legally clean but pins emOS to one FireOS build. A
 self-contained ramdisk would need our own userspace — a static Go binary and
 busybox, no bionic. Not legal advice; and never ship Amazon marks or branding.
 
+## How it boots, and what the ring tells you
+
+Twelve stages, twelve LEDs. The ring is claimed before the first step that can
+fail, fills blue one LED per stage, goes fully green when the network is up and
+then fades out — handing the LEDs to the firmware, so anything shown afterwards
+is EchoMuse's to explain. **A stage that fails leaves the ring RED at the point
+it reached**, so a device that dies says where without a cable.
+
+**Amber means a rollback is in progress** (see below). Cold boot to a working
+voice assistant is about 35 seconds.
+
+## Services
+
+PID 1 keeps a table and one supervisor loop that reaps every child (orphans
+reparent to init and nobody else collects them), respawns with backoff, and on
+`SIGTERM` stops services, syncs and remounts `/data` read-only before resetting.
+**`kill -TERM 1` is the clean reboot.**
+
+- A run shorter than `FAST_EXIT` counts as a failure and backs off 2→60s; a
+  longer one resets the count. It never gives up permanently — the causes here
+  are usually transient, and a device that has silently stopped trying is worse
+  than one still retrying slowly.
+- `req` means "must exist or give up, reported once"; `after` means "wait for
+  this and keep waiting". EchoMuse uses both: it is absent on a device where it
+  is not installed, and it waits on `/run/net-up` so the boot ring has finished
+  before the firmware claims the same twelve LEDs.
+- EchoMuse is started through `start_server.sh`, not directly, because that
+  script owns the A/B slot symlink and fast-exit backoff the OTA system depends
+  on. Starting the binary would silently bypass firmware rollback.
+
+## Logs, crashes and storage
+
+The device runs for years on eMMC that cannot be replaced, so **routine logging
+never touches flash**:
+
+| what | where | flash cost |
+|---|---|---|
+| live syslog + kernel log | `/run` tmpfs | none |
+| log at shutdown | `/data/emos/messages.last` | one bounded write |
+| previous boot's kernel log | `/data/emos/last_kmsg.prev`, `.1`, `.2` | one per boot |
+
+`last_kmsg` is **rotated three deep** on purpose: keeping one copy meant a
+device that reboot-loops overwrote the crash that started it with the boring
+ones that followed — the exact case it exists for.
+
+Note busybox's own `-C` RAM ring does NOT work here: it needs System V shared
+memory this kernel lacks, and the failure is silent (`logread` reports
+"can't find syslogd buffer"), leaving no logging at all. tmpfs gives the same
+property and does work.
+
+## Rollback
+
+init keeps the running image at `/data/emos/boot-good.img` and counts boots
+that were never confirmed. **A boot is confirmed when the network comes up** —
+reachability is the property that makes a device fixable without hands on it.
+After three unconfirmed boots init restores the known-good image, shows an
+amber ring and reboots.
+
+This is deliberately NOT the bootloader's A/B. biscuit has a real second slot
+(`boot_b_x`, `mmcblk0p11`) but LK chooses between them and we have not reverse
+engineered how; the standing guess is three tries per slot and then a soft
+brick, which is plausible and **untested**. Building on that guess risks a
+device booting something we did not choose.
+
+**The limit, plainly: an image that fails before init runs executes none of
+this and still needs recovery over USB.** The byte-exact packer and the
+flash verification below exist to make that rare.
+
+## Security posture
+
+**Nothing listens.** Zero TCP and zero UDP listening sockets — that is the
+primary control, and it is the property to re-check whenever a daemon is added.
+Stock FireOS is also zero, so this is parity to preserve rather than a win.
+
+The packet filter is the second layer: outbound-only, `INPUT`/`FORWARD` DROP on
+both IPv4 and IPv6, applied before the interface comes up and with every ACCEPT
+installed before the policy flips. Four exceptions, each verified on hardware —
+loopback, `ESTABLISHED,RELATED`, DHCP offers (broadcast, so conntrack cannot
+help), and **mDNS responses, without which the device boots perfectly and never
+finds its controller**. ICMP is allowed deliberately: not meaningful attack
+surface, and ping is the cheapest liveness check there is.
+
+**No SELinux policy and no unprivileged service user, deliberately.** The server
+needs root for what it does — codec mixer controls, `/dev/snd`, raw HCI on
+`/dev/stpbt`, i2c LED sysfs, GPIO, evdev, CPU governor, and reflashing itself
+for OTA — so dropping privileges would mean granting almost all of it back
+through another mechanism. A policy for a single-purpose device running one
+process would mostly encode "our process may do everything" at permanent
+maintenance cost, and helps against neither realistic threat: a compromised
+controller already has a root shell by design, and physical access means
+reflashing.
+
+Remote shell is the controller's outbound-dialled `/shell/{device_id}` plane,
+not sshd. If someone genuinely needs sshd it is dropbear, per-device opt-in,
+off by default — not a listener every device carries.
+
+## Flashing safely
+
+**A `dd` to the boot partition can complete at page-cache speed and be lost on
+the next reboot.** One flash reported 222MB/s; real writes to this eMMC run
+2.5–9MB/s. Verifying by reading back *from the same cache* passes and proves
+nothing — the device then boots the old image. So:
+
+```sh
+busybox dd if=new.img of=/dev/block/mmcblk0p10 bs=2048 conv=fsync
+sync; echo 3 > /proc/sys/vm/drop_caches       # BEFORE reading back
+busybox dd if=/dev/block/mmcblk0p10 bs=2048 count=<blocks> | busybox md5sum
+```
+
+Toolbox `dd` rejects `conv=fsync`; use busybox. And "the device is reachable"
+is not proof it rebooted — compare uptime or a build fingerprint.
+
 ## Known gaps
 
-None of these is unsolved, only unbuilt:
-
-- **The clock is wrong** (reads 2010) — no NTP. Every log timestamp is
-  therefore uncorrelatable, which blocks most other observability work. busybox
-  has `ntpd`. Fix this first.
-- **`/proc/last_kmsg` is not captured at boot**, so a crash is lost on the
-  following reboot unless someone is watching.
-- **No clean shutdown and no `fsck`.** `/data` is mounted read-write and
-  reboots do not sync, unmount or signal children.
-- **PID 1 does not reap orphans** — it waits only on the console shell.
-- **The EchoMuse server is not started by init**; it is launched by hand. Each
-  capability is its own hand-coded stage with its own ad-hoc supervisor, which
-  does not scale. A declarative service table would replace all of them.
+- **The clock is wrong** (reads 2010), so every timestamp is uncorrelatable.
+  `ntpd` cannot use a hostname because **bionic resolves through Android's
+  property service, not `/etc/resolv.conf`** — no bionic-linked binary has DNS
+  here, though Go binaries are fine since Go carries its own resolver. Pointed
+  at the gateway, which does not serve NTP on the network tested. **The agreed
+  direction is for the controller to tell the device the time**, over the
+  authenticated outbound link it already trusts: no DNS, no listener, no
+  external dependency.
 - **Line out plays the left channel only.** The codec is symmetric and the
   firmware duplicates mono into both channels, so the jack's right pin is
-  likely not driven by the headphone right driver on this board. The unused
+  probably not driven by the headphone right driver on this board. The unused
   `LOL`/`LOR` line-out drivers are the untested lead.
 - The speaker amp idles on and hisses. Gating it on idle is **not** the fix —
   toggling it clicks audibly, which is why the injected silence stream exists.
+- Hardware is resolved by fixed major/minor numbers, against the project's own
+  "resolve by name, not number" rule. Fine for biscuit, wrong for a second
+  board.
+- The boot trail is a fixed-size buffer rewritten in place, so a shorter trail
+  leaves the tail of the previous boot's behind and can be misread.
 
 ## What emOS is worth beyond the stunt
 

--- a/emos/README.md
+++ b/emos/README.md
@@ -165,13 +165,18 @@ Hashing is still worth it, for a different asset: it does not protect the
 DEVICE, it protects the PASSWORD, which the owner has probably reused somewhere
 that matters. Salted SHA-256, iterated, written out by hand in `init.c` because
 this is a static binary with no crypto library. `init/pwcheck.c` includes
-`init.c` whole and prints records for the same vectors
-`controller/tests/test_console_pw.py` carries, so the two implementations are
-compared rather than assumed:
+`init.c` whole and prints a record for each of its vectors, leading with the
+password that produced it, so the two implementations are compared rather than
+assumed:
 
 ```sh
 cd init && cc -O2 -o /tmp/pwcheck pwcheck.c && /tmp/pwcheck
 ```
+
+CI runs that and recomputes every record with `hashlib`, so a drift between the
+C and the Python fails a check rather than a login over USB. The password is in
+the output for exactly that reason: the checker derives the expected hash from
+`pwcheck`'s own inputs and needs no second copy of the table.
 
 Two behaviours chosen so a mistake fails open rather than shut: a record that
 cannot be parsed means NO password, and wrong answers slow down but never lock
@@ -355,7 +360,10 @@ cd init && cc -O2 -o /tmp/ringsim ringsim.c -lm
 Nothing is reimplemented there, so it cannot drift from what the device runs.
 It checks that the ring is never still for 400ms, that the head never travels
 backwards, that nothing lights ahead of it, and that the ring is handed back
-dark. Note the display is gamma-corrected: rendered linearly the dark blue
+dark. CI runs `--check` on every PR, so those invariants hold without anyone
+remembering to look. Only the clean boot is asserted: the failure display ends
+with the ring lit on purpose, so it fails the handed-back-dark check by design
+and needs its own invariants before it can be asserted too. Note the display is gamma-corrected: rendered linearly the dark blue
 trail reads as blank, which is a property of the ramp and not of the ring.
 
 **Three constants in `init.c` are still guesses** and are gathered under "Four

--- a/emos/README.md
+++ b/emos/README.md
@@ -143,6 +143,41 @@ diagnosis (two shells fighting over one tty; there was one, and the second
 console — a script here, or the provisioning wizard over WebSerial, which has
 no `stty` to remind you — must do it explicitly.
 
+### The console password
+
+The console is an unauthenticated root shell — anyone with a cable gets one,
+and the WiFi PSK is in `/data/misc/wifi/wpa_supplicant.conf`. Stock FireOS is
+better than us here, since adbd honours `ro.adb.secure`.
+
+Set it fleet-wide from the dashboard (Config → Advanced → USB console). The
+controller hashes it, pushes the record, and the firmware writes
+`/data/local/etc/echomuse/console.pw`; **init reads that file and prompts before
+handing over the shell**. Only the shell is gated — the boot trail and
+everything else the device prints stay readable, so a dead device is still
+diagnosable.
+
+**It is a nod to security, not Fort Knox.** The record is on `/data`: delete the
+file from TWRP and you are back in. It is an inconvenience for a casual
+opportunist and nothing more, and it should not be hardened later into
+something more complicated.
+
+Hashing is still worth it, for a different asset: it does not protect the
+DEVICE, it protects the PASSWORD, which the owner has probably reused somewhere
+that matters. Salted SHA-256, iterated, written out by hand in `init.c` because
+this is a static binary with no crypto library. `init/pwcheck.c` includes
+`init.c` whole and prints records for the same vectors
+`controller/tests/test_console_pw.py` carries, so the two implementations are
+compared rather than assumed:
+
+```sh
+cd init && cc -O2 -o /tmp/pwcheck pwcheck.c && /tmp/pwcheck
+```
+
+Two behaviours chosen so a mistake fails open rather than shut: a record that
+cannot be parsed means NO password, and wrong answers slow down but never lock
+out. Any lockout a power cycle clears is theatre, and one that survived a reboot
+would only ever trap the owner.
+
 ### What the kernel cmdline actually contains
 
 `/proc/cmdline` is not the boot image's cmdline: **LK appends its own

--- a/emos/README.md
+++ b/emos/README.md
@@ -199,45 +199,107 @@ Knowing which one you are looking at is most of the diagnosis:
 | what you see | who is driving it | what it means |
 |---|---|---|
 | solid dark blue | the bootloader | powered, before Linux. We have not confirmed whether this is the preloader or LK |
-| dark blue ring, one lighter segment orbiting | the **kernel**, via the `is31fl3236` driver's `boot_animation` | the kernel is up and **our init has not run**. It keeps orbiting until userspace claims the ring, so an orbit that never becomes a progress head means PID 1 never started or died before its first instruction |
-| dark blue trail behind a lighter blue head | emOS init | booting, and the head's position is how far |
-| both sides filling bottom to top, brightening, fading | emOS init | up, on the network, ring handed back |
-| red head, stopped | emOS init | that stage failed |
+| full blue ring, one cyan segment orbiting | the **kernel**, via the `is31fl3236` driver's `boot_animation` | the kernel is up and **our init has not run**. It orbits until userspace claims the ring, so an orbit that never becomes a progress head means PID 1 never started, or died before its first instruction |
+| the ring fading out, one cyan LED left at position 1 | emOS init | the handover: we have just taken the ring |
+| blue arc growing behind a cyan head | emOS init | booting, and the head's position is how far |
+| positions 12 and 1 lit and throbbing | emOS init | every stage done, waiting on the network — most of the boot |
+| both sides filling to the top, then white, then fading | emOS init | up, on the network, ring handed back |
+| red, stopped | emOS init | a stage failed, at the point it reached |
 | solid amber | emOS init | rolling back to the known-good image |
 
-Ours is deliberately a continuation of the kernel's orbit rather than a
-different display — same two blues, same direction, a lighter head leading a
-dark blue trail — because the user should see one object making progress, not
-three unrelated lights.
+### Positions
 
-**The head moves continuously, not in twelve jumps.** Stages are nothing like
-evenly spaced in time, so a head that advanced only on completion would sit
-motionless through `fsck` and WiFi association — the two longest stages, and
-precisely the ones someone reads as a hang. It eases towards the next stage and
-decelerates as it approaches, never arriving until that stage actually
-completes; a completed stage gives it a visible kick forward. It never claims
-progress that has not happened, and it is never still.
+The ring is twelve LEDs at 30°, numbered here the way it physically sits:
+**1 just left of 6 o'clock**, up the left side to **6 just left of 12
+o'clock**, then **7 just right of 12 o'clock**, down to **12 just right of 6
+o'clock**. So there is a GAP at dead bottom and dead top rather than an LED,
+which is why the balanced pairs are the ones either side of each gap. The
+kernel starts its orbit on physical index 0, which is position **2** — the
+mapping constant is `LED_BOTTOM`, and getting it wrong rotates the whole
+display by one LED including where the closing sweep meets.
 
-Twelve stages, twelve LEDs:
+### The handover
 
-| # | reached when |
-|---|---|
-| 1 | `proc`/`sys`/`devpts` mounted and every device node created |
-| 2 | `/system` mounted read-only |
-| 3 | `e2fsck -p` on `/data` finished |
-| 4 | `/data` mounted read-write |
-| 5 | the `/etc` symlink farm is built |
-| 6 | the previous boot's kernel log is preserved |
-| 7 | busybox applets linked |
-| 8 | the USB gadget is up |
-| 9 | `/dev/ttyGS0` exists — the console is open |
-| 10 | `wlan0` exists |
-| 11 | associating |
-| 12 | carrier and an address — the boot is confirmed |
+Ours is a continuation of the kernel's orbit rather than a different display,
+and the palette is measured off the driver rather than eyeballed — `frame` is a
+read/write attribute, so writing 1 to `boot_animation` on a running device
+replays the orbit and each frame reads back exactly as displayed. Measured on
+EFF, 2026-09-05: ground `0000ff` on **all twelve** LEDs, head `00ffff` cyan,
+rising physical index, 109ms per step (min 100, max 120, n=13), 1.31s per
+revolution. Sampling at 100ms first suggested exactly one step per sample,
+which is aliasing rather than a measurement — the figures come from a second
+pass at full speed against `/proc/uptime`.
 
-Stage 10 did not exist until 2026-09-05: both the wlan0 and associating steps
-pinned the same number, so one LED never lit and the two states were the same
-picture. Harmless on a bar that fills; a visible stumble once the head travels.
+The animation runs until userspace stops it, so WHEN we stop it is ours to
+choose: `anim_claim` polls the position and takes the ring the instant the
+orbit's head reaches **position 12**. Our next act is lighting position 1 —
+the step the orbit would have taken anyway — so the motion carries straight on.
+The blue ring then fades out from under that head, which is what buys the
+contrast: against a lit ring the progress arc was two shades of blue from the
+ground and did not read at all, so the ring is cleared and the tail **repaints**
+the orbit's own blue as the head travels.
+
+### The head
+
+**It moves continuously, not in twelve jumps**, and that is the point of it
+rather than a flourish. It eases towards the next stage and decelerates as it
+approaches, never arriving until that stage actually completes; completing one
+gives it a visible kick. It never claims progress that has not happened.
+
+It is **steady while travelling and throbs only once it stops**, because those
+say opposite things — movement is progress, the throb is waiting. "Stopped"
+means visually stationary, not arithmetically: the ease decelerates to 1/256 of
+a segment per tick, which changes no pixel.
+
+The head is never a plain cross-fade across the two segments it straddles. That
+halves its brightness at the midpoint, and at the bottom of a breath each half
+falls *below* the tail — so the leading edge stops being the brightest thing on
+the ring. The nearer LED takes the head at full and the further one a
+proportional glow.
+
+### The stages
+
+| # | reached when | measured |
+|---|---|---|
+| 1 | `proc`/`sys`/`devpts` mounted, every device node created | 2210ms |
+| 2 | `/system` mounted read-only | 2218ms |
+| 3 | `e2fsck -p` on `/data` finished | 2254ms |
+| 4 | `/data` mounted read-write | 2261ms |
+| 5 | the `/etc` symlink farm is built | 2265ms |
+| 6 | the previous boot's kernel log is preserved | 2277ms |
+| 7 | busybox applets linked | 2849ms |
+| 8 | the USB gadget is up | 2886ms |
+| 9 | `/dev/ttyGS0` exists — the console is open | 3888ms |
+| 10 | `wlan0` exists | 7738ms |
+| 11 | associating | 7738ms |
+| 12 | carrier and an address — the boot is confirmed | ~35366ms |
+
+Those are real, off EFF on 2026-09-05 (`note()` and `netlog()` timestamp every
+line from `CLOCK_MONOTONIC`). They are worth reading before changing anything
+here, because the shape is not what anyone assumes: **`fsck` is 36ms**, stages
+1-8 all land inside 676ms, and **association plus DHCP is 27.6 seconds — four
+fifths of the whole boot**. The head therefore arrives at position 12 at 7.7s
+and waits there for the rest, which is what the throbbing pair at 12 and 1 is
+for. Pacing the ring by elapsed time instead was considered and is not needed
+for that reason; it would also mean predicting durations, which this does not.
+
+Stage 10 did not exist until 2026-09-05: the wlan0 and associating steps pinned
+the same number, so one LED never lit. Note they still fire in the same
+millisecond, so 10 is lit and superseded immediately.
+
+### When a stage fails
+
+**Only two stages can fail this way** — `led_fail()` has exactly two callers,
+mounting `/system` (2) and mounting `/data` (4). The head turns red at the
+point it reached and **everything stops**, including the throb: a device that
+is stuck should look stuck.
+
+Everything else fails by *hanging* rather than by reporting, and that looks
+different: the head simply stays where it is. A hang before `/data` is mounted
+is the one to know about, because the rollback counter lives in
+`/data/emos/boot.state` and cannot be incremented until then — so a boot that
+dies earlier than that is never counted, never rolls back, and needs recovery
+over USB.
 
 **Amber means a rollback is in progress** (see below). Cold boot to a working
 voice assistant is about 35 seconds.

--- a/emos/README.md
+++ b/emos/README.md
@@ -1,0 +1,170 @@
+# emOS
+
+A Linux distribution for the Amazon Echo Dot Gen 2 ("biscuit") that runs
+EchoMuse with **no Amazon userspace at all** — no Android init, no
+`system_server`, no `mediaserver`, no audio HAL.
+
+It is a distribution in the ordinary sense: it does not include a kernel of its
+own. It pairs the device's existing MediaTek 3.18 kernel with our own PID 1,
+busybox, and bionic and tinyalsa mounted read-only from the device's `/system`.
+
+**Status: 0.1, bench-proven, not a release.** One device, one day. A complete
+voice turn has run on it — wake word scored on-device, Home Assistant pipeline,
+spoken answer — along with WiFi, the 9-channel mic array, hardware AEC, the BLE
+proxy, buttons, ambient light, jack detect and the LED ring. The known gaps are
+listed at the bottom and none of them is a research problem.
+
+## Why
+
+EchoMuse's stated direction is to not depend on Amazon's software. The
+Android-specific surface in the firmware is about twenty call sites, and the
+assumption was always that the remaining dependency was thin. It was thinner
+than that in one sense and much thicker in another:
+
+- SETUP.md claimed Amazon's audio HAL was what started the I2S clock and that
+  playback would hang without it. **That was reasoning, not measurement, and it
+  is false.** Both directions clock with no HAL, no mediaserver and no
+  framework.
+- But the HAL *was* silently configuring the codec for us. Nothing in the
+  firmware ever closed the codec's DAPM routes, because the HAL always got
+  there first. On a device with no Android, both the microphones and the
+  speaker are powered down. See `device/internal/bindings/codec`.
+
+That second finding is the argument for keeping a device on emOS permanently
+even while the fleet runs FireOS: it is the only instrument that makes this
+class of dependency visible. No log, test or dashboard could show it.
+
+## Build and install
+
+```sh
+# 1. Pull the device's own boot partition. KEEP THIS FILE — it is both the
+#    build input and the recovery image.
+adb shell su -c 'dd if=/dev/block/mmcblk0p10' > boot_a_x.img
+
+# 2. Build. Reuses the kernel and DTBs out of your own image.
+./build.sh boot_a_x.img emos-boot.img
+
+# 3. Flash (TWRP, or over the network from a running emOS — see below).
+dd if=emos-boot.img of=/dev/block/mmcblk0p10
+```
+
+**Recovery is a `dd` of the file from step 1 and takes about ten seconds.**
+Prove recovery works before the first flash, not after. Doing that first is
+what made a day of failed boots cheap rather than frightening.
+
+Once emOS is running and on the network, flashing no longer needs TWRP:
+`curl` the image onto the device and `dd` it, about thirty seconds a cycle.
+
+## What the boot actually does
+
+`init/init.c` is a static AArch64 binary, PID 1, ~500 lines. In order: mount
+`proc`/`sys`/`devpts`; create every device node by hand; mount `/system`
+read-only and `/data` read-write; symlink `/etc` and `/vendor`; link busybox's
+applets; bring up the USB serial console; fork the WiFi stage; then supervise a
+shell on the console.
+
+Five things in there each failed *silently* before they were understood, and
+every one of them is a comment in the source rather than folklore:
+
+1. **The init must be a static C binary.** Three boots with a busybox shell
+   init produced no output at all — no marker, nothing — which is
+   indistinguishable from a kernel that never started, and cost most of a day.
+   A static binary removes the interpreter, `PATH` and dynamic loader from
+   between the kernel and the evidence. **The instrument was the bug**, and a
+   broken instrument reads exactly like a broken subject.
+2. **There is no devtmpfs.** Android's `/dev` is a tmpfs populated by `ueventd`
+   from uevents, and we do not run `ueventd`, so nothing appears on its own.
+   Every node is `mknod`'d from numbers read off a running device, never
+   guessed.
+3. **MUSB must be put in device mode** — write `1` to
+   `/sys/devices/platform/mt_usb/cmode`. `cmode 2` is charging-only, and the
+   gadget above it reports `DISCONNECTED` forever no matter how correctly it is
+   configured.
+4. **`f_acm`, not adbd.** adbd needs functionfs descriptors and Android's
+   property service. `f_acm` needs no daemon: the kernel exposes `/dev/ttyGS0`
+   and init puts a shell on it.
+5. **`/etc` must be a symlink to `/system/etc`.** The kernel firmware loader
+   searches `/etc/firmware` for the WiFi blob, so without it the combo chip
+   powers on, reports success, and no `wlan0` is ever created. Nothing in the
+   failure mentions `/etc`.
+
+### WiFi
+
+Amazon's own sequence, read off a running FireOS device rather than
+reconstructed — but two steps appear in no `.rc` file on the device and were
+each found the hard way. `wmt_loader` must run **first** (it registers the
+stp/wmt/BT character devices; without it `6620_launcher` idles forever with
+nothing to open), and `wpa_supplicant` does not associate on its own here — it
+needs a `wpa_cli reassociate` nudge, which the supervisor issues until carrier
+appears. `dhcpcd` is started only after association, because it is given `-K`
+to match stock and so never retries a lease it failed to get before the link
+was up.
+
+Cold boot to on-the-network is about 32 seconds.
+
+## Diagnostics
+
+There is no UART without opening the case, and the LED ring is the kernel's
+own `is31fl3236` boot animation, so it says nothing about our progress. Two
+channels exist instead:
+
+- **The progress trail.** init writes a marker at offset 0 of the cache
+  partition, `/proc/version` at 512, and an append-only trail at 1024, flushed
+  after every step. It is what turned "nothing happened" into
+  "`ttyGS0` open failed errno=2" and then into a shell, in three boots.
+- **`/proc/last_kmsg`.** There is no pstore on this kernel, but MediaTek's
+  ram_console publishes the *previous* boot's kernel log here across a warm
+  reset. It is how a spontaneous reboot was root-caused to a kernel crash in
+  the audio IRQ handler. **Read it first after any unexplained reboot** — the
+  next reboot destroys it.
+
+## Licensing
+
+Three layers, three different answers, and the design follows from them:
+
+- **Amazon's kernel** — a boot image contains it, so redistributing one carries
+  GPL-2.0 obligations. **We therefore distribute a builder, not an image.**
+  `build.sh` takes the user's own boot partition as its reference and reuses
+  that kernel and those DTBs, so the artifact is reconstructed on their side
+  and emOS ships no Amazon code.
+- **Amazon's `/system`** — bionic, the linker, tinyalsa, wpa_supplicant. No
+  licence to redistribute. Mounting it at runtime on a device that already has
+  it is a different act from shipping it.
+- **Our code** — MIT, like the rest of the repo. busybox is GPL-2.0 and is the
+  device's own copy, not ours.
+
+Leaning on `/system` is legally clean but pins emOS to one FireOS build. A
+self-contained ramdisk would need our own userspace — a static Go binary and
+busybox, no bionic. Not legal advice; and never ship Amazon marks or branding.
+
+## Known gaps
+
+None of these is unsolved, only unbuilt:
+
+- **The clock is wrong** (reads 2010) — no NTP. Every log timestamp is
+  therefore uncorrelatable, which blocks most other observability work. busybox
+  has `ntpd`. Fix this first.
+- **`/proc/last_kmsg` is not captured at boot**, so a crash is lost on the
+  following reboot unless someone is watching.
+- **No clean shutdown and no `fsck`.** `/data` is mounted read-write and
+  reboots do not sync, unmount or signal children.
+- **PID 1 does not reap orphans** — it waits only on the console shell.
+- **The EchoMuse server is not started by init**; it is launched by hand. Each
+  capability is its own hand-coded stage with its own ad-hoc supervisor, which
+  does not scale. A declarative service table would replace all of them.
+- **Line out plays the left channel only.** The codec is symmetric and the
+  firmware duplicates mono into both channels, so the jack's right pin is
+  likely not driven by the headphone right driver on this board. The unused
+  `LOL`/`LOR` line-out drivers are the untested lead.
+- The speaker amp idles on and hisses. Gating it on idle is **not** the fix —
+  toggling it clicks audibly, which is why the injected silence stream exists.
+
+## What emOS is worth beyond the stunt
+
+It is a known-good userspace that boots on this hardware, so any future
+kernel can be tested with this exact initramfs and debugged interactively
+rather than one bit per ten-minute cycle. It also removes the reasons for
+several Android call sites in the firmware: the `stop <service>` sites exist
+only to fight mediaserver for the audio path, and the jack drift reconciler
+exists only because the HAL rewrites our mixer settings. Neither has anything
+to fight here.

--- a/emos/README.md
+++ b/emos/README.md
@@ -121,6 +121,57 @@ the LED ring is the first of them, since init takes it off the kernel's own
   the audio IRQ handler. **Read it first after any unexplained reboot** — the
   next reboot destroys it.
 
+
+### Talking to the console: turn ECHO OFF
+
+**A serial port opened with default termios has `ECHO` on, so everything the
+device sends is echoed straight back into its own input.** The shell then
+executes its own prompt —
+
+```
+/system/bin/sh: root@androi: not found
+/system/bin/sh: 127: not found
+```
+
+— and every command returns 127. The console looks alive, echoes what you
+type, and runs nothing.
+
+This cost most of an evening on 2026-09-04 and produced a confident wrong
+diagnosis (two shells fighting over one tty; there was one, and the second
+`/system/bin/sh` was `start_server.sh`) plus a commit that had to be reverted.
+`tty.setraw(fd)` or `stty raw -echo` fixes it instantly. Anything driving this
+console — a script here, or the provisioning wizard over WebSerial, which has
+no `stty` to remind you — must do it explicitly.
+
+### What the kernel cmdline actually contains
+
+`/proc/cmdline` is not the boot image's cmdline: **LK appends its own
+parameters after ours, including a DUPLICATE `androidboot.selinux=enforce`
+that supersedes the `permissive` token the provisioning wizard patches in.**
+LK also supplies `androidboot.hardware`, `androidboot.slot_suffix` and
+`androidboot.serialno` — the last being where the firmware's serial fallback
+gets it on a system with no property service.
+
+Nothing under emOS reads any of them: there is no `/sys/fs/selinux` and no
+SELinux line in `dmesg`. So the wizard's permissive patch is inert here, which
+is why an emOS install does not need the boot patch at all.
+
+### WiFi comes from /data, and wpa_supplicant makes its own entropy
+
+`wpa_supplicant.conf` and `entropy.bin` both live in `/data/misc/wifi`, so
+they survive a boot-partition write — which is what lets a device be
+configured over adb on FireOS and then crossed to emOS. **`entropy.bin` is
+created if absent**: deleted on EFF, the device rebooted and was back on WiFi
+in 25 seconds with the file recreated. A device that never completed Alexa
+setup is not stranded.
+
+`wpa_cli -p /data/misc/wifi/sockets -i wlan0` works for `scan`,
+`scan_results` (bssid, frequency, signal, flags), `get_capability key_mgmt`
+and `save_config`. Note `get_capability key_mgmt` returns
+`NONE IEEE8021X WPA-EAP WPA-PSK` — **no SAE, so this radio cannot join WPA3**,
+and `save_config` needs `update_config=1` in the conf or it silently keeps
+nothing.
+
 ## Licensing
 
 Three layers, three different answers, and the design follows from them:
@@ -262,10 +313,13 @@ is not proof it rebooted — compare uptime or a build fingerprint.
   direction is for the controller to tell the device the time**, over the
   authenticated outbound link it already trusts: no DNS, no listener, no
   external dependency.
-- **Line out plays the left channel only.** The codec is symmetric and the
-  firmware duplicates mono into both channels, so the jack's right pin is
-  probably not driven by the headphone right driver on this board. The unused
-  `LOL`/`LOR` line-out drivers are the untested lead.
+- ~~Line out plays the left channel only.~~ **Fixed 2026-09-04.** A plug-out
+  and plug-in cycle now moves audio between the external speaker and the
+  internal driver in both directions with no interruption, verified against
+  the controller rather than by ear: no `no mic frames` warning, no defensive
+  `mic_start`, no escalation and no connection close — which together were the
+  whole of #117's signature, and which FireOS produced within seconds of every
+  unplug.
 - The speaker amp idles on and hisses. Gating it on idle is **not** the fix —
   toggling it clicks audibly, which is why the injected silence stream exists.
 - Hardware is resolved by fixed major/minor numbers, against the project's own

--- a/emos/build.sh
+++ b/emos/build.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Build an emOS boot image from a device's OWN boot partition.
+#
+# The reference image is required and is never shipped: mkboot.py reuses the
+# kernel and DTBs out of it, so the artifact is reconstructed on the user's
+# side from software already on their device. See README.md.
+#
+#   ./build.sh <reference boot_a_x.img> [output.img]
+#
+# Pull the reference off a rooted device first:
+#   adb shell su -c 'dd if=/dev/block/mmcblk0p10' > boot_a_x.img
+#
+# and KEEP IT. It is the recovery image as well as the build input.
+set -e
+
+REF=${1:?usage: build.sh <reference boot_a_x.img> [output.img]}
+OUT=${2:-emos-boot.img}
+HERE=$(cd "$(dirname "$0")" && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+[ -f "$REF" ] || { echo "reference image not found: $REF" >&2; exit 1; }
+
+# The init is a STATIC binary with no interpreter and no dynamic loader.
+# That is not a size optimisation — three separate boots with a busybox
+# `#!/bin/busybox sh` init produced no output whatsoever, which is
+# indistinguishable from a kernel that never started. See README.md.
+NDK=${NDK:-/opt/android/ndk/21.4.7075529/toolchains/llvm/prebuilt/linux-x86_64/bin}
+CC=${CC:-$NDK/aarch64-linux-android21-clang}
+
+if [ -x "$CC" ]; then
+    "$CC" -static -O2 -Wall -o "$WORK/init" "$HERE/init/init.c"
+else
+    echo "building init in the echomuse-compiler image ($CC not found)"
+    docker run --rm -v "$HERE":/emos -v "$WORK":/out -w /emos echomuse-compiler \
+        bash -lc "$NDK/aarch64-linux-android21-clang -static -O2 -Wall -o /out/init init/init.c"
+fi
+
+# The ramdisk is init plus the empty mountpoints it needs. Everything else the
+# system uses is mounted from the device's own /system at runtime, which is why
+# no Amazon code is redistributed.
+mkdir -p "$WORK/root"/{dev,proc,sys,system,data}
+install -m 0755 "$WORK/init" "$WORK/root/init"
+( cd "$WORK/root" && find . | cpio -o -H newc 2>/dev/null | gzip -9 ) > "$WORK/ramdisk.gz"
+
+# LK gunzips an AArch64 Image, so the kernel must go back in COMPRESSED — the
+# same bytes the reference image carries. Handing it an uncompressed Image
+# silently doubles the image and does not boot.
+python3 "$HERE/mkboot.py" "$REF" <(python3 - "$REF" <<'EOF'
+import struct, sys
+ref = open(sys.argv[1], "rb").read()
+ksz = struct.unpack("<I", ref[8:12])[0]
+kernel = ref[2048:2048 + ksz][0x200:]
+i = kernel.find(b"\xd0\x0d\xfe\xed")          # first DTB ends the kernel
+sys.stdout.buffer.write(kernel[:i])
+EOF
+) "$WORK/ramdisk.gz" "$OUT"
+
+echo
+echo "built $OUT — flash with:"
+echo "  dd if=$OUT of=/dev/block/mmcblk0p10   (boot_a_x on biscuit)"
+echo "recover with:"
+echo "  dd if=$REF of=/dev/block/mmcblk0p10"

--- a/emos/build.sh
+++ b/emos/build.sh
@@ -39,7 +39,27 @@ fi
 # The ramdisk is init plus the empty mountpoints it needs. Everything else the
 # system uses is mounted from the device's own /system at runtime, which is why
 # no Amazon code is redistributed.
-mkdir -p "$WORK/root"/{dev,proc,sys,system,data}
+mkdir -p "$WORK/root"/{dev,proc,sys,system,data,etc}
+
+# Build identity, stamped in at build time rather than written at boot: it
+# describes the IMAGE, so it must not be something a running system can drift
+# from. /etc/os-release is the standard location and format, so ordinary
+# tooling can read it without knowing anything about emOS. init's /etc symlink
+# farm leaves it alone — symlink() into an existing name simply fails.
+# emOS has its own tag namespace. Without --match, `git describe` picks up the
+# nearest tag of ANY kind and stamps the image with a controller release
+# number, which is worse than "unknown" because it looks plausible.
+EMOS_VERSION=${EMOS_VERSION:-$(git -C "$HERE" describe --tags --match 'emos-v*' --dirty 2>/dev/null \
+    || echo "0.1-$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || echo unknown)")}
+cat > "$WORK/root/etc/os-release" <<OSREL
+NAME="emOS"
+ID=emos
+PRETTY_NAME="emOS $EMOS_VERSION"
+VERSION="$EMOS_VERSION"
+VERSION_ID="$EMOS_VERSION"
+BUILD_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+HOME_URL="https://github.com/wilbowes/EchoMuse"
+OSREL
 install -m 0755 "$WORK/init" "$WORK/root/init"
 ( cd "$WORK/root" && find . | cpio -o -H newc 2>/dev/null | gzip -9 ) > "$WORK/ramdisk.gz"
 

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -638,6 +638,9 @@ static void net_main(void)
                     led_frame(LED_N, 0x00, 0xFF, 0x00);
                     usleep(400000);
                     led_fade_out(0x00, 0xFF, 0x00);
+                    /* Ring handed back and the network is up: services that
+                     * wait on the boot completing may now start. */
+                    close(open("/run/net-up", O_WRONLY | O_CREAT, 0644));
                     /* The boot is confirmed: the device is reachable, which
                      * is the property that makes it fixable without hands. */
                     write_state(0);
@@ -664,7 +667,8 @@ static void rdstate(const char *tag)
 }
 
 /* Defined below, with the supervision machinery. */
-static void svc_add(const char *name, char *const *argv, const char *req);
+static void svc_add(const char *name, char *const *argv, const char *req,
+                    const char *after);
 static void supervise(void);
 
 int main(void)
@@ -958,11 +962,20 @@ int main(void)
     char *echomuse[] = { "/system/bin/sh", "/data/local/bin/start_server.sh",
                          NULL };
 
-    svc_add("net", NULL, NULL);          /* forked in-process, see below */
-    svc_add("syslogd", syslogd, NULL);
-    svc_add("klogd", klogd, NULL);
-    svc_add("echomuse", echomuse, "/data/local/bin/start_server.sh");
-    svc_add("console", NULL, NULL);      /* needs the tty as its stdio */
+    svc_add("net", NULL, NULL, NULL);       /* forked in-process, see below */
+    svc_add("syslogd", syslogd, NULL, NULL);
+    svc_add("klogd", klogd, NULL, NULL);
+    /* EchoMuse waits for the network stage to finish, and the wait is about
+     * the LED RING as much as connectivity. The firmware claims the ring the
+     * moment it starts, so a server starting mid-boot drives the same twelve
+     * LEDs as the boot progress bar and the two fight — the identical
+     * two-writer conflict, over the same i2C device, that the kernel's
+     * boot_animation caused. Waiting for /run/net-up means the ring has
+     * finished and faded before the firmware touches it, and EchoMuse has a
+     * controller to reach when it does start. */
+    svc_add("echomuse", echomuse, "/data/local/bin/start_server.sh",
+            "/run/net-up");
+    svc_add("console", NULL, NULL, NULL);   /* needs the tty as its stdio */
 
     supervise();
     return 0;
@@ -983,6 +996,7 @@ struct svc {
     const char  *name;
     char *const *argv;   /* NULL for the two services started specially */
     const char  *req;    /* must exist for the service to run; NULL = argv[0] */
+    const char  *after;  /* wait until this exists; unlike req, keep waiting */
     pid_t        pid;
     time_t       started;
     int          fails;  /* consecutive fast exits */
@@ -995,11 +1009,12 @@ static volatile sig_atomic_t want_shutdown;
 
 static void on_term(int sig) { (void)sig; want_shutdown = 1; }
 
-static void svc_add(const char *name, char *const *argv, const char *req)
+static void svc_add(const char *name, char *const *argv, const char *req,
+                    const char *after)
 {
     if (nsvc < MAX_SVC)
-        svcs[nsvc++] = (struct svc){ .name = name, .argv = argv,
-                                     .req = req, .pid = -1 };
+        svcs[nsvc++] = (struct svc){ .name = name, .argv = argv, .req = req,
+                                     .after = after, .pid = -1 };
 }
 
 /* How long to wait before restarting a service that keeps dying.
@@ -1112,6 +1127,10 @@ static void supervise(void)
             if (s->pid > 0 || s->gone)
                 continue;
             if (now - s->started < svc_backoff(s->fails))
+                continue;
+            /* Ordering, not just presence: a service with `after` waits for
+             * it and keeps waiting, where a missing `req` means give up. */
+            if (s->after && access(s->after, F_OK) != 0)
                 continue;
             /* Not installed is not a failure to retry: EchoMuse may simply not
              * be on this device yet. Say so once and leave it alone. */

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -489,6 +489,58 @@ static void write_resolv_conf(void)
     netlog("resolv.conf nameserver %s\n", gwip);
 }
 
+/* Outbound-only packet filter, applied BEFORE the interface comes up.
+ *
+ * The device already holds no listening sockets at all — verified with
+ * netstat, zero TCP and zero UDP — so there is nothing to connect to. This is
+ * the second layer: it means a daemon that starts listening by accident, or a
+ * future one added without thinking, is not reachable anyway. Stock FireOS
+ * ships no rules whatsoever, so this is emOS being stricter than the thing it
+ * replaces rather than catching up to it.
+ *
+ * Order matters: every ACCEPT is installed before the policy flips to DROP, so
+ * the window where everything is dropped never exists. And it runs before
+ * ifup, so the interface is never up without the policy.
+ *
+ * Four exceptions, each needed and each verified on hardware:
+ *
+ *   - lo, or anything talking to itself breaks.
+ *   - ESTABLISHED,RELATED — the replies to our own outbound connections. This
+ *     is what makes "outbound only" work at all.
+ *   - udp sport 67 -> dport 68: DHCP offers are broadcast, so they match no
+ *     connection and conntrack cannot help. Without this the device gets no
+ *     address.
+ *   - udp sport 5353: mDNS responses. The device FINDS ITS CONTROLLER this
+ *     way, so dropping these is a device that boots perfectly and never
+ *     connects to anything. Tested by killing the server and watching it
+ *     rediscover: "mDNS: found Clara server at 10.10.1.81:8767".
+ *
+ * ICMP is allowed deliberately. It is not attack surface in any meaningful
+ * sense and ping is the cheapest way to tell whether a device is alive — the
+ * diagnostic value outweighs the theoretical purity of dropping it. Remove
+ * this line if that trade ever stops being worth it.
+ *
+ * IPv6 gets the same treatment; ICMPv6 must be allowed or IPv6 cannot
+ * function at all (neighbour discovery rides it).
+ */
+static void firewall(void)
+{
+    char *fw[] = { "/system/bin/sh", "-c",
+        "for T in iptables ip6tables; do "
+        "  $T -F INPUT; "
+        "  $T -A INPUT -i lo -j ACCEPT; "
+        "  $T -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT; "
+        "  $T -A INPUT -p udp --sport 5353 -j ACCEPT; "
+        "  $T -P INPUT DROP; "
+        "  $T -P FORWARD DROP; "
+        "done; "
+        "iptables -I INPUT 4 -p udp --sport 67 --dport 68 -j ACCEPT; "
+        "iptables -I INPUT 5 -p icmp -j ACCEPT; "
+        "ip6tables -I INPUT 4 -p icmpv6 -j ACCEPT", NULL };
+    int st = run_wait(fw);
+    netlog("firewall applied status=%d\n", st);
+}
+
 static int ifup(const char *name)
 {
     struct ifreq ifr;
@@ -551,6 +603,7 @@ static void net_main(void)
 
     for (int i = 0; i < 20 && access("/sys/class/net/wlan0", F_OK); i++)
         sleep(1);
+    firewall();                 /* before the interface is ever up */
     r = ifup("wlan0");
     netlog("wlan0 present=%d ifup=%d\n",
          access("/sys/class/net/wlan0", F_OK) == 0, r);
@@ -677,7 +730,13 @@ int main(void)
 
     /* mknod's mode is masked by the umask, so without this every node below
      * comes out 0644 no matter what it asks for — which is how dhcpcd's hook
-     * script ended up unable to open /dev/null for writing. */
+     * script ended up unable to open /dev/null for writing.
+     *
+     * It is restored to 022 as soon as the nodes exist, and that matters more
+     * than it looks: umask is INHERITED by every child, so leaving it at 0
+     * made PID 1 hand a permissive mask to every process on the device. The
+     * syslog and anything a spawned shell created came out world-writable
+     * (-rw-rw-rw-). Narrow the window to the thing that needs it. */
     umask(0);
 
     mkdir("/dev", 0755);
@@ -722,6 +781,8 @@ int main(void)
     for (unsigned i = 0; i < sizeof nodes / sizeof nodes[0]; i++)
         mknod(nodes[i].path, S_IFCHR | 0600,
               makedev(nodes[i].major, nodes[i].minor));
+
+    umask(022);   /* nodes exist; every child inherits a sane mask from here */
 
     snprintf(buf, sizeof buf, "EM64-INIT-OK acm-console\n");
     write_at(0, buf, strlen(buf));

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/mman.h>
 #include <sys/mount.h>
 #include <sys/reboot.h>
 #include <sys/socket.h>
@@ -101,73 +102,376 @@ static const struct node nodes[] = {
  * firmware's LED binding uses, so nothing here is a new mechanism.
  *
  * Until userspace clears `boot_animation` the kernel driver runs its own
- * orbiting animation on these LEDs, which tells the user nothing about whether
- * the boot is progressing, stuck or dead — and fights any frame we write. So
+ * orbiting animation: a dark blue ring with one lighter segment travelling
+ * round it. That animation and the bootloader's ring before it are the only
+ * things a user sees until we arrive, and it fights any frame we write — so
  * the ring is claimed as the FIRST thing init does, before any step that can
- * fail, and one LED is lit per stage completed.
+ * fail.
  *
- * That turns the single most opaque part of this device into a progress bar:
- * a boot that stops at six LEDs stops in a knowable place, on hardware whose
- * only other diagnostic channel is a raw partition read from recovery.
+ * What replaces it is deliberately a CONTINUATION of it rather than a
+ * different display: the same two blues, a lighter head leading a dark blue
+ * trail, in the same direction at the same rate. The head's position is the
+ * boot's progress — twelve stages, one LED each, arriving back at the bottom
+ * as the network comes up.
+ *
+ * The head moves continuously rather than in twelve jumps, and that is the
+ * whole point of it. Stages are nothing like evenly spaced in time — linking
+ * busybox applets is instant, fsck and WiFi association are seconds — so a
+ * head that moved only on stage completion would sit motionless through
+ * exactly the parts of the boot someone is most likely to read as hung. It
+ * therefore eases towards the next stage and DECELERATES as it approaches,
+ * never arriving until that stage really completes, and completing one gives
+ * it a visible kick forward. It is never still, and it never claims progress
+ * that has not happened.
+ *
+ * Rendering a fractional position on twelve LEDs is a cross-fade between the
+ * two segments either side of it, which is also what makes it read as the same
+ * object as the kernel's orbit rather than a chunky imitation of one.
+ *
+ * A stage that fails turns the head red and stops it. That is a clue, not a
+ * diagnosis: the trail on the cache partition is the diagnosis.
+ *
+ * The animation runs in a FORKED CHILD holding the ring on its own ticker,
+ * because everything it renders over — fsck, mounts, association — blocks PID
+ * 1 for seconds at a time. The parent only ever publishes the stage it has
+ * reached into shared memory; it never writes a frame while the child lives.
  */
+/* Overridable so the ring animation can be rendered and checked off-target;
+ * see emos/init/ringsim.c. */
+#ifndef LEDDIR
 #define LEDDIR "/sys/devices/soc/11007000.i2c/i2c-0/0-003f"
+#endif
 #define LED_N  12
 
+/* Defined further down; declared here so the orbit probe can record into the
+ * boot trail. */
+static void note(const char *fmt, ...);
+
+/* ── Four numbers nobody has measured yet ────────────────────────────────────
+ *
+ * Nothing in this project has ever needed to know how the ring is ORIENTED:
+ * every animation we ship is rotationally symmetric, and the spinner's
+ * direction was a free choice. This is the first display that is not, so the
+ * geometry and the palette are guesses and are gathered here to be corrected
+ * in one place rather than hunted for.
+ *
+ * LED_BOTTOM — settled: the ring's existing fill starts at the LED just left
+ *              of bottom centre, and that is where this one starts too (Wil,
+ *              2026-09-05). Twelve LEDs at 30° put no LED at dead bottom, so
+ *              the bottom is the gap between positions 0 and 11 and the
+ *              finale's arms are the pairs either side of it.
+ * LED_DIR    — still a guess. It only has to match the direction the kernel's
+ *              orbit travels, which the probe below answers.
+ * C_TRAIL / C_HEAD     — set ORBIT_PROBE, boot once, read the trail. The
+ *                        kernel's own frames come back as hex, so the two
+ *                        blues can be copied exactly rather than eyeballed,
+ *                        and the sample interval gives the orbit's direction
+ *                        and period to match ORBIT_MS against.
+ */
+#define LED_BOTTOM 0        /* physical index of the LED at the bottom */
+#define LED_DIR    1        /* +1 if rising physical index runs clockwise */
+#define ORBIT_MS   2000     /* the kernel orbit's period, for rate-matching */
+#define ORBIT_PROBE 1       /* sample the kernel's frames before claiming */
+
+static const unsigned char C_TRAIL[3] = { 0x00, 0x08, 0x30 };  /* dark ground */
+static const unsigned char C_HEAD[3]  = { 0x30, 0x80, 0xFF };  /* light head  */
+static const unsigned char C_FAIL[3]  = { 0xFF, 0x00, 0x00 };
+static const unsigned char C_AMBER[3] = { 0xFF, 0x60, 0x00 };
+/* The ring's last moment before it fades. Green here would say "network
+ * confirmed" the way the old ring did; it is one line if that is ever wanted
+ * back, but confirmation is a diagnostic and this ring is not one. */
+static const unsigned char C_PEAK[3]  = { 0x80, 0xD0, 0xFF };
+
+#define SUB       256                  /* sub-LED position units */
+#define TICK_MS   33                   /* ~30fps; 36 bytes of i2c per frame */
+#define CREEP     ((SUB * 7) / 10)     /* how far into the next segment the
+                                        * head may run while its stage is
+                                        * still going. Under one whole LED, so
+                                        * it can never reach a checkpoint the
+                                        * boot has not actually passed. */
+#define BREATH_MIN ((SUB * 13) / 20)   /* the head dips to 65%, never dark */
+
+enum { ANIM_RUN = 0, ANIM_FAIL, ANIM_FINISH, ANIM_OFF, ANIM_DONE };
+
+struct ledshm {
+    volatile int stage;                /* stages completed, 0..LED_N */
+    volatile int mode;
+};
+static struct ledshm *ledst;
+static pid_t led_pid = -1;
 static int bootstep;
 
-static void led_frame(int lit, int r, int g, int b)
+static const char HEXD[] = "0123456789ABCDEF";
+
+static void puthex(char *o, unsigned char v)
 {
-    char f[LED_N * 6 + 1];
-    for (int i = 0; i < LED_N; i++)
-        snprintf(f + i * 6, 7, "%02X%02X%02X",
-                 i < lit ? r : 0, i < lit ? g : 0, i < lit ? b : 0);
+    o[0] = HEXD[v >> 4];
+    o[1] = HEXD[v & 15];
+}
+
+/* Write one frame, mapping LOGICAL positions (0 = bottom, rising the way the
+ * orbit travels) onto physical LED indices. Every animation here is written in
+ * logical space so the geometry lives in exactly one place.
+ *
+ * Note the hex is laid down two characters at a time rather than with
+ * snprintf: the physical indices are not visited in order, so a terminating
+ * NUL would land on the first character of a slot that had already been
+ * written. */
+static void led_write(const unsigned char f[LED_N][3])
+{
+    char hex[LED_N * 6];
+    for (int i = 0; i < LED_N; i++) {
+        int p = (LED_BOTTOM + LED_DIR * i) % LED_N;
+        if (p < 0)
+            p += LED_N;
+        puthex(hex + p * 6,     f[i][0]);
+        puthex(hex + p * 6 + 2, f[i][1]);
+        puthex(hex + p * 6 + 4, f[i][2]);
+    }
     int fd = open(LEDDIR "/frame", O_WRONLY);
     if (fd < 0)
         return;
-    write(fd, f, LED_N * 6);
+    write(fd, hex, sizeof hex);
     close(fd);
 }
 
-/* Take the ring off the kernel's animation and set the drive current. */
+static void led_solid(const unsigned char c[3])
+{
+    unsigned char f[LED_N][3];
+    for (int p = 0; p < LED_N; p++)
+        memcpy(f[p], c, 3);
+    led_write(f);
+}
+
+/* out = a, with w/SUB of b laid over it. */
+static void blend(unsigned char out[3], const unsigned char a[3],
+                  const unsigned char b[3], int w)
+{
+    for (int i = 0; i < 3; i++)
+        out[i] = (unsigned char)(a[i] + ((int)b[i] - (int)a[i]) * w / SUB);
+}
+
+static void scale(unsigned char out[3], const unsigned char c[3], int w)
+{
+    for (int i = 0; i < 3; i++)
+        out[i] = (unsigned char)(c[i] * w / SUB);
+}
+
+/* A slow rise and fall, squared so it lingers dim and peaks softly rather than
+ * pulsing evenly. This is what keeps the ring alive during a stage that takes
+ * seconds: the head stops travelling as it approaches the next checkpoint, but
+ * it never stops moving. */
+static int breath(int tick)
+{
+    int per = 2400 / TICK_MS;
+    int x = tick % per;
+    int tri = x < per / 2 ? x * 2 * SUB / per : (per - x) * 2 * SUB / per;
+    return tri * tri / SUB;
+}
+
+/* head_q is a position in SUB units around the ring, 0..LED_N*SUB. */
+static void anim_render(int head_q, int tick, int failed)
+{
+    unsigned char f[LED_N][3], head[3];
+
+    scale(head, failed ? C_FAIL : C_HEAD,
+          failed ? SUB : BREATH_MIN + breath(tick) * (SUB - BREATH_MIN) / SUB);
+
+    int i = head_q / SUB, fr = head_q % SUB;
+    for (int p = 0; p < LED_N; p++) {
+        if (p < i)
+            memcpy(f[p], C_TRAIL, 3);
+        else
+            memset(f[p], 0, 3);
+    }
+    /* The head straddles two segments. Modulo, so a head arriving at LED_N
+     * lands back on the bottom rather than off the end of the ring. */
+    blend(f[i % LED_N], f[i % LED_N], head, SUB - fr);
+    if (fr)
+        blend(f[(i + 1) % LED_N], f[(i + 1) % LED_N], head, fr);
+    led_write(f);
+}
+
+/* Boot complete: close the ring, fill both sides from the bottom to the top,
+ * take it to full and then take it away. The fade hands the LEDs back, so
+ * anything shown afterwards is the firmware's to explain. */
+static void anim_finale(int head_q, int tick)
+{
+    unsigned char f[LED_N][3];
+
+    while (head_q < LED_N * SUB) {
+        int step = (LED_N * SUB - head_q) / 6;
+        if (step < 3)
+            step = 3;
+        head_q += step;
+        if (head_q > LED_N * SUB)
+            head_q = LED_N * SUB;
+        anim_render(head_q, tick++, 0);
+        usleep(TICK_MS * 1000);
+    }
+
+    /* Both sides, bottom to top. There is no LED at dead bottom — twelve at
+     * 30° leaves the bottom BETWEEN two of them, position 0 sitting just left
+     * of centre — so the arms are the pairs either side of that gap, (0,11),
+     * (1,10) … meeting at the top between 5 and 6. Starting from a single LED
+     * would put the seam a half-segment off and lean the whole figure. */
+    for (int s = 0; s < LED_N / 2; s++) {
+        for (int p = 0; p < LED_N; p++)
+            memcpy(f[p], C_TRAIL, 3);
+        for (int k = 0; k <= s; k++) {
+            memcpy(f[k], C_HEAD, 3);
+            memcpy(f[LED_N - 1 - k], C_HEAD, 3);
+        }
+        led_write(f);
+        usleep(70000);
+    }
+
+    for (int v = 0; v <= SUB; v += 16) {
+        for (int p = 0; p < LED_N; p++)
+            blend(f[p], C_HEAD, C_PEAK, v);
+        led_write(f);
+        usleep(12000);
+    }
+    for (int v = SUB; v > 0; v -= 10) {
+        for (int p = 0; p < LED_N; p++)
+            scale(f[p], C_PEAK, v);
+        led_write(f);
+        usleep(10000);
+    }
+    memset(f, 0, sizeof f);
+    led_write(f);
+}
+
+/* The animator. Owns the ring for as long as it lives; reads the stage the
+ * parent has reached and never writes it. */
+static void anim_main(void)
+{
+    int head_q = 0, tick = 0;
+
+    for (;;) {
+        int mode = ledst->mode;
+
+        if (mode == ANIM_OFF) {
+            led_solid((const unsigned char[3]){ 0, 0, 0 });
+            ledst->mode = ANIM_DONE;
+            _exit(0);
+        }
+        if (mode == ANIM_FINISH) {
+            anim_finale(head_q, tick);
+            ledst->mode = ANIM_DONE;
+            _exit(0);
+        }
+        if (mode != ANIM_FAIL) {
+            int stage = ledst->stage;
+            if (stage > LED_N)
+                stage = LED_N;
+            int target = stage * SUB + (stage < LED_N ? CREEP : 0);
+            if (head_q < target) {
+                /* Exponential ease, with a floor so integer truncation cannot
+                 * stall it short of the target. */
+                int step = (target - head_q) / 8;
+                if (step < 1)
+                    step = 1;
+                head_q += step;
+                if (head_q > target)
+                    head_q = target;
+            }
+        }
+        anim_render(head_q, tick++, mode == ANIM_FAIL);
+        usleep(TICK_MS * 1000);
+    }
+}
+
+/* Sample the kernel's own animation before taking the ring away from it.
+ *
+ * `frame` is read/write, so the driver hands back exactly what it is
+ * displaying — which turns "match the orbit's blues" from an eyeballing job
+ * into two constants copied off a boot trail, and the sample interval gives
+ * its direction and period as well. Costs ~400ms of a boot; compile it out
+ * once the numbers above are filled in. */
+static void orbit_probe(void)
+{
+#if ORBIT_PROBE
+    for (int i = 0; i < 10; i++) {
+        int fd = open(LEDDIR "/frame", O_RDONLY);
+        if (fd < 0) {
+            note("orbit probe: frame unreadable errno=%d\n", errno);
+            return;
+        }
+        char b[LED_N * 6 + 8];
+        int n = read(fd, b, sizeof b - 1);
+        close(fd);
+        if (n <= 0) {
+            note("orbit probe: read n=%d errno=%d\n", n, errno);
+            return;
+        }
+        b[n] = 0;
+        for (int k = 0; k < n; k++)
+            if (b[k] == '\n')
+                b[k] = 0;
+        note("orbit %d %s\n", i, b);
+        usleep(40000);
+    }
+#endif
+}
+
+/* Take the ring off the kernel's animation, set the drive current, and start
+ * the animator. */
 static void led_claim(void)
 {
+    orbit_probe();
+
     int fd = open(LEDDIR "/boot_animation", O_WRONLY);
     if (fd >= 0) { write(fd, "0", 1); close(fd); }
     fd = open(LEDDIR "/led_current", O_WRONLY);
     if (fd >= 0) { write(fd, "3", 1); close(fd); }
-    led_frame(0, 0, 0, 0);
+
+    ledst = mmap(NULL, sizeof *ledst, PROT_READ | PROT_WRITE,
+                 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (ledst == MAP_FAILED) {
+        ledst = NULL;
+        note("led: mmap failed errno=%d — no boot ring\n", errno);
+        return;
+    }
+    ledst->stage = 0;
+    ledst->mode  = ANIM_RUN;
+
+    led_pid = fork();
+    if (led_pid == 0) {
+        anim_main();
+        _exit(0);
+    }
 }
 
-/* One more stage done. Blue while booting; the net stage finishes in green. */
+/* One more stage done. Publishing the number is the whole of it — the head
+ * eases there on its own ticker. */
 static void led_step(void)
 {
     if (bootstep < LED_N)
         bootstep++;
-    led_frame(bootstep, 0x00, 0x30, 0xFF);
+    if (ledst)
+        ledst->stage = bootstep;
 }
 
-/* Fade the ring out once the boot has finished.
- *
- * A ring left lit is just another light that means nothing — the same problem
- * as the kernel animation this replaced. Fading says "done" and hands the LEDs
- * back, so anything the ring shows afterwards is the firmware's to explain.
- * ~640ms, slow enough to read as deliberate rather than as a glitch.
- */
-static void led_fade_out(int r, int g, int b)
-{
-    for (int v = 255; v > 0; v -= 8) {
-        led_frame(LED_N, r * v / 255, g * v / 255, b * v / 255);
-        usleep(20000);
-    }
-    led_frame(0, 0, 0, 0);
-}
-
-/* A stage that failed leaves the ring red at the point it reached, so a dead
- * device says WHERE it died without a cable. */
 static void led_fail(void)
 {
-    led_frame(bootstep + 1, 0xFF, 0x00, 0x00);
+    if (ledst)
+        ledst->mode = ANIM_FAIL;
 }
+
+/* Hand the ring back. Bounded: the boot is never held up by an animation. */
+static void led_end(int mode)
+{
+    if (!ledst)
+        return;
+    ledst->mode = mode;
+    for (int i = 0; i < 60 && ledst->mode != ANIM_DONE; i++)
+        usleep(50000);
+}
+
+#define led_finish() do { if (ledst) ledst->stage = LED_N; \
+                          led_end(ANIM_FINISH); } while (0)
+#define led_stop()   led_end(ANIM_OFF)
 
 /* ── Boot rollback ───────────────────────────────────────────────────────────
  *
@@ -270,7 +574,8 @@ static void restore_good(void)
     close(out);
     close(in);
     note("rollback restored rc=%d bytes=%ld\n", rc, (long)st.st_size);
-    led_frame(LED_N, 0xFF, 0x60, 0x00);      /* amber: rolling back */
+    led_stop();                              /* the animator owns the ring */
+    led_solid(C_AMBER);                      /* amber: rolling back */
     write_state(0);
     sync();
     sleep(2);
@@ -607,7 +912,7 @@ static void net_main(void)
     r = ifup("wlan0");
     netlog("wlan0 present=%d ifup=%d\n",
          access("/sys/class/net/wlan0", F_OK) == 0, r);
-    bootstep = 10; led_step();                   /* 10: wlan0 exists */
+    bootstep = 9; led_step();                    /* 10: wlan0 exists */
 
     /* Supervise, driven by wlan0's carrier rather than by a fixed sequence.
      *
@@ -664,7 +969,11 @@ static void net_main(void)
                 kill(dhc, SIGTERM);
             if (nudges++ % 3 == 0)
                 spawn(reassoc);
-            bootstep = 10; led_step();           /* 11: associating */
+            bootstep = 10; led_step();           /* 11: associating.
+                                                  * Pinned rather than
+                                                  * incremented: this is a
+                                                  * supervision loop and may
+                                                  * run many times. */
             dry = 0;
         } else {
             nudges = 0;
@@ -687,10 +996,9 @@ static void net_main(void)
                  */
                 if (!netup) {
                     netup = 1;
-                    /* Fully up: the ring goes green, then fades out. */
-                    led_frame(LED_N, 0x00, 0xFF, 0x00);
-                    usleep(400000);
-                    led_fade_out(0x00, 0xFF, 0x00);
+                    /* Fully up: the head comes home to the bottom, the ring
+                     * fills from there to the top, brightens and fades. */
+                    led_finish();
                     /* Ring handed back and the network is up: services that
                      * wait on the boot completing may now start. */
                     close(open("/run/net-up", O_WRONLY | O_CREAT, 0644));

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -147,40 +147,47 @@ static const struct node nodes[] = {
  * boot trail. */
 static void note(const char *fmt, ...);
 
-/* ── Four numbers nobody has measured yet ────────────────────────────────────
+/* ── The orbit, as measured off EFF on 2026-09-05 ────────────────────────────
  *
- * Nothing in this project has ever needed to know how the ring is ORIENTED:
- * every animation we ship is rotationally symmetric, and the spinner's
- * direction was a free choice. This is the first display that is not, so the
- * geometry and the palette are guesses and are gathered here to be corrected
- * in one place rather than hunted for.
+ * Read straight out of the driver rather than eyeballed: `frame` is a
+ * read/write attribute on Amazon's 3.18 driver too, so writing 1 to
+ * boot_animation on a running device replays the orbit and each frame can be
+ * read back exactly as the kernel is displaying it.
  *
- * LED_BOTTOM — settled: the ring's existing fill starts at the LED just left
- *              of bottom centre, and that is where this one starts too (Wil,
- *              2026-09-05). Twelve LEDs at 30° put no LED at dead bottom, so
- *              the bottom is the gap between positions 0 and 11 and the
- *              finale's arms are the pairs either side of it.
- * LED_DIR    — still a guess. It only has to match the direction the kernel's
- *              orbit travels, which the probe below answers.
- * C_TRAIL / C_HEAD     — set ORBIT_PROBE, boot once, read the trail. The
- *                        kernel's own frames come back as hex, so the two
- *                        blues can be copied exactly rather than eyeballed,
- *                        and the sample interval gives the orbit's direction
- *                        and period to match ORBIT_MS against.
+ *   ground     0000ff on ALL TWELVE LEDs — a complete blue ring, not a dark
+ *              one with a lit segment. This is the fact the design turns on:
+ *              anything of ours that leaves LEDs dark is a hard cut at the
+ *              handover, however well the colours match.
+ *   head       00ffff — cyan. Not a lighter blue.
+ *   direction  rising physical index, wrapping 11 -> 0.
+ *   rate       109ms per step, min 100 max 120 over 13 clean transitions;
+ *              1.31s per revolution.
+ *
+ * Sampling at 100ms first suggested exactly one step per sample, which is the
+ * signature of aliasing rather than a measurement — hence the second pass at
+ * full speed against /proc/uptime.
+ *
+ * LED_BOTTOM is settled differently: the ring's existing fill starts at the
+ * LED just left of bottom centre and this one starts there too (Wil,
+ * 2026-09-05). Twelve LEDs at 30° put none at dead bottom, so the bottom is
+ * the GAP between positions 0 and 11, and the finale's arms are the pairs
+ * either side of it.
  */
 #define LED_BOTTOM 0        /* physical index of the LED at the bottom */
-#define LED_DIR    1        /* +1 if rising physical index runs clockwise */
-#define ORBIT_MS   2000     /* the kernel orbit's period, for rate-matching */
+#define LED_DIR    1        /* +1: the orbit runs on rising physical index */
+#define ORBIT_STEP_MS 109   /* measured; the wind-in matches this exactly */
 #define ORBIT_PROBE 1       /* sample the kernel's frames before claiming */
 
-static const unsigned char C_TRAIL[3] = { 0x00, 0x08, 0x30 };  /* dark ground */
-static const unsigned char C_HEAD[3]  = { 0x30, 0x80, 0xFF };  /* light head  */
-static const unsigned char C_FAIL[3]  = { 0xFF, 0x00, 0x00 };
-static const unsigned char C_AMBER[3] = { 0xFF, 0x60, 0x00 };
-/* The ring's last moment before it fades. Green here would say "network
- * confirmed" the way the old ring did; it is one line if that is ever wanted
- * back, but confirmation is a diagnostic and this ring is not one. */
-static const unsigned char C_PEAK[3]  = { 0x80, 0xD0, 0xFF };
+static const unsigned char C_GROUND[3] = { 0x00, 0x00, 0xFF }; /* the orbit's ring */
+static const unsigned char C_HEAD[3]   = { 0x00, 0xFF, 0xFF }; /* the orbit's head */
+/* Progress is the arc between the two: far enough toward the head to read as a
+ * filling ring, still plainly the same blue family as the ground. */
+static const unsigned char C_TRAIL[3]  = { 0x00, 0x70, 0xFF };
+static const unsigned char C_FAIL[3]   = { 0xFF, 0x00, 0x00 };
+static const unsigned char C_AMBER[3]  = { 0xFF, 0x60, 0x00 };
+/* Cyan is already full on two channels, so the only way UP is toward white —
+ * adding red is what "brighter" means once green and blue are at 0xFF. */
+static const unsigned char C_PEAK[3]   = { 0xFF, 0xFF, 0xFF };
 
 #define SUB       256                  /* sub-LED position units */
 #define TICK_MS   33                   /* ~30fps; 36 bytes of i2c per frame */
@@ -269,27 +276,85 @@ static int breath(int tick)
     return tri * tri / SUB;
 }
 
-/* head_q is a position in SUB units around the ring, 0..LED_N*SUB. */
-static void anim_render(int head_q, int tick, int failed)
+/* head_q is a position in SUB units around the ring, 0..LED_N*SUB. `trail`
+ * shows progress behind the head; during the wind-in there is none to show. */
+static void anim_render(int head_q, int tick, int failed, int trail)
 {
     unsigned char f[LED_N][3], head[3];
 
-    scale(head, failed ? C_FAIL : C_HEAD,
-          failed ? SUB : BREATH_MIN + breath(tick) * (SUB - BREATH_MIN) / SUB);
+    /* The head breathes between the GROUND and the head colour rather than
+     * toward black. Scaling cyan down takes the blue channel with it, so the
+     * head would go dimmer than the ring it sits on; mixing keeps blue at full
+     * and moves only the green, which reads as the head brightening and
+     * settling rather than blinking. */
+    if (failed)
+        memcpy(head, C_FAIL, 3);
+    else
+        blend(head, C_GROUND, C_HEAD,
+              BREATH_MIN + breath(tick) * (SUB - BREATH_MIN) / SUB);
 
+    /* The ground is the orbit's own ring, lit on every LED. Leaving the
+     * unreached segments dark is what would make the handover a cut, however
+     * well the colours matched. */
     int i = head_q / SUB, fr = head_q % SUB;
-    for (int p = 0; p < LED_N; p++) {
-        if (p < i)
-            memcpy(f[p], C_TRAIL, 3);
-        else
-            memset(f[p], 0, 3);
-    }
-    /* The head straddles two segments. Modulo, so a head arriving at LED_N
-     * lands back on the bottom rather than off the end of the ring. */
-    blend(f[i % LED_N], f[i % LED_N], head, SUB - fr);
-    if (fr)
-        blend(f[(i + 1) % LED_N], f[(i + 1) % LED_N], head, fr);
+    for (int p = 0; p < LED_N; p++)
+        memcpy(f[p], trail && p < i ? C_TRAIL : C_GROUND, 3);
+
+    /* The head straddles two segments, but it is NOT a plain cross-fade: the
+     * nearer LED always gets the head at full and the further one takes a
+     * proportional glow, widening to two full segments as it passes the
+     * midpoint. A plain cross-fade splits the head's brightness in half there,
+     * and at the bottom of the breath each half falls BELOW the trail — so the
+     * leading edge stops being the brightest thing on the ring and the trail
+     * reads as the head. Caught in ringsim, not on hardware.
+     *
+     * Modulo throughout, so a head arriving at LED_N lands back on the bottom
+     * rather than off the end of the ring. */
+    int near = fr < SUB / 2 ? i : i + 1;
+    int far  = fr < SUB / 2 ? i + 1 : i;
+    int glow = fr < SUB / 2 ? fr * 2 : (SUB - fr) * 2;
+    blend(f[near % LED_N], f[near % LED_N], head, SUB);
+    if (glow)
+        blend(f[far % LED_N], f[far % LED_N], head, glow);
     led_write(f);
+}
+
+/* Where the kernel's orbit had got to, in logical positions, so ours can carry
+ * on from there instead of jumping to the bottom. The head is whichever single
+ * segment is not the ground colour; anything else — a dark ring, a frame
+ * already claimed by somebody, two lit segments — is not an orbit we can join,
+ * and returns -1 to start at the bottom as before. */
+static int orbit_head_pos(void)
+{
+    int fd = open(LEDDIR "/frame", O_RDONLY);
+    if (fd < 0)
+        return -1;
+    char b[LED_N * 6 + 8];
+    int n = read(fd, b, sizeof b - 1);
+    close(fd);
+    if (n < LED_N * 6)
+        return -1;
+
+    char want[6];
+    puthex(want,     C_GROUND[0]);
+    puthex(want + 2, C_GROUND[1]);
+    puthex(want + 4, C_GROUND[2]);
+
+    int found = -1, count = 0;
+    for (int L = 0; L < LED_N; L++) {
+        int p = (LED_BOTTOM + LED_DIR * L) % LED_N;
+        if (p < 0)
+            p += LED_N;
+        int same = 1;
+        for (int k = 0; k < 6; k++) {
+            char a = b[p * 6 + k], w = want[k];
+            if (a >= 'a' && a <= 'f') a -= 32;   /* the kernel prints lower */
+            if (w >= 'a' && w <= 'f') w -= 32;
+            if (a != w) { same = 0; break; }
+        }
+        if (!same) { found = L; count++; }
+    }
+    return count == 1 ? found : -1;
 }
 
 /* Boot complete: close the ring, fill both sides from the bottom to the top,
@@ -306,7 +371,7 @@ static void anim_finale(int head_q, int tick)
         head_q += step;
         if (head_q > LED_N * SUB)
             head_q = LED_N * SUB;
-        anim_render(head_q, tick++, 0);
+        anim_render(head_q, tick++, 0, 1);
         usleep(TICK_MS * 1000);
     }
 
@@ -344,9 +409,20 @@ static void anim_finale(int head_q, int tick)
 
 /* The animator. Owns the ring for as long as it lives; reads the stage the
  * parent has reached and never writes it. */
-static void anim_main(void)
+static void anim_main(int start_pos)
 {
-    int head_q = 0, tick = 0;
+    int head_q = 0, tick = 0, winding = 0;
+
+    /* Carry the orbit on from wherever it had reached, at its own measured
+     * rate, until the head comes round to the bottom — then progress takes
+     * over from there. At most one lap, so 1.31s, spent while /system mounts
+     * and fsck runs. The one difference is that this glides where the kernel
+     * stepped a whole LED at a time; it is the same movement at the same rate,
+     * and the smoothing is the point rather than an accident. */
+    if (start_pos > 0) {
+        head_q = start_pos * SUB;
+        winding = 1;
+    }
 
     for (;;) {
         int mode = ledst->mode;
@@ -361,6 +437,18 @@ static void anim_main(void)
             ledst->mode = ANIM_DONE;
             _exit(0);
         }
+        if (winding && mode == ANIM_RUN) {
+            head_q += SUB * TICK_MS / ORBIT_STEP_MS;
+            if (head_q >= LED_N * SUB) {
+                head_q = 0;
+                winding = 0;
+            }
+            anim_render(head_q, tick++, 0, 0);
+            usleep(TICK_MS * 1000);
+            continue;
+        }
+        winding = 0;      /* a failure or a finish ends the wind-in early */
+
         if (mode != ANIM_FAIL) {
             int stage = ledst->stage;
             if (stage > LED_N)
@@ -377,7 +465,7 @@ static void anim_main(void)
                     head_q = target;
             }
         }
-        anim_render(head_q, tick++, mode == ANIM_FAIL);
+        anim_render(head_q, tick++, mode == ANIM_FAIL, 1);
         usleep(TICK_MS * 1000);
     }
 }
@@ -421,6 +509,11 @@ static void led_claim(void)
 {
     orbit_probe();
 
+    /* Read where the orbit is BEFORE stopping it — the frame keeps its last
+     * contents afterwards, but reading it live is the honest moment. */
+    int start_pos = orbit_head_pos();
+    note("orbit head at %d\n", start_pos);
+
     int fd = open(LEDDIR "/boot_animation", O_WRONLY);
     if (fd >= 0) { write(fd, "0", 1); close(fd); }
     fd = open(LEDDIR "/led_current", O_WRONLY);
@@ -438,7 +531,7 @@ static void led_claim(void)
 
     led_pid = fork();
     if (led_pid == 0) {
-        anim_main();
+        anim_main(start_pos);
         _exit(0);
     }
 }

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -1,0 +1,510 @@
+/*
+ * First-boot init for biscuit: bring up a serial console over USB.
+ *
+ * Depends on nothing but the kernel — no shell, no shebang, no busybox, no
+ * dynamic loader. An earlier busybox-script version produced no evidence at
+ * all on three boots, which is indistinguishable from a kernel that never
+ * started and cost most of a day to tell apart. Every step appends to a
+ * progress trail on the cache partition, because on this device that trail is
+ * the only diagnostic channel: no UART without opening the case, and the LED
+ * ring is animated by the kernel's own is31fl3236 driver (its boot_animation
+ * attribute, at i2c-0 0x3f) until userspace clears it, so it reports nothing
+ * about our progress. It is not the LP55231 an earlier version of this comment
+ * named — those probes fail with -6 on this board.
+ *
+ * ACM rather than adbd, deliberately. adbd needs functionfs descriptors and
+ * Android's property service; with the gadget configured and adbd running,
+ * android_usb sat at DISCONNECTED for ten seconds straight. f_acm needs no
+ * daemon at all — the kernel exposes /dev/ttyGS0 and we put a shell on it.
+ * The recipe is copied from the device's own init.mt8163.usb.rc.
+ */
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <net/if.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mount.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+
+#define CACHE     "/dev/block/mmcblk0p15"
+#define USBDIR    "/sys/class/android_usb/android0"
+#define TTY       "/dev/ttyGS0"
+#define TRAIL_OFF 1024
+
+
+/* Every device node this system needs, created by hand.
+ *
+ * There is no devtmpfs on this kernel — Android's /dev is a tmpfs populated by
+ * ueventd from uevents, and we do not run ueventd. Numbers were read off a
+ * running FireOS device, never guessed. The firmware resolves input devices by
+ * NAME via /proc/bus/input/devices, so the node numbering here only has to
+ * make them openable, not meaningful: event2 is the volume button on biscuit
+ * and something else entirely on other boards.
+ */
+struct node { const char *path; int major, minor; };
+
+static const struct node nodes[] = {
+    { "/dev/input/event0", 13, 64 },   /* ACCDET  */
+    { "/dev/input/event1", 13, 65 },   /* mtk-kpd */
+    { "/dev/input/event2", 13, 66 },   /* keys    */
+
+    { "/dev/snd/controlC0", 116,  2 },
+    { "/dev/snd/seq",       116,  1 },
+    { "/dev/snd/timer",     116, 33 },
+    { "/dev/snd/pcmC0D0p",  116,  3 }, { "/dev/snd/pcmC0D1c",  116,  4 },
+    { "/dev/snd/pcmC0D2p",  116,  5 }, { "/dev/snd/pcmC0D2c",  116,  6 },
+    { "/dev/snd/pcmC0D3p",  116,  7 }, { "/dev/snd/pcmC0D3c",  116,  8 },
+    { "/dev/snd/pcmC0D4p",  116,  9 }, { "/dev/snd/pcmC0D4c",  116, 10 },
+    { "/dev/snd/pcmC0D5p",  116, 11 }, { "/dev/snd/pcmC0D5c",  116, 12 },
+    { "/dev/snd/pcmC0D6p",  116, 13 }, { "/dev/snd/pcmC0D6c",  116, 14 },
+    { "/dev/snd/pcmC0D7p",  116, 15 }, { "/dev/snd/pcmC0D7c",  116, 16 },
+    { "/dev/snd/pcmC0D8p",  116, 17 }, { "/dev/snd/pcmC0D9c",  116, 18 },
+    { "/dev/snd/pcmC0D10p", 116, 19 }, { "/dev/snd/pcmC0D11p", 116, 20 },
+    { "/dev/snd/pcmC0D12c", 116, 21 }, { "/dev/snd/pcmC0D13c", 116, 22 },
+    { "/dev/snd/pcmC0D14p", 116, 23 }, { "/dev/snd/pcmC0D15c", 116, 24 },
+    { "/dev/snd/pcmC0D16c", 116, 25 }, { "/dev/snd/pcmC0D17p", 116, 26 },
+    { "/dev/snd/pcmC0D17c", 116, 27 }, { "/dev/snd/pcmC0D18p", 116, 28 },
+    { "/dev/snd/pcmC0D19p", 116, 29 }, { "/dev/snd/pcmC0D20p", 116, 30 },
+    { "/dev/snd/pcmC0D21p", 116, 31 }, { "/dev/snd/pcmC0D21c", 116, 34 },
+    { "/dev/snd/pcmC0D22p", 116, 35 }, { "/dev/snd/pcmC0D22c", 116, 36 },
+    { "/dev/snd/pcmC0D23p", 116, 37 }, /* speaker */
+    { "/dev/snd/pcmC0D24c", 116, 38 }, /* the 9-channel mic array */
+    { "/dev/snd/pcmC0D25p", 116, 39 },
+
+    /* MediaTek combo chip (WiFi + BT). wmtdetect is registered by the kernel
+     * at boot; the other three chrdevs do not exist until wmt_loader has
+     * detected the chip, but a node is only a pair of numbers, so creating
+     * them up front is harmless and keeps all the numbering in one table. */
+    { "/dev/wmtdetect", 154, 0 },
+    { "/dev/stpwmt",    190, 0 },
+    { "/dev/wmtWifi",   153, 0 },
+    { "/dev/stpbt",     192, 0 },
+};
+
+static char trail[3072];
+static size_t trail_len;
+
+static int write_at(off_t off, const char *buf, size_t n)
+{
+    int fd = open(CACHE, O_WRONLY);
+    if (fd < 0)
+        return -1;
+    ssize_t w = pwrite(fd, buf, n, off);
+    fsync(fd);
+    close(fd);
+    return w == (ssize_t)n ? 0 : -1;
+}
+
+static void note(const char *fmt, ...)
+{
+    char line[256];
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(line, sizeof line, fmt, ap);
+    va_end(ap);
+    if (n < 0)
+        return;
+    if (n > (int)sizeof line - 1)
+        n = sizeof line - 1;
+    if (trail_len + n + 1 < sizeof trail) {
+        memcpy(trail + trail_len, line, n);
+        trail_len += n;
+        trail[trail_len] = 0;
+    }
+    write_at(TRAIL_OFF, trail, trail_len);
+}
+
+static int wr(const char *path, const char *val)
+{
+    int fd = open(path, O_WRONLY);
+    if (fd < 0)
+        return -1;
+    ssize_t n = write(fd, val, strlen(val));
+    close(fd);
+    return n > 0 ? 0 : -1;
+}
+
+static void usbwr(const char *leaf, const char *val)
+{
+    char p[256];
+    snprintf(p, sizeof p, USBDIR "/%s", leaf);
+    int r = wr(p, val);
+    note("usb %s=%s rc=%d errno=%d\n", leaf, val, r, r ? errno : 0);
+}
+
+#define NETLOG "/data/local/tmp/net.log"
+
+/* The WiFi stage runs in a forked child, so it must NOT use note(): fork copies
+ * the trail buffer, and both halves would then pwrite divergent contents to the
+ * same offset on the cache partition. /data is mounted by the time this runs. */
+static void netlog(const char *fmt, ...)
+{
+    char line[256];
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(line, sizeof line, fmt, ap);
+    va_end(ap);
+    if (n <= 0)
+        return;
+    int fd = open(NETLOG, O_WRONLY | O_CREAT | O_APPEND, 0644);
+    if (fd < 0)
+        return;
+    write(fd, line, n > (int)sizeof line - 1 ? (int)sizeof line - 1 : n);
+    close(fd);
+}
+
+/* fork+exec, returning the pid. NULL-terminated argv, argv[0] is the path. */
+static pid_t spawn(char *const argv[])
+{
+    pid_t pid = fork();
+    if (pid == 0) {
+        char *envp[] = { "HOME=/", "ANDROID_ROOT=/system",
+                         "PATH=/sbin:/system/bin:/system/xbin", NULL };
+        int n = open(NETLOG, O_WRONLY | O_CREAT | O_APPEND, 0644);
+        if (n < 0)
+            n = open("/dev/null", O_RDWR);
+        if (n >= 0) { dup2(n, 1); dup2(n, 2); if (n > 2) close(n); }
+        int z = open("/dev/null", O_RDONLY);
+        if (z >= 0) { dup2(z, 0); if (z > 0) close(z); }
+        execve(argv[0], argv, envp);
+        _exit(127);
+    }
+    return pid;
+}
+
+/* Read a small integer out of a sysfs file; -1 if it cannot be read. */
+static int readint(const char *path)
+{
+    char b[32] = {0};
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return -1;
+    int n = read(fd, b, sizeof b - 1);
+    close(fd);
+    return n > 0 ? atoi(b) : -1;
+}
+
+static int has_ip(const char *name)
+{
+    struct ifreq ifr;
+    int s = socket(AF_INET, SOCK_DGRAM, 0);
+    if (s < 0)
+        return 0;
+    memset(&ifr, 0, sizeof ifr);
+    strncpy(ifr.ifr_name, name, IFNAMSIZ - 1);
+    int r = ioctl(s, SIOCGIFADDR, &ifr);
+    close(s);
+    return r == 0;
+}
+
+static int ifup(const char *name)
+{
+    struct ifreq ifr;
+    int s = socket(AF_INET, SOCK_DGRAM, 0);
+    if (s < 0)
+        return -1;
+    memset(&ifr, 0, sizeof ifr);
+    strncpy(ifr.ifr_name, name, IFNAMSIZ - 1);
+    int r = ioctl(s, SIOCGIFFLAGS, &ifr);
+    if (r == 0) {
+        ifr.ifr_flags |= IFF_UP | IFF_RUNNING;
+        r = ioctl(s, SIOCSIFFLAGS, &ifr);
+    }
+    close(s);
+    return r;
+}
+
+/* Bring up WiFi, then supervise the two daemons that keep it up.
+ *
+ * This is Amazon's own sequence, read off a running FireOS device rather than
+ * reconstructed: init.project.rc runs 6620_launcher, init.wifi.rc writes "1" to
+ * /dev/wmtWifi, and wpa_supplicant/dhcpcd are started with the arguments the
+ * running processes reported. Two steps had no counterpart in any rc file and
+ * were found the hard way:
+ *
+ *   - wmt_loader must run FIRST. The stp/wmt/BT chrdevs are registered when it
+ *     detects the chip over /dev/wmtdetect, so without it the majors simply do
+ *     not exist and 6620_launcher sits idle forever with nothing to open.
+ *
+ *   - /etc must exist as a symlink to /system/etc. The kernel firmware loader
+ *     searches /etc/firmware for WIFI_RAM_CODE, and our ramdisk has no /etc,
+ *     so the combo chip powers on ("WMT turn on WIFI success!") and then
+ *     wlanProbe fails on kalFirmwareOpen and no wlan0 is ever created. The
+ *     symlink is the whole fix; it is not a WiFi thing at all, and anything
+ *     else that goes looking under /etc or /vendor was equally broken.
+ *
+ * Writing "1" to /dev/wmtWifi blocks for ~13s while the chip is powered and the
+ * firmware loaded, which is why this runs in its own process.
+ */
+static void net_main(void)
+{
+    char *loader[] = { "/system/bin/wmt_loader", NULL };
+    char *launch[] = { "/system/bin/6620_launcher", "-p",
+                       "/system/etc/firmware/", NULL };
+    char *supp[]   = { "/system/bin/wpa_supplicant", "-iwlan0", "-Dnl80211",
+                       "-c/data/misc/wifi/wpa_supplicant.conf",
+                       "-e/data/misc/wifi/entropy.bin", NULL };
+    char *dhcp[]   = { "/system/bin/dhcpcd", "-ABK", "-f",
+                       "/system/etc/dhcpcd/dhcpcd.conf", "wlan0", NULL };
+    int st = 0;
+
+    waitpid(spawn(loader), &st, 0);
+    netlog("wmt_loader status=%d\n", st);
+
+    pid_t launcher = spawn(launch);
+    sleep(2);
+
+    int r = wr("/dev/wmtWifi", "1");
+    netlog("wmtWifi=1 rc=%d errno=%d\n", r, r ? errno : 0);
+
+    for (int i = 0; i < 20 && access("/sys/class/net/wlan0", F_OK); i++)
+        sleep(1);
+    r = ifup("wlan0");
+    netlog("wlan0 present=%d ifup=%d\n",
+         access("/sys/class/net/wlan0", F_OK) == 0, r);
+
+    /* Supervise, driven by wlan0's carrier rather than by a fixed sequence.
+     *
+     * Two things were measured on hardware and neither is defensive coding:
+     *
+     *   - wpa_supplicant does NOT associate on its own here. Started fresh at
+     *     boot it sat at wpa_state=DISCONNECTED for three minutes with its
+     *     network enabled and unblocked; a single `wpa_cli reassociate`
+     *     connected it in under ten seconds. So it gets nudged until carrier.
+     *
+     *   - dhcpcd must not start before association. Stock gets away with
+     *     starting it early because Android's framework restarts it on link
+     *     events; ours is given -K (ignore link messages) to match stock, so a
+     *     dhcpcd started pre-association exhausts its attempts, keeps running,
+     *     and never retries — a device associated to the AP with no address.
+     *
+     * dhcpcd is therefore started only once carrier is up, killed when carrier
+     * goes away, and killed (to be respawned) if it has held carrier for 20s
+     * without getting an address.
+     */
+    char *reassoc[] = { "/system/bin/wpa_cli", "-p/data/misc/wifi/sockets",
+                        "-iwlan0", "reassociate", NULL };
+    pid_t wpa = spawn(supp);
+    pid_t dhc = -1;
+    int nudges = 0, dry = 0;
+
+    for (;;) {
+        pid_t d;
+        while ((d = waitpid(-1, &st, WNOHANG)) > 0) {
+            if (d == launcher)   launcher = spawn(launch);
+            else if (d == wpa)   wpa = spawn(supp);
+            else if (d == dhc)   dhc = -1;
+        }
+
+        if (readint("/sys/class/net/wlan0/carrier") != 1) {
+            if (dhc > 0)
+                kill(dhc, SIGTERM);
+            if (nudges++ % 3 == 0)
+                spawn(reassoc);
+            dry = 0;
+        } else {
+            nudges = 0;
+            if (dhc < 0) {
+                dhc = spawn(dhcp);
+                dry = 0;
+            } else if (has_ip("wlan0")) {
+                dry = 0;
+            } else if (++dry >= 4) {
+                kill(dhc, SIGTERM);
+                dry = 0;
+            }
+        }
+        sleep(5);
+    }
+}
+
+static void rdstate(const char *tag)
+{
+    char st[64] = {0};
+    int f = open(USBDIR "/state", O_RDONLY);
+    if (f >= 0) { read(f, st, sizeof st - 1); close(f); }
+    for (char *c = st; *c; c++) if (*c == '\n') *c = 0;
+    note("%s state=%s\n", tag, st);
+}
+
+int main(void)
+{
+    char buf[512];
+
+    /* mknod's mode is masked by the umask, so without this every node below
+     * comes out 0644 no matter what it asks for — which is how dhcpcd's hook
+     * script ended up unable to open /dev/null for writing. */
+    umask(0);
+
+    mkdir("/dev", 0755);
+    mkdir("/proc", 0755);
+    mkdir("/sys", 0755);
+    int dtr = mount("devtmpfs", "/dev", "devtmpfs", 0, NULL);
+    mount("proc", "/proc", "proc", 0, NULL);
+    mount("sysfs", "/sys", "sysfs", 0, NULL);
+    mkdir("/dev/block", 0755);
+
+    /* Every device node is created by hand.
+     *
+     * This kernel has no devtmpfs — Android's /dev is a plain tmpfs populated
+     * by ueventd from uevents, and we are not running ueventd. Nothing appears
+     * on its own. The block nodes worked only because they were mknod'd
+     * explicitly; /dev/ttyGS0 was assumed and therefore absent, which is why
+     * the gadget reached CONFIGURED with nothing listening on it.
+     *
+     * 247:0 is ttyGS0, read off a running FireOS device rather than guessed.
+     */
+    mknod(CACHE, S_IFBLK | 0600, makedev(179, 15));
+    mknod("/dev/null",    S_IFCHR | 0666, makedev(1, 3));
+    mknod("/dev/zero",    S_IFCHR | 0666, makedev(1, 5));
+    mknod("/dev/tty",     S_IFCHR | 0666, makedev(5, 0));
+    mknod("/dev/console", S_IFCHR | 0600, makedev(5, 1));
+    mknod("/dev/ptmx",    S_IFCHR | 0666, makedev(5, 2));
+    /* wpa_supplicant refuses to start without both of these. */
+    mknod("/dev/random",  S_IFCHR | 0666, makedev(1, 8));
+    mknod("/dev/urandom", S_IFCHR | 0666, makedev(1, 9));
+    mknod(TTY,            S_IFCHR | 0600, makedev(247, 0));
+    mkdir("/dev/pts", 0755);
+    mount("devpts", "/dev/pts", "devpts", 0, NULL);
+    mkdir("/dev/input", 0755);
+    mkdir("/dev/snd", 0755);
+    for (unsigned i = 0; i < sizeof nodes / sizeof nodes[0]; i++)
+        mknod(nodes[i].path, S_IFCHR | 0600,
+              makedev(nodes[i].major, nodes[i].minor));
+
+    snprintf(buf, sizeof buf, "EM64-INIT-OK acm-console\n");
+    write_at(0, buf, strlen(buf));
+
+    int fd = open("/proc/version", O_RDONLY);
+    if (fd >= 0) {
+        int n = read(fd, buf, sizeof buf - 1);
+        close(fd);
+        if (n > 0) write_at(512, buf, n);
+    }
+    note("stage=mounts done devtmpfs_rc=%d tty=%d\n", dtr, access(TTY, F_OK));
+
+    /* /system read-only: this is a diagnostic boot and nothing here should be
+     * able to damage the Android install we still rely on for recovery. */
+    mkdir("/system", 0755);
+    mknod("/dev/block/mmcblk0p13", S_IFBLK | 0600, makedev(179, 13));
+    int r = mount("/dev/block/mmcblk0p13", "/system", "ext4", MS_RDONLY, NULL);
+    note("stage=mount_system rc=%d errno=%d sh=%d\n", r, r ? errno : 0,
+         access("/system/bin/sh", X_OK));
+
+    /* /data read-WRITE: the firmware keeps config, wake-word models and logs
+     * there. /system stays read-only — nothing here should be able to damage
+     * the Android install we still rely on for recovery. */
+    mkdir("/data", 0755);
+    mknod("/dev/block/mmcblk0p16", S_IFBLK | 0600, makedev(179, 16));
+    r = mount("/dev/block/mmcblk0p16", "/data", "ext4", 0, NULL);
+    note("stage=mount_data rc=%d errno=%d\n", r, r ? errno : 0);
+
+    /* Android's own root has these two symlinks and a surprising amount of
+     * /system depends on them — the kernel firmware loader most of all, which
+     * is what kept wlan0 from ever appearing. */
+    symlink("/system/etc", "/etc");
+    symlink("/system/vendor", "/vendor");
+
+    /* Put busybox's applets on PATH.
+     *
+     * /system ships busybox with 354 applets — vi, head, tail, sed, awk, less,
+     * find, xargs, diff, stat, nc, wget, tar — but nothing symlinks them, so
+     * every one has to be invoked as `busybox tail`, which is miserable over a
+     * serial console and is most of what makes this device feel primitive.
+     * Android's toolbox has none of them.
+     *
+     * Only applets that do NOT already exist in /system/bin or /system/xbin are
+     * linked, so `busybox --install` is deliberately not used: /sbin comes
+     * first on PATH, and installing all 354 would shadow toolbox's ps, mount,
+     * id and kill with busybox versions that print different output. Nothing
+     * the firmware execs (tinymix, stop, getprop, svc, pm) is a busybox applet,
+     * and it stays that way by construction. 301 applets link on this build.
+     *
+     * A shell is used here, unlike everywhere else in this file, because by
+     * this point /system is mounted and sh is the same binary we hand the
+     * console. The no-shell rule exists for the early boot path, where a
+     * broken interpreter is indistinguishable from a kernel that never ran.
+     */
+    mkdir("/sbin", 0755);
+    char *link[] = { "/system/bin/sh", "-c",
+        "for a in $(busybox --list); do "
+        "  [ -e /system/bin/$a ] || [ -e /system/xbin/$a ] || "
+        "    busybox ln -sf /system/bin/busybox /sbin/$a; "
+        "done", NULL };
+    int lst = 0;
+    waitpid(spawn(link), &lst, 0);
+    note("stage=applets status=%d vi=%d\n", lst, access("/sbin/vi", X_OK));
+
+    /* Device mode: cmode 2 is charging-only, cmode 1 is device. */
+    r = wr("/sys/devices/platform/mt_usb/cmode", "1");
+    note("mt_usb cmode=1 rc=%d\n", r);
+
+    usbwr("enable", "0");
+    usbwr("idVendor", "1949");
+    usbwr("idProduct", "2007");
+    usbwr("f_acm/instances", "1");
+    usbwr("functions", "acm");
+    usbwr("bDeviceClass", "02");
+    usbwr("enable", "1");
+
+    for (int i = 0; i < 15; i++) {
+        sleep(1);
+        char tag[32];
+        snprintf(tag, sizeof tag, "wait=%d tty=%d", i, access(TTY, F_OK));
+        rdstate(tag);
+        if (access(TTY, F_OK) == 0)
+            break;
+    }
+
+    /* WiFi runs in its own process: the wmtWifi write blocks for ~13s and the
+     * daemons behind it need supervising, neither of which should hold up the
+     * console. */
+    pid_t net = fork();
+    if (net == 0) {
+        net_main();
+        _exit(0);
+    }
+    netlog("stage started pid=%d\n", (int)net);
+
+    /* A console that exits once because the host had not attached yet is
+     * indistinguishable from one that never worked, so respawn. */
+    for (int gen = 0;; gen++) {
+        int t = open(TTY, O_RDWR | O_NOCTTY);
+        if (t < 0) {
+            if (gen % 30 == 0)
+                note("open %s failed errno=%d\n", TTY, errno);
+            sleep(2);
+            continue;
+        }
+        pid_t pid = fork();
+        if (pid == 0) {
+            setsid();
+            ioctl(t, TIOCSCTTY, 1);
+            dup2(t, 0); dup2(t, 1); dup2(t, 2);
+            if (t > 2) close(t);
+            char *argv[] = { "/system/bin/sh", NULL };
+            char *envp[] = { "HOME=/", "TERM=vt100",
+                             "PATH=/sbin:/system/bin:/system/xbin", NULL };
+            execve("/system/bin/sh", argv, envp);
+            _exit(127);
+        }
+        close(t);
+        if (gen < 3)
+            note("shell started gen=%d pid=%d\n", gen, (int)pid);
+        int st = 0;
+        waitpid(pid, &st, 0);
+        if (gen < 3)
+            note("shell exited gen=%d status=%d\n", gen, st);
+        sleep(1);
+    }
+}

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -508,7 +508,7 @@ static void rdstate(const char *tag)
 }
 
 /* Defined below, with the supervision machinery. */
-static void svc_add(const char *name, char *const *argv);
+static void svc_add(const char *name, char *const *argv, const char *req);
 static void supervise(void);
 
 int main(void)
@@ -655,6 +655,7 @@ int main(void)
      */
     /* RAM-backed scratch for logs and runtime state, so routine logging never
      * touches the eMMC. 4MB is ample for a 256KB x2 syslog rotation. */
+    mkdir("/tmp", 01777);          /* rootfs is a ramdisk: RAM-backed, as on stock */
     mkdir("/run", 0755);
     mount("tmpfs", "/run", "tmpfs", 0, "size=4m");
 
@@ -777,10 +778,22 @@ int main(void)
                         "-O", "/run/messages", "-s", "256", "-b", "2", NULL };
     char *klogd[]   = { "/system/bin/busybox", "klogd", "-n", NULL };
 
-    svc_add("net", NULL);          /* forked in-process, see below */
-    svc_add("syslogd", syslogd);
-    svc_add("klogd", klogd);
-    svc_add("console", NULL);      /* needs the tty as its stdio */
+    /* EchoMuse itself, via its OWN supervisor rather than directly.
+     *
+     * start_server.sh owns the A/B slot symlink, the fast-exit backoff and the
+     * log trimming that the OTA system depends on, so init starting the binary
+     * would quietly bypass firmware rollback. Android's init launched the same
+     * script; emOS does the job it used to. It is absent on a device where
+     * EchoMuse has not been installed, which is an ordinary state, not a fault.
+     */
+    char *echomuse[] = { "/system/bin/sh", "/data/local/bin/start_server.sh",
+                         NULL };
+
+    svc_add("net", NULL, NULL);          /* forked in-process, see below */
+    svc_add("syslogd", syslogd, NULL);
+    svc_add("klogd", klogd, NULL);
+    svc_add("echomuse", echomuse, "/data/local/bin/start_server.sh");
+    svc_add("console", NULL, NULL);      /* needs the tty as its stdio */
 
     supervise();
     return 0;
@@ -800,8 +813,11 @@ int main(void)
 struct svc {
     const char  *name;
     char *const *argv;   /* NULL for the two services started specially */
+    const char  *req;    /* must exist for the service to run; NULL = argv[0] */
     pid_t        pid;
     time_t       started;
+    int          fails;  /* consecutive fast exits */
+    int          gone;   /* logged as not-installed; stop trying */
 };
 static struct svc svcs[MAX_SVC];
 static int nsvc;
@@ -810,10 +826,31 @@ static volatile sig_atomic_t want_shutdown;
 
 static void on_term(int sig) { (void)sig; want_shutdown = 1; }
 
-static void svc_add(const char *name, char *const *argv)
+static void svc_add(const char *name, char *const *argv, const char *req)
 {
     if (nsvc < MAX_SVC)
-        svcs[nsvc++] = (struct svc){ .name = name, .argv = argv, .pid = -1 };
+        svcs[nsvc++] = (struct svc){ .name = name, .argv = argv,
+                                     .req = req, .pid = -1 };
+}
+
+/* How long to wait before restarting a service that keeps dying.
+ *
+ * A service that exits immediately used to be restarted every 2s forever,
+ * which spins PID 1, fills the log with its own failure, and buries whatever
+ * else was wrong. Anything that survives FAST_EXIT is treated as a normal
+ * run and resets the count; repeated fast exits back off 2,4,8,16,32,60s and
+ * stay at a minute. It never gives up permanently, because the reason is
+ * usually transient on this hardware — a PCM still held, a partition not
+ * mounted yet — and a device that has quietly stopped trying is worse than
+ * one that is still retrying slowly.
+ */
+#define FAST_EXIT 10
+static int svc_backoff(int fails)
+{
+    if (fails <= 1)
+        return 2;
+    int b = 2 << (fails - 1);
+    return b > 60 ? 60 : b;
 }
 
 /* The console is the one service that needs a controlling terminal, and it
@@ -890,17 +927,31 @@ static void supervise(void)
         pid_t d;
         while ((d = waitpid(-1, &st, WNOHANG)) > 0)
             for (int i = 0; i < nsvc; i++)
-                if (svcs[i].pid == d)
+                if (svcs[i].pid == d) {
                     svcs[i].pid = -1;
+                    if (time(NULL) - svcs[i].started < FAST_EXIT) {
+                        if (++svcs[i].fails == 3)
+                            note("svc %s failing fast, backing off\n",
+                                 svcs[i].name);
+                    } else
+                        svcs[i].fails = 0;
+                }
 
         time_t now = time(NULL);
         for (int i = 0; i < nsvc; i++) {
             struct svc *s = &svcs[i];
-            if (s->pid > 0)
+            if (s->pid > 0 || s->gone)
                 continue;
-            /* Backoff, so a service that dies instantly cannot spin PID 1. */
-            if (now - s->started < 2)
+            if (now - s->started < svc_backoff(s->fails))
                 continue;
+            /* Not installed is not a failure to retry: EchoMuse may simply not
+             * be on this device yet. Say so once and leave it alone. */
+            const char *need = s->req ? s->req : (s->argv ? s->argv[0] : NULL);
+            if (need && access(need, F_OK) != 0) {
+                note("svc %s absent (%s)\n", s->name, need);
+                s->gone = 1;
+                continue;
+            }
             s->started = now;
             if (!strcmp(s->name, "console"))
                 s->pid = start_console();

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -1676,6 +1676,282 @@ static int svc_backoff(int fails)
  * cannot be started until the host has attached to the ACM gadget. A console
  * that exits once because nobody was listening yet is indistinguishable from
  * one that never worked, which is why it is respawned rather than run once. */
+/* ── The console password ────────────────────────────────────────────────────
+ *
+ * The USB console hands out a root shell to anyone who plugs in a cable, and
+ * the WiFi PSK is sitting in /data/misc/wifi/wpa_supplicant.conf. This puts a
+ * prompt in front of the shell.
+ *
+ * It is a NOD TO SECURITY, not Fort Knox, and it should not be "hardened"
+ * later into something more complicated: the record lives on /data, so anyone
+ * who can hold the device deletes it from TWRP and walks in. It is an
+ * inconvenience for a casual opportunist, nothing more.
+ *
+ * So why hash rather than compare a string? Because the two are not the same
+ * asset. The hash does not protect the DEVICE — deleting the file defeats it
+ * either way — it protects the PASSWORD, which the owner has probably reused
+ * somewhere that matters. Someone who dumps /data should get work to do rather
+ * than a credential.
+ *
+ * SHA-256 is written out by hand here because this is a static binary with no
+ * crypto library available. bcrypt would be better in the abstract and is not
+ * on the table; the iteration count is what buys margin instead, and it is
+ * carried in the record so it can be raised without stranding devices holding
+ * an older one. The controller's default of 100,000 rounds was measured on
+ * this hardware at 0.32s — a login prompt, so nobody notices.
+ *
+ * The record is `<iterations>:<salt hex>:<hash hex>`, written by the firmware
+ * from the controller's config push (config.WriteConsolePassword), and the
+ * hash is sha256(salt||password) folded `iterations` times.
+ * controller/em_console_pw.py is the other half of this and the two MUST
+ * agree — tests/test_console_pw.py carries the shared vectors.
+ *
+ * A record we cannot read means NO password. That is deliberate: refusing
+ * every login on the strength of a corrupt string would lock the owner out
+ * with nothing to type, and the file is the only thing standing between them
+ * and a device they own.
+ */
+#define CONSOLE_PW "/data/local/etc/echomuse/console.pw"
+
+struct sha256 {
+    unsigned int  h[8];
+    unsigned char buf[64];
+    unsigned long long len;
+    int n;
+};
+
+static const unsigned int SHA_K[64] = {
+    0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,
+    0x923f82a4,0xab1c5ed5,0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,
+    0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,0xe49b69c1,0xefbe4786,
+    0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+    0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,
+    0x06ca6351,0x14292967,0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,
+    0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,0xa2bfe8a1,0xa81a664b,
+    0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+    0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,
+    0x5b9cca4f,0x682e6ff3,0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,
+    0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2,
+};
+
+#define ROR(x, n) (((x) >> (n)) | ((x) << (32 - (n))))
+
+static void sha256_block(struct sha256 *c, const unsigned char *p)
+{
+    unsigned int w[64], a, b, cc, d, e, f, g, h, t1, t2;
+    for (int i = 0; i < 16; i++)
+        w[i] = (unsigned int)p[i*4] << 24 | (unsigned int)p[i*4+1] << 16 |
+               (unsigned int)p[i*4+2] << 8 | (unsigned int)p[i*4+3];
+    for (int i = 16; i < 64; i++) {
+        unsigned int s0 = ROR(w[i-15],7) ^ ROR(w[i-15],18) ^ (w[i-15] >> 3);
+        unsigned int s1 = ROR(w[i-2],17) ^ ROR(w[i-2],19) ^ (w[i-2] >> 10);
+        w[i] = w[i-16] + s0 + w[i-7] + s1;
+    }
+    a=c->h[0]; b=c->h[1]; cc=c->h[2]; d=c->h[3];
+    e=c->h[4]; f=c->h[5]; g=c->h[6]; h=c->h[7];
+    for (int i = 0; i < 64; i++) {
+        unsigned int S1 = ROR(e,6) ^ ROR(e,11) ^ ROR(e,25);
+        unsigned int ch = (e & f) ^ ((~e) & g);
+        t1 = h + S1 + ch + SHA_K[i] + w[i];
+        unsigned int S0 = ROR(a,2) ^ ROR(a,13) ^ ROR(a,22);
+        unsigned int mj = (a & b) ^ (a & cc) ^ (b & cc);
+        t2 = S0 + mj;
+        h=g; g=f; f=e; e=d+t1; d=cc; cc=b; b=a; a=t1+t2;
+    }
+    c->h[0]+=a; c->h[1]+=b; c->h[2]+=cc; c->h[3]+=d;
+    c->h[4]+=e; c->h[5]+=f; c->h[6]+=g; c->h[7]+=h;
+}
+
+static void sha256_init(struct sha256 *c)
+{
+    static const unsigned int iv[8] = {
+        0x6a09e667,0xbb67ae85,0x3c6ef372,0xa54ff53a,
+        0x510e527f,0x9b05688c,0x1f83d9ab,0x5be0cd19,
+    };
+    for (int i = 0; i < 8; i++)
+        c->h[i] = iv[i];
+    c->len = 0;
+    c->n = 0;
+}
+
+static void sha256_update(struct sha256 *c, const void *data, unsigned len)
+{
+    const unsigned char *p = data;
+    c->len += (unsigned long long)len * 8;
+    while (len) {
+        unsigned take = 64 - c->n;
+        if (take > len)
+            take = len;
+        memcpy(c->buf + c->n, p, take);
+        c->n += take; p += take; len -= take;
+        if (c->n == 64) { sha256_block(c, c->buf); c->n = 0; }
+    }
+}
+
+static void sha256_final(struct sha256 *c, unsigned char out[32])
+{
+    unsigned long long bits = c->len;
+    unsigned char pad = 0x80;
+    sha256_update(c, &pad, 1);
+    pad = 0;
+    while (c->n != 56)
+        sha256_update(c, &pad, 1);
+    unsigned char len8[8];
+    for (int i = 0; i < 8; i++)
+        len8[i] = (unsigned char)(bits >> (56 - i * 8));
+    sha256_update(c, len8, 8);
+    for (int i = 0; i < 8; i++) {
+        out[i*4]   = (unsigned char)(c->h[i] >> 24);
+        out[i*4+1] = (unsigned char)(c->h[i] >> 16);
+        out[i*4+2] = (unsigned char)(c->h[i] >> 8);
+        out[i*4+3] = (unsigned char)c->h[i];
+    }
+}
+
+static int unhex(const char *s, unsigned char *out, int max)
+{
+    int n = 0;
+    for (; s[0] && s[1] && n < max; s += 2, n++) {
+        int hi = -1, lo = -1;
+        for (int k = 0; k < 2; k++) {
+            char ch = s[k];
+            int v = ch >= '0' && ch <= '9' ? ch - '0'
+                  : ch >= 'a' && ch <= 'f' ? ch - 'a' + 10
+                  : ch >= 'A' && ch <= 'F' ? ch - 'A' + 10 : -1;
+            if (v < 0)
+                return -1;
+            if (k == 0) hi = v; else lo = v;
+        }
+        out[n] = (unsigned char)(hi << 4 | lo);
+    }
+    return s[0] ? -1 : n;
+}
+
+/* Fold sha256(salt||password) `iters` times, matching em_console_pw.py. */
+static void pw_hash(const unsigned char *salt, int saltlen,
+                    const char *pw, long iters, unsigned char out[32])
+{
+    struct sha256 c;
+    sha256_init(&c);
+    sha256_update(&c, salt, saltlen);
+    sha256_update(&c, pw, (unsigned)strlen(pw));
+    sha256_final(&c, out);
+    for (long i = 1; i < iters; i++) {
+        unsigned char t[32];
+        memcpy(t, out, 32);
+        sha256_init(&c);
+        sha256_update(&c, t, 32);
+        sha256_final(&c, out);
+    }
+}
+
+/* Read the record. Returns 0 when there is no password to enforce. */
+static int pw_load(long *iters, unsigned char *salt, int *saltlen,
+                   unsigned char want[32])
+{
+    int fd = open(CONSOLE_PW, O_RDONLY);
+    if (fd < 0)
+        return 0;
+    char b[256];
+    int n = read(fd, b, sizeof b - 1);
+    close(fd);
+    if (n <= 0)
+        return 0;
+    b[n] = 0;
+    char *nl = strchr(b, '\n');
+    if (nl) *nl = 0;
+
+    char *c1 = strchr(b, ':');
+    if (!c1) return 0;
+    *c1++ = 0;
+    char *c2 = strchr(c1, ':');
+    if (!c2) return 0;
+    *c2++ = 0;
+
+    *iters = atol(b);
+    if (*iters < 1)
+        return 0;
+    *saltlen = unhex(c1, salt, 32);
+    if (*saltlen <= 0)
+        return 0;
+    return unhex(c2, want, 32) == 32;
+}
+
+/* Prompt on the console until the password is right.
+ *
+ * Runs in the console child, after the tty is its stdio and before the shell
+ * is exec'd — so the boot trail and everything else the device prints stay
+ * freely readable, and only the SHELL is behind the prompt.
+ *
+ * ECHO is turned off while typing, which on this console is doubly worth
+ * doing: it stops the password appearing on the wire, and the device echoing
+ * its own output back into its input is the trap that cost an evening here
+ * once already (see README).
+ */
+static void console_gate(void)
+{
+    long iters;
+    unsigned char salt[32], want[32], got[32];
+    int saltlen;
+
+    if (!pw_load(&iters, salt, &saltlen, want))
+        return;
+
+    struct termios t, saved;
+    int have_t = tcgetattr(0, &t) == 0;
+    if (have_t) {
+        saved = t;
+        t.c_lflag &= ~(unsigned)ECHO;
+        tcsetattr(0, TCSANOW, &t);
+    }
+
+    for (int tries = 0; ; tries++) {
+        /* Slow down after a few wrong answers. Not a lockout: there is no
+         * lockout that a power cycle would not clear, and one that outlived a
+         * reboot would lock out the owner rather than anyone else. */
+        if (tries >= 3)
+            sleep(tries > 8 ? 5 : 2);
+
+        const char *p = "\r\nemOS console password: ";
+        write(1, p, strlen(p));
+
+        char in[128];
+        int n = 0;
+        while (n < (int)sizeof in - 1) {
+            char ch;
+            int r = read(0, &ch, 1);
+            if (r <= 0) {          /* cable pulled, or the port closed */
+                if (have_t) tcsetattr(0, TCSANOW, &saved);
+                _exit(0);
+            }
+            if (ch == '\r' || ch == '\n')
+                break;
+            if ((ch == 8 || ch == 127)) {      /* backspace */
+                if (n) n--;
+                continue;
+            }
+            in[n++] = ch;
+        }
+        in[n] = 0;
+        write(1, "\r\n", 2);
+
+        pw_hash(salt, saltlen, in, iters, got);
+        int ok = 1;
+        for (int i = 0; i < 32; i++)
+            if (got[i] != want[i])
+                ok = 0;
+        memset(in, 0, sizeof in);
+        if (ok)
+            break;
+
+        const char *no = "wrong\r\n";
+        write(1, no, strlen(no));
+    }
+
+    if (have_t)
+        tcsetattr(0, TCSANOW, &saved);
+}
+
 static pid_t start_console(void)
 {
     int t = open(TTY, O_RDWR | O_NOCTTY);
@@ -1687,6 +1963,7 @@ static pid_t start_console(void)
         ioctl(t, TIOCSCTTY, 1);
         dup2(t, 0); dup2(t, 1); dup2(t, 2);
         if (t > 2) close(t);
+        console_gate();
         char *argv[] = { "/system/bin/sh", NULL };
         char *envp[] = { "HOME=/", "TERM=vt100", "ANDROID_ROOT=/system",
                          "PATH=/sbin:/system/bin:/system/xbin", NULL };

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -653,9 +653,18 @@ int main(void)
      * whoever asks about it later, including a user on the other side of the
      * world who has since rebooted twice.
      */
+    /* RAM-backed scratch for logs and runtime state, so routine logging never
+     * touches the eMMC. 4MB is ample for a 256KB x2 syslog rotation. */
+    mkdir("/run", 0755);
+    mount("tmpfs", "/run", "tmpfs", 0, "size=4m");
+
     mkdir("/data/emos", 0755);
     int lk = open("/proc/last_kmsg", O_RDONLY);
     if (lk >= 0) {
+        /* Rotate, so a device that reboot-loops cannot overwrite the crash
+         * that started it with the boring ones that followed. */
+        rename("/data/emos/last_kmsg.1", "/data/emos/last_kmsg.2");
+        rename("/data/emos/last_kmsg.prev", "/data/emos/last_kmsg.1");
         int out = open("/data/emos/last_kmsg.prev", O_WRONLY | O_CREAT | O_TRUNC, 0644);
         long long copied = 0;
         if (out >= 0) {
@@ -744,8 +753,28 @@ int main(void)
      * plus -L, and emOS holds no inbound sockets at all. klogd feeds the
      * kernel ring into the same file so a userspace fault and the kernel
      * message that explains it land in one timestamped stream. */
+    /* Routine logging goes to a RAM ring, NOT to flash.
+     *
+     * This device is meant to run for years on eMMC that cannot be replaced,
+     * and a syslog writing continuously is pure wear for logs nobody reads:
+     * measured at ~19 bytes/s idle, so ~1.6MB a day, forever. -C gives an
+     * in-memory circular buffer instead, read with `logread`, costing zero
+     * writes. (A console session inflates that rate a hundredfold, because
+     * this kernel logs one line PER BYTE transmitted on ttyGS0 — so the
+     * measurement above is the idle device, not a device being debugged.)
+     *
+     * A tmpfs is used rather than busybox's own -C ring, which needs System V
+     * shared memory this kernel does not have — `logread` returns "can't find
+     * syslogd buffer: Function not implemented". tmpfs is present and gives
+     * the same property: the log lives in RAM and costs no writes.
+     *
+     * Flash is reserved for post-mortems, which is the thing actually worth
+     * keeping: the previous boot's kernel log is copied at startup, and
+     * dump_log() spills the ring on the way down. Crashes survive; chatter
+     * does not.
+     */
     char *syslogd[] = { "/system/bin/busybox", "syslogd", "-n",
-                        "-O", "/data/emos/messages", "-s", "512", "-b", "3", NULL };
+                        "-O", "/run/messages", "-s", "256", "-b", "2", NULL };
     char *klogd[]   = { "/system/bin/busybox", "klogd", "-n", NULL };
 
     svc_add("net", NULL);          /* forked in-process, see below */
@@ -832,6 +861,12 @@ static void do_shutdown(void)
         usleep(100000);
     }
     kill(-1, SIGKILL);
+    /* Spill the in-memory log to flash. One bounded write per shutdown is a
+     * cost worth paying; the continuous stream that produced it is not. */
+    char *dump[] = { "/system/bin/sh", "-c",
+                     "cat /run/messages* > /data/emos/messages.last "
+                     "2>/dev/null", NULL };
+    run_wait(dump);
     sync();
     sync();
     mount(NULL, "/data", NULL, MS_REMOUNT | MS_RDONLY, NULL);

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -32,6 +32,7 @@
 #include <sys/reboot.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <stdint.h>
 #include <sys/sysmacros.h>
 #include <sys/wait.h>
 #include <termios.h>
@@ -166,6 +167,157 @@ static void led_fade_out(int r, int g, int b)
 static void led_fail(void)
 {
     led_frame(bootstep + 1, 0xFF, 0x00, 0x00);
+}
+
+/* ── Boot rollback ───────────────────────────────────────────────────────────
+ *
+ * A boot image that starts init but then fails to become useful is the failure
+ * this recovers, and it is the one we actually hit: an image that reached the
+ * USB gadget and then crash-looped, needing TWRP and physical handling.
+ *
+ * The mechanism is deliberately ours and not the bootloader's. biscuit has a
+ * real second slot (boot_b_x, mmcblk0p11) but LK chooses between them and we
+ * have not reverse-engineered how — the standing guess is three tries per slot
+ * and then a soft brick, which is plausible and UNTESTED. Building on that
+ * guess would risk a device that boots something we did not choose, so instead
+ * init keeps its own known-good copy on /data and restores it.
+ *
+ * Honest about what it does NOT cover: an image that fails before init runs
+ * executes none of this and still needs recovery over USB. That case is what
+ * the byte-exact packer and the cache-dropped flash verification exist to make
+ * rare.
+ *
+ * A boot is CONFIRMED when the network comes up, not when init finishes.
+ * Reachability is the property that matters — a device we can reach is one we
+ * can fix without touching it.
+ */
+/* Defined further down; declared here so the rollback can use them. */
+static void note(const char *fmt, ...);
+static void netlog(const char *fmt, ...);
+static int  readint(const char *path);
+
+#define BOOTDEV   "/dev/block/mmcblk0p10"
+#define GOODIMG   "/data/emos/boot-good.img"
+#define BOOTSTATE "/data/emos/boot.state"
+#define MAX_TRIES 3
+
+static unsigned pad2048(unsigned n) { return (n + 2047u) / 2048u * 2048u; }
+
+/* Length of the Android boot image on the partition, from its own header, so
+ * only the image is copied rather than the whole 16MB partition. */
+static long boot_image_len(int fd)
+{
+    unsigned char h[64];
+    if (pread(fd, h, sizeof h, 0) != (ssize_t)sizeof h)
+        return -1;
+    if (memcmp(h, "ANDROID!", 8) != 0)
+        return -1;
+    unsigned ksz, rsz, ssz, ps;
+    memcpy(&ksz, h + 8,  4);
+    memcpy(&rsz, h + 16, 4);
+    memcpy(&ssz, h + 24, 4);
+    memcpy(&ps,  h + 36, 4);
+    if (ps != 2048)
+        return -1;
+    return (long)ps + pad2048(ksz) + pad2048(rsz) + pad2048(ssz);
+}
+
+static int copy_range(int in, int out, long len)
+{
+    char b[65536];
+    long done = 0;
+    while (done < len) {
+        long want = len - done < (long)sizeof b ? len - done : (long)sizeof b;
+        ssize_t n = read(in, b, want);
+        if (n <= 0)
+            return -1;
+        if (write(out, b, n) != n)
+            return -1;
+        done += n;
+    }
+    return 0;
+}
+
+static int read_state(void)
+{
+    return readint(BOOTSTATE);
+}
+
+static void write_state(int n)
+{
+    int fd = open(BOOTSTATE, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0)
+        return;
+    char b[16];
+    int k = snprintf(b, sizeof b, "%d\n", n);
+    write(fd, b, k);
+    fsync(fd);
+    close(fd);
+}
+
+/* Write the known-good image back over the boot partition and reboot into it. */
+static void restore_good(void)
+{
+    int in = open(GOODIMG, O_RDONLY);
+    if (in < 0)
+        return;
+    struct stat st;
+    if (fstat(in, &st) != 0 || st.st_size < 2048) { close(in); return; }
+    int out = open(BOOTDEV, O_WRONLY);
+    if (out < 0) { close(in); return; }
+    int rc = copy_range(in, out, st.st_size);
+    fsync(out);
+    close(out);
+    close(in);
+    note("rollback restored rc=%d bytes=%ld\n", rc, (long)st.st_size);
+    led_frame(LED_N, 0xFF, 0x60, 0x00);      /* amber: rolling back */
+    write_state(0);
+    sync();
+    sleep(2);
+    reboot(RB_AUTOBOOT);
+}
+
+/* Keep the running image as the fallback, once it has proved itself. Only on
+ * change, so an unchanged image costs no writes at all. */
+static void promote_good(void)
+{
+    int in = open(BOOTDEV, O_RDONLY);
+    if (in < 0)
+        return;
+    long len = boot_image_len(in);
+    if (len <= 0) { close(in); return; }
+
+    /* Compare by the boot header's SHA1 image id, not by size: every emOS
+     * image built so far is byte-for-byte the same LENGTH, so a size check
+     * would never promote a new one and the fallback would stay pinned to the
+     * first image ever confirmed. The id is a digest over kernel and ramdisk,
+     * so it changes exactly when the image does. It sits after the magic, the
+     * ten header words, the 16-byte product name and the 512-byte cmdline. */
+    unsigned char id_dev[32], id_good[32];
+    if (pread(in, id_dev, sizeof id_dev, 576) == (ssize_t)sizeof id_dev) {
+        int g = open(GOODIMG, O_RDONLY);
+        if (g >= 0) {
+            ssize_t n = pread(g, id_good, sizeof id_good, 576);
+            close(g);
+            if (n == (ssize_t)sizeof id_good &&
+                memcmp(id_dev, id_good, sizeof id_dev) == 0) {
+                close(in);
+                return;                          /* already the known-good one */
+            }
+        }
+    }
+    if (lseek(in, 0, SEEK_SET) != 0) { close(in); return; }
+    int out = open(GOODIMG ".new", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (out < 0) { close(in); return; }
+    int rc = copy_range(in, out, len);
+    fsync(out);
+    close(out);
+    close(in);
+    if (rc == 0)
+        rename(GOODIMG ".new", GOODIMG);
+    else
+        unlink(GOODIMG ".new");
+    netlog("rollback promoted rc=%d bytes=%ld\n", rc, len);
 }
 
 static char trail[3072];
@@ -486,6 +638,10 @@ static void net_main(void)
                     led_frame(LED_N, 0x00, 0xFF, 0x00);
                     usleep(400000);
                     led_fade_out(0x00, 0xFF, 0x00);
+                    /* The boot is confirmed: the device is reachable, which
+                     * is the property that makes it fixable without hands. */
+                    write_state(0);
+                    promote_good();
                     write_resolv_conf();
                     ntp = spawn(ntpd);
                 }
@@ -660,6 +816,19 @@ int main(void)
     mount("tmpfs", "/run", "tmpfs", 0, "size=4m");
 
     mkdir("/data/emos", 0755);
+
+    /* Rollback bookkeeping. This runs as early as /data allows, because a boot
+     * that dies later must still have been counted — the counter is the only
+     * evidence that the previous boots failed. */
+    int tries = read_state();
+    if (tries < 0)
+        tries = 0;
+    note("stage=boot try=%d\n", tries + 1);
+    if (tries >= MAX_TRIES && access(GOODIMG, R_OK) == 0) {
+        note("rollback: %d unconfirmed boots, restoring known-good\n", tries);
+        restore_good();                 /* reboots; returns only on failure */
+    }
+    write_state(tries + 1);
     int lk = open("/proc/last_kmsg", O_RDONLY);
     if (lk >= 0) {
         /* Rotate, so a device that reboot-loops cannot overwrite the crash

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -178,11 +178,9 @@ static void note(const char *fmt, ...);
 #define ORBIT_STEP_MS 109   /* measured; the wind-in matches this exactly */
 #define ORBIT_PROBE 1       /* sample the kernel's frames before claiming */
 
-static const unsigned char C_GROUND[3] = { 0x00, 0x00, 0xFF }; /* the orbit's ring */
+/* The orbit's ring, which is also what the tail repaints it with. */
+static const unsigned char C_ORBIT[3]  = { 0x00, 0x00, 0xFF };
 static const unsigned char C_HEAD[3]   = { 0x00, 0xFF, 0xFF }; /* the orbit's head */
-/* Progress is the arc between the two: far enough toward the head to read as a
- * filling ring, still plainly the same blue family as the ground. */
-static const unsigned char C_TRAIL[3]  = { 0x00, 0x70, 0xFF };
 static const unsigned char C_FAIL[3]   = { 0xFF, 0x00, 0x00 };
 static const unsigned char C_AMBER[3]  = { 0xFF, 0x60, 0x00 };
 /* Cyan is already full on two channels, so the only way UP is toward white —
@@ -290,15 +288,22 @@ static void anim_render(int head_q, int tick, int failed, int trail)
     if (failed)
         memcpy(head, C_FAIL, 3);
     else
-        blend(head, C_GROUND, C_HEAD,
+        blend(head, C_ORBIT, C_HEAD,
               BREATH_MIN + breath(tick) * (SUB - BREATH_MIN) / SUB);
 
-    /* The ground is the orbit's own ring, lit on every LED. Leaving the
-     * unreached segments dark is what would make the handover a cut, however
-     * well the colours matched. */
+    /* Ahead of the head the ring is DARK, and the tail paints the orbit's own
+     * blue back onto it as it goes. Carrying the lit ring through instead —
+     * the first version of this — put the tail and the ground two shades of
+     * the same blue apart, and on the device that read as no progress bar at
+     * all (Wil, from video, 2026-09-05). The handover is covered by fading the
+     * ring out rather than by keeping it lit; see anim_handover. */
     int i = head_q / SUB, fr = head_q % SUB;
-    for (int p = 0; p < LED_N; p++)
-        memcpy(f[p], trail && p < i ? C_TRAIL : C_GROUND, 3);
+    for (int p = 0; p < LED_N; p++) {
+        if (trail && p < i)
+            memcpy(f[p], C_ORBIT, 3);
+        else
+            memset(f[p], 0, 3);
+    }
 
     /* The head straddles two segments, but it is NOT a plain cross-fade: the
      * nearer LED always gets the head at full and the further one takes a
@@ -336,9 +341,9 @@ static int orbit_head_pos(void)
         return -1;
 
     char want[6];
-    puthex(want,     C_GROUND[0]);
-    puthex(want + 2, C_GROUND[1]);
-    puthex(want + 4, C_GROUND[2]);
+    puthex(want,     C_ORBIT[0]);
+    puthex(want + 2, C_ORBIT[1]);
+    puthex(want + 4, C_ORBIT[2]);
 
     int found = -1, count = 0;
     for (int L = 0; L < LED_N; L++) {
@@ -382,7 +387,7 @@ static void anim_finale(int head_q, int tick)
      * would put the seam a half-segment off and lean the whole figure. */
     for (int s = 0; s < LED_N / 2; s++) {
         for (int p = 0; p < LED_N; p++)
-            memcpy(f[p], C_TRAIL, 3);
+            memcpy(f[p], C_ORBIT, 3);
         for (int k = 0; k <= s; k++) {
             memcpy(f[k], C_HEAD, 3);
             memcpy(f[LED_N - 1 - k], C_HEAD, 3);
@@ -437,11 +442,39 @@ static void anim_claim(void)
     if (fd >= 0) { write(fd, "3", 1); close(fd); }
 }
 
+/* The handover: take the lit ring away, and leave the head behind.
+ *
+ * We stop the kernel's animation with its head at the bottom, so at this
+ * instant the ring is exactly what it has been showing all along. Fading the
+ * blue out from under that head — rather than cutting to a dark ring, or
+ * carrying the lit ring through — is what makes the two animations read as
+ * one: nothing jumps, nothing changes colour, the ring simply clears and the
+ * head is left standing where the orbit left it, about to travel.
+ *
+ * It also buys the contrast the progress display needs. Against a lit ring the
+ * tail was two shades of blue away from the ground and did not read as a
+ * progress bar at all; against a dark one it paints the orbit's own blue back
+ * on as it goes.
+ */
+static void anim_handover(void)
+{
+    unsigned char f[LED_N][3];
+
+    for (int v = SUB; v >= 0; v -= 16) {
+        for (int p = 0; p < LED_N; p++)
+            scale(f[p], C_ORBIT, v);
+        memcpy(f[0], C_HEAD, 3);      /* the head stays, and stays put */
+        led_write(f);
+        usleep(TICK_MS * 1000);
+    }
+}
+
 static void anim_main(void)
 {
     int head_q = 0, tick = 0;
 
     anim_claim();
+    anim_handover();
 
     for (;;) {
         int mode = ledst->mode;

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -145,6 +145,22 @@ static void led_step(void)
     led_frame(bootstep, 0x00, 0x30, 0xFF);
 }
 
+/* Fade the ring out once the boot has finished.
+ *
+ * A ring left lit is just another light that means nothing — the same problem
+ * as the kernel animation this replaced. Fading says "done" and hands the LEDs
+ * back, so anything the ring shows afterwards is the firmware's to explain.
+ * ~640ms, slow enough to read as deliberate rather than as a glitch.
+ */
+static void led_fade_out(int r, int g, int b)
+{
+    for (int v = 255; v > 0; v -= 8) {
+        led_frame(LED_N, r * v / 255, g * v / 255, b * v / 255);
+        usleep(20000);
+    }
+    led_frame(0, 0, 0, 0);
+}
+
 /* A stage that failed leaves the ring red at the point it reached, so a dead
  * device says WHERE it died without a cable. */
 static void led_fail(void)
@@ -466,9 +482,10 @@ static void net_main(void)
                  */
                 if (!netup) {
                     netup = 1;
-                    /* Fully up: the whole ring goes green and stays there
-                     * until the firmware claims it. */
+                    /* Fully up: the ring goes green, then fades out. */
                     led_frame(LED_N, 0x00, 0xFF, 0x00);
+                    usleep(400000);
+                    led_fade_out(0x00, 0xFF, 0x00);
                     write_resolv_conf();
                     ntp = spawn(ntpd);
                 }

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -143,9 +143,11 @@ static const struct node nodes[] = {
 #endif
 #define LED_N  12
 
-/* Defined further down; declared here so the orbit probe can record into the
- * boot trail. */
+/* Defined further down; declared here so the orbit probe and the stage marks
+ * can record into the boot trail and the network log. */
 static void note(const char *fmt, ...);
+static void netlog(const char *fmt, ...);
+static long mono_ms(void);
 
 /* ── The orbit, as measured off EFF on 2026-09-05 ────────────────────────────
  *
@@ -204,6 +206,7 @@ struct ledshm {
 };
 static struct ledshm *ledst;
 static pid_t led_pid = -1;
+static pid_t main_pid;
 static int bootstep;
 
 static const char HEXD[] = "0123456789ABCDEF";
@@ -272,6 +275,35 @@ static int breath(int tick)
     int x = tick % per;
     int tri = x < per / 2 ? x * 2 * SUB / per : (per - x) * 2 * SUB / per;
     return tri * tri / SUB;
+}
+
+/* Where the head goes next, given the stage the boot has reached.
+ *
+ * Split out because ringsim USED to carry its own copy of this loop, so a cap
+ * added here silently did not apply there — the drift the simulator exists to
+ * make impossible. One function, called by both.
+ */
+static int head_advance(int head_q, int stage)
+{
+    if (stage > LED_N)
+        stage = LED_N;
+    int target = stage * SUB + (stage < LED_N ? CREEP : 0);
+    /* Never past the LAST segment while the boot is still running. The creep
+     * carried the head to 11.7, which renders mostly on position 0 — so it had
+     * visually completed the lap and come back to the bottom with the boot
+     * unfinished, and the finale then had no journey home to make. Bringing
+     * the ring home is the finale's job (Wil, from video, 2026-09-05). */
+    if (target > (LED_N - 1) * SUB)
+        target = (LED_N - 1) * SUB;
+    if (head_q >= target)
+        return head_q;
+    /* Exponential ease, with a floor so integer truncation cannot stall it
+     * short of the target. */
+    int step = (target - head_q) / 8;
+    if (step < 1)
+        step = 1;
+    head_q += step;
+    return head_q > target ? target : head_q;
 }
 
 /* head_q is a position in SUB units around the ring, 0..LED_N*SUB. `trail`
@@ -489,22 +521,8 @@ static void anim_main(void)
             ledst->mode = ANIM_DONE;
             _exit(0);
         }
-        if (mode != ANIM_FAIL) {
-            int stage = ledst->stage;
-            if (stage > LED_N)
-                stage = LED_N;
-            int target = stage * SUB + (stage < LED_N ? CREEP : 0);
-            if (head_q < target) {
-                /* Exponential ease, with a floor so integer truncation cannot
-                 * stall it short of the target. */
-                int step = (target - head_q) / 8;
-                if (step < 1)
-                    step = 1;
-                head_q += step;
-                if (head_q > target)
-                    head_q = target;
-            }
-        }
+        if (mode != ANIM_FAIL)
+            head_q = head_advance(head_q, ledst->stage);
         anim_render(head_q, tick++, mode == ANIM_FAIL, 1);
         usleep(TICK_MS * 1000);
     }
@@ -546,6 +564,7 @@ static void orbit_probe(void)
 /* Start the animator. It claims the ring itself — see anim_claim. */
 static void led_claim(void)
 {
+    main_pid = getpid();
     orbit_probe();
     note("orbit head at %d\n", orbit_head_pos());
 
@@ -576,6 +595,14 @@ static void led_step(void)
         bootstep++;
     if (ledst)
         ledst->stage = bootstep;
+    /* Timestamp every stage, so the trail can answer which of them actually
+     * cost anything. note() rewrites a buffer that fork() has copied, so the
+     * network stages — which run in a child, and are the slow ones — have to
+     * go to the append-only log instead. */
+    if (getpid() == main_pid)
+        note("stage %d reached\n", bootstep);
+    else
+        netlog("stage %d reached\n", bootstep);
 }
 
 static void led_fail(void)
@@ -764,15 +791,31 @@ static int write_at(off_t off, const char *buf, size_t n)
     return w == (ssize_t)n ? 0 : -1;
 }
 
+/* Milliseconds since the kernel started. CLOCK_MONOTONIC begins at boot, so
+ * this covers the kernel's own time as well as ours and needs nothing set up.
+ * It is not for the clock — it is for knowing which stages actually cost
+ * anything, which the trail could not answer until now. */
+static long mono_ms(void)
+{
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+        return 0;
+    return ts.tv_sec * 1000L + ts.tv_nsec / 1000000L;
+}
+
 static void note(const char *fmt, ...)
 {
     char line[256];
+    int p = snprintf(line, sizeof line, "[%7ld] ", mono_ms());
+    if (p < 0 || p >= (int)sizeof line)
+        p = 0;
     va_list ap;
     va_start(ap, fmt);
-    int n = vsnprintf(line, sizeof line, fmt, ap);
+    int n = vsnprintf(line + p, sizeof line - p, fmt, ap);
     va_end(ap);
     if (n < 0)
         return;
+    n += p;
     if (n > (int)sizeof line - 1)
         n = sizeof line - 1;
     if (trail_len + n + 1 < sizeof trail) {
@@ -809,12 +852,16 @@ static void usbwr(const char *leaf, const char *val)
 static void netlog(const char *fmt, ...)
 {
     char line[256];
+    int p = snprintf(line, sizeof line, "[%7ld] ", mono_ms());
+    if (p < 0 || p >= (int)sizeof line)
+        p = 0;
     va_list ap;
     va_start(ap, fmt);
-    int n = vsnprintf(line, sizeof line, fmt, ap);
+    int n = vsnprintf(line + p, sizeof line - p, fmt, ap);
     va_end(ap);
     if (n <= 0)
         return;
+    n += p;
     int fd = open(NETLOG, O_WRONLY | O_CREAT | O_APPEND, 0644);
     if (fd < 0)
         return;

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -186,7 +186,11 @@ static long mono_ms(void);
 #define LED_BOTTOM 11
 #define LED_DIR    1        /* +1: the orbit runs on rising physical index */
 #define ORBIT_STEP_MS 109   /* measured; the wind-in matches this exactly */
-#define ORBIT_PROBE 1       /* sample the kernel's frames before claiming */
+/* Sampling the kernel's own frames before we stop it. OFF: it has done its
+ * job — the palette and rate above are measured and written down — and it
+ * costs ~400ms of every boot plus ten lines of the trail. Turn it back on if
+ * the orbit ever needs re-measuring, on this board or another. */
+#define ORBIT_PROBE 0
 
 /* The orbit's ring, which is also what the tail repaints it with. */
 static const unsigned char C_ORBIT[3]  = { 0x00, 0x00, 0xFF };

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -204,7 +204,20 @@ static const unsigned char C_PEAK[3]   = { 0xFF, 0xFF, 0xFF };
                                         * still going. Under one whole LED, so
                                         * it can never reach a checkpoint the
                                         * boot has not actually passed. */
-#define BREATH_MIN ((SUB * 13) / 20)   /* the head dips to 65%, never dark */
+/* How far the head falls back toward the ground colour at the bottom of its
+ * breath. Two depths, because the breath is doing two different jobs.
+ *
+ * While the head is TRAVELLING it only has to look alive, and the movement
+ * carries that on its own — a deep pulse there would compete with the motion.
+ * Once it parks on position 12 and waits for the network, the breath is the
+ * only thing happening at all, for 27.6 seconds of a 35 second boot, so it has
+ * to actually read: 65% was measured on the device as not noticeable (Wil,
+ * 2026-09-05). Parked it swings most of the way back to blue, and slower, so
+ * it reads as waiting rather than as activity. */
+#define BREATH_MIN     ((SUB * 13) / 20)   /* moving: 65%, a shimmer */
+#define BREATH_PARKED  ((SUB *  1) / 5)    /* parked: 20%, a throb   */
+#define BREATH_MS         2400
+#define BREATH_PARKED_MS  3600
 
 enum { ANIM_RUN = 0, ANIM_FAIL, ANIM_FINISH, ANIM_OFF, ANIM_DONE };
 
@@ -277,11 +290,18 @@ static void scale(unsigned char out[3], const unsigned char c[3], int w)
  * pulsing evenly. This is what keeps the ring alive during a stage that takes
  * seconds: the head stops travelling as it approaches the next checkpoint, but
  * it never stops moving. */
-static int breath(int tick)
+/* A dip and a return, starting at FULL.
+ *
+ * Phased on how long the head has been still rather than on a free-running
+ * tick, and it begins at the top — so the moment the head stops, the breath
+ * starts from exactly the brightness the head already had. On a free tick it
+ * would jump to wherever the wave happened to be. */
+static int breath(int still, int period_ms)
 {
-    int per = 2400 / TICK_MS;
-    int x = tick % per;
-    int tri = x < per / 2 ? x * 2 * SUB / per : (per - x) * 2 * SUB / per;
+    int per = period_ms / TICK_MS;
+    int x = still % per;
+    int d = x < per / 2 ? per / 2 - x : x - per / 2;
+    int tri = d * 2 * SUB / per;
     return tri * tri / SUB;
 }
 
@@ -316,20 +336,47 @@ static int head_advance(int head_q, int stage)
 
 /* head_q is a position in SUB units around the ring, 0..LED_N*SUB. `trail`
  * shows progress behind the head; during the wind-in there is none to show. */
-static void anim_render(int head_q, int tick, int failed, int trail)
+/* still = ticks the head has been visually stationary; 0 means it is moving.
+ *
+ * The head is STEADY while it travels and throbs only once it stops. Both were
+ * happening at once, and they say opposite things — movement means progress,
+ * the throb means waiting — so overlapping them left the head restless without
+ * either reading clearly (Wil, 2026-09-05).
+ *
+ * The head mixes between the GROUND and the head colour rather than scaling
+ * toward black: scaling cyan down takes the blue channel with it, so the head
+ * would go dimmer than the ring it sits on. Mixing holds blue at full and
+ * moves only the green.
+ */
+static void anim_render(int head_q, int still, int failed, int trail)
 {
     unsigned char f[LED_N][3], head[3];
 
-    /* The head breathes between the GROUND and the head colour rather than
-     * toward black. Scaling cyan down takes the blue channel with it, so the
-     * head would go dimmer than the ring it sits on; mixing keeps blue at full
-     * and moves only the green, which reads as the head brightening and
-     * settling rather than blinking. */
+    /* Parked: arrived at the last segment with the boot still running. */
+    int parked = trail && head_q >= (LED_N - 1) * SUB;
+    int lo     = parked ? BREATH_PARKED : BREATH_MIN;
+    int mix    = still
+               ? lo + breath(still, parked ? BREATH_PARKED_MS : BREATH_MS)
+                      * (SUB - lo) / SUB
+               : SUB;
+
     if (failed)
         memcpy(head, C_FAIL, 3);
     else
-        blend(head, C_ORBIT, C_HEAD,
-              BREATH_MIN + breath(tick) * (SUB - BREATH_MIN) / SUB);
+        blend(head, C_ORBIT, C_HEAD, mix);
+
+    /* Parked is drawn on its own terms: the build colour all the way round and
+     * JUST the pair either side of the bottom gap throbbing on top of it. No
+     * comet glow on a neighbour — the head is not travelling any more, and a
+     * smear beside it reads as a tail that has not finished arriving. */
+    if (parked) {
+        for (int p = 0; p < LED_N; p++)
+            memcpy(f[p], C_ORBIT, 3);
+        memcpy(f[0], head, 3);
+        memcpy(f[LED_N - 1], head, 3);
+        led_write(f);
+        return;
+    }
 
     /* Ahead of the head the ring is DARK, and the tail paints the orbit's own
      * blue back onto it as it goes. Carrying the lit ring through instead —
@@ -362,13 +409,6 @@ static void anim_render(int head_q, int tick, int failed, int trail)
     if (glow)
         blend(f[far % LED_N], f[far % LED_N], head, glow);
 
-    /* Once the head reaches the last segment, the FIRST one lights with it and
-     * the pair closes the ring across the bottom gap, breathing together until
-     * the boot finishes. That wait is real and long — association and DHCP are
-     * most of the boot — so it wants something deliberate rather than a head
-     * sitting on its own. */
-    if (trail && head_q >= (LED_N - 1) * SUB)
-        blend(f[0], f[0], head, SUB);
     led_write(f);
 }
 
@@ -413,9 +453,29 @@ static int orbit_head_pos(void)
 /* Boot complete: close the ring, fill both sides from the bottom to the top,
  * take it to full and then take it away. The fade hands the LEDs back, so
  * anything shown afterwards is the firmware's to explain. */
-static void anim_finale(void)
+static void anim_finale(int still)
 {
-    unsigned char f[LED_N][3];
+    unsigned char f[LED_N][3], head[3];
+
+    /* Settle the throb to full before the sweep begins.
+     *
+     * The pair has been breathing for the whole network wait, so without this
+     * the first arm frame snaps it from wherever the breath happened to be
+     * straight to full — a flicker if it was caught near the bottom, and pure
+     * luck if it was not. Ramping from the CURRENT breath level means the
+     * brightening reads as one deliberate move into the sweep whatever phase
+     * it was in (Wil, 2026-09-05). */
+    int lo = BREATH_PARKED
+           + breath(still, BREATH_PARKED_MS) * (SUB - BREATH_PARKED) / SUB;
+    for (int v = lo; v < SUB; v += 24) {
+        for (int p = 0; p < LED_N; p++)
+            memcpy(f[p], C_ORBIT, 3);
+        blend(head, C_ORBIT, C_HEAD, v);
+        memcpy(f[0], head, 3);
+        memcpy(f[LED_N - 1], head, 3);
+        led_write(f);
+        usleep(TICK_MS * 1000);
+    }
 
     /* Both sides, bottom to top.
      *
@@ -526,7 +586,7 @@ static void anim_handover(void)
 
 static void anim_main(void)
 {
-    int head_q = 0, tick = 0;
+    int head_q = 0, still = 0;
 
     anim_claim();
     anim_handover();
@@ -540,13 +600,20 @@ static void anim_main(void)
             _exit(0);
         }
         if (mode == ANIM_FINISH) {
-            anim_finale();
+            anim_finale(still);
             ledst->mode = ANIM_DONE;
             _exit(0);
         }
-        if (mode != ANIM_FAIL)
+        if (mode != ANIM_FAIL) {
+            int was = head_q;
             head_q = head_advance(head_q, ledst->stage);
-        anim_render(head_q, tick++, mode == ANIM_FAIL, 1);
+            /* Visually stationary, not arithmetically: the ease decelerates to
+             * a crawl of one unit a tick, which is 1/256 of a segment and
+             * changes no pixel. Treating that as movement would suppress the
+             * throb for seconds while nothing appeared to happen. */
+            still = (head_q - was >= SUB / 32) ? 0 : still + 1;
+        }
+        anim_render(head_q, still, mode == ANIM_FAIL, 1);
         usleep(TICK_MS * 1000);
     }
 }

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -397,26 +397,24 @@ static int orbit_head_pos(void)
 /* Boot complete: close the ring, fill both sides from the bottom to the top,
  * take it to full and then take it away. The fade hands the LEDs back, so
  * anything shown afterwards is the firmware's to explain. */
-static void anim_finale(int head_q, int tick)
+static void anim_finale(void)
 {
     unsigned char f[LED_N][3];
 
-    while (head_q < LED_N * SUB) {
-        int step = (LED_N * SUB - head_q) / 6;
-        if (step < 3)
-            step = 3;
-        head_q += step;
-        if (head_q > LED_N * SUB)
-            head_q = LED_N * SUB;
-        anim_render(head_q, tick++, 0, 1);
-        usleep(TICK_MS * 1000);
-    }
-
-    /* Both sides, bottom to top. There is no LED at dead bottom — twelve at
-     * 30° leaves the bottom BETWEEN two of them, position 0 sitting just left
-     * of centre — so the arms are the pairs either side of that gap, (0,11),
-     * (1,10) … meeting at the top between 5 and 6. Starting from a single LED
-     * would put the seam a half-segment off and lean the whole figure. */
+    /* Both sides, bottom to top.
+     *
+     * Numbering the ring 1-12 the way it physically sits: 1 is just left of 6
+     * o'clock, 6 just left of 12 o'clock, 7 just right of 12 o'clock, 12 just
+     * right of 6 o'clock. So there is no LED at dead bottom or dead top —
+     * there is a GAP at each — and the balanced arms are the pairs either side
+     * of the bottom gap: (1,12), (2,11) … meeting at the top gap between 6 and
+     * 7. Zero-indexed here, so (0,11) up to (5,6).
+     *
+     * The progress head finishes on LED 12. This lights LED 1 alongside it
+     * rather than TRAVELLING the head across the bottom gap to reach it, which
+     * is what the first version did: that read as the head overshooting, and
+     * started the sweep off balance (Wil, 2026-09-05).
+     */
     for (int s = 0; s < LED_N / 2; s++) {
         for (int p = 0; p < LED_N; p++)
             memcpy(f[p], C_ORBIT, 3);
@@ -517,7 +515,7 @@ static void anim_main(void)
             _exit(0);
         }
         if (mode == ANIM_FINISH) {
-            anim_finale(head_q, tick);
+            anim_finale();
             ledst->mode = ANIM_DONE;
             _exit(0);
         }

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -409,20 +409,39 @@ static void anim_finale(int head_q, int tick)
 
 /* The animator. Owns the ring for as long as it lives; reads the stage the
  * parent has reached and never writes it. */
-static void anim_main(int start_pos)
+/* Take the ring off the kernel, choosing WHEN rather than accepting wherever
+ * the orbit happens to be.
+ *
+ * The animation runs until userspace stops it, so the moment is ours to pick:
+ * wait for the orbit's head to reach the bottom and stop it exactly there.
+ * Our head then starts where its head was, and the handover has nothing to
+ * reconcile — no jump, and no winding the head round to the bottom afterwards,
+ * which is what this replaces.
+ *
+ * It costs nothing, because it happens in the animator child while init gets
+ * on with mounting /system. Bounded a little past one revolution so a ring we
+ * cannot read is a plain takeover rather than a hang, and polled well inside
+ * the 109ms step so the bottom is not missed.
+ */
+static void anim_claim(void)
 {
-    int head_q = 0, tick = 0, winding = 0;
-
-    /* Carry the orbit on from wherever it had reached, at its own measured
-     * rate, until the head comes round to the bottom — then progress takes
-     * over from there. At most one lap, so 1.31s, spent while /system mounts
-     * and fsck runs. The one difference is that this glides where the kernel
-     * stepped a whole LED at a time; it is the same movement at the same rate,
-     * and the smoothing is the point rather than an accident. */
-    if (start_pos > 0) {
-        head_q = start_pos * SUB;
-        winding = 1;
+    for (int i = 0; i < 100; i++) {
+        int p = orbit_head_pos();
+        if (p <= 0)              /* at the bottom, or not an orbit we can read */
+            break;
+        usleep(20000);
     }
+    int fd = open(LEDDIR "/boot_animation", O_WRONLY);
+    if (fd >= 0) { write(fd, "0", 1); close(fd); }
+    fd = open(LEDDIR "/led_current", O_WRONLY);
+    if (fd >= 0) { write(fd, "3", 1); close(fd); }
+}
+
+static void anim_main(void)
+{
+    int head_q = 0, tick = 0;
+
+    anim_claim();
 
     for (;;) {
         int mode = ledst->mode;
@@ -437,18 +456,6 @@ static void anim_main(int start_pos)
             ledst->mode = ANIM_DONE;
             _exit(0);
         }
-        if (winding && mode == ANIM_RUN) {
-            head_q += SUB * TICK_MS / ORBIT_STEP_MS;
-            if (head_q >= LED_N * SUB) {
-                head_q = 0;
-                winding = 0;
-            }
-            anim_render(head_q, tick++, 0, 0);
-            usleep(TICK_MS * 1000);
-            continue;
-        }
-        winding = 0;      /* a failure or a finish ends the wind-in early */
-
         if (mode != ANIM_FAIL) {
             int stage = ledst->stage;
             if (stage > LED_N)
@@ -503,22 +510,14 @@ static void orbit_probe(void)
 #endif
 }
 
-/* Take the ring off the kernel's animation, set the drive current, and start
- * the animator. */
+/* Start the animator. It claims the ring itself — see anim_claim. */
 static void led_claim(void)
 {
     orbit_probe();
+    note("orbit head at %d\n", orbit_head_pos());
 
-    /* Read where the orbit is BEFORE stopping it — the frame keeps its last
-     * contents afterwards, but reading it live is the honest moment. */
-    int start_pos = orbit_head_pos();
-    note("orbit head at %d\n", start_pos);
-
-    int fd = open(LEDDIR "/boot_animation", O_WRONLY);
-    if (fd >= 0) { write(fd, "0", 1); close(fd); }
-    fd = open(LEDDIR "/led_current", O_WRONLY);
-    if (fd >= 0) { write(fd, "3", 1); close(fd); }
-
+    /* The ring is NOT stopped here. anim_claim does it, in the child, once the
+     * orbit reaches the bottom — so init is not held up waiting for it. */
     ledst = mmap(NULL, sizeof *ledst, PROT_READ | PROT_WRITE,
                  MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     if (ledst == MAP_FAILED) {
@@ -531,7 +530,7 @@ static void led_claim(void)
 
     led_pid = fork();
     if (led_pid == 0) {
-        anim_main(start_pos);
+        anim_main();
         _exit(0);
     }
 }

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -175,7 +175,15 @@ static long mono_ms(void);
  * the GAP between positions 0 and 11, and the finale's arms are the pairs
  * either side of it.
  */
-#define LED_BOTTOM 0        /* physical index of the LED at the bottom */
+/* Physical index of logical 0 — the LED just left of 6 o'clock, which is
+ * position 1 when the ring is numbered 1-12 the way it physically sits.
+ *
+ * It was 0, and that was one LED out: the takeover landed on position 2 rather
+ * than position 1, and every arm of the closing sweep was rotated with it, so
+ * the two sides met right of 12 o'clock instead of across it. Confirmed from
+ * the device — the kernel starts its orbit on physical 0, which is seen as
+ * position 2 (Wil, from video, 2026-09-05). */
+#define LED_BOTTOM 11
 #define LED_DIR    1        /* +1: the orbit runs on rising physical index */
 #define ORBIT_STEP_MS 109   /* measured; the wind-in matches this exactly */
 #define ORBIT_PROBE 1       /* sample the kernel's frames before claiming */
@@ -353,6 +361,14 @@ static void anim_render(int head_q, int tick, int failed, int trail)
     blend(f[near % LED_N], f[near % LED_N], head, SUB);
     if (glow)
         blend(f[far % LED_N], f[far % LED_N], head, glow);
+
+    /* Once the head reaches the last segment, the FIRST one lights with it and
+     * the pair closes the ring across the bottom gap, breathing together until
+     * the boot finishes. That wait is real and long — association and DHCP are
+     * most of the boot — so it wants something deliberate rather than a head
+     * sitting on its own. */
+    if (trail && head_q >= (LED_N - 1) * SUB)
+        blend(f[0], f[0], head, SUB);
     led_write(f);
 }
 
@@ -415,10 +431,15 @@ static void anim_finale(void)
      * is what the first version did: that read as the head overshooting, and
      * started the sweep off balance (Wil, 2026-09-05).
      */
-    for (int s = 0; s < LED_N / 2; s++) {
+    for (int s = 1; s < LED_N / 2; s++) {
         for (int p = 0; p < LED_N; p++)
             memcpy(f[p], C_ORBIT, 3);
-        for (int k = 0; k <= s; k++) {
+        /* 1 and 12 are already lit — the run ended on them — so the sweep
+         * ADDS to that pair rather than starting from it: 2,11 then 3,10,
+         * 4,9, 5,8 and finally 6,7 closing across 12 o'clock. */
+        memcpy(f[0], C_HEAD, 3);
+        memcpy(f[LED_N - 1], C_HEAD, 3);
+        for (int k = 1; k <= s; k++) {
             memcpy(f[k], C_HEAD, 3);
             memcpy(f[LED_N - 1 - k], C_HEAD, 3);
         }
@@ -462,7 +483,11 @@ static void anim_claim(void)
 {
     for (int i = 0; i < 100; i++) {
         int p = orbit_head_pos();
-        if (p <= 0)              /* at the bottom, or not an orbit we can read */
+        /* Position 12 — the LAST segment, not the first. Taking it there means
+         * our very next act is lighting position 1, which is the step the
+         * orbit would have taken anyway, so the motion carries straight on
+         * instead of repeating a position or starting a step late. */
+        if (p < 0 || p == LED_N - 1)
             break;
         usleep(20000);
     }

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -29,11 +29,13 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/mount.h>
+#include <sys/reboot.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <sys/wait.h>
 #include <termios.h>
+#include <time.h>
 #include <unistd.h>
 
 #define CACHE     "/dev/block/mmcblk0p15"
@@ -90,6 +92,65 @@ static const struct node nodes[] = {
     { "/dev/wmtWifi",   153, 0 },
     { "/dev/stpbt",     192, 0 },
 };
+
+/* ── The boot progress ring ──────────────────────────────────────────────────
+ *
+ * The twelve-LED ring is an is31fl3236 at i2c-0 0x3f, driven by writing 12
+ * RGB triplets as ASCII hex to its `frame` attribute — the same interface the
+ * firmware's LED binding uses, so nothing here is a new mechanism.
+ *
+ * Until userspace clears `boot_animation` the kernel driver runs its own
+ * orbiting animation on these LEDs, which tells the user nothing about whether
+ * the boot is progressing, stuck or dead — and fights any frame we write. So
+ * the ring is claimed as the FIRST thing init does, before any step that can
+ * fail, and one LED is lit per stage completed.
+ *
+ * That turns the single most opaque part of this device into a progress bar:
+ * a boot that stops at six LEDs stops in a knowable place, on hardware whose
+ * only other diagnostic channel is a raw partition read from recovery.
+ */
+#define LEDDIR "/sys/devices/soc/11007000.i2c/i2c-0/0-003f"
+#define LED_N  12
+
+static int bootstep;
+
+static void led_frame(int lit, int r, int g, int b)
+{
+    char f[LED_N * 6 + 1];
+    for (int i = 0; i < LED_N; i++)
+        snprintf(f + i * 6, 7, "%02X%02X%02X",
+                 i < lit ? r : 0, i < lit ? g : 0, i < lit ? b : 0);
+    int fd = open(LEDDIR "/frame", O_WRONLY);
+    if (fd < 0)
+        return;
+    write(fd, f, LED_N * 6);
+    close(fd);
+}
+
+/* Take the ring off the kernel's animation and set the drive current. */
+static void led_claim(void)
+{
+    int fd = open(LEDDIR "/boot_animation", O_WRONLY);
+    if (fd >= 0) { write(fd, "0", 1); close(fd); }
+    fd = open(LEDDIR "/led_current", O_WRONLY);
+    if (fd >= 0) { write(fd, "3", 1); close(fd); }
+    led_frame(0, 0, 0, 0);
+}
+
+/* One more stage done. Blue while booting; the net stage finishes in green. */
+static void led_step(void)
+{
+    if (bootstep < LED_N)
+        bootstep++;
+    led_frame(bootstep, 0x00, 0x30, 0xFF);
+}
+
+/* A stage that failed leaves the ring red at the point it reached, so a dead
+ * device says WHERE it died without a cable. */
+static void led_fail(void)
+{
+    led_frame(bootstep + 1, 0xFF, 0x00, 0x00);
+}
 
 static char trail[3072];
 static size_t trail_len;
@@ -207,6 +268,59 @@ static int has_ip(const char *name)
     return r == 0;
 }
 
+/* Run one command to completion and return its exit status. */
+static int run_wait(char *const argv[])
+{
+    int st = 0;
+    pid_t p = spawn(argv);
+    if (p < 0)
+        return -1;
+    waitpid(p, &st, 0);
+    return st;
+}
+
+/* Write /etc/resolv.conf pointing at the default gateway.
+ *
+ * The device has NO working DNS otherwise: FireOS keeps resolvers in Android
+ * properties rather than a file, there is no /system/etc/resolv.conf at all,
+ * and dhcpcd's "could not set property" lines are it failing to publish them
+ * to a property service we do not run. Nothing noticed for a long time because
+ * EchoMuse finds its controller over mDNS and connects by IP.
+ *
+ * The gateway is an ASSUMPTION, not a lease value: parsing dhcpcd's binary
+ * lease would be the correct source, and on the overwhelming majority of home
+ * networks the router that served DHCP is also the resolver. Stated here so
+ * that whoever hits the exception knows exactly which line lied to them.
+ */
+static char gwip[32];
+
+static void write_resolv_conf(void)
+{
+    FILE *f = fopen("/proc/net/route", "r");
+    if (!f)
+        return;
+    char line[256], iface[32];
+    unsigned dest, gw;
+    while (fgets(line, sizeof line, f)) {
+        if (sscanf(line, "%31s %x %x", iface, &dest, &gw) == 3 && dest == 0 && gw) {
+            snprintf(gwip, sizeof gwip, "%u.%u.%u.%u",
+                     gw & 0xff, (gw >> 8) & 0xff, (gw >> 16) & 0xff, (gw >> 24) & 0xff);
+            break;
+        }
+    }
+    fclose(f);
+    if (!gwip[0])
+        return;
+    int fd = open("/etc/resolv.conf", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0)
+        return;
+    char buf[64];
+    int n = snprintf(buf, sizeof buf, "nameserver %s\n", gwip);
+    write(fd, buf, n);
+    close(fd);
+    netlog("resolv.conf nameserver %s\n", gwip);
+}
+
 static int ifup(const char *name)
 {
     struct ifreq ifr;
@@ -272,6 +386,7 @@ static void net_main(void)
     r = ifup("wlan0");
     netlog("wlan0 present=%d ifup=%d\n",
          access("/sys/class/net/wlan0", F_OK) == 0, r);
+    bootstep = 10; led_step();                   /* 10: wlan0 exists */
 
     /* Supervise, driven by wlan0's carrier rather than by a fixed sequence.
      *
@@ -294,9 +409,25 @@ static void net_main(void)
      */
     char *reassoc[] = { "/system/bin/wpa_cli", "-p/data/misc/wifi/sockets",
                         "-iwlan0", "reassociate", NULL };
+    /* ntpd is pointed at the GATEWAY by IP, never at a hostname.
+     *
+     * bionic resolves DNS through Android's property service, not
+     * /etc/resolv.conf, so a bionic-linked binary has no working resolver on a
+     * device with no property service — busybox ntpd fails "bad address
+     * pool.ntp.org" however correct that file is. (Our Go firmware is fine: Go
+     * carries its own resolver and does read the file.)
+     *
+     * The gateway is the best available guess at a reachable time source and
+     * many home routers serve NTP; where it does not, the clock stays wrong
+     * and says so in this log rather than silently half-working.
+     *
+     * Client only. busybox ntpd SERVES time if given -l, and emOS holds no
+     * inbound sockets at all — every daemon added here has to keep it that way.
+     */
+    char *ntpd[] = { "/system/bin/busybox", "ntpd", "-n", "-p", gwip, NULL };
     pid_t wpa = spawn(supp);
-    pid_t dhc = -1;
-    int nudges = 0, dry = 0;
+    pid_t dhc = -1, ntp = -1;
+    int nudges = 0, dry = 0, netup = 0;
 
     for (;;) {
         pid_t d;
@@ -304,6 +435,7 @@ static void net_main(void)
             if (d == launcher)   launcher = spawn(launch);
             else if (d == wpa)   wpa = spawn(supp);
             else if (d == dhc)   dhc = -1;
+            else if (d == ntp)   ntp = netup ? spawn(ntpd) : -1;
         }
 
         if (readint("/sys/class/net/wlan0/carrier") != 1) {
@@ -311,6 +443,7 @@ static void net_main(void)
                 kill(dhc, SIGTERM);
             if (nudges++ % 3 == 0)
                 spawn(reassoc);
+            bootstep = 10; led_step();           /* 11: associating */
             dry = 0;
         } else {
             nudges = 0;
@@ -319,6 +452,26 @@ static void net_main(void)
                 dry = 0;
             } else if (has_ip("wlan0")) {
                 dry = 0;
+                /* First address of this boot: DNS, then the clock.
+                 *
+                 * ntpd is CLIENT-ONLY and must stay that way — busybox ntpd
+                 * serves time if given -l, and emOS listens on nothing. The
+                 * device holds no inbound sockets at all (verified with
+                 * netstat: zero TCP and zero UDP listeners), and every daemon
+                 * added here has to preserve that.
+                 *
+                 * -q would set the clock once and exit, which loses it again
+                 * on the next drift; -n keeps it in the foreground so the
+                 * supervisor above owns its lifetime like everything else.
+                 */
+                if (!netup) {
+                    netup = 1;
+                    /* Fully up: the whole ring goes green and stays there
+                     * until the firmware claims it. */
+                    led_frame(LED_N, 0x00, 0xFF, 0x00);
+                    write_resolv_conf();
+                    ntp = spawn(ntpd);
+                }
             } else if (++dry >= 4) {
                 kill(dhc, SIGTERM);
                 dry = 0;
@@ -336,6 +489,10 @@ static void rdstate(const char *tag)
     for (char *c = st; *c; c++) if (*c == '\n') *c = 0;
     note("%s state=%s\n", tag, st);
 }
+
+/* Defined below, with the supervision machinery. */
+static void svc_add(const char *name, char *const *argv);
+static void supervise(void);
 
 int main(void)
 {
@@ -365,6 +522,13 @@ int main(void)
      * 247:0 is ttyGS0, read off a running FireOS device rather than guessed.
      */
     mknod(CACHE, S_IFBLK | 0600, makedev(179, 15));
+    /* boot_a_x, so emOS can reflash itself over the network: the device has
+     * curl, busybox and dd, which turns a flash cycle from a TWRP trip into
+     * about thirty seconds. It is also the recovery target, so verify any
+     * write to it by dropping caches and reading BACK — a dd here can complete
+     * at page-cache speed, verify against that same cache, and be lost on the
+     * next reboot. Real writes to this eMMC run at about 9MB/s. */
+    mknod("/dev/block/mmcblk0p10", S_IFBLK | 0600, makedev(179, 10));
     mknod("/dev/null",    S_IFCHR | 0666, makedev(1, 3));
     mknod("/dev/zero",    S_IFCHR | 0666, makedev(1, 5));
     mknod("/dev/tty",     S_IFCHR | 0666, makedev(5, 0));
@@ -392,6 +556,8 @@ int main(void)
         if (n > 0) write_at(512, buf, n);
     }
     note("stage=mounts done devtmpfs_rc=%d tty=%d\n", dtr, access(TTY, F_OK));
+    led_claim();
+    led_step();                                  /* 1: mounts and device nodes */
 
     /* /system read-only: this is a diagnostic boot and nothing here should be
      * able to damage the Android install we still rely on for recovery. */
@@ -400,20 +566,95 @@ int main(void)
     int r = mount("/dev/block/mmcblk0p13", "/system", "ext4", MS_RDONLY, NULL);
     note("stage=mount_system rc=%d errno=%d sh=%d\n", r, r ? errno : 0,
          access("/system/bin/sh", X_OK));
+    if (r) led_fail(); else led_step();          /* 2: /system */
 
     /* /data read-WRITE: the firmware keeps config, wake-word models and logs
      * there. /system stays read-only — nothing here should be able to damage
      * the Android install we still rely on for recovery. */
     mkdir("/data", 0755);
     mknod("/dev/block/mmcblk0p16", S_IFBLK | 0600, makedev(179, 16));
+
+    /* Check /data before mounting it read-write.
+     *
+     * This is the one partition emOS writes, and the one whose loss a remote
+     * user cannot recover from. e2fsck is on /system (which is already mounted
+     * by this point, read-only, so it is safe to run from). -p is preen mode:
+     * fix only what is unambiguously safe and never ask a question, because
+     * there is nobody at the console to answer one. Anything needing a real
+     * decision is left alone and shows up in the trail.
+     */
+    char *fsck[] = { "/system/bin/e2fsck", "-p", "/dev/block/mmcblk0p16", NULL };
+    int fs = run_wait(fsck);
+    note("stage=fsck_data status=%d\n", fs);
+    led_step();                                  /* 3: fsck /data */
+
     r = mount("/dev/block/mmcblk0p16", "/data", "ext4", 0, NULL);
     note("stage=mount_data rc=%d errno=%d\n", r, r ? errno : 0);
+    if (r) led_fail(); else led_step();          /* 4: /data */
 
     /* Android's own root has these two symlinks and a surprising amount of
      * /system depends on them — the kernel firmware loader most of all, which
      * is what kept wlan0 from ever appearing. */
-    symlink("/system/etc", "/etc");
+    /* /etc is a real directory of symlinks, NOT a symlink to /system/etc.
+     *
+     * Android's root symlinks it, and copying that costs the system a writable
+     * /etc, because /system is mounted read-only and must stay that way. The
+     * casualty is resolv.conf: FireOS keeps resolvers in properties and ships
+     * no /system/etc/resolv.conf at all, so a symlinked /etc means the device
+     * can never have working DNS. A symlink farm gives every /system/etc entry
+     * at its expected path AND room to add our own files beside them.
+     *
+     * /vendor stays a plain symlink — nothing needs to write there.
+     */
+    mkdir("/etc", 0755);
     symlink("/system/vendor", "/vendor");
+    DIR *ed = opendir("/system/etc");
+    if (ed) {
+        struct dirent *de;
+        while ((de = readdir(ed))) {
+            if (de->d_name[0] == '.')
+                continue;
+            char src[512], dst[512];
+            snprintf(src, sizeof src, "/system/etc/%s", de->d_name);
+            snprintf(dst, sizeof dst, "/etc/%s", de->d_name);
+            symlink(src, dst);
+        }
+        closedir(ed);
+    }
+    note("stage=etc farm=%d\n", access("/etc/dhcpcd", F_OK) == 0);
+    led_step();                                  /* 5: /etc */
+
+    /* Preserve the previous boot's kernel log.
+     *
+     * MediaTek's ram_console publishes it at /proc/last_kmsg across a warm
+     * reset, and it is the ONLY channel this device has for a crash: there is
+     * no pstore on this kernel, and a fault that takes the box down leaves
+     * nothing in any userspace log. It was what root-caused a spontaneous
+     * reboot to a kernel data abort in the audio IRQ handler — but only
+     * because someone happened to read it within two minutes, since the NEXT
+     * reboot overwrites it. Copying it here means every crash survives for
+     * whoever asks about it later, including a user on the other side of the
+     * world who has since rebooted twice.
+     */
+    mkdir("/data/emos", 0755);
+    int lk = open("/proc/last_kmsg", O_RDONLY);
+    if (lk >= 0) {
+        int out = open("/data/emos/last_kmsg.prev", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        long long copied = 0;
+        if (out >= 0) {
+            char b[8192];
+            int n;
+            while ((n = read(lk, b, sizeof b)) > 0) {
+                if (write(out, b, n) != n)
+                    break;
+                copied += n;
+            }
+            close(out);
+        }
+        close(lk);
+        note("stage=last_kmsg bytes=%lld\n", copied);
+    led_step();                                  /* 6: previous kernel log kept */
+    }
 
     /* Put busybox's applets on PATH.
      *
@@ -444,6 +685,7 @@ int main(void)
     int lst = 0;
     waitpid(spawn(link), &lst, 0);
     note("stage=applets status=%d vi=%d\n", lst, access("/sbin/vi", X_OK));
+    led_step();                                  /* 7: busybox applets */
 
     /* Device mode: cmode 2 is charging-only, cmode 1 is device. */
     r = wr("/sys/devices/platform/mt_usb/cmode", "1");
@@ -456,55 +698,167 @@ int main(void)
     usbwr("functions", "acm");
     usbwr("bDeviceClass", "02");
     usbwr("enable", "1");
+    led_step();                                  /* 8: USB gadget */
 
     for (int i = 0; i < 15; i++) {
         sleep(1);
         char tag[32];
         snprintf(tag, sizeof tag, "wait=%d tty=%d", i, access(TTY, F_OK));
         rdstate(tag);
-        if (access(TTY, F_OK) == 0)
+        if (access(TTY, F_OK) == 0) {
+            led_step();                              /* 9: console */
             break;
+        }
     }
 
-    /* WiFi runs in its own process: the wmtWifi write blocks for ~13s and the
-     * daemons behind it need supervising, neither of which should hold up the
-     * console. */
-    pid_t net = fork();
-    if (net == 0) {
-        net_main();
-        _exit(0);
-    }
-    netlog("stage started pid=%d\n", (int)net);
+    /* WiFi is a supervised service like everything else — see svc_add below.
+     * It is NOT forked here.
+     *
+     * It was, once, and the leftover fork survived the move to the supervisor,
+     * so two WiFi stages ran concurrently: two wmt_loaders, two 6620_launchers
+     * and two `echo 1 > /dev/wmtWifi` power-ons racing each other on the
+     * MediaTek combo chip. The device crash-boot-looped. That is the same
+     * subsystem whose firmware assert took a kernel down on 2026-09-04, so
+     * racing its power-on is not a small thing to get wrong.
+     */
 
-    /* A console that exits once because the host had not attached yet is
-     * indistinguishable from one that never worked, so respawn. */
-    for (int gen = 0;; gen++) {
-        int t = open(TTY, O_RDWR | O_NOCTTY);
-        if (t < 0) {
-            if (gen % 30 == 0)
-                note("open %s failed errno=%d\n", TTY, errno);
-            sleep(2);
-            continue;
+    /* Local logging. Both of these are LOCAL ONLY and must stay that way:
+     * busybox syslogd forwards to a remote host with -R and listens with -R
+     * plus -L, and emOS holds no inbound sockets at all. klogd feeds the
+     * kernel ring into the same file so a userspace fault and the kernel
+     * message that explains it land in one timestamped stream. */
+    char *syslogd[] = { "/system/bin/busybox", "syslogd", "-n",
+                        "-O", "/data/emos/messages", "-s", "512", "-b", "3", NULL };
+    char *klogd[]   = { "/system/bin/busybox", "klogd", "-n", NULL };
+
+    svc_add("net", NULL);          /* forked in-process, see below */
+    svc_add("syslogd", syslogd);
+    svc_add("klogd", klogd);
+    svc_add("console", NULL);      /* needs the tty as its stdio */
+
+    supervise();
+    return 0;
+}
+
+/* ── Supervision ─────────────────────────────────────────────────────────────
+ *
+ * PID 1 has three jobs and the first version of this init did only one of
+ * them: it supervised a console, never reaped orphans (so anything that
+ * reparented to init became a permanent zombie), and had no shutdown path at
+ * all — reboots went through `reboot -f`, which leaves /data mounted
+ * read-write with unflushed writes. ext4's journal covered for that, but a
+ * corrupted /data is precisely the failure a remote user cannot recover from.
+ */
+
+#define MAX_SVC 8
+struct svc {
+    const char  *name;
+    char *const *argv;   /* NULL for the two services started specially */
+    pid_t        pid;
+    time_t       started;
+};
+static struct svc svcs[MAX_SVC];
+static int nsvc;
+
+static volatile sig_atomic_t want_shutdown;
+
+static void on_term(int sig) { (void)sig; want_shutdown = 1; }
+
+static void svc_add(const char *name, char *const *argv)
+{
+    if (nsvc < MAX_SVC)
+        svcs[nsvc++] = (struct svc){ .name = name, .argv = argv, .pid = -1 };
+}
+
+/* The console is the one service that needs a controlling terminal, and it
+ * cannot be started until the host has attached to the ACM gadget. A console
+ * that exits once because nobody was listening yet is indistinguishable from
+ * one that never worked, which is why it is respawned rather than run once. */
+static pid_t start_console(void)
+{
+    int t = open(TTY, O_RDWR | O_NOCTTY);
+    if (t < 0)
+        return -1;
+    pid_t pid = fork();
+    if (pid == 0) {
+        setsid();
+        ioctl(t, TIOCSCTTY, 1);
+        dup2(t, 0); dup2(t, 1); dup2(t, 2);
+        if (t > 2) close(t);
+        char *argv[] = { "/system/bin/sh", NULL };
+        char *envp[] = { "HOME=/", "TERM=vt100", "ANDROID_ROOT=/system",
+                         "PATH=/sbin:/system/bin:/system/xbin", NULL };
+        execve("/system/bin/sh", argv, envp);
+        _exit(127);
+    }
+    close(t);
+    return pid;
+}
+
+/* Stop everything, flush, and let the kernel reset.
+ *
+ * Order matters and none of it is optional: SIGTERM first so daemons can
+ * close their files, a bounded wait rather than an unbounded one (a service
+ * that will not die must not hang the reboot forever), then sync twice and
+ * remount /data read-only. The remount is the step that actually protects the
+ * filesystem — sync alone leaves the journal open.
+ */
+static void do_shutdown(void)
+{
+    note("stage=shutdown\n");
+    for (int i = 0; i < nsvc; i++)
+        if (svcs[i].pid > 0)
+            kill(svcs[i].pid, SIGTERM);
+    for (int i = 0; i < 50; i++) {          /* up to 5s */
+        if (waitpid(-1, NULL, WNOHANG) <= 0 && errno == ECHILD)
+            break;
+        usleep(100000);
+    }
+    kill(-1, SIGKILL);
+    sync();
+    sync();
+    mount(NULL, "/data", NULL, MS_REMOUNT | MS_RDONLY, NULL);
+    note("stage=shutdown done\n");
+    sync();
+    reboot(RB_AUTOBOOT);
+}
+
+static void supervise(void)
+{
+    signal(SIGTERM, on_term);
+    signal(SIGINT, on_term);
+
+    for (;;) {
+        if (want_shutdown)
+            do_shutdown();
+
+        /* Reap EVERYTHING, not just our own services: orphans reparent to PID
+         * 1 and nobody else will ever collect them. */
+        int st;
+        pid_t d;
+        while ((d = waitpid(-1, &st, WNOHANG)) > 0)
+            for (int i = 0; i < nsvc; i++)
+                if (svcs[i].pid == d)
+                    svcs[i].pid = -1;
+
+        time_t now = time(NULL);
+        for (int i = 0; i < nsvc; i++) {
+            struct svc *s = &svcs[i];
+            if (s->pid > 0)
+                continue;
+            /* Backoff, so a service that dies instantly cannot spin PID 1. */
+            if (now - s->started < 2)
+                continue;
+            s->started = now;
+            if (!strcmp(s->name, "console"))
+                s->pid = start_console();
+            else if (!strcmp(s->name, "net")) {
+                pid_t p = fork();
+                if (p == 0) { net_main(); _exit(0); }
+                s->pid = p;
+            } else
+                s->pid = spawn(s->argv);
         }
-        pid_t pid = fork();
-        if (pid == 0) {
-            setsid();
-            ioctl(t, TIOCSCTTY, 1);
-            dup2(t, 0); dup2(t, 1); dup2(t, 2);
-            if (t > 2) close(t);
-            char *argv[] = { "/system/bin/sh", NULL };
-            char *envp[] = { "HOME=/", "TERM=vt100",
-                             "PATH=/sbin:/system/bin:/system/xbin", NULL };
-            execve("/system/bin/sh", argv, envp);
-            _exit(127);
-        }
-        close(t);
-        if (gen < 3)
-            note("shell started gen=%d pid=%d\n", gen, (int)pid);
-        int st = 0;
-        waitpid(pid, &st, 0);
-        if (gen < 3)
-            note("shell exited gen=%d status=%d\n", gen, st);
         sleep(1);
     }
 }

--- a/emos/init/pwcheck.c
+++ b/emos/init/pwcheck.c
@@ -1,0 +1,56 @@
+/* Prove init.c's SHA-256 and password folding agree with the controller's.
+ *
+ * The two implementations are written in different languages by different
+ * hands and can only be known to match by hashing the same inputs. If they
+ * drift, the device refuses a password the dashboard just told it to accept,
+ * and NOTHING else in either tree notices — the failure surfaces as "the
+ * console won't let me in" on hardware, which is the worst place to find it.
+ *
+ * init.c is included whole, the same trick ringsim.c uses, so this drives the
+ * real functions rather than a copy of them.
+ *
+ *   cc -O2 -o pwcheck pwcheck.c && ./pwcheck
+ *
+ * It prints `<iterations>:<salt hex>:<hash hex>` records that
+ * controller/tests/test_console_pw.py must reproduce exactly.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define LEDDIR "/tmp/emos-pwcheck"
+#define main   init_main_unused
+
+#include "init.c"
+
+#undef main
+
+static void emit(const char *pw, const char *salthex, long iters)
+{
+    unsigned char salt[32], out[32];
+    int saltlen = unhex(salthex, salt, sizeof salt);
+    if (saltlen <= 0) {
+        printf("BAD SALT %s\n", salthex);
+        return;
+    }
+    pw_hash(salt, saltlen, pw, iters, out);
+    printf("%ld:%s:", iters, salthex);
+    for (int i = 0; i < 32; i++)
+        printf("%02x", out[i]);
+    printf("\n");
+}
+
+int main(void)
+{
+    /* Same inputs as KNOWN_VECTORS in controller/tests/test_console_pw.py.
+     * Low iteration counts on purpose: a mistake in the LOOP shows up here
+     * rather than being buried under a hundred thousand identical rounds. */
+    emit("hunter2", "0001020304050607", 1);
+    emit("hunter2", "0001020304050607", 2);
+    emit("pw",      "aabbccdd00112233", 3);
+    /* One at the real count, to confirm the loop is not quietly quadratic or
+     * capped somewhere. */
+    emit("correct horse battery staple", "0f1e2d3c4b5a6978", 100000);
+    return 0;
+}

--- a/emos/init/pwcheck.c
+++ b/emos/init/pwcheck.c
@@ -35,7 +35,13 @@ static void emit(const char *pw, const char *salthex, long iters)
         return;
     }
     pw_hash(salt, saltlen, pw, iters, out);
-    printf("%ld:%s:", iters, salthex);
+    /* The password leads the line, tab-separated, so a reader has every input
+     * that produced the record and can recompute it without being told what
+     * the inputs were. CI does exactly that: without this field the checker
+     * would need its own copy of the table below, which is the drift this
+     * file exists to catch rather than commit. A password may contain spaces,
+     * so the separator is a tab. */
+    printf("%s\t%ld:%s:", pw, iters, salthex);
     for (int i = 0; i < 32; i++)
         printf("%02x", out[i]);
     printf("\n");

--- a/emos/init/ringsim.c
+++ b/emos/init/ringsim.c
@@ -1,0 +1,230 @@
+/* Render the boot ring off-target, so the animation can be judged and its
+ * invariants checked without flashing a device.
+ *
+ * The ring is the one part of emOS whose whole purpose is how it LOOKS, and it
+ * appears for thirty seconds on hardware that has to be reflashed to change
+ * it. So it is driven here instead: init.c is included whole — the animation
+ * functions are static — with LEDDIR pointed at a temp file and main renamed.
+ * Nothing is reimplemented, so this cannot drift from what the device runs.
+ *
+ *   cc -O2 -o ringsim ringsim.c && ./ringsim          # frames as text
+ *   ./ringsim --check                                 # invariants only
+ *
+ * Timing is simulated, not slept, so a 30-second boot checks in milliseconds.
+ */
+/* Headers first: init.c's own includes then no-op behind their guards, so the
+ * usleep macro below cannot rewrite unistd.h's prototype. */
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define LEDDIR "/tmp/emos-ringsim"
+#define main   init_main_unused
+#define usleep sim_usleep
+
+static void sim_usleep(unsigned us);
+
+#include "init.c"
+
+#undef main
+#undef usleep
+
+/* Time is simulated rather than slept, and every frame the animation writes is
+ * followed by a sleep — so capturing here catches all of them, including the
+ * finale's, without a hook inside the animation itself. */
+static void capture(void);
+static long sim_now_us;
+static void sim_usleep(unsigned us) { capture(); sim_now_us += us; }
+
+/* ── Capture ────────────────────────────────────────────────────────────────*/
+
+#define MAXFR 20000
+static struct { unsigned char rgb[LED_N][3]; long t; } frames[MAXFR];
+static int nframes;
+
+/* led_write goes to a file; read it back so the check sees exactly the bytes
+ * the driver would. */
+static void capture(void)
+{
+    FILE *f = fopen(LEDDIR "/frame", "rb");
+    if (!f) return;
+    char hex[LED_N * 6 + 1];
+    size_t n = fread(hex, 1, LED_N * 6, f);
+    fclose(f);
+    if (n != LED_N * 6 || nframes >= MAXFR) return;
+    for (int i = 0; i < LED_N; i++) {
+        int p = (LED_BOTTOM + LED_DIR * i) % LED_N;
+        if (p < 0) p += LED_N;
+        unsigned r, g, b;
+        sscanf(hex + p * 6, "%2x%2x%2x", &r, &g, &b);
+        frames[nframes].rgb[i][0] = r;
+        frames[nframes].rgb[i][1] = g;
+        frames[nframes].rgb[i][2] = b;
+    }
+    frames[nframes].t = sim_now_us;
+    nframes++;
+}
+
+/* ── A boot, as it actually runs ────────────────────────────────────────────*/
+
+/* Measured shape of a real boot: most stages are instant, three are not.
+ * Milliseconds spent IN each stage, i.e. before it completes. */
+static const int stage_ms[LED_N] = {
+    120,    /*  1 mounts and device nodes */
+    260,    /*  2 /system                 */
+    4200,   /*  3 fsck /data              — seconds, and silent */
+    340,    /*  4 /data                   */
+    60,     /*  5 /etc                    */
+    40,     /*  6 last_kmsg               */
+    90,     /*  7 busybox applets         */
+    150,    /*  8 USB gadget              */
+    1100,   /*  9 console                 */
+    2600,   /* 10 wlan0 exists            */
+    9000,   /* 11 associating             — the long silent one */
+    900,    /* 12 address                 */
+};
+
+static void run_boot(int fail_at)
+{
+    ledst = calloc(1, sizeof *ledst);
+    ledst->mode = ANIM_RUN;
+    bootstep = 0;
+
+    int head_q = 0, tick = 0;
+    for (int s = 0; s < LED_N; s++) {
+        int ticks = stage_ms[s] / TICK_MS;
+        for (int k = 0; k < ticks; k++) {
+            int stage = ledst->stage;
+            int target = stage * SUB + (stage < LED_N ? CREEP : 0);
+            if (head_q < target) {
+                int step = (target - head_q) / 8;
+                if (step < 1) step = 1;
+                head_q += step;
+                if (head_q > target) head_q = target;
+            }
+            anim_render(head_q, tick++, 0);
+            sim_usleep(TICK_MS * 1000);
+        }
+        if (fail_at == s + 1) {
+            for (int k = 0; k < 30; k++) {
+                anim_render(head_q, tick++, 1);
+                sim_usleep(TICK_MS * 1000);
+            }
+            return;
+        }
+        led_step();
+    }
+    anim_finale(head_q, tick);
+    capture();   /* the finale's last frame is black and has no sleep after it */
+}
+
+/* ── Output ────────────────────────────────────────────────────────────────*/
+
+static const char *ramp = ".:-=+*#%@";
+
+/* Gamma-corrected, because the eye is not linear and neither is an LED at low
+ * drive: a 0x30 blue that computes to 4% of full luminance is plainly visible
+ * on the ring. Rendering the ramp linearly showed the dark blue trail as
+ * blank, which would have had me brightening a trail that is probably fine. */
+static void show(void)
+{
+    for (int i = 0; i < nframes; i++) {
+        printf("%6ldms ", frames[i].t / 1000);
+        for (int p = 0; p < LED_N; p++) {
+            const unsigned char *c = frames[i].rgb[p];
+            int lum = (c[0] * 30 + c[1] * 59 + c[2] * 11) / 100;
+            int red = c[0] > 100 && c[2] < 60;
+            if (!lum) { putchar(' '); continue; }
+            int v = (int)(pow(lum / 255.0, 1 / 2.2) * 8.999);
+            putchar(red ? 'R' : ramp[v]);
+        }
+        printf("\n");
+    }
+}
+
+/* ── Invariants ────────────────────────────────────────────────────────────*/
+
+static int fails;
+static void ck(int ok, const char *what)
+{
+    printf("%-58s %s\n", what, ok ? "ok" : "FAIL");
+    if (!ok) fails++;
+}
+
+/* Position of the head: the brightest segment, in logical order. */
+static int headpos(int i)
+{
+    int best = 0, bl = -1;
+    for (int p = 0; p < LED_N; p++) {
+        const unsigned char *c = frames[i].rgb[p];
+        int lum = c[0] * 30 + c[1] * 59 + c[2] * 11;
+        if (lum > bl) { bl = lum; best = p; }
+    }
+    return best;
+}
+
+static void check_run(void)
+{
+    /* The head must never be still for long: that is the entire design goal,
+     * and the stages it has to survive are fsck (4.2s) and association (9s). */
+    int worst = 0, run = 0;
+    for (int i = 1; i < nframes; i++) {
+        if (memcmp(frames[i].rgb, frames[i - 1].rgb, sizeof frames[i].rgb) == 0)
+            run++;
+        else
+            run = 0;
+        if (run > worst) worst = run;
+    }
+    printf("longest identical run: %d frames (%dms)\n", worst, worst * TICK_MS);
+    ck(worst * TICK_MS < 400, "ring is never still for 400ms");
+
+    /* Progress is monotonic and never overtakes the boot. */
+    int back = 0;
+    for (int i = 1; i < nframes; i++)
+        if (headpos(i) < headpos(i - 1) && headpos(i - 1) - headpos(i) < LED_N / 2)
+            back++;
+    ck(back == 0, "head never travels backwards");
+
+    /* Everything behind the head is trail, nothing ahead of it is lit. */
+    int ahead = 0;
+    for (int i = 0; i < nframes / 2; i++) {
+        int h = headpos(i);
+        for (int p = h + 2; p < LED_N; p++)
+            if (frames[i].rgb[p][0] | frames[i].rgb[p][1] | frames[i].rgb[p][2])
+                ahead++;
+    }
+    ck(ahead == 0, "nothing lights ahead of the head");
+
+    /* The ring must be handed back dark. A ring left lit is the thing the fade
+     * exists to prevent — anything shown after this is the firmware's. */
+    int lit = 0;
+    for (int p = 0; p < LED_N; p++)
+        lit |= frames[nframes - 1].rgb[p][0] | frames[nframes - 1].rgb[p][1]
+             | frames[nframes - 1].rgb[p][2];
+    ck(!lit, "the ring is handed back dark");
+}
+
+int main(int argc, char **argv)
+{
+    /* led_write opens the frame O_WRONLY with no O_CREAT, which is correct for
+     * a sysfs attribute and means the stand-in has to exist first. It did not,
+     * so the first run of this captured nothing and every check below passed
+     * on an empty array — hence the count assertion. */
+    mkdir(LEDDIR, 0755);
+    close(open(LEDDIR "/frame", O_WRONLY | O_CREAT, 0644));
+
+    int check = argc > 1 && !strcmp(argv[1], "--check");
+    int fail  = argc > 2 ? atoi(argv[2]) : 0;
+
+    run_boot(fail);
+    if (!check) { show(); return 0; }
+
+    printf("frames=%d simulated=%ldms\n\n", nframes, sim_now_us / 1000);
+    ck(nframes > 100, "the animation actually produced frames");
+    check_run();
+    printf("\n%s\n", fails ? "FAILED" : "all ok");
+    return fails ? 1 : 0;
+}

--- a/emos/init/ringsim.c
+++ b/emos/init/ringsim.c
@@ -115,14 +115,7 @@ static void run_boot(int fail_at, int start_pos)
     for (int s = 0; s < LED_N; s++) {
         int ticks = stage_ms[s] / TICK_MS;
         for (int k = 0; k < ticks; k++) {
-            int stage = ledst->stage;
-            int target = stage * SUB + (stage < LED_N ? CREEP : 0);
-            if (head_q < target) {
-                int step = (target - head_q) / 8;
-                if (step < 1) step = 1;
-                head_q += step;
-                if (head_q > target) head_q = target;
-            }
+            head_q = head_advance(head_q, ledst->stage);
             cur_head_q = head_q;
             anim_render(head_q, tick++, 0, 1);
             sim_usleep(TICK_MS * 1000);
@@ -276,7 +269,8 @@ int main(int argc, char **argv)
     run_boot(fail, argc > 3 ? atoi(argv[3]) : 7);
     if (!check) { show(); return 0; }
 
-    printf("frames=%d simulated=%ldms\n\n", nframes, sim_now_us / 1000);
+    printf("frames=%d simulated=%ldms handover_ends=%d boot_ends=%d\n\n",
+           nframes, sim_now_us / 1000, handover_frames, boot_frames);
     ck(nframes > 100, "the animation actually produced frames");
     check_run();
     printf("\n%s\n", fails ? "FAILED" : "all ok");

--- a/emos/init/ringsim.c
+++ b/emos/init/ringsim.c
@@ -42,8 +42,14 @@ static void sim_usleep(unsigned us) { capture(); sim_now_us += us; }
 /* ── Capture ────────────────────────────────────────────────────────────────*/
 
 #define MAXFR 20000
-static struct { unsigned char rgb[LED_N][3]; long t; } frames[MAXFR];
+static struct { unsigned char rgb[LED_N][3]; long t; int head_q; } frames[MAXFR];
 static int nframes;
+static int boot_frames;   /* frames before the finale begins */
+/* The head position the animation was asked to draw, recorded per frame.
+ * Inferring it from brightness works until the head wraps past the top and
+ * the trail covers most of the ring, at which point the brightest segment is
+ * the head sitting at the BOTTOM and every inference from it is inverted. */
+static int cur_head_q;
 
 /* led_write goes to a file; read it back so the check sees exactly the bytes
  * the driver would. */
@@ -65,6 +71,7 @@ static void capture(void)
         frames[nframes].rgb[i][2] = b;
     }
     frames[nframes].t = sim_now_us;
+    frames[nframes].head_q = cur_head_q;
     nframes++;
 }
 
@@ -87,13 +94,28 @@ static const int stage_ms[LED_N] = {
     900,    /* 12 address                 */
 };
 
-static void run_boot(int fail_at)
+/* start_pos is where the kernel's orbit had reached when we claimed the ring;
+ * 7 is simply a mid-ring value, since it can be anything. */
+static void run_boot(int fail_at, int start_pos)
 {
     ledst = calloc(1, sizeof *ledst);
     ledst->mode = ANIM_RUN;
     bootstep = 0;
 
     int head_q = 0, tick = 0;
+
+    /* The wind-in, at the orbit's own measured rate. */
+    if (start_pos > 0) {
+        head_q = start_pos * SUB;
+        while (head_q < LED_N * SUB) {
+            head_q += SUB * TICK_MS / ORBIT_STEP_MS;
+            cur_head_q = head_q >= LED_N * SUB ? LED_N * SUB - 1 : head_q;
+            anim_render(cur_head_q, tick++, 0, 0);
+            sim_usleep(TICK_MS * 1000);
+        }
+        head_q = 0;
+    }
+
     for (int s = 0; s < LED_N; s++) {
         int ticks = stage_ms[s] / TICK_MS;
         for (int k = 0; k < ticks; k++) {
@@ -105,18 +127,25 @@ static void run_boot(int fail_at)
                 head_q += step;
                 if (head_q > target) head_q = target;
             }
-            anim_render(head_q, tick++, 0);
+            cur_head_q = head_q;
+            anim_render(head_q, tick++, 0, 1);
             sim_usleep(TICK_MS * 1000);
         }
         if (fail_at == s + 1) {
             for (int k = 0; k < 30; k++) {
-                anim_render(head_q, tick++, 1);
+                cur_head_q = head_q;
+                anim_render(head_q, tick++, 1, 1);
                 sim_usleep(TICK_MS * 1000);
             }
             return;
         }
         led_step();
     }
+    /* The invariants below describe the PROGRESS phase. The finale
+     * deliberately breaks two of them — it lights the whole ring in the head
+     * colour and then takes it to white — so it is measured separately rather
+     * than folded in, which is what made these read as failures at first. */
+    boot_frames = nframes;
     anim_finale(head_q, tick);
     capture();   /* the finale's last frame is black and has no sleep after it */
 }
@@ -181,22 +210,45 @@ static void check_run(void)
     printf("longest identical run: %d frames (%dms)\n", worst, worst * TICK_MS);
     ck(worst * TICK_MS < 400, "ring is never still for 400ms");
 
-    /* Progress is monotonic and never overtakes the boot. */
+    /* Progress is monotonic and never overtakes the boot. Wraps excluded: the
+     * wind-in legitimately carries the head round past 11 to the bottom. */
     int back = 0;
-    for (int i = 1; i < nframes; i++)
-        if (headpos(i) < headpos(i - 1) && headpos(i - 1) - headpos(i) < LED_N / 2)
+    for (int i = 1; i < boot_frames; i++)
+        if (headpos(i) < headpos(i - 1) && headpos(i - 1) - headpos(i) < LED_N / 2) {
+            if (back < 4)
+                printf("  backwards at frame %d (%ldms): %d -> %d\n",
+                       i, frames[i].t / 1000, headpos(i - 1), headpos(i));
             back++;
+        }
     ck(back == 0, "head never travels backwards");
 
-    /* Everything behind the head is trail, nothing ahead of it is lit. */
-    int ahead = 0;
-    for (int i = 0; i < nframes / 2; i++) {
-        int h = headpos(i);
+    /* Every LED is lit for the whole boot. This is the seamlessness property:
+     * the orbit hands over a complete blue ring, and any dark segment of ours
+     * is a visible cut at the handover however well the colours match. The
+     * fade at the very end is the one place the ring may go dark. */
+    int dark = 0;
+    for (int i = 0; i < boot_frames; i++)
+        for (int p = 0; p < LED_N; p++)
+            if (!(frames[i].rgb[p][0] | frames[i].rgb[p][1] | frames[i].rgb[p][2]))
+                dark++;
+    ck(dark == 0, "no LED is ever dark before the fade");
+
+    /* Unreached segments are exactly the orbit's ground colour. */
+    /* "Unreached" means strictly ahead of the head and its glow, measured
+     * from the position the animation was actually given. */
+    int off = 0;
+    for (int i = 0; i < boot_frames; i++) {
+        int h = frames[i].head_q / SUB;
         for (int p = h + 2; p < LED_N; p++)
-            if (frames[i].rgb[p][0] | frames[i].rgb[p][1] | frames[i].rgb[p][2])
-                ahead++;
+            if (memcmp(frames[i].rgb[p], C_GROUND, 3) != 0) {
+                if (off < 4)
+                    printf("  frame %d (%ldms) head=%d led %d = %02x%02x%02x\n",
+                           i, frames[i].t / 1000, h, p, frames[i].rgb[p][0],
+                           frames[i].rgb[p][1], frames[i].rgb[p][2]);
+                off++;
+            }
     }
-    ck(ahead == 0, "nothing lights ahead of the head");
+    ck(off == 0, "unreached segments sit at the orbit's ground colour");
 
     /* The ring must be handed back dark. A ring left lit is the thing the fade
      * exists to prevent — anything shown after this is the firmware's. */
@@ -219,7 +271,7 @@ int main(int argc, char **argv)
     int check = argc > 1 && !strcmp(argv[1], "--check");
     int fail  = argc > 2 ? atoi(argv[2]) : 0;
 
-    run_boot(fail);
+    run_boot(fail, argc > 3 ? atoi(argv[3]) : 7);
     if (!check) { show(); return 0; }
 
     printf("frames=%d simulated=%ldms\n\n", nframes, sim_now_us / 1000);

--- a/emos/init/ringsim.c
+++ b/emos/init/ringsim.c
@@ -44,7 +44,8 @@ static void sim_usleep(unsigned us) { capture(); sim_now_us += us; }
 #define MAXFR 20000
 static struct { unsigned char rgb[LED_N][3]; long t; int head_q; } frames[MAXFR];
 static int nframes;
-static int boot_frames;   /* frames before the finale begins */
+static int boot_frames;       /* frames before the finale begins */
+static int handover_frames;   /* frames before the progress display starts */
 /* The head position the animation was asked to draw, recorded per frame.
  * Inferring it from brightness works until the head wraps past the top and
  * the trail covers most of the ring, at which point the brightest segment is
@@ -105,8 +106,11 @@ static void run_boot(int fail_at, int start_pos)
     int head_q = 0, tick = 0;
 
     /* No wind-in to model: anim_claim waits for the orbit to reach the bottom
-     * before taking the ring, so our head always starts there. */
+     * before taking the ring, so our head always starts there. The handover
+     * fade IS modelled — it is the transition the whole design turns on. */
     (void)start_pos;
+    anim_handover();
+    handover_frames = nframes;
 
     for (int s = 0; s < LED_N; s++) {
         int ticks = stage_ms[s] / TICK_MS;
@@ -214,25 +218,31 @@ static void check_run(void)
         }
     ck(back == 0, "head never travels backwards");
 
-    /* Every LED is lit for the whole boot. This is the seamlessness property:
-     * the orbit hands over a complete blue ring, and any dark segment of ours
-     * is a visible cut at the handover however well the colours match. The
-     * fade at the very end is the one place the ring may go dark. */
-    int dark = 0;
-    for (int i = 0; i < boot_frames; i++)
-        for (int p = 0; p < LED_N; p++)
-            if (!(frames[i].rgb[p][0] | frames[i].rgb[p][1] | frames[i].rgb[p][2]))
-                dark++;
-    ck(dark == 0, "no LED is ever dark before the fade");
+    /* The head is always the brightest thing on the ring. It stopped being so
+     * once — a plain cross-fade halved it across two segments and the tail
+     * behind it won — and that is the failure that reads as a broken display
+     * rather than a wrong one. */
+    int dim = 0;
+    for (int i = handover_frames; i < boot_frames; i++) {
+        int hl = 0, tl = 0;
+        for (int p = 0; p < LED_N; p++) {
+            const unsigned char *c = frames[i].rgb[p];
+            int l = c[0] * 30 + c[1] * 59 + c[2] * 11;
+            if (memcmp(c, C_ORBIT, 3) == 0) { if (l > tl) tl = l; }
+            else if (l > hl) hl = l;
+        }
+        if (tl && hl && hl <= tl) dim++;
+    }
+    ck(dim == 0, "the head is always brighter than the tail");
 
     /* Unreached segments are exactly the orbit's ground colour. */
     /* "Unreached" means strictly ahead of the head and its glow, measured
      * from the position the animation was actually given. */
     int off = 0;
-    for (int i = 0; i < boot_frames; i++) {
+    for (int i = handover_frames; i < boot_frames; i++) {
         int h = frames[i].head_q / SUB;
         for (int p = h + 2; p < LED_N; p++)
-            if (memcmp(frames[i].rgb[p], C_GROUND, 3) != 0) {
+            if (frames[i].rgb[p][0] | frames[i].rgb[p][1] | frames[i].rgb[p][2]) {
                 if (off < 4)
                     printf("  frame %d (%ldms) head=%d led %d = %02x%02x%02x\n",
                            i, frames[i].t / 1000, h, p, frames[i].rgb[p][0],
@@ -240,7 +250,7 @@ static void check_run(void)
                 off++;
             }
     }
-    ck(off == 0, "unreached segments sit at the orbit's ground colour");
+    ck(off == 0, "the ring ahead of the head is dark");
 
     /* The ring must be handed back dark. A ring left lit is the thing the fade
      * exists to prevent — anything shown after this is the firmware's. */

--- a/emos/init/ringsim.c
+++ b/emos/init/ringsim.c
@@ -109,7 +109,7 @@ static void run_boot(int fail_at, int start_pos)
     ledst->mode = ANIM_RUN;
     bootstep = 0;
 
-    int head_q = 0, tick = 0;
+    int head_q = 0, tick = 0, still = 0;
 
     /* No wind-in to model: anim_claim waits for the orbit to reach the bottom
      * before taking the ring, so our head always starts there. The handover
@@ -121,15 +121,17 @@ static void run_boot(int fail_at, int start_pos)
     for (int s = 0; s < LED_N; s++) {
         int ticks = stage_ms[s] / TICK_MS;
         for (int k = 0; k < ticks; k++) {
+            int was = head_q;
             head_q = head_advance(head_q, ledst->stage);
+            still = (head_q - was >= SUB / 32) ? 0 : still + 1;
             cur_head_q = head_q;
-            anim_render(head_q, tick++, 0, 1);
+            anim_render(head_q, still, 0, 1);
             sim_usleep(TICK_MS * 1000);
         }
         if (fail_at == s + 1) {
             for (int k = 0; k < 30; k++) {
                 cur_head_q = head_q;
-                anim_render(head_q, tick++, 1, 1);
+                anim_render(head_q, still, 1, 1);
                 sim_usleep(TICK_MS * 1000);
             }
             return;
@@ -141,7 +143,7 @@ static void run_boot(int fail_at, int start_pos)
      * colour and then takes it to white — so it is measured separately rather
      * than folded in, which is what made these read as failures at first. */
     boot_frames = nframes;
-    anim_finale();
+    anim_finale(still);
     capture();   /* the finale's last frame is black and has no sleep after it */
 }
 

--- a/emos/init/ringsim.c
+++ b/emos/init/ringsim.c
@@ -104,17 +104,9 @@ static void run_boot(int fail_at, int start_pos)
 
     int head_q = 0, tick = 0;
 
-    /* The wind-in, at the orbit's own measured rate. */
-    if (start_pos > 0) {
-        head_q = start_pos * SUB;
-        while (head_q < LED_N * SUB) {
-            head_q += SUB * TICK_MS / ORBIT_STEP_MS;
-            cur_head_q = head_q >= LED_N * SUB ? LED_N * SUB - 1 : head_q;
-            anim_render(cur_head_q, tick++, 0, 0);
-            sim_usleep(TICK_MS * 1000);
-        }
-        head_q = 0;
-    }
+    /* No wind-in to model: anim_claim waits for the orbit to reach the bottom
+     * before taking the ring, so our head always starts there. */
+    (void)start_pos;
 
     for (int s = 0; s < LED_N; s++) {
         int ticks = stage_ms[s] / TICK_MS;

--- a/emos/init/ringsim.c
+++ b/emos/init/ringsim.c
@@ -78,23 +78,29 @@ static void capture(void)
 
 /* ── A boot, as it actually runs ────────────────────────────────────────────*/
 
-/* Measured shape of a real boot: most stages are instant, three are not.
- * Milliseconds spent IN each stage, i.e. before it completes. */
+/* The real shape of a boot, measured off EFF on 2026-09-05 from the trail's
+ * own timestamps. Milliseconds spent IN each stage before it completes.
+ *
+ * The guesses these replace were badly wrong in both directions: fsck was
+ * assumed to take seconds and takes 36ms, while the final stage — association
+ * and DHCP — was assumed to be 900ms and is 27.6 SECONDS, four fifths of the
+ * whole boot. Simulating it honestly is the only way the long dwell at the end
+ * gets exercised at all.
+ */
 static const int stage_ms[LED_N] = {
-    120,    /*  1 mounts and device nodes */
-    260,    /*  2 /system                 */
-    4200,   /*  3 fsck /data              — seconds, and silent */
-    340,    /*  4 /data                   */
-    60,     /*  5 /etc                    */
-    40,     /*  6 last_kmsg               */
-    90,     /*  7 busybox applets         */
-    150,    /*  8 USB gadget              */
-    1100,   /*  9 console                 */
-    2600,   /* 10 wlan0 exists            */
-    9000,   /* 11 associating             — the long silent one */
-    900,    /* 12 address                 */
+       20,   /*  1 mounts and device nodes */
+        8,   /*  2 /system                 */
+       36,   /*  3 fsck /data              */
+        7,   /*  4 /data                   */
+        4,   /*  5 /etc                    */
+       12,   /*  6 last_kmsg               */
+      572,   /*  7 busybox applets         */
+       37,   /*  8 USB gadget              */
+     1002,   /*  9 console                 */
+     3850,   /* 10 wlan0 exists            */
+        0,   /* 11 associating — same millisecond as 10 */
+    27628,   /* 12 carrier and an address  */
 };
-
 /* start_pos is where the kernel's orbit had reached when we claimed the ring;
  * 7 is simply a mid-ring value, since it can be anything. */
 static void run_boot(int fail_at, int start_pos)

--- a/emos/init/ringsim.c
+++ b/emos/init/ringsim.c
@@ -135,7 +135,7 @@ static void run_boot(int fail_at, int start_pos)
      * colour and then takes it to white — so it is measured separately rather
      * than folded in, which is what made these read as failures at first. */
     boot_frames = nframes;
-    anim_finale(head_q, tick);
+    anim_finale();
     capture();   /* the finale's last frame is black and has no sleep after it */
 }
 

--- a/emos/mkboot.py
+++ b/emos/mkboot.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Pack a 6.1 zImage + initramfs into the MTK/Android boot image biscuit's LK expects.
+
+Every constant here is READ OUT OF THE DEVICE'S OWN WORKING IMAGE rather than
+taken from documentation. pmOS's deviceinfo for this board, for instance, gives
+a kernel load address of 0x40008000; the image the device actually boots uses
+0x40080000. Copying the wrong one produces a device that takes the flash and
+then does nothing, which is the single most expensive failure mode available
+here — so the reference image is the source of truth and this script asserts
+against it.
+
+Layout, confirmed by parsing boot_a_x off a running device:
+
+    page 0            Android boot header ("ANDROID!"), page_size 2048
+    kernel area       MTK header (0x200, magic 0x58881688, name "KERNEL")
+                      followed by zImage then one or more appended DTBs
+    ramdisk area      RAW gzip cpio — NOT MTK-wrapped, unlike the kernel
+
+The DTBs are carried over verbatim from the reference image. LK selects among
+the three by board revision, and reproducing that selection ourselves is work
+with no upside for a first boot test.
+"""
+import hashlib
+import struct
+import sys
+
+MTK_MAGIC = 0x58881688
+PAGE = 2048
+
+
+def mtk_wrap(payload: bytes, name: bytes) -> bytes:
+    """Prepend the 0x200-byte MediaTek header LK validates before jumping."""
+    hdr = struct.pack("<II", MTK_MAGIC, len(payload))
+    hdr += name.ljust(32, b"\0")
+    # Padded with 0x00, READ OFF THE DEVICE'S OWN IMAGE. An earlier version of
+    # this script padded with 0xff on the strength of a note that turned out to
+    # be wrong; round-tripping stock through this packer put 472 differing
+    # bytes inside the very header LK validates before it jumps.
+    hdr = hdr.ljust(0x200, b"\0")
+    return hdr + payload
+
+
+def pad(b: bytes) -> bytes:
+    return b + b"\0" * (-len(b) % PAGE)
+
+
+def split_reference(ref: bytes):
+    """Return (dtb_blob, header_fields) from the device's own boot image."""
+    if ref[:8] != b"ANDROID!":
+        raise SystemExit("reference image is not an Android boot image")
+    f = struct.unpack("<10I", ref[8:48])
+    ksz, kaddr, rsz, raddr, ssz, saddr, tags, psz, hdrv, osv = f
+    if psz != PAGE:
+        raise SystemExit(f"unexpected page size {psz}")
+    kernel = ref[PAGE:PAGE + ksz]
+    if struct.unpack("<I", kernel[:4])[0] != MTK_MAGIC:
+        raise SystemExit("reference kernel is not MTK-wrapped as expected")
+    payload = kernel[0x200:]
+    # First DTB magic marks the end of the zImage and the start of the blobs.
+    i = payload.find(b"\xd0\x0d\xfe\xed")
+    if i < 0:
+        raise SystemExit("no DTB found in reference kernel payload")
+    return payload[i:], dict(kaddr=kaddr, raddr=raddr, saddr=saddr,
+                             tags=tags, hdrv=hdrv, osv=osv,
+                             cmdline=ref[64:64 + 512].rstrip(b"\0"))
+
+
+# Point ramoops at the region the VENDOR device tree already reserves:
+#
+#   ram_console-reserved-memory@44400000 {
+#       compatible = "mediatek,ram_console";
+#       reg = <0x00 0x44400000 0x00 0x200000>;   /* 2MB */
+#   };
+#
+# That matters twice over. It is memory nothing else claims, so we are not
+# guessing at a safe address; and FireOS's own MediaTek ram_console driver
+# reads that same region back after a reboot and publishes it as
+# /proc/last_kmsg — verified holding 64,622 bytes of a previous boot. So a 6.1
+# kernel that panics before userspace can still be read afterwards from
+# FireOS, with no UART and without opening the case.
+#
+# Clear of the initramfs, which loads at 0x44000000 and is ~1MB.
+RAMOOPS_CMDLINE = (
+    "ramoops.mem_address=0x44400000 ramoops.mem_size=0x200000 "
+    "ramoops.record_size=0x20000 ramoops.console_size=0x80000 "
+    "ramoops.dump_oops=1"
+)
+
+
+def main():
+    ref_p, z_p, rd_p, out_p = sys.argv[1:5]
+    dtb_p = sys.argv[5] if len(sys.argv) > 5 else None
+    extra = sys.argv[6] if len(sys.argv) > 6 else RAMOOPS_CMDLINE
+    ref = open(ref_p, "rb").read()
+    dtbs, hf = split_reference(ref)
+    if dtb_p:
+        # Ship ONE dtb, the one this board actually boots.
+        #
+        # The vendor image carries three and LK chooses; but amonet-k32 ships a
+        # single blob, which implies LK may simply take the first. Ours is the
+        # THIRD (identified by cpu@0-3 matching this quad-core board, and by the
+        # dacmux pin groups present in the live tree) — so leaving all three in
+        # risks booting dtb1, which has neither.
+        dtbs = open(dtb_p, "rb").read()
+    zimage = open(z_p, "rb").read()
+    ramdisk = open(rd_p, "rb").read()
+
+    cmdline = hf["cmdline"]
+    if extra:
+        cmdline = cmdline + b" " + extra.encode()
+    if len(cmdline) > 511:
+        raise SystemExit(f"cmdline too long for the 512-byte field: {len(cmdline)}")
+
+    kernel = mtk_wrap(zimage + dtbs, b"KERNEL")
+
+    hdr = b"ANDROID!"
+    hdr += struct.pack("<10I", len(kernel), hf["kaddr"],
+                       len(ramdisk), hf["raddr"],
+                       0, hf["saddr"], hf["tags"], PAGE, hf["hdrv"], hf["osv"])
+    hdr += b"\0" * 16                       # product name, empty in the vendor image
+    hdr += cmdline.ljust(512, b"\0")        # device cmdline + our ramoops params
+    # The Android image id: SHA1 over each region followed by its length, in
+    # kernel/ramdisk/second order. Stock carries a real one and reproducing it
+    # is free, so there is no reason to ship zeroes and find out the hard way
+    # whether anything downstream reads it.
+    digest = hashlib.sha1()
+    for region, size in ((kernel, len(kernel)), (ramdisk, len(ramdisk)), (b"", 0)):
+        digest.update(region)
+        digest.update(struct.pack("<I", size))
+    hdr += digest.digest().ljust(32, b"\0")
+    hdr += b"\0" * 1024                     # extra cmdline
+
+    img = pad(hdr) + pad(kernel) + pad(ramdisk)
+    open(out_p, "wb").write(img)
+
+    print(f"reference : {ref_p} ({len(ref)} bytes)")
+    print(f"  dtb               : {dtb_p or 'carried over from reference'} ({len(dtbs)} bytes)")
+    print(f"  kernel load addr  : 0x{hf['kaddr']:08x}")
+    print(f"  ramdisk addr      : 0x{hf['raddr']:08x}")
+    print(f"  cmdline           : {cmdline.decode(errors='replace')}")
+    print(f"built     : {out_p} ({len(img)} bytes)")
+    print(f"  zImage            : {len(zimage)} bytes")
+    print(f"  initramfs         : {len(ramdisk)} bytes")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**emOS 0.1 — an Echo Dot that runs EchoMuse with no Amazon userspace at all.** No Android init, no `system_server`, no `mediaserver`, no audio HAL. A complete voice turn has run on it: wake word scored on-device, Home Assistant pipeline, spoken answer, plus WiFi, the 9-channel mic array, hardware AEC, the BLE proxy, buttons, ambient light, jack detect and the LED ring.

**This PR asks a scope question before it asks for a review.** It is ~3,300 lines of new C and docs for a second operating system, on one device, bench-proven over two days. Whether that belongs on `main` at this stage is a judgement about the project rather than about the code, and the code is written to be easy to say no to — everything lands under `emos/`, nothing outside it changes behaviour.

### Three things worth knowing

- **It is a distribution, not a kernel.** It pairs the device's existing MediaTek 3.18 kernel with our own PID 1, busybox, and bionic and tinyalsa mounted read-only from the device's own `/system`. Nothing of Amazon's is redistributed — `build.sh` reuses the kernel out of a boot image the user pulls off their own device, which is also their recovery image. Recovery is a `dd` and takes about ten seconds.
- **It falsified a claim we had been reasoning from.** SETUP.md said Amazon's audio HAL was what started the I2S clock and that playback would hang without it. Both directions clock with no HAL, no mediaserver and no framework. What the HAL *was* silently doing is configuring the codec's DAPM routes — nothing in our firmware ever has, because the HAL always got there first, so on a device with no Android both the microphones and the speaker are powered down. That fix is already on main (#426); this is the instrument that made it visible, and no log, test or dashboard could have.
- **CI now builds and checks it**, which is the last commit here and the reason the rest is proposable. `emos/` was ~1,900 lines that nothing in CI compiled, on the code with the longest feedback loop in the project — a change reaches a verdict by flashing a boot partition and watching the device.

### What CI does with it

- Builds `init.c` for **aarch64, static**, in the pinned compiler image, and asserts both properties. There is no dynamic loader at PID 1 time; three boots with a script init produced no output at all, which is indistinguishable from a kernel that never started.
- Runs `ringsim --check` — the boot ring's invariants, off-target against a simulated clock. Clean boot only: the failure display ends with the ring lit on purpose.
- Runs `pwcheck` against `hashlib`, closing a gap where nothing compared the C password hash to the controller's Python. `pwcheck` now prints the password behind each record so the checker recomputes from the C's own inputs rather than keeping a third copy of the vector table.
- `mkboot.py` gets the undefined-name check only; it cannot run without a reference boot image, the one input we never ship.

Neither `ringsim.c` nor `pwcheck.c` reimplements anything — both `#include init.c` whole and drive the real functions, so neither can drift from what the device runs.

### Not in this PR

The **controller half of the console password** — schema v21, the dashboard control, `em_console_pw.py` — is a separate branch and a separate review surface. The device half here fails open by design (no file means no password), so it is coherent alone, but the feature is inert until that lands. `pwcheck.c`'s comment refers forward to `controller/tests/test_console_pw.py` for that reason.

### Status, stated plainly

**0.1, bench-proven, not a release.** One device, two days. The known gaps are listed at the bottom of `emos/README.md` and none of them is a research problem. Nothing here is proposed for the fleet, and nothing changes for a device running FireOS.

Happy to break this into smaller PRs, or to park it on a branch, if either reads better.

— Team EchoMuse (powered by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnaaMUXL7M2KQKAAZJJHdL
