### PR TITLE
Make the emOS console readable and give it a supplicant to talk to

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -3028,13 +3028,35 @@ class _EmosConsole {
   // Commands are kept SHORT deliberately: the device's own echo garbles long
   // ones into a 127, which is the second half of the same trap.
   async run(cmd, timeoutMs = 15000) {
-    const mark = `__EM${Math.random().toString(36).slice(2, 8)}__`;
+    const id   = Math.random().toString(36).slice(2, 8);
+    const mark = `__EM${id}__`;
     this.buf = '';
-    await this._send(`${cmd}; echo ${mark}`);
+    // The marker is ASSEMBLED ON THE DEVICE, so it cannot appear in the
+    // shell's echo of this very command. Sending `echo __EMxxx__` looks
+    // obvious and is the bug: with echo on, the marker arrives in the echo
+    // before the command has run, indexOf finds it immediately, and run()
+    // returns the text of its own request as the answer. That is exactly what
+    // happened on 2026-09-06 — `uname -a` "answered" with "uname -a; echo ",
+    // and the os-release check then received the text of the os-release
+    // command and reported the device was not emOS. It was; the console was
+    // reading itself.
+    //
+    // disableEcho() is still sent first and still preferred, but it depends on
+    // stty being present and on the shell being up, and neither is something
+    // this can afford to assume. Splitting the marker makes run() correct
+    // whether echo is on or off, which is the property worth having.
+    await this._send(`${cmd}; __a=__EM; __b=${id}__; echo "$__a$__b"`);
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       const i = this.buf.indexOf(mark);
-      if (i >= 0) return this.buf.slice(0, i);
+      if (i >= 0) {
+        let out = this.buf.slice(0, i);
+        // With echo on, the first line is the request. Drop it rather than
+        // returning it as output.
+        const nl = out.indexOf('\n');
+        if (nl >= 0 && out.slice(0, nl).includes(cmd)) out = out.slice(nl + 1);
+        return out;
+      }
       await new Promise(r => setTimeout(r, 100));
     }
     throw new Error(`The console did not answer "${cmd}" within `
@@ -4822,6 +4844,59 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
         addLog('TLS credentials installed — device will connect over wss.', 'ok');
       }
     }
+
+    // A wpa_supplicant.conf that at least declares a control socket, written
+    // only if the device does not already have one.
+    //
+    // emOS starts wpa_supplicant with -c/data/misc/wifi/wpa_supplicant.conf
+    // (init.c) and the CONTROL SOCKET comes from ctrl_interface inside that
+    // file — so with no file the supplicant exits immediately, creates no
+    // socket, and every wpa_cli fails with "Failed to connect to non-global
+    // ctrl_ifname". That includes init's own `reassociate` nudge, which is
+    // what association depends on here, so the device sits at boot stage 11
+    // for ever with the ring throbbing at position 12.
+    //
+    // The emOS flow never wrote one: WiFi moved to the END of that flow, to be
+    // configured over the console against emOS's own supplicant — which
+    // presumes a supplicant that is running. It is a chicken and egg, and it
+    // only stayed hidden because EFF had been through the FireOS WiFi step
+    // first and crossed to emOS carrying its conf on /data. A device that goes
+    // straight to emOS has never had one. Measured on 3611NF 2026-09-06:
+    // wpa_supplicant and wpa_cli both zombies, sockets/ empty, no conf.
+    //
+    // Step 4 rather than step 9 because /data is writable here and this is
+    // before the flash, so the FIRST emOS boot comes up with a socket instead
+    // of needing a console rescue.
+    //
+    // NEVER overwritten. A device that has been through the FireOS WiFi step
+    // has a conf with real networks in it, and clobbering that would take the
+    // device off the air — the skeleton is a floor, not a template.
+    addLog('Checking the WiFi supplicant config…');
+    const wpaConf = '/data/misc/wifi/wpa_supplicant.conf';
+    const wpaOut = (await c.shell(
+      `su -c 'mkdir -p /data/misc/wifi/sockets; `
+      + `if [ -f ${wpaConf} ]; then echo KEPT; else `
+      + `  { echo ctrl_interface=/data/misc/wifi/sockets; echo update_config=1; } > ${wpaConf} `
+      + `  && echo WROTE; fi; `
+      // uid/gid 1010 is "wifi" — numeric because TWRP's passwd database does
+      // not necessarily carry Android's names, and the supplicant runs as that
+      // user (confirmed in ps on the device).
+      + `chown -R 1010:1010 /data/misc/wifi 2>/dev/null; `
+      + `chmod 660 ${wpaConf} 2>/dev/null; `
+      + `grep -c ctrl_interface ${wpaConf}' 2>&1`)).trim();
+    if (/WROTE/.test(wpaOut)) {
+      addLog('  wrote a minimal wpa_supplicant.conf — emOS needs one to open '
+           + 'its control socket');
+    } else if (/KEPT/.test(wpaOut)) {
+      addLog('  existing wpa_supplicant.conf left alone');
+    }
+    // The last line is grep -c: a config with no ctrl_interface produces no
+    // socket just as surely as no config at all, and that is worth saying now
+    // rather than discovering it at stage 11.
+    if (!/(^|\n)[1-9]\d*$/.test(wpaOut)) {
+      addLog(`  WARNING: ${wpaConf} declares no ctrl_interface, so emOS will `
+           + 'not be able to configure WiFi. Output was: ' + wpaOut.replace(/\n/g, ' | '), 'warn');
+    }
     // NO reboot here. This step used to end the wizard, so it rebooted, closed
     // the connection and cleared `adb` — and when the wake word asset step was
     // appended after it, that step's auto-run gate (`&& adb`) was false, so it
@@ -5345,6 +5420,22 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     await port.open({ baudRate: 115200 });
     const con = new _EmosConsole(port, addLog);
     setEmosConsole(con);
+    // Everything from here is wrapped so a failure CLOSES the port. Without
+    // this, the first failed attempt left it open and every retry died with
+    // "Failed to execute 'open' on 'SerialPort': The port is already open" —
+    // an error about the browser's port table that says nothing about the
+    // device, and which no amount of retrying can clear. Measured 2026-09-06:
+    // three attempts lost to it after one genuine failure.
+    try {
+      await _watchFirstBoot(con);
+    } catch (e) {
+      setEmosConsole(null);
+      try { await con.close(); } catch {}
+      throw e;
+    }
+  }
+
+  async function _watchFirstBoot(con) {
     // ECHO OFF FIRST, ALWAYS. A port opened with default termios echoes
     // everything the device sends back into its own input; the shell then
     // executes its own prompt and every command returns 127. It looks alive,
@@ -5370,23 +5461,30 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     if (!wifiSsid) throw new Error('Choose a network first.');
 
     addLog(`Joining ${wifiSsid}…`);
+    // Every call carries -p. wpa_cli defaults to /var/run/wpa_supplicant and
+    // emOS's supplicant is started with -p/data/misc/wifi/sockets (init.c:1202,
+    // and the same path the FireOS flow uses), so without it every command
+    // fails with "Failed to connect to non-global ctrl_ifname: wlan0". Found
+    // by hand on the console 2026-09-06, before this step had ever run — it
+    // would have failed on its first call.
+    //
     // wpa_cli against emOS's own supplicant — the real radio, so a network
     // this hardware cannot join fails here rather than after a flash. Note
     // this radio reports no SAE, so it genuinely cannot do WPA3 (#82).
-    const id = (await con.run('wpa_cli -i wlan0 add_network')).trim().split('\n').pop().trim();
+    const id = (await con.run('wpa_cli -p /data/misc/wifi/sockets -i wlan0 add_network')).trim().split('\n').pop().trim();
     if (!/^\d+$/.test(id)) throw new Error(`wpa_cli would not add a network (said "${id}").`);
-    await con.run(`wpa_cli -i wlan0 set_network ${id} ssid '"${wifiSsid}"'`);
+    await con.run(`wpa_cli -p /data/misc/wifi/sockets -i wlan0 set_network ${id} ssid '"${wifiSsid}"'`);
     if (wifiPsk) {
-      await con.run(`wpa_cli -i wlan0 set_network ${id} psk '"${wifiPsk}"'`);
+      await con.run(`wpa_cli -p /data/misc/wifi/sockets -i wlan0 set_network ${id} psk '"${wifiPsk}"'`);
     } else {
-      await con.run(`wpa_cli -i wlan0 set_network ${id} key_mgmt NONE`);
+      await con.run(`wpa_cli -p /data/misc/wifi/sockets -i wlan0 set_network ${id} key_mgmt NONE`);
     }
-    const en = await con.run(`wpa_cli -i wlan0 enable_network ${id}`);
+    const en = await con.run(`wpa_cli -p /data/misc/wifi/sockets -i wlan0 enable_network ${id}`);
     if (!/OK/.test(en)) throw new Error(`wpa_cli refused to enable the network: ${en.trim()}`);
 
     // save_config keeps NOTHING without update_config=1 in the conf, and says
     // OK either way — so the device would join now and forget on reboot.
-    const saved = await con.run('wpa_cli -i wlan0 save_config');
+    const saved = await con.run('wpa_cli -p /data/misc/wifi/sockets -i wlan0 save_config');
     if (!/OK/.test(saved)) {
       addLog('wpa_cli could not save the network, so this will be forgotten on '
            + 'reboot. Check update_config=1 in wpa_supplicant.conf.', 'warn');
@@ -5405,7 +5503,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       const known = new Set((knownDevices || []).map(d => d.device_id));
       seen = list.find(d => !known.has(d.device_id));
       if (seen) break;
-      const st = (await con.run('wpa_cli -i wlan0 status | grep wpa_state')).trim();
+      const st = (await con.run('wpa_cli -p /data/misc/wifi/sockets -i wlan0 status | grep wpa_state')).trim();
       addLog(`  ${st || 'no answer'}`);
     }
     if (!seen) {

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -2405,11 +2405,54 @@ def test_the_serial_console_disables_echo_before_anything_else():
     cls = cls[:cls.index("\n}")]
     assert "stty -echo" in cls, "the console client must disable echo"
 
-    watch = src[src.index("async function runRebootAndWatch"):]
+    watch = src[src.index("async function _watchFirstBoot"):]
     watch = watch[:watch.index("\n  async function ", 1)]
     assert "disableEcho" in watch, "the reboot step must disable echo"
     assert watch.index("disableEcho") < watch.index("con.run("), \
         "echo must be disabled BEFORE the first command, or its reply is garbled"
+
+    # Disabling echo is not enough on its own, and 2026-09-06 is how we know:
+    # stty is not guaranteed present and the shell is not guaranteed up, so
+    # echo survived and every run() returned the text of its OWN request. The
+    # marker must therefore be assembled ON THE DEVICE, so it cannot appear in
+    # the shell's echo of the command that asks for it.
+    assert "; echo ${mark}" not in cls and "; echo ${mark}`" not in cls, (
+        "the completion marker must not be sent whole — with echo on it "
+        "arrives before the command runs and run() answers with its own request")
+    assert "__a=__EM" in cls, (
+        "the marker must be assembled on the device from parts that do not "
+        "spell it in the echoed command")
+
+    # A failed attempt must release the serial port. The browser refuses to
+    # reopen one that is already open, and no amount of retrying clears it.
+    step = src[src.index("async function runRebootAndWatch"):]
+    step = step[:step.index("\n  async function ", 1)]
+    assert "con.close()" in step, (
+        "a failed first-boot watch must close the port, or every retry fails "
+        "with 'The port is already open'")
+
+
+def test_emos_wpa_cli_calls_carry_the_control_socket_path():
+    """
+    wpa_cli defaults to /var/run/wpa_supplicant. emOS starts its supplicant
+    with -p/data/misc/wifi/sockets (init.c), so a bare `wpa_cli -i wlan0`
+    fails every time with "Failed to connect to non-global ctrl_ifname".
+
+    Found by hand on the console on 2026-09-06, before the WiFi step had ever
+    run on hardware — it would have failed on its first call. The FireOS flow
+    has always passed -p; the emOS step was written without it.
+
+    Comments are stripped first: the explanation of this rule necessarily
+    quotes the broken form, and a guard that greps for the thing it forbids
+    otherwise fails a file that is correct.
+    """
+    src = _jsx()
+    body = re.sub(r"^\s*//.*$", "", src, flags=re.M)
+    bare = [ln.strip() for ln in body.splitlines()
+            if "wpa_cli -i " in ln]
+    assert not bare, (
+        "every wpa_cli invocation must pass -p /data/misc/wifi/sockets: "
+        + "; ".join(bare))
 
 
 def test_the_emos_build_endpoint_stores_nothing():

--- a/device/internal/server/link_state_test.go
+++ b/device/internal/server/link_state_test.go
@@ -1,6 +1,10 @@
 package server
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/wilbowes/EchoMuse/pkg/led"
+)
 
 // A muted device that lost its controller sat there showing the red mute
 // ring — which does not merely say less than the orange link pulse, it says
@@ -51,5 +55,40 @@ func TestLinkDownDefaultsToConnected(t *testing.T) {
 	if s.LinkDown() {
 		t.Fatal("SetLinkDown(false) not recorded — the ring would never go " +
 			"back to the controller after a reconnect")
+	}
+}
+
+// RestoreMuteRing paints a FULL RED RING, and red on this device means one
+// thing: muted. It was called unconditionally on every reconnect, so an
+// unmuted device pending approval — which reconnects repeatedly — showed a red
+// flash through its pending pulse, over and over, saying something false about
+// a device that was working. Seen on 3611NF's first emOS boot, 2026-09-06.
+//
+// Every other painter of this ring already checks: the startup path in
+// server.go gates on IsMuted(), and volume.go's display-expiry gates on
+// isMuted(). This was the one that did not.
+func TestRestoreMuteRingOnlyPaintsWhenMuted(t *testing.T) {
+	reached := 0
+	// showMuteLEDs calls ledCtrl() first, so counting that call counts
+	// whether the paint was REACHED. Returning nil makes it a no-op after
+	// that, which is what we want — the assertion is about the guard.
+	s := &Server{mute: &muteController{
+		ledCtrl: func() led.Controller { reached++; return nil },
+	}}
+
+	if s.mute.IsMuted() {
+		t.Fatal("a fresh muteController must not report muted")
+	}
+	s.RestoreMuteRing()
+	if reached != 0 {
+		t.Errorf("unmuted: reached the paint %d times, want 0", reached)
+	}
+
+	s.mute.mu.Lock()
+	s.mute.muted = true
+	s.mute.mu.Unlock()
+	s.RestoreMuteRing()
+	if reached != 1 {
+		t.Errorf("muted: reached the paint %d times, want 1", reached)
 	}
 }

--- a/device/internal/server/server.go
+++ b/device/internal/server/server.go
@@ -230,9 +230,24 @@ func (s *Server) CancelVolumeDisplay() {
 	s.volume.CancelDisplay()
 }
 
-// RestoreMuteRing re-applies the red mute ring. Called on reconnect to
-// recover the visual state that the orange pulse animation overwrote.
+// RestoreMuteRing re-applies the red mute ring IF the device is muted. Called
+// on reconnect to recover the visual state that the orange pulse animation
+// overwrote.
+//
+// The guard is the whole function. Without it this painted a full red ring on
+// every reconnect regardless of mute state — and a device pending approval
+// reconnects repeatedly, so the pending pulse was interrupted by a red flash
+// every time, on a device whose mic was not muted. Seen on 3611NF's first emOS
+// boot, 2026-09-06, and read as a fault indicator, which is exactly what a red
+// ring means to anyone looking at it.
+//
+// Every other painter of this ring already checks: server.go's startup path
+// gates on IsMuted(), and volume.go's display-expiry gates on isMuted(). This
+// was the one that did not.
 func (s *Server) RestoreMuteRing() {
+	if !s.mute.IsMuted() {
+		return
+	}
 	s.mute.showMuteLEDs()
 }
 

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -930,6 +930,49 @@ static int wr(const char *path, const char *val)
     return n > 0 ? 0 : -1;
 }
 
+/* The device's serial, read from androidboot.serialno on the kernel cmdline.
+ *
+ * LK puts it there (confirmed in /proc/cmdline on this board), which is the
+ * only source available to us: there is no property service under emOS, so
+ * getprop ro.serialno does not exist, and /system carries the BUILD's identity
+ * rather than this unit's.
+ *
+ * Returns a pointer to a static buffer, empty if it could not be read. Callers
+ * must treat empty as "unknown" and carry on — nothing here is worth failing a
+ * boot over.
+ */
+static const char *serialno(void)
+{
+    static char buf[64];
+    static int done;
+    if (done)
+        return buf;
+    done = 1;
+
+    int fd = open("/proc/cmdline", O_RDONLY);
+    if (fd < 0)
+        return buf;
+    char line[2048];
+    ssize_t n = read(fd, line, sizeof line - 1);
+    close(fd);
+    if (n <= 0)
+        return buf;
+    line[n] = 0;
+
+    const char *key = "androidboot.serialno=";
+    char *p = strstr(line, key);
+    if (!p)
+        return buf;
+    p += strlen(key);
+    size_t i = 0;
+    while (p[i] && p[i] != ' ' && p[i] != '\n' && i < sizeof buf - 1) {
+        buf[i] = p[i];
+        i++;
+    }
+    buf[i] = 0;
+    return buf;
+}
+
 static void usbwr(const char *leaf, const char *val)
 {
     char p[256];
@@ -1456,6 +1499,28 @@ int main(void)
 
     mkdir("/data/emos", 0755);
 
+    /* Name the device. The kernel default is "android", so every console
+     * session and every log line said root@android — which is actively
+     * misleading on a device whose whole point is that Android is gone, and
+     * useless for telling two Echoes apart over USB. mksh reads gethostname()
+     * when it builds its prompt, so this has to happen before any shell is
+     * spawned, which is why it sits here rather than beside the USB gadget.
+     *
+     * Falls back to plain "emos" when the serial cannot be read: a nameless
+     * device is better than a boot that stopped over a cosmetic. */
+    {
+        char host[80];
+        const char *sn = serialno();
+        snprintf(host, sizeof host, *sn ? "em-%s" : "emos", sn);
+        /* Via /proc rather than sethostname(2): bionic does not declare that
+         * at API 21, and an implicit declaration in a static PID 1 is not
+         * something to ship — the failure would be silent and on the device.
+         * The sysctl is equivalent and wr() is already the way everything
+         * else here writes to /proc. */
+        int hr = wr("/proc/sys/kernel/hostname", host);
+        note("hostname=%s rc=%d\n", host, hr);
+    }
+
     /* Rollback bookkeeping. This runs as early as /data allows, because a boot
      * that dies later must still have been counted — the counter is the only
      * evidence that the previous boots failed. */
@@ -1529,6 +1594,16 @@ int main(void)
     usbwr("enable", "0");
     usbwr("idVendor", "1949");
     usbwr("idProduct", "2007");
+    /* Say what this is. Without these the descriptor carries no strings at all
+     * and the host falls back to whatever it has cached for the port — on a
+     * Mac that showed as "MT65xx Android Phone", left over from the same
+     * device in preloader or FireOS mode, so the operator picking a serial
+     * port in the provisioning wizard has nothing to aim at. Stock sets all
+     * three (Amazon / AEOBC / serial); we were setting none. */
+    usbwr("iManufacturer", "EchoMuse");
+    usbwr("iProduct", "emOS console");
+    if (*serialno())
+        usbwr("iSerial", serialno());
     usbwr("f_acm/instances", "1");
     usbwr("functions", "acm");
     usbwr("bDeviceClass", "02");


### PR DESCRIPTION
First run to reach steps 8 and 9. The flash verified, the device booted emOS, and sat at boot stage 11 with the ring throbbing at position 12 — which is the ring correctly reporting "associating, no address yet". Four bugs, none of which had ever executed.

## The console read itself

`run()` sent `cmd; echo __EMxxx__`, so with echo on the marker arrived in the **echo** before the command ran: `indexOf` matched immediately and the function returned the text of its own request. `uname -a` "answered" with `uname -a; echo `, and the os-release check then received the text of the os-release command and reported the device was not emOS. It was.

The marker is now assembled **on the device** from parts that never spell it in the echoed command, so `run()` is correct whether echo is on or off. `disableEcho` still runs first but is no longer what correctness rests on — it needs `stty` present and the shell up, and neither is safe to assume.

## The port was never closed on failure

After one genuine failure every retry died with `The port is already open` — an error about the browser's port table that says nothing about the device and that retrying cannot clear. Three attempts lost to it, and it also blocked `screen(1)` from outside the browser, which is how it was spotted.

## Every `wpa_cli` call in step 9 was missing `-p`

`wpa_cli` defaults to `/var/run/wpa_supplicant`; emOS's supplicant uses `/data/misc/wifi/sockets` — the same path `init.c:1202` passes its own `reassociate` nudge. Seven call sites, none of which had ever run.

## And step 9 had nothing to talk to

emOS starts `wpa_supplicant` with `-c/data/misc/wifi/wpa_supplicant.conf`, and the control socket comes from `ctrl_interface` **inside that file** — but the emOS flow never wrote one. WiFi moved to the end of that flow to be configured over the console against a supplicant that is running, which is a chicken and egg.

Measured on 3611NF: no conf, `sockets/` empty, `wpa_supplicant` and `wpa_cli` both zombies, and init's nudge failing every five seconds for ever.

```
wifi 759 ... Z wpa_supplicant      ← started, exited on the missing conf
wifi 760 ... Z wpa_cli             ← init's reassociate, failing
```

It stayed hidden because EFF had been through the FireOS WiFi step first and crossed to emOS carrying a good conf on `/data` — the exact path `emos/README.md:238` describes. **A device that goes straight to emOS has never had one.**

The skeleton is written at **step 4**, where `/data` is writable and it is before the flash, so the first emOS boot has a socket rather than needing a console rescue. **Never overwritten** — a FireOS-provisioned device's conf has real networks in it and clobbering it would take the device off the air. A conf that exists but declares no `ctrl_interface` is warned about, since that produces no socket just as surely as no conf at all.

## Guards

No bare `wpa_cli -i`, and the console marker must not be sent whole. Both verified by reintroducing the bug, and both strip comments first so the prose explaining the rule cannot satisfy it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgf491o1DBmA4zeUFBnNQS