### PR TITLE
Say WHERE the packer could not reproduce a boot image

### DIFF
--- a/controller/em_emos_build.py
+++ b/controller/em_emos_build.py
@@ -237,10 +237,60 @@ def roundtrip_identical(ref: bytes) -> bool:
     and the correct response is to refuse to build rather than to flash
     something assembled by a parser that has already been shown to be wrong.
     """
+    return roundtrip_diff(ref) is None
+
+
+# Which header field a byte offset falls in, for the message below. Offsets are
+# the Android boot header v0 layout, which split_reference already assumes.
+_HDR_FIELDS = (
+    (0, 8, "the ANDROID! magic"),
+    (8, 48, "the size/address fields"),
+    (48, 64, "the product name"),
+    (64, 576, "the kernel command line"),
+    (576, 608, "the image id (a SHA1 of the regions)"),
+    (608, 1632, "the extra command line"),
+)
+
+
+def roundtrip_diff(ref: bytes):
+    """Where the repacked reference stops matching the original, or None.
+
+    Split out of roundtrip_identical because a bare False is not actionable.
+    The refusal it drives is correct and the operator could do nothing with it:
+    on 2026-09-06 a stock+f1r30s image was refused, and finding out why meant
+    dumping the header by hand over adb and decoding it a field at a time.
+
+    Returns (offset, description, ref_bytes, rebuilt_bytes) for the first
+    difference, with 16 bytes of context either side.
+    """
     parts = split_reference(ref)
     rebuilt = pack(parts, parts["zimage"], parts["dtbs"], parts["ramdisk"],
                    extra_cmdline="")
-    return rebuilt == ref
+    if rebuilt == ref:
+        return None
+    if len(rebuilt) != len(ref):
+        return (min(len(rebuilt), len(ref)),
+                f"the lengths differ: the reference is {len(ref)} bytes and "
+                f"repacking it gives {len(rebuilt)}", b"", b"")
+    off = next(i for i in range(len(ref)) if ref[i] != rebuilt[i])
+
+    where = f"offset {off}"
+    for start, end, name in _HDR_FIELDS:
+        if start <= off < end:
+            where = f"{name} (offset {off})"
+            break
+    else:
+        page = parts.get("psz", PAGE)
+        koff = page + len(pad(pack_kernel_of(parts)))
+        where = (f"the kernel image (offset {off})" if off < koff
+                 else f"the ramdisk (offset {off})")
+    return (off, where, ref[off:off + 16], rebuilt[off:off + 16])
+
+
+def pack_kernel_of(parts: dict) -> bytes:
+    """The MTK-wrapped kernel as pack() will emit it. Used only for locating a
+    difference; pack() builds its own."""
+    return mtk_wrap(parts["zimage"] + parts["dtbs"], b"KERNEL")
 
 
 def init_binary_problems(init_binary: bytes) -> list:
@@ -284,11 +334,19 @@ def build_emos_image(reference: bytes, init_binary: bytes, version: str,
         raise BuildError("; ".join(problems))
 
     parts = split_reference(reference)
-    if not roundtrip_identical(reference):
+    diff = roundtrip_diff(reference)
+    if diff is not None:
+        _, where, got, made = diff
+        detail = f" It first differs in {where}"
+        if got or made:
+            detail += (f": the image has {got.hex()} and repacking it produces "
+                       f"{made.hex()}")
+        detail += "."
         raise BuildError(
             "The packer could not reproduce this boot image byte for byte, so "
             "it does not fully understand it. Refusing to build rather than "
-            "flash something assembled by a parser already shown to be wrong.")
+            "flash something assembled by a parser already shown to be wrong."
+            + detail)
 
     ramdisk = build_ramdisk(init_binary, version, build_id)
     image = pack(parts, parts["zimage"], parts["dtbs"], ramdisk)


### PR DESCRIPTION
`roundtrip_identical` returns a bare bool, and the refusal it drives quotes it verbatim: *"the packer could not reproduce this boot image byte for byte"*. The refusal is **correct** — it is the gate that runs before any flash, and it has now caught three real problems — but the operator can do nothing with it.

Met tonight with a **stock FireOS 5 + f1r30s** image, which is exactly the state `docs/rooting.md` tells users to be in. Finding out why meant dumping the boot header over adb and decoding it field by field against `pack()`'s assumptions — which ruled out all four candidates (`second_size` is 0, product name is zeros, extra cmdline is zeros, id is present) and left the answer still unknown.

## Change

`roundtrip_diff` returns the first differing offset, which header field it falls in, and both byte sequences. `build_emos_image` puts that in the message. A length mismatch is reported as a length mismatch rather than as an offset, since those are different problems.

Field names come from the Android boot header v0 layout `split_reference` already assumes, so the message can say *"the image id (a SHA1 of the regions)"* rather than *"offset 576"*. An offset past the header resolves to the kernel or the ramdisk.

```
the image id (a SHA1 of the regions) (offset 576)
the product name (offset 50)
the ramdisk (offset 12188)
```

Exercised against synthetic images differing only in the id, only in the product name, and deep in the ramdisk; a clean round trip still reports `None`.

## What this deliberately does NOT do

It does not fix the refusal. What differs is not yet known, and a packer that guesses is the thing this gate exists to prevent. The next build attempt will simply say which bytes, instead of costing a hex dump and a manual decode.

Controller suite: 995 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgf491o1DBmA4zeUFBnNQS