### PR TITLE
Correct the FAQ entry that told people to cause #79

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -66,12 +66,25 @@ Add your HA URL at `chrome://flags/#unsafely-treat-insecure-origin-as-secure`
 — e.g. `http://homeassistant.local:8123` — and restart the browser. Tracked as
 [#170](https://github.com/wilbowes/EchoMuse/issues/170).
 
-### The USB connection drops immediately after a reboot step.
-Known on some devices ([#79](https://github.com/wilbowes/EchoMuse/issues/79)).
-Setting `persist.sys.usb.config` to `mtp,adb` before the reboot keeps it on
-the bus. If you hit this, please add your `getprop ro.build.fingerprint` and
-`getprop persist.sys.usb.config` to that issue — we can't reproduce it and
-want to know why some devices arrive unconfigured.
+### The USB connection drops and re-enumerates every few seconds.
+`persist.sys.usb.config` is set to `mtp,adb`, and the composite gadget is what
+drops the bus — roughly every six seconds, with `device firmware changed` in
+`dmesg` each time. Forcing it to `adb` alone fixes it. Nothing EchoMuse does
+needs MTP.
+
+**`setprop` from a booted device will not work.** Android's property service
+refuses that specific property whatever `ro.secure` and `ro.debuggable` say
+(`init: sys_prop: permission denied uid:2000 name:sys.usb.config`), so it has
+to be changed before that layer applies. From TWRP, unpack the boot image, edit
+`default.prop` to read `persist.sys.usb.config=adb`, add
+`persist.sys.usb.state=adb`, repack and write it back — the full commands are
+in [#79](https://github.com/wilbowes/EchoMuse/issues/79).
+
+Root-caused by @kylegordon and confirmed independently by @midiland, who found
+`setprop` did work on his device — worth trying first, since it costs nothing.
+
+*(This entry previously advised setting `mtp,adb`, which is the cause rather
+than the fix. Corrected 2026-09-05.)*
 
 ### A wizard step failed and I don't know why.
 Every failed step offers diagnostics. Grab those before retrying — the state


### PR DESCRIPTION
**The USB-disconnect FAQ entry advised setting `persist.sys.usb.config` to `mtp,adb`. That is the cause, not the fix.**

It has been telling people to reproduce the fault since @kylegordon root-caused it on 21 August — he ruled out six other theories by direct testing, matched the `dmesg` signature to an independent XDA report, and fixed it by forcing the gadget to `adb` alone: 2+ minutes stable against a disconnect every six seconds, with provisioning then completing end to end. @midiland confirmed it independently on 2 September.

The rewritten entry carries the part that is easy to lose an evening to: **`setprop` from a booted device is refused for this property** whatever `ro.secure` and `ro.debuggable` say, so it has to be baked into `default.prop` from recovery. It keeps @midiland's finding that `setprop` did work on his device, since trying it first costs nothing.

**The correction is marked as one.** Somebody may have followed the old advice and be sitting on a device that now does this; a silently edited FAQ gives them no way to work that out.

Not fixed here, and both are in #79: the wizard still does not set it, and `f1r30s.zip`'s own installer is what writes `mtp,adb` in the first place. The TWRP-only provisioning flow is the natural home for the first, since that is where the property can actually be changed.

— Team EchoMuse (powered by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnaaMUXL7M2KQKAAZJJHdL