### PR TITLE
Early Access 2.23.0-ea.4

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## 2.23.0-ea.4 (Early Access)
+
+**Your Echo can now run without any of Amazon's software on it, and the
+provisioning wizard installs it that way by default.** This release migrates
+the database (schema 21) — a backup is taken automatically before it does.
+Nothing to change on your devices.
+
+### emOS: an Echo with no Android on it at all
+
+emOS replaces the Echo Dot's entire Amazon userspace — no Android init, no
+system_server, no mediaserver, no audio HAL — while keeping the device's own
+kernel. A complete voice turn runs on it: wake word, Home Assistant, spoken
+answer, along with WiFi, the microphone array, the Bluetooth proxy, the buttons
+and the light ring.
+
+**It is proven on one device over two days, and it is not a finished product.**
+Nothing about your existing Echoes changes, and nothing here reaches a device
+unless you deliberately install it.
+
+### The provisioning wizard now installs emOS
+
+Setting up a new Echo takes nine steps instead of thirteen, and all of them
+happen in TWRP recovery — Magisk, the boot image patch and the root checks are
+gone, because none of them are needed when Android is never started. The most
+dangerous step in the old wizard went with them.
+
+Before it changes anything, the wizard reads your Echo's existing boot
+partition and hands you the file. That one file puts the device back exactly as
+it was, in about ten seconds, and leaves everything installed on it untouched.
+
+**It has not been tested on hardware end to end.** The last two steps, which
+watch the first boot and set up WiFi over the USB console, have never talked to
+a real device. Treat this as something to try on a spare Echo rather than on
+one you rely on — and keep the boot image it gives you at step 2.
+
+**Once an Echo is on emOS the wizard cannot be run against it again.** Setup
+needs Android's debug bridge and emOS does not have one, so the first step will
+not find the device. Going back is a manual job: hold the button combo to reach
+TWRP recovery, wipe cache, wipe data, and sideload a FireOS image. That erases
+the device, so it is a real undo rather than a convenient one. Re-provisioning
+an emOS Echo properly, over the network, is not built yet.
+
+The old FireOS install is unchanged and still available at `?flow=fireos` on
+the dashboard URL.
+
+### A password for the emOS console
+
+emOS puts a root shell on the USB port, which anyone with a cable could reach.
+You can now set a password for it under Config → Advanced → USB console, and it
+applies to every device at once. The password is hashed before it is stored or
+sent, so the plain text is never written down anywhere.
+
+This is a nod to security rather than a lock: anyone holding the device can
+delete the password from recovery. What it protects is the password itself,
+which people tend to reuse somewhere that matters. Forgetting it costs a
+reflash, not a device. FireOS devices are unaffected.
+
+### Smaller things
+
+- An Echo running emOS started EchoMuse **122 seconds late on every boot**,
+  waiting for an Amazon service that cannot exist there. It now starts in about
+  35 seconds.
+- Support bundles no longer include a console password record if one is quoted
+  in a log line.
+
 ## 2.23.0-ea.3 (Early Access)
 
 **Your Echoes will know what time it is, and updates stop stalling on things

--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -17,7 +17,7 @@ name: "EchoMuse (Early Access)"
 # derives from the controller-v* tag (controller-v2.18.0 -> 2.18.0). Bump
 # both together: Supervisor pulls `image:version`, so a version with no
 # matching tag on GHCR fails to install.
-version: "2.23.0-ea.3"
+version: "2.23.0-ea.4"
 # Pull the published multi-arch image rather than building on the user's
 # machine. Without this Supervisor builds from this directory's Dockerfile,
 # which downloads a few hundred MB on whatever the user runs Home Assistant

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## 2.23.0-ea.4 (Early Access)
+
+**Your Echo can now run without any of Amazon's software on it, and the
+provisioning wizard installs it that way by default.** This release migrates
+the database (schema 21) — a backup is taken automatically before it does.
+Nothing to change on your devices.
+
+### emOS: an Echo with no Android on it at all
+
+emOS replaces the Echo Dot's entire Amazon userspace — no Android init, no
+system_server, no mediaserver, no audio HAL — while keeping the device's own
+kernel. A complete voice turn runs on it: wake word, Home Assistant, spoken
+answer, along with WiFi, the microphone array, the Bluetooth proxy, the buttons
+and the light ring.
+
+**It is proven on one device over two days, and it is not a finished product.**
+Nothing about your existing Echoes changes, and nothing here reaches a device
+unless you deliberately install it.
+
+### The provisioning wizard now installs emOS
+
+Setting up a new Echo takes nine steps instead of thirteen, and all of them
+happen in TWRP recovery — Magisk, the boot image patch and the root checks are
+gone, because none of them are needed when Android is never started. The most
+dangerous step in the old wizard went with them.
+
+Before it changes anything, the wizard reads your Echo's existing boot
+partition and hands you the file. That one file puts the device back exactly as
+it was, in about ten seconds, and leaves everything installed on it untouched.
+
+**It has not been tested on hardware end to end.** The last two steps, which
+watch the first boot and set up WiFi over the USB console, have never talked to
+a real device. Treat this as something to try on a spare Echo rather than on
+one you rely on — and keep the boot image it gives you at step 2.
+
+**Once an Echo is on emOS the wizard cannot be run against it again.** Setup
+needs Android's debug bridge and emOS does not have one, so the first step will
+not find the device. Going back is a manual job: hold the button combo to reach
+TWRP recovery, wipe cache, wipe data, and sideload a FireOS image. That erases
+the device, so it is a real undo rather than a convenient one. Re-provisioning
+an emOS Echo properly, over the network, is not built yet.
+
+The old FireOS install is unchanged and still available at `?flow=fireos` on
+the dashboard URL.
+
+### A password for the emOS console
+
+emOS puts a root shell on the USB port, which anyone with a cable could reach.
+You can now set a password for it under Config → Advanced → USB console, and it
+applies to every device at once. The password is hashed before it is stored or
+sent, so the plain text is never written down anywhere.
+
+This is a nod to security rather than a lock: anyone holding the device can
+delete the password from recovery. What it protects is the password itself,
+which people tend to reuse somewhere that matters. Forgetting it costs a
+reflash, not a device. FireOS devices are unaffected.
+
+### Smaller things
+
+- An Echo running emOS started EchoMuse **122 seconds late on every boot**,
+  waiting for an Amazon service that cannot exist there. It now starts in about
+  35 seconds.
+- Support bundles no longer include a console password record if one is quoted
+  in a log line.
+
 ## 2.23.0-ea.3 (Early Access)
 
 **Your Echoes will know what time it is, and updates stop stalling on things

--- a/emos/README.md
+++ b/emos/README.md
@@ -8,11 +8,18 @@ It is a distribution in the ordinary sense: it does not include a kernel of its
 own. It pairs the device's existing MediaTek 3.18 kernel with our own PID 1,
 busybox, and bionic and tinyalsa mounted read-only from the device's `/system`.
 
-**Status: 0.1, bench-proven, not a release.** One device, one day. A complete
-voice turn has run on it — wake word scored on-device, Home Assistant pipeline,
-spoken answer — along with WiFi, the 9-channel mic array, hardware AEC, the BLE
-proxy, buttons, ambient light, jack detect and the LED ring. The known gaps are
-listed at the bottom and none of them is a research problem.
+**Status: 0.1, bench-proven, not field-proven.** One device, two days. A
+complete voice turn has run on it — wake word scored on-device, Home Assistant
+pipeline, spoken answer — along with WiFi, the 9-channel mic array, hardware
+AEC, the BLE proxy, buttons, ambient light, jack detect and the LED ring. The
+known gaps are listed at the bottom and none of them is a research problem.
+
+`emos-v0.1` is tagged and published so the provisioning wizard can fetch the
+init, which is the only part of an image that can be distributed. **A tag is
+not a claim that this is finished**: it has run on one device, and the wizard
+that installs it has not been through a full run on hardware at all. Try it on
+a spare Echo, and read the Known gaps first — in particular, a device on emOS
+cannot be re-provisioned by the wizard, and going back wipes it.
 
 ## Why
 
@@ -529,6 +536,35 @@ is not proof it rebooted — compare uptime or a build fingerprint.
   board.
 - The boot trail is a fixed-size buffer rewritten in place, so a shorter trail
   leaves the tail of the previous boot's behind and can be misread.
+- **A device on emOS cannot be re-provisioned by the wizard, and nothing in
+  the wizard says so.** Step 0 needs adbd, which emOS does not have and will
+  not — `f_acm` is the whole point of not needing a daemon. So the USB picker
+  offers nothing and the step fails with an error about the wrong device,
+  which does not name the actual reason. The duplicate-serial guard would
+  refuse it a second time over, since a provisioned device is registered.
+
+  Noticed by Wil on 2026-09-05, after the flow was built. The design's open
+  questions covered FireOS → emOS and deferred it; **nobody asked the
+  reverse**, which is how it got this far.
+
+  Three paths exist and none of them is in the wizard:
+
+  - **Return to stock, by hand.** Boot into TWRP with the button combo, wipe
+    cache, wipe data, and sideload the FireOS 5 image. This is the documented
+    answer and the one to give users today — see the recovery table in the
+    provisioning design and `docs/rooting.md`. Note it WIPES `/data`, so
+    EchoMuse and its config go with it; that is the difference between this
+    and restoring the escrowed boot image, which leaves `/data` alone but
+    also leaves the device on FireOS with emOS's install still sitting there.
+  - **Flash over the network from the running emOS**, which is how development
+    images are already moved (~30s a cycle). The device has a root shell and
+    the controller can reach it, so this is the natural home for a real
+    re-provision and needs no USB at all.
+  - **The console**, for a device that is on emOS but not on the network.
+
+  The middle one is the fix worth building, and it is the same self-flash the
+  design deferred for FireOS → emOS. Until then this is a one-way door: keep
+  the escrowed boot image.
 
 ## What emOS is worth beyond the stunt
 


### PR DESCRIPTION
**Cuts EA 2.23.0-ea.4.** Changelog entry, `controller-ea/` pinned via `sync_channels.py --set-version`, and the emOS README's status line updated because `emos-v0.1` is being tagged alongside this.

Since ea.3: emOS on main with CI (#434), the console password end to end (#435), the provisioning wizard's emOS path (#436), and the 122-second boot delay (#432).

The changelog leads with emOS rather than the console password, because what an EA user actually meets is the provisioning wizard installing a different operating system by default. It states three things plainly:

- **The wizard has not been through a full run on hardware.** The last two steps have never talked to a device.
- **This release migrates the database** (schema 21), unlike ea.3.
- **A device on emOS cannot be re-provisioned by the wizard** — emOS has no adbd, so step 0 cannot see it. Going back is TWRP, wipe cache, wipe data, sideload FireOS, and that **erases the device**. Recorded under Known gaps in `emos/README.md` with the three routes that do exist; flashing over the network from the running emOS is the fix worth building.

994 tests passing; `sync_channels.py --check` and `test_channels.py` both clean.

— Team EchoMuse (powered by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnaaMUXL7M2KQKAAZJJHdL