### PR TITLE
Make every wizard step verify what it inherits and what it did

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## 2.23.0-ea.5 (Early Access)
+
+**Fixes a provisioning wizard that could not install emOS at all, and adds a
+one-click undo if the flash goes wrong.** Nothing changes on devices already
+running; this is entirely the setup flow.
+
+### The emOS install steps now work
+
+Provisioning stopped at "Install EchoMuse" with every command reporting
+`su: not found`, having said the recovery environment was ready a step
+earlier. TWRP is already root, so the wizard installs a small `su` stand-in to
+let the shared install steps run unchanged — and it was written pointing at a
+shell path that does not exist in recovery, so it could never run. Worse, a
+retry then *skipped* the check that had just caught it, which is why step 3
+turned green and step 4 failed anyway.
+
+The stand-in is now built against the shell the device actually has, it is
+tested by running it rather than by looking for the file, and each step that
+needs it sets it up itself — reconnecting between steps used to quietly remove
+it.
+
+### If a flash fails, the wizard puts your image back
+
+A failed boot-partition write used to end with a warning and a command to type
+yourself. There is now a **Restore escrowed boot image** button on the flash
+and first-boot steps: it writes back the image the wizard escrowed before it
+changed anything, verifies it against the partition, and leaves everything on
+`/data` untouched. If the page has been reloaded, it accepts the `.img` file
+you downloaded at the escrow step.
+
+The flash itself also retries once automatically before giving up, refuses an
+image too large for the partition instead of writing a truncated one, and can
+now tell a short write from a corrupt one and a bad partition from an
+unreliable read.
+
+### Steps that said they worked when they had not
+
+Four places reported success having achieved nothing: the install step logged
+"Cleared." after every command failed, wake word assets were checked where they
+were uploaded rather than where they were installed, the startup script was
+copied without verification while the binary beside it was checked byte for
+byte, and WiFi's "Skip (already connected)" marked itself done without asking
+the device anything. All four now check.
+
+### Safer partition handling
+
+The wizard's one partition write now goes to the partition it ran its safety
+check against, rather than re-resolving a symlink that could answer
+differently. And every step confirms the device is in the mode it needs —
+unplugging an Echo powers it off, so a replug comes back in Android, and a
+recovery step run there had nothing but one guard in front of it.
+
 ## 2.23.0-ea.4 (Early Access)
 
 **Your Echo can now run without any of Amazon's software on it, and the

--- a/controller-ea/config.yaml
+++ b/controller-ea/config.yaml
@@ -17,7 +17,7 @@ name: "EchoMuse (Early Access)"
 # derives from the controller-v* tag (controller-v2.18.0 -> 2.18.0). Bump
 # both together: Supervisor pulls `image:version`, so a version with no
 # matching tag on GHCR fails to install.
-version: "2.23.0-ea.4"
+version: "2.23.0-ea.5"
 # Pull the published multi-arch image rather than building on the user's
 # machine. Without this Supervisor builds from this directory's Dockerfile,
 # which downloads a few hundred MB on whatever the user runs Home Assistant

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## 2.23.0-ea.5 (Early Access)
+
+**Fixes a provisioning wizard that could not install emOS at all, and adds a
+one-click undo if the flash goes wrong.** Nothing changes on devices already
+running; this is entirely the setup flow.
+
+### The emOS install steps now work
+
+Provisioning stopped at "Install EchoMuse" with every command reporting
+`su: not found`, having said the recovery environment was ready a step
+earlier. TWRP is already root, so the wizard installs a small `su` stand-in to
+let the shared install steps run unchanged — and it was written pointing at a
+shell path that does not exist in recovery, so it could never run. Worse, a
+retry then *skipped* the check that had just caught it, which is why step 3
+turned green and step 4 failed anyway.
+
+The stand-in is now built against the shell the device actually has, it is
+tested by running it rather than by looking for the file, and each step that
+needs it sets it up itself — reconnecting between steps used to quietly remove
+it.
+
+### If a flash fails, the wizard puts your image back
+
+A failed boot-partition write used to end with a warning and a command to type
+yourself. There is now a **Restore escrowed boot image** button on the flash
+and first-boot steps: it writes back the image the wizard escrowed before it
+changed anything, verifies it against the partition, and leaves everything on
+`/data` untouched. If the page has been reloaded, it accepts the `.img` file
+you downloaded at the escrow step.
+
+The flash itself also retries once automatically before giving up, refuses an
+image too large for the partition instead of writing a truncated one, and can
+now tell a short write from a corrupt one and a bad partition from an
+unreliable read.
+
+### Steps that said they worked when they had not
+
+Four places reported success having achieved nothing: the install step logged
+"Cleared." after every command failed, wake word assets were checked where they
+were uploaded rather than where they were installed, the startup script was
+copied without verification while the binary beside it was checked byte for
+byte, and WiFi's "Skip (already connected)" marked itself done without asking
+the device anything. All four now check.
+
+### Safer partition handling
+
+The wizard's one partition write now goes to the partition it ran its safety
+check against, rather than re-resolving a symlink that could answer
+differently. And every step confirms the device is in the mode it needs —
+unplugging an Echo powers it off, so a replug comes back in Android, and a
+recovery step run there had nothing but one guard in front of it.
+
 ## 2.23.0-ea.4 (Early Access)
 
 **Your Echo can now run without any of Amazon's software on it, and the

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -3066,7 +3066,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   const [adb, setAdb]           = useState(null);
   const [magiskFile, setMagiskFile] = useState(null);
   const [binaryFile, setBinaryFile] = useState(null);
-  // emOS flow. `emosRef` is the escrowed stock boot image — the build input
+  // emOS flow. `emosRef` is the escrowed boot image — the build input
   // and the undo — held in the page for the length of the wizard; the copy
   // that matters is the one downloaded to the operator's disk at step 2.
   const [emosRef, setEmosRef]       = useState(null);
@@ -3074,7 +3074,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   const [emosImage, setEmosImage]   = useState(null);
   // Holds the operator's own copy of the escrowed image when this session no
   // longer has one — a page reload loses emosRef, which is exactly when the
-  // restore is needed. See restoreStockBoot.
+  // restore is needed. See restoreEscrowedBoot.
   const [restoreFile, setRestoreFile] = useState(null);
   const [initFile, setInitFile]     = useState(null);
   const [emosConsole, setEmosConsole] = useState(null);
@@ -5057,7 +5057,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     if (err) {
       throw new Error(
         `${err}\n\nDO NOT REBOOT — the device is still in TWRP and recoverable from `
-        + 'here. Use "Restore stock boot image" below to put your escrowed image '
+        + 'here. Use "Restore escrowed boot image" below to put it back '
         + 'back; it takes about ten seconds and leaves /data untouched.');
     }
     addLog('The device is now an emOS device. If anything below goes wrong, '
@@ -5065,8 +5065,15 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
          + 'everything installed on /data alone.', 'warn');
   }
 
-  // Put the device back the way it was found. Offered on a flash or first-boot
-  // failure rather than printed as a dd command for the operator to run: the
+  // Put the device back the way it was found — which is NOT necessarily stock.
+  // On a device that has been through the FireOS flow the escrow carries our
+  // own permissive cmdline patch (measured 2026-09-06: slot A reads exactly
+  // `bootopt=64S3,32N2,64N2 androidboot.selinux=permissive`, slot B still has
+  // the untouched FireOS one). What was on the partition is the right thing to
+  // put back, so the copy says "escrowed", never "stock".
+  //
+  // Offered on a flash or first-boot failure rather than printed as a dd
+  // command for the operator to run: the
   // escrowed bytes are already in the page, the write path is the same verified
   // one the flash uses, and someone whose device will not boot is not in a good
   // position to be handed homework.
@@ -5074,7 +5081,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   // `file` overrides the in-page escrow, because a page reload loses emosRef
   // and that is exactly when this is needed — the copy downloaded at step 3 is
   // the same bytes.
-  async function restoreStockBoot(file) {
+  async function restoreEscrowedBoot(file) {
     setRunning(true);
     try {
       const c = adb;
@@ -5104,21 +5111,21 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
           + `(got "${magic.replace(/[^\x20-\x7e]/g, '.')}"), so it is not a boot image. `
           + 'Nothing has been written.');
       }
-      addLog('── RESTORE STOCK BOOT IMAGE ──', 'head');
-      let err = await _writeBootPartition(c, target, bytes, md5, 'stock boot image');
+      addLog('── RESTORE ESCROWED BOOT IMAGE ──', 'head');
+      let err = await _writeBootPartition(c, target, bytes, md5, 'escrowed image');
       if (err) {
         addLog(`${err}`, 'error');
         addLog('Retrying the restore once…', 'warn');
-        err = await _writeBootPartition(c, target, bytes, md5, 'stock boot image (retry)');
+        err = await _writeBootPartition(c, target, bytes, md5, 'escrowed image (retry)');
       }
       if (err) {
         throw new Error(`${err}\n\nThe restore did not verify. Do not reboot. The `
           + `device is still in TWRP, and the image can also be written by hand from `
-          + `a TWRP shell with:\n  dd if=<your stock boot image> of=${target}`);
+          + `a TWRP shell with:\n  dd if=<your escrowed .img> of=${target}`);
       }
-      addLog('Stock boot image restored and verified against the partition. The '
-           + 'device will boot FireOS as it did before. Everything installed on '
-           + '/data is untouched.', 'ok');
+      addLog('Escrowed image restored and verified against the partition. The '
+           + 'device will boot exactly as it did before this run. Everything '
+           + 'installed on /data is untouched.', 'ok');
     } catch (e) {
       addLog(`Restore failed: ${e.message}`, 'error');
     } finally {
@@ -5670,8 +5677,8 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
                   onChange={e => setRestoreFile(e.target.files[0] || null)}
                   style={{ fontFamily: "'DM Mono',monospace", fontSize: 10 }} />
                 <Pill danger disabled={!adb || (!emosRef && !restoreFile)}
-                  onClick={() => restoreStockBoot(restoreFile)}>
-                  Restore stock boot image
+                  onClick={() => restoreEscrowedBoot(restoreFile)}>
+                  Restore escrowed boot image
                 </Pill>
               </div>
             )}

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -3492,7 +3492,16 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     // stderr carried through rather than discarded: dd reports its record
     // counts there, and a silenced read failure used to reach magiskboot as
     // an empty file with nothing in the log to say why.
-    const pullOut = await c.shell('dd if=/dev/block/other-boot of=/tmp/work/boot.img bs=1048576 2>&1');
+    // Every read and write below uses boot.target — the node classifyBootTarget
+    // actually reached a verdict about — never /dev/block/other-boot again.
+    // Re-resolving the symlink at write time means the safety check and the
+    // write are asking two different questions moments apart, and the log line
+    // at the flash claims boot.target either way, so a disagreement would be
+    // invisible. It also made the read-back self-consistent: a wrong-but-stable
+    // resolution reads back exactly what it just wrote and passes. Same reason
+    // the ESPHome mac is resolved once and passed rather than derived twice,
+    // and the emOS flow below already does it this way.
+    const pullOut = await c.shell(`dd if=${boot.target} of=/tmp/work/boot.img bs=1048576 2>&1`);
     addLog(pullOut.trim() || '(done)');
     const bootImg = await c.pull('/tmp/work/boot.img');
     addLog(`Boot image: ${(bootImg.length / 1024 / 1024).toFixed(1)} MB`);
@@ -3565,14 +3574,14 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     addLog(repackOut || '(done)');
 
     addLog(`Flashing patched boot image to ${boot.names.length ? `${boot.names.join(', ')} (${boot.target})` : boot.target}…`);
-    const flashOut = await c.shell('dd if=/tmp/work/new-boot.img of=/dev/block/other-boot bs=1048576 2>&1');
+    const flashOut = await c.shell(`dd if=/tmp/work/new-boot.img of=${boot.target} bs=1048576 2>&1`);
     addLog(flashOut.trim() || '(done)');
 
     // Read the cmdline back off the partition rather than trusting dd's exit.
     // This is the write the device has to boot from next, and a bad one costs
     // a rollback and a boot attempt to discover — the same reasoning the OTA
     // path applies to md5 before it moves a symlink.
-    const readback = await c.shell('dd if=/dev/block/other-boot bs=1 skip=64 count=512 2>/dev/null');
+    const readback = await c.shell(`dd if=${boot.target} bs=1 skip=64 count=512 2>/dev/null`);
     if (!readback.includes('androidboot.selinux=permissive')) {
       throw new Error(
         `Flashed the patched image to ${boot.target} but reading it back does not show the `
@@ -4291,6 +4300,41 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     throw new Error(`Associated to "${ssid}" but did not get an IP within 20s. Check device logcat for DHCP issues.`);
   }
 
+  // "Skip (already connected)" used to mark the step done and advance, having
+  // asked the device nothing. The button makes a claim about the device, and
+  // the claim is testable with the same wpa_cli the step itself waits on — so
+  // test it. Skipping on a device that is not actually associated provisions a
+  // Dot that then never reaches the controller, and the wizard's transcript
+  // says WiFi was fine.
+  async function skipWifiIfConnected() {
+    setRunning(true);
+    try {
+      const status = await adb.shell(
+        "su -c 'wpa_cli -p /data/misc/wifi/sockets -i wlan0 status' 2>&1");
+      const state = (status.match(/wpa_state=(\S+)/) || [])[1];
+      if (state !== 'COMPLETED') {
+        addLog(`Not skipping: the device reports wpa_state=${state || 'nothing readable'}, `
+             + 'so it is not on a network. Pick one above and join it.', 'error');
+        return;
+      }
+      const ssid = (status.match(/^ssid=(.+)$/m) || [])[1];
+      const ip   = (await adb.shell(
+        "su -c 'ip addr show wlan0 | grep \"inet \" | while read proto addr rest; do echo ${addr%/*}; done'")).trim();
+      if (!/\d+\.\d+\.\d+\.\d+/.test(ip)) {
+        addLog(`Not skipping: associated to "${ssid || '?'}" but with no IP address, `
+             + 'so nothing can reach the controller.', 'error');
+        return;
+      }
+      addLog(`Already connected to "${ssid || '?'}" (${ip}) — skipping WiFi setup.`, 'ok');
+      markStep(10, 'done');
+      setStep(11);
+    } catch (e) {
+      addLog(`Could not confirm the device is already connected: ${e.message}`, 'error');
+    } finally {
+      setRunning(false);
+    }
+  }
+
   async function runDisableAlexa(c) {
     // `su -c id` succeeding (the previous step) only confirms Magisk/root
     // is up — it does NOT mean the Android framework has finished booting.
@@ -4526,7 +4570,19 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     // empty output, so capturing stderr here would corrupt the "empty
     // means gone" check below. Discard stderr instead, matching the
     // existing proven pattern in em_api.py exactly.
-    const linkAfterClear = (await c.shell('su -c "readlink /data/local/bin/server" 2>/dev/null')).trim();
+    // The sentinel is what separates "the symlink is gone" from "su could not
+    // run", which discarded stderr renders identical — and the second answer
+    // read as success, so a run where every su failed still logged "Cleared."
+    // and went on to install nothing (measured 2026-09-06). echo and readlink
+    // are both already proven on this device.
+    const clearProbe = await c.shell(
+      'su -c "readlink /data/local/bin/server; echo _CLEARCHK" 2>/dev/null');
+    if (!clearProbe.includes('_CLEARCHK')) {
+      throw new Error('Could not confirm the install was cleared — the check '
+        + 'produced no output at all, so "su" is not working on this device '
+        + 'rather than the symlink being gone. Retry the previous step.');
+    }
+    const linkAfterClear = clearProbe.replace('_CLEARCHK', '').trim();
     if (linkAfterClear) {
       throw new Error(`Failed to clear pre-existing install — /data/local/bin/server still links to "${linkAfterClear}" after rm. Check permissions/mount state with "su -c mount" before retrying.`);
     }
@@ -4593,7 +4649,22 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     // can race with the cat process. start_server.sh isn't executed
     // immediately here (only copied), so push() is safe for this one.
     await c.push('/sdcard/start_server.sh', new TextEncoder().encode(script));
-    await c.shell("su -c 'cp /sdcard/start_server.sh /data/local/bin/start_server.sh && chmod 755 /data/local/bin/start_server.sh'");
+    const scriptOut = (await c.shell("su -c 'cp /sdcard/start_server.sh /data/local/bin/start_server.sh && chmod 755 /data/local/bin/start_server.sh' 2>&1")).trim();
+    if (scriptOut) addLog(`  → ${scriptOut}`);
+    // The binary above is verified byte for byte and this was not checked at
+    // all — and this is the file init actually executes, so a device with a
+    // perfect binary and no start script never runs EchoMuse and says nothing
+    // about why. md5 rather than a cat comparison: the shell mangles line
+    // endings and the OTA path already treats md5 as the only definition of a
+    // successful transfer.
+    const scriptWant = await _md5Hex(new TextEncoder().encode(script));
+    const scriptGot  = (await c.shell(
+      "su -c 'busybox md5sum /data/local/bin/start_server.sh' 2>/dev/null")).trim().split(/\s+/)[0];
+    if (scriptGot !== scriptWant) {
+      throw new Error('Startup script install verification failed — '
+        + `/data/local/bin/start_server.sh reads ${scriptGot || 'unreadable'}, expected `
+        + `${scriptWant}. Without it the device will never start EchoMuse.`);
+    }
     addLog('EchoMuse installed.', 'ok');
 
     // Device-link TLS credentials — pushed pre-first-contact so the very
@@ -4666,14 +4737,41 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     if (uid !== '0') {
       throw new Error(`Expected a root shell in TWRP, got uid ${uid || '(unknown)'}.`);
     }
-    const hasSu = (await c.shell('command -v su >/dev/null 2>&1 && echo yes || echo no')).trim();
-    if (hasSu !== 'yes') {
-      addLog('  no su in recovery — installing a shim (everything here is already root)');
-      await c.shell("printf '#!/bin/sh\\n[ \"$1\" = \"-c\" ] && shift\\nexec /bin/sh -c \"$*\"\\n' > /sbin/su; chmod 755 /sbin/su");
-      const shimOk = (await c.shell('su -c "id -u" 2>&1')).trim();
-      if (shimOk !== '0') {
-        throw new Error(`Could not make "su" work in recovery (got "${shimOk}").`);
+    // The test is whether `su` RUNS, never whether a file called su exists.
+    // A shim with an unusable interpreter is on PATH and executable, so
+    // `command -v su` says yes and every `su -c` after it still dies with
+    // "su: not found" — the shell's message for ENOENT on exec is the same
+    // whether the binary or its interpreter is the thing missing. That made a
+    // failed first attempt hand the retry a broken shim, which then SKIPPED
+    // this whole block and reported the environment ready (measured on
+    // G090LF11803611NF, 2026-09-06: step 3 green, every su in step 4 dead).
+    let suUid = (await c.shell('su -c "id -u" 2>&1')).trim();
+    if (suUid !== '0') {
+      addLog('  no working su in recovery — installing a shim (everything here is already root)');
+      // There is no /bin on Android or in a TWRP ramdisk — the shell is
+      // /sbin/sh here and /system/bin/sh under Android — so a `#!/bin/sh`
+      // shim is unrunnable by construction. Ask the device which one it has
+      // rather than naming one and hoping.
+      const sh = (await c.shell(
+        'for p in /sbin/sh /system/bin/sh /bin/sh; do [ -x "$p" ] && { echo "$p"; break; }; done'
+      )).trim();
+      if (!sh) {
+        throw new Error('No usable shell found in recovery (tried /sbin/sh, '
+          + '/system/bin/sh, /bin/sh), so "su" cannot be shimmed.');
       }
+      const writeOut = (await c.shell(
+        `printf '#!${sh}\\n[ "$1" = "-c" ] && shift\\nexec ${sh} -c "$*"\\n' > /sbin/su 2>&1; `
+        + 'chmod 755 /sbin/su 2>&1'
+      )).trim();
+      if (writeOut) addLog(`  → ${writeOut}`);
+      suUid = (await c.shell('su -c "id -u" 2>&1')).trim();
+      if (suUid !== '0') {
+        throw new Error(`Could not make "su" work in recovery (shell ${sh}, `
+          + `got "${suUid}"). /sbin is a tmpfs and should be writable — if the `
+          + 'write above reported an error, this TWRP build is not one the '
+          + 'wizard can drive.');
+      }
+      addLog(`  su → ${sh}`);
     }
 
     // The shared steps stage uploads through /sdcard. In recovery that is not
@@ -5019,7 +5117,20 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
         await c.shell('su -c "rm -f /sdcard/em_oww_asset"');
         throw new Error(`${a.name} arrived corrupted (md5 ${got || 'unreadable'}, expected ${a.md5}).`);
       }
-      await c.shell(`su -c "mv /sdcard/em_oww_asset ${manifest.dir}/${a.name} && chmod 644 ${manifest.dir}/${a.name}"`);
+      // The md5 above proves the bytes reached /sdcard, which is NOT where they
+      // have to end up. The move was unchecked and the tick was printed either
+      // way, so a full /data or a broken su logged fifteen megabytes of
+      // successful pushes and installed nothing — the failure then surfaces at
+      // dlopen on the device, naming nothing useful. Hash the destination.
+      const moveOut = (await c.shell(
+        `su -c "mv /sdcard/em_oww_asset ${manifest.dir}/${a.name} && chmod 644 ${manifest.dir}/${a.name}" 2>&1`)).trim();
+      if (moveOut) addLog(`  → ${moveOut}`);
+      const landed = (await c.shell(
+        `su -c "busybox md5sum ${manifest.dir}/${a.name}" 2>/dev/null`)).trim().split(/\s+/)[0];
+      if (landed !== a.md5) {
+        throw new Error(`${a.name} did not land in ${manifest.dir} `
+          + `(md5 ${landed || 'unreadable'}, expected ${a.md5}). Check free space on /data.`);
+      }
       addLog(`  ✓ ${a.name}`);
     }
     addLog('Wake word assets installed. On-device scoring is off by default — '
@@ -5077,12 +5188,43 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
         throw new Error('There is no ADB connection. Click Reconnect, pick the '
                       + 'device from the USB picker, then Retry this step.');
       }
+      // The mode the device is actually in, checked against the mode this step
+      // needs, on EVERY run. _STEP_MODE existed before this and was consulted
+      // in exactly one place — reconnectAdb — where a mismatch only logged a
+      // line and left Retry enabled, so a TWRP step could still be run against
+      // Android. That was the wrong shape twice over: pulling the cable powers
+      // the Dot off and a replug is a cold boot into Android, so arriving in
+      // the wrong mode is the NORMAL consequence of the recovery the wizard
+      // invites; and in Android /dev/block/other-boot is amonet's unlock
+      // payload rather than a kernel. classifyBootTarget refuses that write,
+      // but it was the only thing standing in front of it, and a guard is
+      // worth more when it is not the last one. Steps run over the serial
+      // console have no ADB handle and are exempt via needsAdb.
+      const wantMode = STEP_MODE[stepIdx];
+      const gotMode  = _bannerMode(c?.banner);
+      if (needsAdb && wantMode && gotMode !== 'unknown' && gotMode !== wantMode) {
+        throw new Error(
+          `This step runs in ${_MODE_NAME[wantMode]}, but the device is in `
+          + `${_MODE_NAME[gotMode]} (banner "${c.banner}"). Nothing has been run. `
+          + (wantMode === 'twrp'
+              ? 'Unplug, plug back in, and hold the mute button for about 5 seconds '
+                + 'as soon as the blue LED appears, then Reconnect.'
+              : 'Reboot the device to Android and Reconnect.'));
+      }
       if (isEmos) switch (stepIdx) {
         case 0: c = await runConnectAndroid(); break;
         case 1: c = await runConnectTwrp(); break;
         case 2: await runEscrowBoot(c); break;
-        case 3: await runInstallEchoMuse(c, binaryFile, useLatest); break;
-        case 4: await runInstallOwwAssets(c); break;
+        // Every TWRP step prepares its own environment rather than inheriting
+        // step 2's. The su shim and the /sdcard symlink both live in the
+        // recovery ramdisk, so a Reconnect between steps — which the operator
+        // is invited to do on any failure — silently takes them away, and the
+        // steps below are the shared FireOS ones that assume both. It is
+        // idempotent and costs three shell round trips.
+        case 3: await prepareTwrpForInstall(c);
+                await runInstallEchoMuse(c, binaryFile, useLatest); break;
+        case 4: await prepareTwrpForInstall(c);
+                await runInstallOwwAssets(c); break;
         case 5: await runBuildEmos(useLatest); break;
         case 6: await runFlashEmos(c); break;
         case 7: await runRebootAndWatch(c); break;
@@ -5393,7 +5535,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
                 onScan={() => scanWifi(adb).then(nets => setWifiNetworks(nets)).catch(e => addLog(`Scan failed: ${e.message}`, 'error'))}
                 networks={wifiNetworks}
                 onConnect={() => { if (wifiSsid) runStep(10); }}
-                onSkip={() => { markStep(10, 'done'); setStep(11); }}
+                onSkip={skipWifiIfConnected}
                 onAbort={() => { markStep(10, 'error'); addLog('WiFi skipped — provision incomplete.', 'warn'); }}
               />
             )}

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -3072,6 +3072,10 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   const [emosRef, setEmosRef]       = useState(null);
   const [emosTarget, setEmosTarget] = useState(null);
   const [emosImage, setEmosImage]   = useState(null);
+  // Holds the operator's own copy of the escrowed image when this session no
+  // longer has one — a page reload loses emosRef, which is exactly when the
+  // restore is needed. See restoreStockBoot.
+  const [restoreFile, setRestoreFile] = useState(null);
   const [initFile, setInitFile]     = useState(null);
   const [emosConsole, setEmosConsole] = useState(null);
   const [wifiSsid, setWifiSsid] = useState('');
@@ -4923,21 +4927,37 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   }
 
   // Step 6 — flash and verify.
-  async function runFlashEmos(c) {
-    if (!emosImage) throw new Error('Nothing built yet — run the Build emOS step first.');
-    const target = emosTarget || emosRef?.target;
-    if (!target) throw new Error('No flash target resolved — re-run the escrow step.');
+  // dd's stderr, which is logged and was never read. "16+0 records in / 16+0
+  // records out" is the whole diagnosis of a short write, and a short write and
+  // a corrupt one want opposite responses — one means the image does not fit or
+  // the partition ended early, the other means retry.
+  function _ddShortWrite(out) {
+    const rec = [...out.matchAll(/^(\d+)\+(\d+) records (in|out)$/gm)];
+    const inn = rec.find(m => m[3] === 'in');
+    const got = rec.find(m => m[3] === 'out');
+    if (!inn || !got) return null;
+    if (inn[1] === got[1] && inn[2] === got[2]) return null;
+    return `${got[1]}+${got[2]} of ${inn[1]}+${inn[2]} blocks reached the partition`;
+  }
 
-    addLog(`Uploading the image to the device…`);
-    await c.push('/tmp/emos_boot.img', emosImage.bytes,
-      pct => setProgress({ label: 'Uploading image', pct }));
+  // One write to the boot partition, verified against the partition itself.
+  // Shared by the flash and the restore rather than copied: this is the only
+  // code in the wizard that can leave a device unbootable, and a second copy
+  // is one that drifts from the checks this one carries.
+  //
+  // Returns null on success, or a string naming what went wrong — the caller
+  // decides whether that is a retry, a restore, or a stop.
+  async function _writeBootPartition(c, target, bytes, md5, what) {
+    addLog(`Uploading the ${what} to the device…`);
+    await c.push('/tmp/emos_boot.img', bytes,
+      pct => setProgress({ label: `Uploading ${what}`, pct }));
     setProgress(null);
 
     const staged = (await c.shell('busybox md5sum /tmp/emos_boot.img 2>/dev/null')).trim().split(/\s+/)[0];
-    if (staged !== emosImage.md5) {
+    if (staged !== md5) {
       await c.shell('rm -f /tmp/emos_boot.img');
-      throw new Error(`The image arrived on the device corrupted (md5 ${staged || 'unreadable'}, `
-                    + `expected ${emosImage.md5}). Nothing has been written.`);
+      return `The ${what} arrived on the device corrupted (md5 ${staged || 'unreadable'}, `
+           + `expected ${md5}). Nothing has been written.`;
     }
     addLog('  staged and verified on the device');
 
@@ -4951,36 +4971,159 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       `busybox dd if=/tmp/emos_boot.img of=${target} bs=1048576 conv=fsync 2>&1; sync`);
     const secs = (Date.now() - t0) / 1000;
     addLog(wrote.trim() || '(done)');
-    const mbps = (emosImage.bytes.length / 1024 / 1024) / Math.max(secs, 0.001);
+    const mbps = (bytes.length / 1024 / 1024) / Math.max(secs, 0.001);
     addLog(`  ${mbps.toFixed(1)} MB/s over ${secs.toFixed(1)}s`);
     if (mbps > 60) {
       addLog('That throughput is not achievable on this eMMC, so the write '
            + 'probably went to cache. The read-back below is the check that '
            + 'matters.', 'warn');
     }
+    const short = _ddShortWrite(wrote);
+    if (short) {
+      addLog(`  dd reports a short write: ${short}`, 'error');
+    }
+    if (/no space left/i.test(wrote)) {
+      addLog('  the partition filled before the image ended — the image is '
+           + 'larger than the partition it is being written to', 'error');
+    }
 
-    await c.shell('echo 3 > /proc/sys/vm/drop_caches 2>/dev/null; sync');
-    addLog('Reading it back…');
-    const back = (await c.shell(
-      `busybox dd if=${target} bs=1048576 count=${Math.ceil(emosImage.bytes.length / 1048576)} `
-      + `2>/dev/null | busybox md5sum`)).trim().split(/\s+/)[0];
+    const blocks = Math.ceil(bytes.length / 1048576);
+    const padded = new Uint8Array(blocks * 1048576);
+    padded.set(bytes);
     // dd reads whole megabytes, so hash the image padded the same way rather
     // than comparing against the image's own md5 — otherwise a perfectly good
     // flash fails on the tail padding.
-    const padded = new Uint8Array(Math.ceil(emosImage.bytes.length / 1048576) * 1048576);
-    padded.set(emosImage.bytes);
     const want = await _md5Hex(padded);
-    if (back !== want) {
-      throw new Error(
-        `The partition does not contain what we wrote (read ${back || 'nothing'}, `
-        + `expected ${want}). DO NOT REBOOT. Restore the escrowed image with:\n`
-        + `  dd if=<your stock boot image> of=${target}`);
+    const readBack = async () => {
+      await c.shell('echo 3 > /proc/sys/vm/drop_caches 2>/dev/null; sync');
+      return (await c.shell(
+        `busybox dd if=${target} bs=1048576 count=${blocks} 2>/dev/null | busybox md5sum`))
+        .trim().split(/\s+/)[0];
+    };
+    addLog('Reading it back…');
+    const back = await readBack();
+    if (back === want) {
+      await c.shell('rm -f /tmp/emos_boot.img');
+      addLog('Write verified against the partition itself.', 'ok');
+      return null;
     }
-    await c.shell('rm -f /tmp/emos_boot.img');
-    addLog('Flash verified against the partition itself.', 'ok');
+
+    // A second read separates a partition that genuinely holds the wrong bytes
+    // from a read that is unstable or still cached — same answer twice is the
+    // partition, a different answer twice is not, and they are not the same
+    // problem. Cheap, and it runs once, on a path that has already failed.
+    addLog('  read-back does not match — reading a second time to tell a bad '
+         + 'write from an unstable read…', 'warn');
+    const again = await readBack();
+    const detail = again === back
+      ? `the partition consistently reads ${back || 'nothing'}, expected ${want}`
+      : `two reads of the partition disagree (${back || 'nothing'} then `
+        + `${again || 'nothing'}), so the read itself is unreliable`;
+    return `The write did not take: ${detail}.`
+         + (short ? ` ${short}.` : '');
+  }
+
+  async function runFlashEmos(c) {
+    if (!emosImage) throw new Error('Nothing built yet — run the Build emOS step first.');
+    const target = emosTarget || emosRef?.target;
+    if (!target) throw new Error('No flash target resolved — re-run the escrow step.');
+
+    // The escrow is a whole-partition read (dd bs=1M with no count), so the
+    // reference length IS the partition size. An image larger than it cannot
+    // be written, and nothing asserted that — not the builder, not here. It
+    // would have failed correctly at the read-back and then blamed the
+    // partition, sending the operator to restore a device that was never
+    // touched by anything worse than a truncated write. Refuse before writing.
+    if (emosRef && emosImage.bytes.length > emosRef.bytes.length) {
+      throw new Error(
+        `The built image is ${(emosImage.bytes.length/1024/1024).toFixed(1)} MB but the boot `
+        + `partition is ${(emosRef.bytes.length/1024/1024).toFixed(1)} MB, so it cannot fit. `
+        + 'Nothing has been written and the device is untouched — this is a build '
+        + 'problem, not a device one. Re-run Build emOS.');
+    }
+
+    let err = await _writeBootPartition(
+      c, target, emosImage.bytes, emosImage.md5, 'emOS image');
+    if (err) {
+      // One retry, automatically. The device is already sitting on a boot
+      // partition that does not hold what we wanted, so writing the same bytes
+      // again cannot make it worse, and a transient eMMC write failure is the
+      // likeliest cause of a single bad verify. Once, never in a loop.
+      addLog(`${err}`, 'error');
+      addLog('Retrying the write once before giving up…', 'warn');
+      err = await _writeBootPartition(
+        c, target, emosImage.bytes, emosImage.md5, 'emOS image (retry)');
+    }
+    if (err) {
+      throw new Error(
+        `${err}\n\nDO NOT REBOOT — the device is still in TWRP and recoverable from `
+        + 'here. Use "Restore stock boot image" below to put your escrowed image '
+        + 'back; it takes about ten seconds and leaves /data untouched.');
+    }
     addLog('The device is now an emOS device. If anything below goes wrong, '
          + 'restoring the escrowed image takes about ten seconds and leaves '
          + 'everything installed on /data alone.', 'warn');
+  }
+
+  // Put the device back the way it was found. Offered on a flash or first-boot
+  // failure rather than printed as a dd command for the operator to run: the
+  // escrowed bytes are already in the page, the write path is the same verified
+  // one the flash uses, and someone whose device will not boot is not in a good
+  // position to be handed homework.
+  //
+  // `file` overrides the in-page escrow, because a page reload loses emosRef
+  // and that is exactly when this is needed — the copy downloaded at step 3 is
+  // the same bytes.
+  async function restoreStockBoot(file) {
+    setRunning(true);
+    try {
+      const c = adb;
+      if (!c) throw new Error('There is no ADB connection. Click Reconnect and try again.');
+      const target = emosTarget || emosRef?.target;
+      if (!target) {
+        throw new Error('No partition target is known in this session. Re-run the '
+          + 'Escrow Boot Image step — it only reads, and it resolves the target.');
+      }
+      let bytes = emosRef?.bytes;
+      let md5   = emosRef?.md5;
+      if (file) {
+        bytes = new Uint8Array(await file.arrayBuffer());
+        md5   = await _md5Hex(bytes);
+        addLog(`Using ${file.name} (${(bytes.length/1024/1024).toFixed(1)} MB, md5 ${md5}).`);
+      }
+      if (!bytes) {
+        throw new Error('No escrowed image in this session. Choose the '
+          + 'echomuse-stock-boot-*.img file downloaded at the escrow step.');
+      }
+      // The same guard the escrow and the patch step apply. Restoring is the
+      // one operation nobody will check afterwards, so a file that is not a
+      // boot image must not reach the partition.
+      const magic = new TextDecoder().decode(bytes.slice(0, 8));
+      if (magic !== 'ANDROID!') {
+        throw new Error(`That file does not start with "ANDROID!" `
+          + `(got "${magic.replace(/[^\x20-\x7e]/g, '.')}"), so it is not a boot image. `
+          + 'Nothing has been written.');
+      }
+      addLog('── RESTORE STOCK BOOT IMAGE ──', 'head');
+      let err = await _writeBootPartition(c, target, bytes, md5, 'stock boot image');
+      if (err) {
+        addLog(`${err}`, 'error');
+        addLog('Retrying the restore once…', 'warn');
+        err = await _writeBootPartition(c, target, bytes, md5, 'stock boot image (retry)');
+      }
+      if (err) {
+        throw new Error(`${err}\n\nThe restore did not verify. Do not reboot. The `
+          + `device is still in TWRP, and the image can also be written by hand from `
+          + `a TWRP shell with:\n  dd if=<your stock boot image> of=${target}`);
+      }
+      addLog('Stock boot image restored and verified against the partition. The '
+           + 'device will boot FireOS as it did before. Everything installed on '
+           + '/data is untouched.', 'ok');
+    } catch (e) {
+      addLog(`Restore failed: ${e.message}`, 'error');
+    } finally {
+      setRunning(false);
+    }
   }
 
   // ── Steps 7 and 8 — the serial console ────────────────────────────────────
@@ -5499,6 +5642,37 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
                   Your escrowed image restores it in about ten seconds and leaves /data alone.
                 </div>
                 <Pill accent onClick={() => runStep(6)}>Flash emOS</Pill>
+              </div>
+            )}
+
+            {/* The undo, offered where it is needed rather than printed as a dd
+                command. Shown on a failed flash (6) and a failed first boot (7)
+                — the second is the case that matters most, because a device
+                that took the write and never came back is the one whose
+                operator has nothing else to try. It needs ADB, so it is only
+                useful while the device is still in TWRP; that is exactly the
+                state both failures leave it in. */}
+            {isEmos && (step === 6 || step === 7)
+              && stepState[step] === 'error' && !running && (
+              <div className="em-inset" style={{ marginBottom: 12, display: 'flex', flexDirection: 'column', gap: 8, padding: 10 }}>
+                <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--text2)' }}>
+                  Put {emosTarget || 'the boot partition'} back to the image escrowed at step 3
+                  {emosRef ? ` (md5 ${emosRef.md5.slice(0, 8)}…)` : ''}. Verified against the
+                  partition afterwards, and /data is untouched — everything installed stays.
+                </div>
+                {!emosRef && (
+                  <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--warn)' }}>
+                    This session has no escrowed image — choose the
+                    echomuse-stock-boot-*.img downloaded at step 3.
+                  </div>
+                )}
+                <input type="file" accept=".img"
+                  onChange={e => setRestoreFile(e.target.files[0] || null)}
+                  style={{ fontFamily: "'DM Mono',monospace", fontSize: 10 }} />
+                <Pill danger disabled={!adb || (!emosRef && !restoreFile)}
+                  onClick={() => restoreStockBoot(restoreFile)}>
+                  Restore stock boot image
+                </Pill>
               </div>
             )}
 

--- a/controller/tests/boot_target.test.mjs
+++ b/controller/tests/boot_target.test.mjs
@@ -163,6 +163,34 @@ for (const [part, dev] of [["boot_a", "/dev/block/mmcblk0p17"],
   check("alias order does not change the payload verdict", b.ok === false, JSON.stringify(b));
 }
 
+// The verdict is only worth as much as the node it is spent on. runPatchBoot
+// used to classify /dev/block/other-boot and then read, write and read back
+// through that same symlink rather than through the resolved target it had
+// just been given a verdict about — so the safety check and the write asked
+// two different questions moments apart, the flash log claimed boot.target
+// whichever answer it got, and the read-back would confirm a wrong-but-stable
+// resolution by reading exactly what it had written.
+//
+// Comments are stripped first. A guard that greps for the thing it forbids
+// otherwise finds the comment explaining why it is forbidden and passes — the
+// mistake this repo has now made three times.
+{
+  const body = liftFunction("runPatchBoot")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[ \t]*\/\/.*$/gm, "");
+  check("runPatchBoot resolves the boot partition exactly once",
+        (body.match(/other-boot/g) || []).length === 1,
+        "other-boot should appear only in the probe that resolves it, "
+        + "never in a dd that follows the classifyBootTarget verdict");
+  for (const [what, re] of [
+    ["reads", /dd if=\$\{boot\.target\} of=\/tmp\/work\/boot\.img/],
+    ["writes", /dd if=\/tmp\/work\/new-boot\.img of=\$\{boot\.target\}/],
+    ["reads back", /dd if=\$\{boot\.target\} bs=1 skip=64/],
+  ]) {
+    check(`runPatchBoot ${what} the classified target`, re.test(body), body.slice(0, 0));
+  }
+}
+
 if (failures) {
   console.error(`\n${failures} check(s) failed.`);
   process.exit(1);

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -2339,16 +2339,39 @@ def test_the_flash_step_verifies_against_the_partition():
     device that has not rebooted is still recoverable from where it stands.
     """
     src = _jsx()
-    fn = src[src.index("async function runFlashEmos"):]
-    fn = fn[:fn.index("\n  // ── Steps 7 and 8")]
-    assert "conv=fsync" in fn, "the write must be fsync'd"
-    assert "drop_caches" in fn, (
+    # The write itself lives in _writeBootPartition, shared by the flash and the
+    # restore. Shared rather than copied on purpose: this is the only code in
+    # the wizard that can leave a device unbootable, and a second copy is one
+    # that drifts from the checks this one carries — so pin that both callers
+    # go through it and that neither grew a dd of its own.
+    write = src[src.index("async function _writeBootPartition"):]
+    write = write[:write.index("\n  async function runFlashEmos")]
+    assert "conv=fsync" in write, "the write must be fsync'd"
+    assert "drop_caches" in write, (
         "the page cache must be dropped before the read-back, or the read-back "
         "confirms the cache rather than the partition")
+    assert write.index("drop_caches") < write.index("Reading it back"), \
+        "the caches must be dropped BEFORE the read-back, not after"
+
+    fn = src[src.index("async function runFlashEmos"):]
+    fn = fn[:fn.index("\n  // ── Steps 7 and 8")]
     assert "DO NOT REBOOT" in fn, (
         "a verification failure must tell the operator not to reboot")
-    assert fn.index("drop_caches") < fn.index("Reading it back"), \
-        "the caches must be dropped BEFORE the read-back, not after"
+    # Both callers write through the shared path, and neither writes a
+    # partition any other way.
+    for caller in ("runFlashEmos", "restoreEscrowedBoot"):
+        body = fn[fn.index(f"async function {caller}"):]
+        body = body[:body.index("\n  async function ", 1)] if "\n  async function " in body[1:] else body
+        assert "_writeBootPartition" in body, (
+            f"{caller} must write through _writeBootPartition, not its own dd")
+    # Matched against shell CALLS, not against the text "of=" — the restore's
+    # failure message quotes a dd command for the operator to run by hand, and
+    # a guard that greps for the thing it forbids finds the prose explaining it
+    # and fails on a file that is correct. Three times now.
+    for line in fn.splitlines():
+        assert not ("c.shell(" in line and "of=" in line), (
+            "no caller may issue its own partition write — the one dd that "
+            f"does lives in _writeBootPartition: {line.strip()}")
 
 
 def test_the_serial_console_disables_echo_before_anything_else():

--- a/emos/README.md
+++ b/emos/README.md
@@ -459,10 +459,66 @@ After three unconfirmed boots init restores the known-good image, shows an
 amber ring and reboots.
 
 This is deliberately NOT the bootloader's A/B. biscuit has a real second slot
-(`boot_b_x`, `mmcblk0p11`) but LK chooses between them and we have not reverse
-engineered how; the standing guess is three tries per slot and then a soft
-brick, which is plausible and **untested**. Building on that guess risks a
-device booting something we did not choose.
+and LK chooses between them; we have not reverse engineered how, and the
+standing guess — three tries per slot and then a soft brick — remains
+**untested**. Building on that guess risks a device booting something we did
+not choose.
+
+### What the slots actually contain
+
+Measured on G090LF11803611NF in TWRP, 2026-09-06, all reads. Recorded because
+the paragraph above was written from the partition table alone and three of
+these were unknown.
+
+**Slot B is a full peer, and it is populated.** `boot_a_x` (`p10`) and
+`boot_b_x` (`p11`) are both 32768 sectors — 16MB each. p11 carries a complete
+`ANDROID!` boot image with the untouched stock FireOS cmdline
+(`… rootwait ro init=/init buildvariant=user veritykeyid=…`) and a larger
+ramdisk than A. So a provisioned device carries a **second stock image we did
+not put there**, which is a usable last resort if an operator loses the escrow
+downloaded at the wizard's escrow step. It is not a substitute for that file:
+nothing guarantees B stays pristine, and it boots FireOS without our permissive
+cmdline or the `service echomuse` init entry, so EchoMuse does not start. It
+boots, which is what recovery is for.
+
+**Our cmdline patch DESTROYS the original arguments rather than appending
+them.** `runPatchBoot` zeroes bytes 64–576 of the header and writes 51 bytes,
+so slot A's cmdline is exactly `bootopt=64S3,32N2,64N2
+androidboot.selinux=permissive` and everything FireOS shipped is gone. The
+device boots regardless — LK supplies `root=`, `androidboot.hardware` and the
+rest, and the kernel defaults cover what is left — so this has been true for
+the life of the wizard with nothing to show for it. Slot B is the only reason
+it is visible at all. Appending rather than replacing is the obvious fix and it
+needs a hardware test, since the argument that is currently absent and unmissed
+may be load-bearing on a device that is not this one.
+
+**`misc` (`p8`) holds a boot-control block, and it is empty.** 4KB of zeros
+with one record at offset **0x360**:
+
+```
+00000360  00 41 42 42 01 8f 00 00   |.ABB....|
+```
+
+The first four bytes are little-endian `0x42424100`, which is AOSP's
+`BOOT_CTRL_MAGIC`. Two things do not fit the standard struct: the offset is not
+one AOSP uses, so this is an MTK/Amazon variant; and everything past
+`version=1` and a single flags byte is zero, so the `slot_info[]` array — where
+per-slot priority and `tries_remaining` live — carries nothing.
+
+An empty control block should mean no slot is bootable. The device boots A.
+**So on the evidence LK is not taking its decision from this block**, or it
+ignores it and defaults to A. That is the answer to "could we just select slot
+B and leave FireOS alone": the metadata that would let us choose is present in
+shape, empty in content, and visibly disregarded by the bootloader. Writing a
+priority into it would be acting on a struct we have watched LK ignore, against
+a documented downside — both slots running out of attempts — whose recovery
+means opening the case. The decision lives in `lk_a_real` (`p3`), which we can
+dump freely and have not analysed.
+
+Note the escrow is therefore **not a stock image** on a device that has been
+through the FireOS flow — it is whatever was on the partition, patch included.
+That is the correct thing to restore, and it is why the wizard's restore
+control says "the image escrowed at step 3" rather than "stock".
 
 **The limit, plainly: an image that fails before init runs executes none of
 this and still needs recovery over USB.** The byte-exact packer and the


### PR DESCRIPTION
Provisioning a fresh device for emOS failed at step 4 with every `su -c` reporting `su: not found`, after step 3 had reported the recovery environment ready. Measured on G090LF11803611NF today.

## The failure

**The su shim was unrunnable.** TWRP's shell is `/sbin/sh` and there is no `/bin` on Android or in a recovery ramdisk, so a shim written with `#!/bin/sh` cannot execute — the kernel returns ENOENT for the missing interpreter and the shell prints `su: not found`, the same message it prints for a missing binary. The shell is now discovered on the device rather than named.

**The retry is why step 3 went green and step 4 still died.** The guard was `command -v su`, which asks whether a *file* exists — so the broken shim from the first attempt was on PATH and executable, said yes, and skipped the block including the verification that had just caught it. The test is now whether `su -c "id -u"` returns 0, unconditionally.

**Steps 4 and 5 now prepare their own environment.** The shim and the `/sdcard` symlink live in the recovery ramdisk, so a Reconnect between steps — which the wizard invites on any failure — silently removes them.

## Partition writes

- `runPatchBoot` classified `/dev/block/other-boot` and then read, wrote and read back through that **symlink** rather than the resolved node it had a verdict about. The check and the write asked two different questions moments apart; the flash log claimed `boot.target` either way; and the read-back would confirm a wrong-but-stable resolution by reading exactly what it had written. Every `dd` now uses `boot.target`, which is what the emOS flow already did. Pinned by `boot_target.test.mjs` and verified by reintroducing it.
- `_STEP_MODE` was consulted in one place — `reconnectAdb` — where a mismatch logged a line and left Retry enabled, so a TWRP step could run against Android. Pulling the cable powers the Dot off and a replug is a cold boot into Android, so the wrong mode is the *normal* consequence of the recovery we suggest; and in Android `/dev/block/other-boot` is amonet's unlock payload. `classifyBootTarget` refuses that write and was the only thing in front of it. `runStep` now refuses on the mismatch.

## Steps that reported success having achieved nothing

The rule this wizard already states about itself, broken four ways:

- `Cleared.` was logged after every `su` failed — `readlink`'s stderr is discarded by design, so "the symlink is gone" and "su cannot run" were the same empty string. A sentinel separates them.
- Wake word assets verified md5 at `/sdcard`, which is not where they end up, then printed a tick whichever way the `mv` went. The destination is hashed.
- `start_server.sh` was copied unchecked while the binary beside it was verified byte for byte — and it is the file init executes, so a device with a perfect binary and no start script never runs EchoMuse and says nothing about why.
- **Skip (already connected)** on the WiFi step marked it done having asked the device nothing. The button makes a testable claim; it now tests it.

## Testing

Controller suite 994 passed; all four `.mjs` suites pass; JSX compiles. The `runPatchBoot` guard was verified by reintroducing the bug. **Not exercised on hardware** — the next emOS provisioning run is the real test, and it needs a fresh EA image since the JSX compiles at image build.

## Not changed

`runInstallMagisk` decides success by grepping the TWRP output for "error"/"failed", so silence reads as success. Left alone: `twrp install` has no positive signal worth trusting, and Verify Root is the real check downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgf491o1DBmA4zeUFBnNQS