### PR TITLE
Preserve custom ONNX wake-word metadata through Home Assistant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,18 @@ jobs:
         working-directory: controller
         run: python -m pytest tests/ -v
 
+  forge-metadata-tests:
+    name: ONNX metadata round trip
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      # Keep runtime/model dependencies out of the lightweight controller suite.
+      - run: pip install pytest numpy pyyaml onnx==1.17.0 onnxruntime
+      - run: python -m pytest oww_forge/tests/ -v
+
   controller-lint:
     name: Controller lint (undefined names)
     runs-on: ubuntu-latest

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -98,6 +98,7 @@ COPY em_ble_health.py .
 COPY em_ble_proxy.py .
 COPY em_oww_assets.py  ./
 COPY em_oww_models.py .
+COPY em_oww_metadata.py .
 COPY em_oww_warmup.py .
 COPY em_arbiter.py .
 COPY em_button.py .

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -1102,7 +1102,7 @@ async def _apply_live_config(device_id: str, live, effective: dict) -> None:
         # Refresh HA's wake-word dropdown (lazy import — em_esphome imports
         # em_api at module level).
         import em_esphome
-        em_esphome.update_oww_model(device_id, effective["owwModel"])
+        await em_esphome.update_oww_model(device_id, effective["owwModel"])
     if pending_model:
         # The device is still on its previous wake word, still scoring
         # locally, still answering. Install, then switch.
@@ -4081,7 +4081,7 @@ async def _install_then_switch(device_id: str, model: str) -> None:
     await live.send_control({"type": "config", **effective})
     live.oww_model = model
     import em_esphome
-    em_esphome.update_oww_model(device_id, model)
+    await em_esphome.update_oww_model(device_id, model)
     await _push_log_event(
         device_id, "info", "controller",
         f"Wake word model {model} installed — device switched"

--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -3600,7 +3600,7 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
         # creation — refresh it from the config we just loaded so HA's
         # wake-word dropdown tracks dashboard changes across controller
         # restarts too.
-        esphome.update_oww_model(device_id, device.oww_model)
+        await esphome.update_oww_model(device_id, device.oww_model)
         # BT proxy: mark the device online (brings its proxy listener up if
         # enabled) and reconcile against current config — covers devices
         # approved or toggled while they were offline.

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -85,6 +85,7 @@ import em_announce
 import em_recordings
 import em_runbarrier
 import em_oww_models
+import em_oww_metadata
 import em_player
 import em_timers
 import em_turnclock
@@ -328,6 +329,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         mac_address: str,
         oww_model_id: str,
         on_disconnected_cb,
+        oww_model_info=None,
         owning_server=None,   # DeviceESPhomeServer — back-reference so the
                               # standalone-announce path can read the live
                               # _standalone_play callback rather than a
@@ -344,6 +346,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self.label          = label
         self.mac_address    = mac_address
         self.oww_model_id   = oww_model_id
+        self.oww_model_info = oww_model_info or em_oww_metadata.resolve(oww_model_id)
         self._owning_server  = owning_server
         # Strong references to in-flight timer-event tasks (see the
         # VoiceAssistantTimerEventResponse branch).
@@ -630,8 +633,8 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                 available_wake_words=[
                     api_pb2.VoiceAssistantWakeWord(
                         id=self.oww_model_id,
-                        wake_word=em_oww_models.display_name(self.oww_model_id),
-                        trained_languages=["en"],
+                        wake_word=self.oww_model_info.name,
+                        trained_languages=list(self.oww_model_info.languages),
                     )
                 ],
                 active_wake_words=[self.oww_model_id],
@@ -2181,11 +2184,12 @@ class DeviceESPhomeServer:
     inbound connection is rejected with DisconnectResponse + close.
     """
 
-    def __init__(self, device_id: str, label: str, mac_address: str, oww_model_id: str, port: int) -> None:
+    def __init__(self, device_id: str, label: str, mac_address: str, oww_model_id: str, port: int, oww_model_info=None) -> None:
         self.device_id    = device_id
         self.label        = label
         self.mac_address  = mac_address
         self.oww_model_id = oww_model_id
+        self.oww_model_info = oww_model_info or em_oww_metadata.resolve(oww_model_id)
         self.port         = port
         self._server: Optional[asyncio.AbstractServer] = None
         self._active_satellite: Optional[EchoMuseSatellite] = None
@@ -2311,6 +2315,7 @@ class DeviceESPhomeServer:
             label=self.label,
             mac_address=self.mac_address,
             oww_model_id=self.oww_model_id,
+            oww_model_info=self.oww_model_info,
             on_disconnected_cb=self._on_satellite_disconnected,
             owning_server=self,
         )
@@ -2452,8 +2457,9 @@ async def _register_device_server(device_id: str, label: str | None) -> DeviceES
     # Get OWW model from device config
     config       = await loop.run_in_executor(None, db.get_device_config, device_id)
     # Custom models are file paths in config; HA sees the friendly stem.
-    oww_model_id = em_oww_models.prediction_key(
-        config.get("owwModel", "hey_jarvis_v0.1"))
+    model_name = config.get("owwModel", "hey_jarvis_v0.1")
+    oww_model_id = em_oww_models.prediction_key(model_name)
+    oww_model_info = await loop.run_in_executor(None, em_oww_metadata.resolve, model_name)
 
     # Re-check after the awaits above — a concurrent caller may have
     # created the server while we were in the executor.
@@ -2466,6 +2472,7 @@ async def _register_device_server(device_id: str, label: str | None) -> DeviceES
         label=label,
         mac_address=mac,
         oww_model_id=oww_model_id,
+        oww_model_info=oww_model_info,
         port=port,
     )
     # Capabilities that arrived before this server existed decide which HA
@@ -2848,7 +2855,7 @@ async def trigger_voice_turn(
     # configured, because a model is always configured; what varies is whether
     # it fired. Covers "wakeword(0.522)" and the on-device "wakeword-dev(…)".
     wake_word_phrase = (
-        em_oww_models.display_name(server.oww_model_id)
+        satellite.oww_model_info.name
         if trigger_label.startswith("wakeword") else ""
     )
 
@@ -2921,7 +2928,7 @@ async def push_media_state(device_id: str, state: str) -> None:
         log.debug(f"[{device_id}] media state push failed: {e}")
 
 
-def update_oww_model(device_id: str, model_id: str) -> None:
+async def update_oww_model(device_id: str, model_id: str) -> None:
     """
     Keep HA's wake-word dropdown honest.
 
@@ -2932,11 +2939,21 @@ def update_oww_model(device_id: str, model_id: str) -> None:
     by the next satellite instance) and bounce the active HA connection so
     HA redials (within seconds) and re-requests the configuration.
     """
-    model_id = em_oww_models.prediction_key(model_id)
     server = get_server(device_id)
-    if server is None or server.oww_model_id == model_id:
+    if server is None:
+        return
+    # Runtime initialization must not pause the audio event loop. A newer
+    # request wins if concurrent model reads complete out of order.
+    revision = getattr(server, "_oww_metadata_revision", 0) + 1
+    server._oww_metadata_revision = revision
+    model_info = await asyncio.to_thread(em_oww_metadata.resolve, model_id)
+    if get_server(device_id) is not server or server._oww_metadata_revision != revision:
+        return
+    model_id = em_oww_models.prediction_key(model_id)
+    if server.oww_model_id == model_id and server.oww_model_info == model_info:
         return
     server.oww_model_id = model_id
+    server.oww_model_info = model_info
     satellite = server.get_satellite()
     if satellite is not None:
         log.info(f"[{device_id}] OWW model → {model_id} — bouncing HA "

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -329,7 +329,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         mac_address: str,
         oww_model_id: str,
         on_disconnected_cb,
-        oww_model_info=None,
+        oww_model_info,
         owning_server=None,   # DeviceESPhomeServer — back-reference so the
                               # standalone-announce path can read the live
                               # _standalone_play callback rather than a
@@ -346,7 +346,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         self.label          = label
         self.mac_address    = mac_address
         self.oww_model_id   = oww_model_id
-        self.oww_model_info = oww_model_info or em_oww_metadata.resolve(oww_model_id)
+        self.oww_model_info = oww_model_info
         self._owning_server  = owning_server
         # Strong references to in-flight timer-event tasks (see the
         # VoiceAssistantTimerEventResponse branch).
@@ -2184,12 +2184,20 @@ class DeviceESPhomeServer:
     inbound connection is rejected with DisconnectResponse + close.
     """
 
-    def __init__(self, device_id: str, label: str, mac_address: str, oww_model_id: str, port: int, oww_model_info=None) -> None:
+    def __init__(
+        self,
+        device_id: str,
+        label: str,
+        mac_address: str,
+        oww_model_id: str,
+        port: int,
+        oww_model_info,
+    ) -> None:
         self.device_id    = device_id
         self.label        = label
         self.mac_address  = mac_address
         self.oww_model_id = oww_model_id
-        self.oww_model_info = oww_model_info or em_oww_metadata.resolve(oww_model_id)
+        self.oww_model_info = oww_model_info
         self.port         = port
         self._server: Optional[asyncio.AbstractServer] = None
         self._active_satellite: Optional[EchoMuseSatellite] = None

--- a/controller/em_oww_metadata.py
+++ b/controller/em_oww_metadata.py
@@ -1,0 +1,60 @@
+"""Read optional ONNX identity metadata without changing scoring model IDs.
+
+Runtime imports stay lazy: filename fallback and metadata validation can run
+in the minimal controller test environment.
+"""
+from dataclasses import dataclass
+from functools import lru_cache
+import logging
+from pathlib import Path
+import re
+
+import em_oww_models
+
+log = logging.getLogger(__name__)
+_LANGUAGE = re.compile(r"^[A-Za-z]{2,3}(?:[-_][A-Za-z0-9]{2,8})*$")
+
+
+@dataclass(frozen=True)
+class WakeWord:
+    name: str
+    languages: tuple[str, ...] = ("en",)
+
+
+def from_metadata(model_name: str, metadata: dict) -> WakeWord:
+    """Invalid or missing optional fields retain the stock naming convention."""
+    name = metadata.get("wake_word")
+    if not isinstance(name, str) or not name.strip():
+        name = em_oww_models.display_name(model_name)
+    language = metadata.get("language")
+    languages = (language.replace("_", "-"),) if (
+        isinstance(language, str) and _LANGUAGE.fullmatch(language)
+    ) else ("en",)
+    return WakeWord(name.strip(), languages)
+
+
+@lru_cache(maxsize=32)
+def _read(path: str, mtime_ns: int, size: int, inode: int) -> dict:
+    # Loading is bounded to one small classifier and one runtime thread. The
+    # file identity invalidates the cache when an upload replaces the model.
+    import onnxruntime as ort
+    options = ort.SessionOptions()
+    options.intra_op_num_threads = 1
+    options.inter_op_num_threads = 1
+    session = ort.InferenceSession(path, sess_options=options,
+                                   providers=["CPUExecutionProvider"])
+    return session.get_modelmeta().custom_metadata_map
+
+
+def resolve(model_name: str) -> WakeWord:
+    if not model_name.endswith(".onnx"):
+        return from_metadata(model_name, {})
+    try:
+        path = Path(model_name).resolve()
+        stat = path.stat()
+        metadata = _read(str(path), stat.st_mtime_ns, stat.st_size, stat.st_ino)
+    except Exception as exc:
+        # Metadata must never make an otherwise supported model unusable.
+        log.warning("Cannot read wake-word metadata for %s: %s", model_name, exc)
+        metadata = {}
+    return from_metadata(model_name, metadata)

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -1279,12 +1279,12 @@ def test_wake_word_phrase_is_sent_and_matches_what_we_advertise():
 
     advertised = re.search(r"api_pb2\.VoiceAssistantWakeWord\((.*?)\)", src, re.S)
     assert advertised, "VoiceAssistantWakeWord advertisement not found"
-    assert "em_oww_models.display_name" in advertised.group(1), (
-        "the advertised wake_word must come from em_oww_models.display_name, "
+    assert "self.oww_model_info.name" in advertised.group(1), (
+        "the advertised wake_word must come from the connection metadata, "
         "the same source as the phrase we send")
 
-    assert 'display_name(server.oww_model_id)' in src, (
-        "the phrase must be derived with display_name too — a second spelling "
+    assert 'satellite.oww_model_info.name' in src, (
+        "the phrase must use the same connection metadata — a second spelling "
         "is how it drifts from what we advertised")
 
 

--- a/controller/tests/test_oww_metadata.py
+++ b/controller/tests/test_oww_metadata.py
@@ -1,0 +1,93 @@
+"""Metadata decisions and real refresh logic, without runtime dependencies."""
+import ast
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import em_oww_metadata as metadata
+import em_oww_models
+
+
+@pytest.mark.parametrize("values", [{}, {"wake_word": ""}, {"wake_word": None}, {"wake_word": []}, {"language": "invalid code"}])
+def test_stock_fallback(values):
+    assert metadata.from_metadata("hey_jarvis_v0.1", values) == metadata.WakeWord("hey jarvis")
+
+
+def test_custom_identity_does_not_change_prediction_key():
+    name = "/models/not_the_phrase.onnx"
+    assert metadata.from_metadata(name, {"wake_word": " Hallo Welt ", "language": "de_DE"}) == metadata.WakeWord("Hallo Welt", ("de-DE",))
+    assert em_oww_models.prediction_key(name) == "not_the_phrase"
+
+
+def test_missing_and_unreadable_models_fall_back(tmp_path, monkeypatch):
+    path = tmp_path / "hey_robot.onnx"
+    assert metadata.resolve(str(path)).name == "hey robot"
+    path.write_bytes(b"not an onnx model")
+    def fail(*args):
+        raise RuntimeError("unreadable metadata")
+    monkeypatch.setattr(metadata, "_read", fail)
+    assert metadata.resolve(str(path)).name == "hey robot"
+
+
+def test_file_replacement_changes_reader_identity(tmp_path, monkeypatch):
+    path = tmp_path / "robot.onnx"
+    path.write_bytes(b"first")
+    reader = Mock(return_value={"wake_word": "First"})
+    monkeypatch.setattr(metadata, "_read", reader)
+    assert metadata.resolve(str(path)).name == "First"
+    old = reader.call_args
+    path.write_bytes(b"a different model")
+    reader.return_value = {"wake_word": "Second"}
+    assert metadata.resolve(str(path)).name == "Second"
+    assert reader.call_args != old
+
+
+def test_same_id_metadata_change_refreshes_connection(monkeypatch):
+    # Execute the production refresh function with its network boundary injected.
+    source = Path(__file__).resolve().parents[1] / "em_esphome.py"
+    tree = ast.parse(source.read_text())
+    function = next(n for n in tree.body if isinstance(n, ast.AsyncFunctionDef) and n.name == "update_oww_model")
+    satellite = SimpleNamespace(disconnect=Mock())
+    server = SimpleNamespace(oww_model_id="robot", oww_model_info=metadata.WakeWord("Old"), get_satellite=lambda: satellite)
+    current = metadata.WakeWord("Hallo", ("de",))
+    monkeypatch.setattr(metadata, "resolve", lambda name: current)
+    scope = {"asyncio": asyncio, "em_oww_models": em_oww_models, "em_oww_metadata": metadata,
+             "get_server": lambda device: server, "log": logging.getLogger(__name__)}
+    exec(compile(ast.Module(body=[function], type_ignores=[]), str(source), "exec"), scope)
+    asyncio.run(scope["update_oww_model"]("device", "/models/robot.onnx"))
+    assert server.oww_model_id == "robot"
+    assert server.oww_model_info == current
+    satellite.disconnect.assert_called_once()
+    asyncio.run(scope["update_oww_model"]("device", "/models/robot.onnx"))
+    satellite.disconnect.assert_called_once()
+
+
+def test_newer_refresh_wins_when_reads_finish_out_of_order(monkeypatch):
+    source = Path(__file__).resolve().parents[1] / "em_esphome.py"
+    function = next(n for n in ast.parse(source.read_text()).body
+                    if isinstance(n, ast.AsyncFunctionDef) and n.name == "update_oww_model")
+    satellite = SimpleNamespace(disconnect=Mock())
+    server = SimpleNamespace(oww_model_id="initial", oww_model_info=metadata.WakeWord("Initial"), get_satellite=lambda: satellite)
+    async def run():
+        first_started, release_first = asyncio.Event(), asyncio.Event()
+        async def read(_function, model):
+            if model == "first":
+                first_started.set()
+                await release_first.wait()
+            return metadata.WakeWord(model)
+        scope = {"asyncio": SimpleNamespace(to_thread=read), "em_oww_models": em_oww_models,
+                 "em_oww_metadata": metadata, "get_server": lambda device: server,
+                 "log": logging.getLogger(__name__)}
+        exec(compile(ast.Module(body=[function], type_ignores=[]), str(source), "exec"), scope)
+        first = asyncio.create_task(scope["update_oww_model"]("device", "first"))
+        await first_started.wait()
+        await scope["update_oww_model"]("device", "second")
+        release_first.set()
+        await first
+    asyncio.run(run())
+    assert server.oww_model_id == "second"
+    assert server.oww_model_info.name == "second"
+    satellite.disconnect.assert_called_once()

--- a/controller/tests/test_oww_metadata.py
+++ b/controller/tests/test_oww_metadata.py
@@ -22,6 +22,39 @@ def test_custom_identity_does_not_change_prediction_key():
     assert em_oww_models.prediction_key(name) == "not_the_phrase"
 
 
+@pytest.mark.parametrize(
+    "class_name", ["EchoMuseSatellite", "DeviceESPhomeServer"]
+)
+def test_esphome_constructors_require_resolved_model_metadata(class_name):
+    source = Path(__file__).resolve().parents[1] / "em_esphome.py"
+    tree = ast.parse(source.read_text())
+    class_def = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    constructor = next(
+        node
+        for node in class_def.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    positional = constructor.args.posonlyargs + constructor.args.args
+    required = positional[:len(positional) - len(constructor.args.defaults)]
+    assert "oww_model_info" in {argument.arg for argument in required}
+
+    assignments = [
+        node for node in ast.walk(constructor)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Attribute) and target.attr == "oww_model_info"
+            for target in node.targets
+        )
+    ]
+    assert len(assignments) == 1
+    assert isinstance(assignments[0].value, ast.Name)
+    assert assignments[0].value.id == "oww_model_info"
+
+
 def test_missing_and_unreadable_models_fall_back(tmp_path, monkeypatch):
     path = tmp_path / "hey_robot.onnx"
     assert metadata.resolve(str(path)).name == "hey robot"

--- a/oww_forge/Dockerfile
+++ b/oww_forge/Dockerfile
@@ -73,7 +73,7 @@ RUN sed -i 's/torch.load(checkpoint_path, map_location=device)/torch.load(checkp
       /usr/local/lib/python3.11/site-packages/dp/model/model.py \
     && grep -q "weights_only=False" /usr/local/lib/python3.11/site-packages/dp/model/model.py
 
-COPY forge.py google_tts.py forge_web.py piper_voices.py config.template.yml /opt/forge/
+COPY forge.py model_metadata.py google_tts.py forge_web.py piper_voices.py config.template.yml /opt/forge/
 COPY static/ /opt/forge/static/
 
 WORKDIR /data

--- a/oww_forge/README.md
+++ b/oww_forge/README.md
@@ -282,6 +282,37 @@ plain names). Note openwakeword keys its prediction dict by the filename
 *stem*, not the path — the controller maps path → stem everywhere it reads
 scores (`em_oww_models.prediction_key`), so keep filenames unique.
 
+## Model metadata
+
+New ONNX exports carry `wake_word` (the first `target_phrase`), the complete
+`target_phrases` list, `language`, `trained_by`, and a UTC `training_date`.
+Set `language` in the training config before building a non-English model.
+`recommended_threshold` is optional and advisory: it does not change a device's
+configured threshold. If the build environment supplies `FORGE_VERSION`, that
+value is recorded as `oww_forge_version`; an unknown version is omitted.
+
+The controller uses the metadata name and language when advertising the wake
+word to Home Assistant. A voice turn uses the same name that its HA connection
+advertised; button turns still carry no wake phrase. Model IDs and prediction
+keys remain filename-based. Replacing a model invalidates the metadata cache,
+and a config refresh reconnects HA if its name or language changed, even if
+the filename did not.
+
+Stock models and older or third-party files without metadata retain the existing
+filename-derived name and English language fallback. Unreadable optional metadata
+also falls back, with a warning. Publication preserves other ONNX metadata and
+uses an atomic replacement, so a failed stamp cannot replace a finished model.
+The exported file's hash changes, causing normal model asset synchronization.
+
+This exporter publishes ONNX only. Converting it separately to TFLite does not
+preserve these ONNX fields; metadata must be carried by that converter if a
+future consumer needs it.
+
+The real export/read/inference regression runs in the separate CI job:
+`python -m pytest oww_forge/tests/` (pytest, numpy, pyyaml, onnx and onnxruntime).
+The normal lightweight controller suite tests fallback and refresh behavior
+without importing runtime dependencies.
+
 ## Layout
 
 ```

--- a/oww_forge/config.template.yml
+++ b/oww_forge/config.template.yml
@@ -4,6 +4,11 @@
 
 model_name: "@NAME@"
 
+# Language advertised to Home Assistant for this trained model.
+language: "en"
+# Optional advisory detection threshold, 0..1; never overrides device settings.
+# recommended_threshold: 0.5
+
 # Phrase(s) the model activates on. Multiple entries still train ONE binary
 # model that fires on any of them — use alternate phonetic spellings to cover
 # how the phrase is actually pronounced in your house ("hey clara" is read

--- a/oww_forge/forge.py
+++ b/oww_forge/forge.py
@@ -290,6 +290,11 @@ def cmd_build(args) -> None:
     cfg_path = WAKEWORDS / name / "config.yml"
     if not cfg_path.exists():
         sys.exit(f"no such wake word: {cfg_path} missing (run forge.py new first)")
+    import yaml
+    from model_metadata import publish_model, training_metadata
+    config_text = cfg_path.read_text()
+    config = yaml.safe_load(config_text)
+    training_metadata(config)  # reject invalid identity before expensive training
     missing = missing_assets()
     if missing:
         sys.exit("missing training assets:\n  - " + "\n  - ".join(missing))
@@ -332,7 +337,9 @@ def cmd_build(args) -> None:
             sys.exit(f"training finished but {src} was not produced — check the logs above")
         MODELS.mkdir(parents=True, exist_ok=True)
         dest = MODELS / f"{name}.onnx"
-        shutil.copy2(src, dest)
+        if cfg_path.read_text() != config_text:
+            sys.exit("training config changed during the build; refusing to publish mismatched metadata")
+        publish_model(src, dest, config)
         log(f"model ready: {dest} ({dest.stat().st_size / 1e3:.0f} kB)")
         log("install into EchoMuse: see oww_forge/README.md §Installing")
 

--- a/oww_forge/model_metadata.py
+++ b/oww_forge/model_metadata.py
@@ -1,0 +1,56 @@
+"""Publish trained ONNX models with the identity supplied by their config."""
+from datetime import datetime, timezone
+import json
+import math
+import os
+from pathlib import Path
+import re
+import tempfile
+
+
+def training_metadata(config: dict, version: str = "") -> dict[str, str]:
+    if not isinstance(config, dict):
+        raise ValueError("training config must be a mapping")
+    phrases = config.get("target_phrase")
+    if not isinstance(phrases, list) or not phrases or any(
+        not isinstance(p, str) or not p.strip() for p in phrases
+    ):
+        raise ValueError("target_phrase must be a nonempty list of phrases")
+    language = config.get("language", "en")
+    if not isinstance(language, str) or not re.fullmatch(
+        r"[A-Za-z]{2,3}(?:[-_][A-Za-z0-9]{2,8})*", language
+    ):
+        raise ValueError("language must be a language code such as en or de-DE")
+    result = {
+        "wake_word": phrases[0].strip(),
+        "target_phrases": json.dumps([p.strip() for p in phrases], ensure_ascii=False),
+        "language": language.replace("_", "-"),
+        "trained_by": "oww_forge",
+        "training_date": datetime.now(timezone.utc).isoformat(),
+    }
+    if version:
+        result["oww_forge_version"] = version
+    threshold = config.get("recommended_threshold")
+    if threshold is not None:
+        if isinstance(threshold, bool) or not isinstance(threshold, (int, float)) or not math.isfinite(threshold) or not 0 <= threshold <= 1:
+            raise ValueError("recommended_threshold must be a finite number from 0 to 1")
+        result["recommended_threshold"] = str(threshold)
+    return result
+
+
+def publish_model(source: Path, destination: Path, config: dict) -> None:
+    # Keep ONNX out of forge's other CLI operations and pure config tests.
+    import onnx
+    metadata = training_metadata(config, os.environ.get("FORGE_VERSION", ""))
+    model = onnx.load(source)
+    existing = {entry.key: entry.value for entry in model.metadata_props}
+    existing.update(metadata)
+    onnx.helper.set_model_props(model, existing)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=".model-", suffix=".onnx", dir=destination.parent)
+    os.close(fd)
+    try:
+        onnx.save(model, temporary)
+        os.replace(temporary, destination)
+    finally:
+        Path(temporary).unlink(missing_ok=True)

--- a/oww_forge/tests/test_model_metadata.py
+++ b/oww_forge/tests/test_model_metadata.py
@@ -1,0 +1,88 @@
+"""Real ONNX publication and inference, separate from lightweight controller CI."""
+import json
+from pathlib import Path
+import sys
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [str(ROOT / "oww_forge"), str(ROOT / "controller")]
+from model_metadata import publish_model, training_metadata
+import em_oww_metadata
+
+
+def test_export_preserves_inference_and_overrides_filename(tmp_path):
+    source, destination = tmp_path / "source.onnx", tmp_path / "wrong_filename.onnx"
+    graph = onnx.helper.make_graph([onnx.helper.make_node("Identity", ["x"], ["y"])], "test",
+        [onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1])])
+    model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 17)], ir_version=9)
+    onnx.helper.set_model_props(model, {"unrelated": "preserved"})
+    onnx.save(model, source)
+    config = {"target_phrase": ["Hallo Clara", "Hallo Klara"], "language": "de", "recommended_threshold": 0.6}
+    publish_model(source, destination, config)
+    onnx.checker.check_model(onnx.load(destination))
+    for path in [source, destination]:
+        result = ort.InferenceSession(str(path)).run(None, {"x": np.array([0.25], dtype=np.float32)})
+        np.testing.assert_array_equal(result[0], [0.25])
+    values = {v.key: v.value for v in onnx.load(destination).metadata_props}
+    assert values["unrelated"] == "preserved"
+    assert json.loads(values["target_phrases"]) == config["target_phrase"]
+    assert values["recommended_threshold"] == "0.6"
+    assert values["trained_by"] == "oww_forge"
+    assert "training_date" in values
+    assert em_oww_metadata.resolve(str(destination)) == em_oww_metadata.WakeWord("Hallo Clara", ("de",))
+    assert em_oww_metadata.resolve(str(source)).name == "source"
+    config["target_phrase"] = ["Bonjour Clara"]
+    config["language"] = "fr"
+    publish_model(source, destination, config)
+    assert em_oww_metadata.resolve(str(destination)) == em_oww_metadata.WakeWord("Bonjour Clara", ("fr",))
+
+
+@pytest.mark.parametrize("change", [{"target_phrase": []}, {"target_phrase": [1]}, {"target_phrase": "hello"}, {"language": []}, {"recommended_threshold": float("nan")}, {"recommended_threshold": True}, {"recommended_threshold": 2}])
+def test_invalid_training_metadata_is_rejected(change):
+    with pytest.raises(ValueError):
+        training_metadata({"target_phrase": ["hello"], **change})
+
+
+def test_absent_optional_values_are_not_invented():
+    values = training_metadata({"target_phrase": ["hello"]})
+    assert values["language"] == "en"
+    assert "recommended_threshold" not in values
+    assert "oww_forge_version" not in values
+
+
+def test_invalid_stamp_preserves_existing_published_file(tmp_path):
+    source = tmp_path / "source.onnx"
+    destination = tmp_path / "published.onnx"
+    destination.write_bytes(b"previous published model")
+    with pytest.raises(ValueError):
+        publish_model(source, destination, {"target_phrase": []})
+    assert destination.read_bytes() == b"previous published model"
+    assert not list(tmp_path.glob(".model-*"))
+
+
+def test_build_publishes_training_config_metadata(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+    import forge
+    name = "filename"
+    words = tmp_path / "wakewords"
+    directory = words / name
+    directory.mkdir(parents=True)
+    (directory / "config.yml").write_text('target_phrase: ["Bonjour Clara"]\nlanguage: fr\n')
+    graph = onnx.helper.make_graph([onnx.helper.make_node("Identity", ["x"], ["y"])], "test",
+        [onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1])])
+    model = onnx.helper.make_model(graph, opset_imports=[onnx.helper.make_opsetid("", 17)], ir_version=9)
+    def train(*args, **kwargs):
+        onnx.save(model, directory / f"{name}.onnx")
+    monkeypatch.setattr(forge, "WAKEWORDS", words)
+    monkeypatch.setattr(forge, "MODELS", tmp_path / "models")
+    monkeypatch.setattr(forge, "missing_assets", lambda: [])
+    monkeypatch.setattr(forge.subprocess, "run", train)
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(__version__="fixture", cuda=SimpleNamespace(is_available=lambda: False)))
+    forge.cmd_build(SimpleNamespace(name=name, from_step="train", only_step="train", overwrite=False))
+    assert em_oww_metadata.resolve(str(tmp_path / "models" / f"{name}.onnx")) == em_oww_metadata.WakeWord("Bonjour Clara", ("fr",))


### PR DESCRIPTION
Fixes #181.

Forge now stamps the exported ONNX model with its training-config phrase(s), language and provenance, preserving other metadata and publishing atomically. The controller keeps filename-based model IDs while using one name/language snapshot for both HA advertisement and the pipeline wake phrase. Missing/unreadable metadata retains the existing fallback.

Metadata reads run off the audio loop; replacements invalidate the cache, and same-ID metadata changes refresh HA. Concurrent refreshes cannot overwrite a newer selection. An optional recommended threshold is recorded only as advice; device settings remain authoritative. The Forge README covers version provenance and the ONNX/TFLite boundary.

Validation:
- Controller suite: **1,002 passed, 3 skipped**.
- Metadata/export tests: **21 passed**, including real ONNX read/write/inference, the build publication path with training stubbed, fallback, same-ID refresh and out-of-order refreshes. A separate CI job runs the ONNX tests without expanding lightweight controller dependencies.
- Linux container: `go test ./internal/... ./pkg/...` and `go vet ./internal/... ./pkg/...` passed.
- Undefined-name checks, helper/test pyflakes, channel-generation check and diff check passed.

Implemented with Codex. No Echo hardware, live HA connection, GPU training run or TFLite conversion was tested. Both runtime image COPY lists include the helpers; maintainer logs and generated channel files are untouched.
