### PR TITLE
Do not tell people to restore a device into one that will not boot

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -37,10 +37,15 @@ one you rely on — and keep the boot image it gives you at step 2.
 
 **Once an Echo is on emOS the wizard cannot be run against it again.** Setup
 needs Android's debug bridge and emOS does not have one, so the first step will
-not find the device. Going back is a manual job: hold the button combo to reach
-TWRP recovery, wipe cache, wipe data, and sideload a FireOS image. That erases
-the device, so it is a real undo rather than a convenient one. Re-provisioning
-an emOS Echo properly, over the network, is not built yet.
+not find the device.
+
+Going back is the same four steps that prepare a Dot for EchoMuse in the first
+place, done by hand: reach TWRP recovery with the button combo, wipe cache,
+wipe data, sideload a FireOS 5 image, **then flash `f1r30s.zip`**. Do not skip
+that last one — a stock flash restores dm-verity against a partition table the
+unlock modified, and the device will not boot without it. The sequence erases
+the Echo, so it is a real undo rather than a convenient one. Re-provisioning an
+emOS Echo properly, over the network, is not built yet.
 
 The old FireOS install is unchanged and still available at `?flow=fireos` on
 the dashboard URL.

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -37,10 +37,15 @@ one you rely on — and keep the boot image it gives you at step 2.
 
 **Once an Echo is on emOS the wizard cannot be run against it again.** Setup
 needs Android's debug bridge and emOS does not have one, so the first step will
-not find the device. Going back is a manual job: hold the button combo to reach
-TWRP recovery, wipe cache, wipe data, and sideload a FireOS image. That erases
-the device, so it is a real undo rather than a convenient one. Re-provisioning
-an emOS Echo properly, over the network, is not built yet.
+not find the device.
+
+Going back is the same four steps that prepare a Dot for EchoMuse in the first
+place, done by hand: reach TWRP recovery with the button combo, wipe cache,
+wipe data, sideload a FireOS 5 image, **then flash `f1r30s.zip`**. Do not skip
+that last one — a stock flash restores dm-verity against a partition table the
+unlock modified, and the device will not boot without it. The sequence erases
+the Echo, so it is a real undo rather than a convenient one. Re-provisioning an
+emOS Echo properly, over the network, is not built yet.
 
 The old FireOS install is unchanged and still available at `?flow=fireos` on
 the dashboard URL.

--- a/emos/README.md
+++ b/emos/README.md
@@ -550,12 +550,18 @@ is not proof it rebooted — compare uptime or a build fingerprint.
   Three paths exist and none of them is in the wizard:
 
   - **Return to stock, by hand.** Boot into TWRP with the button combo, wipe
-    cache, wipe data, and sideload the FireOS 5 image. This is the documented
-    answer and the one to give users today — see the recovery table in the
-    provisioning design and `docs/rooting.md`. Note it WIPES `/data`, so
-    EchoMuse and its config go with it; that is the difference between this
-    and restoring the escrowed boot image, which leaves `/data` alone but
-    also leaves the device on FireOS with emOS's install still sitting there.
+    cache, wipe data, sideload the FireOS 5 image, **and then flash
+    `f1r30s.zip`**. That last step is not optional: a stock flash restores
+    dm-verity against a partition table the unlock modified, so **the OS will
+    not boot without it** (`docs/rooting.md`). It is also the same four steps
+    that prepare a device for EchoMuse in the first place, on FireOS or emOS,
+    so this returns the device to the state an install starts from rather than
+    to a factory one.
+
+    Note it WIPES `/data`, so EchoMuse and its config go with it. That is the
+    difference between this and restoring the escrowed boot image, which
+    leaves `/data` alone but also leaves the device on FireOS with emOS's
+    install still sitting there.
   - **Flash over the network from the running emOS**, which is how development
     images are already moved (~30s a cycle). The device has a root shell and
     the controller can reach it, so this is the natural home for a real


### PR DESCRIPTION
**The way back from emOS, as written earlier today, ends with a device that does not boot.**

It gave the sequence as "wipe cache, wipe data, sideload a FireOS image" and stopped there. `f1r30s.zip` is missing, and `docs/rooting.md` is explicit about why that is not a detail: *"Always flash it after a stock firmware image or the OS will not boot"* — a stock flash restores dm-verity against a partition table the unlock modified.

Corrected in both places it appeared: `emos/README.md` under Known gaps, and the 2.23.0-ea.4 changelog, which is the copy EA users actually read.

Also states something neither copy said, and which makes the whole instruction read differently: **these four steps are the prerequisite for installing EchoMuse at all**, on FireOS or emOS. "Return to stock" therefore puts the device in the state an install starts from rather than a factory one — which is both why it is the right answer to give and why it is less drastic than it sounds.

`controller-ea/` regenerated with `tools/sync_channels.py`, not hand-edited.

— Team EchoMuse (powered by Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnaaMUXL7M2KQKAAZJJHdL