### PR TITLE
Do not require a boot image's id to reproduce, and check the escrow's md5

### DIFF
--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -1449,6 +1449,103 @@ Two device behaviours the wizard works around rather than fixes:
   presence is not cosmetic: a run with it running spent 9s cycling
   DISCONNECTED/SCANNING before associating, against 1s on a clean one.
 
+### The emOS flow, and what a run against real hardware found
+
+The nine-step emOS flow ran end to end for the first time on 2026-09-06 and
+failed at four different steps. Every one of those failures was in a CHECK
+rather than in the thing it was checking — the writes and pushes were correct
+throughout — so the rules below are all one rule seen from different angles.
+
+- **Test whether a thing RUNS, never whether a file exists.** TWRP is already
+  root and frequently has no `su`, so the flow installs a shim to let the
+  shared install steps run unchanged. It was written with `#!/bin/sh` and there
+  is no `/bin` in a recovery ramdisk, so it could never execute — and the guard
+  was `command -v su`, which a broken shim satisfies. A failed first attempt
+  therefore handed the retry a shim that was on PATH, executable and unusable,
+  and the retry SKIPPED the verification that had just caught it. Step 3 went
+  green and every `su` in step 4 died. The test is now `su -c "id -u"` returning
+  0, unconditionally.
+- **A check that cannot run must not read as a pass.** `readlink` with stderr
+  discarded returns the same empty string for "the symlink is gone" and for
+  "`su` is not working", and the install step logged `Cleared.` after every
+  command had failed. Probes carry a sentinel (`echo _CLEARCHK`) so the two
+  answers are distinguishable — the same fix `_sync_start_script` needed for
+  `_SHELL_OK`, in a different file.
+- **Verify the bytes you wrote, not the block that contains them.** The flash
+  step read back whole megabytes and compared against the image zero-padded to
+  match, so 425,984 bytes of the PREVIOUS boot image were checked against zeros
+  nobody had written. Every emOS flash failed on a write `dd` reported as
+  complete. It hid because the only path ever exercised was the restore, whose
+  image is the whole 16MB partition — an exact number of blocks, so the padding
+  was empty and the comparison was accidentally right.
+- **The recovery environment is a RAMDISK and every step must build its own.**
+  The `su` shim and the `/sdcard` symlink live in `/sbin` and vanish on a
+  replug — which the wizard actively invites after any failure. Steps 4 and 5
+  call `prepareTwrpForInstall` themselves; it is idempotent and costs three
+  round trips.
+- **Nothing `getprop` returns distinguishes TWRP from Android.** Recovery
+  reports `ro.build.version.release` 5.1.1 and answers every other property
+  with its own values, and `boardOk` passes on `omni_biscuit` because it
+  contains "biscuit" — so step 1 ran to completion against a device in
+  recovery, printed "FireOS 5 confirmed", warned about an untested firmware it
+  had read off the ramdisk, and rebooted recovery into recovery. The BANNER is
+  the only discriminator. The real answers are on `/system`: mount
+  `system_<slot>` read-only, by NAME and by slot rather than as p13, and read
+  `build.prop`. That is also the partition emOS mounts at runtime for bionic
+  and tinyalsa, so it is the build that actually matters.
+- **`_STEP_MODE` is enforced at every step, not only on Reconnect.** It existed
+  and was correct and was consulted in one place, where a mismatch logged a
+  line and left Retry enabled. In Android `/dev/block/other-boot` is amonet's
+  unlock payload, and `classifyBootTarget` was the only thing in front of that
+  write.
+- **A serial console command's completion marker must be assembled ON THE
+  DEVICE.** Sending `cmd; echo __EMxxx__` puts the marker in the shell's echo
+  BEFORE the command runs, so `indexOf` matches instantly and `run()` returns
+  the text of its own request. `uname -a` "answered" with `uname -a; echo `,
+  and the emOS check then received the text of the next command and reported
+  the device was not emOS. `stty -echo` is still sent first but cannot be what
+  correctness rests on: it needs `stty` present and the shell up.
+- **A failed step must release the serial port.** The browser refuses to reopen
+  one that is already open, no retry clears it, and it blocks terminal programs
+  outside the browser too.
+- **Home Assistant's ingress caps a request body far below what the controller
+  accepts** (58MB). Sending the whole 16MB escrow plus the init was refused
+  with a 413 that never reached the add-on at all — no controller log line, so
+  nothing server-side to read. `_bootImageLength` sends the boot image rather
+  than the partition: four little-endian u32s at fixed offsets, verified
+  against real headers, and returning 0 (send everything) on anything it does
+  not understand, because a size optimisation must never be why a build cannot
+  happen.
+- **The emOS flow must leave a `wpa_supplicant.conf` behind.** emOS starts the
+  supplicant with `-c/data/misc/wifi/wpa_supplicant.conf` and the control
+  socket comes from `ctrl_interface` INSIDE that file, so with no file there is
+  no socket and every `wpa_cli` fails — including init's own `reassociate`
+  nudge, which is what association depends on. The device then sits at boot
+  stage 11 for ever. WiFi is configured at the END of this flow, over a console
+  talking to a supplicant that must already be running, so the skeleton is
+  written at step 4 while `/data` is writable and before the flash. **Never
+  overwritten**: a FireOS-provisioned device's conf has real networks in it.
+  It stayed hidden because the first emOS device had crossed from FireOS
+  carrying a good conf on `/data`.
+- **The packer does not require the reference's image id to reproduce.** It is
+  a SHA1 over the kernel and ramdisk, and a tool that repacks a ramdisk while
+  preserving the header verbatim leaves a stale one — f1r30s does, so stock
+  FireOS 5 + f1r30s was refused, which is the state `docs/rooting.md` tells
+  users to be in. The round trip used to double as an integrity check on the
+  escrow through that same id; it now checks the reference's **md5 on
+  arrival**, which covers the whole transfer instead of two of its regions. Do
+  not try to keep both in the id: "stored id does not match the regions" is
+  equally true of a stale id and of a corrupted byte, so any rule tolerating
+  one tolerates the other.
+
+**The restore is the wizard's undo and it is proven.** `_writeBootPartition` is
+shared by the flash and the restore deliberately — it is the only code here
+that can leave a device unbootable, and a second copy is one that drifts from
+its checks. On 2026-09-06 the restore put a device back after two failed
+flashes, verified against the partition, and the device booted. It needs ADB,
+so it only helps while the device is in TWRP — which is where both the flash
+failure and the first-boot failure leave it.
+
 ### The one partition the wizard writes
 
 Patch Boot Image is the only partition write in the whole wizard, and the only

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -4796,6 +4796,9 @@ async def _post_provision_emos_image(request: web.Request) -> web.Response:
                 break
             if field.name in ("reference", "init"):
                 parts[field.name] = await field.read()
+            elif field.name == "reference_md5":
+                parts["reference_md5"] = (await field.read()).decode(
+                    errors="replace")[:64].strip().lower()
             elif field.name == "version":
                 parts["version"] = (await field.read()).decode(errors="replace")[:64]
 
@@ -4809,6 +4812,30 @@ async def _post_provision_emos_image(request: web.Request) -> web.Response:
             return _error("invalid_upload",
                           "Expected multipart field 'init' — the emOS init "
                           "binary", 400)
+
+        # The escrow arrived intact, checked before anything reads it.
+        #
+        # This replaces a property the packer's round-trip used to provide as a
+        # side effect: the boot header carries a SHA1 over the kernel and
+        # ramdisk, so a byte corrupted in transfer made the repack disagree and
+        # was refused. That check had to be relaxed — some images legitimately
+        # carry a stale id that cannot be reproduced by definition, and no rule
+        # can tell a stale id from a corrupted byte — so the integrity half is
+        # now explicit, and covers the WHOLE transfer rather than two of its
+        # regions.
+        #
+        # Absent md5 is accepted: an older wizard does not send one, and
+        # refusing there would break provisioning for a dashboard that has not
+        # been reloaded. Present-and-wrong always refuses.
+        want_md5 = parts.get("reference_md5")
+        if want_md5:
+            got_md5 = hashlib.md5(reference).hexdigest()
+            if got_md5 != want_md5:
+                return _error(
+                    "corrupt_upload",
+                    f"The boot image arrived corrupted: the wizard read "
+                    f"{want_md5} off the device and {got_md5} arrived. "
+                    f"Nothing has been built. Re-run the escrow step.", 400)
 
         version = parts.get("version") or "0.1"
         loop = asyncio.get_event_loop()

--- a/controller/em_emos_build.py
+++ b/controller/em_emos_build.py
@@ -252,7 +252,11 @@ _HDR_FIELDS = (
 )
 
 
-def roundtrip_diff(ref: bytes):
+# The image id: 20 bytes of SHA1 padded to 32, at offset 576 of the header.
+_ID_START, _ID_END = 576, 608
+
+
+def roundtrip_diff(ref: bytes, ignore_id: bool = False):
     """Where the repacked reference stops matching the original, or None.
 
     Split out of roundtrip_identical because a bare False is not actionable.
@@ -272,7 +276,13 @@ def roundtrip_diff(ref: bytes):
         return (min(len(rebuilt), len(ref)),
                 f"the lengths differ: the reference is {len(ref)} bytes and "
                 f"repacking it gives {len(rebuilt)}", b"", b"")
-    off = next(i for i in range(len(ref)) if ref[i] != rebuilt[i])
+    rng = range(len(ref))
+    if ignore_id:
+        rng = [i for i in rng if not (_ID_START <= i < _ID_END)]
+    diffs = [i for i in rng if ref[i] != rebuilt[i]]
+    if not diffs:
+        return None
+    off = diffs[0]
 
     where = f"offset {off}"
     for start, end, name in _HDR_FIELDS:
@@ -334,7 +344,43 @@ def build_emos_image(reference: bytes, init_binary: bytes, version: str,
         raise BuildError("; ".join(problems))
 
     parts = split_reference(reference)
-    diff = roundtrip_diff(reference)
+    # Everything EXCEPT the image id has to reproduce byte for byte.
+    #
+    # The id is a SHA1 over the kernel and ramdisk — regions this build is
+    # about to replace outright, since the whole point is to swap the ramdisk
+    # for emOS's. So the reference's id is not an input to anything we emit:
+    # pack() computes a fresh one over the new contents, and the image we flash
+    # carries a correct id whatever the reference carried.
+    #
+    # Requiring it to match therefore tests the wrong thing. It asks whether
+    # whichever tool last wrote this image recomputed a checksum, not whether
+    # WE understand the layout — and a tool that repacks a ramdisk while
+    # preserving the header verbatim leaves a stale id that is impossible to
+    # reproduce by definition. That is what f1r30s does: measured 2026-09-06 on
+    # a stock FireOS 5 + f1r30s image, the id was the ONLY difference, and
+    # refusing over it blocked the exact state docs/rooting.md tells users to
+    # be in.
+    #
+    # Everything else still has to match exactly, and that is the half that
+    # carries the meaning: if the kernel, the ramdisk, the addresses, the
+    # cmdline or the padding disagree, the packer has misread the image and
+    # the refusal stands.
+    # The id is not required to reproduce, and the reference's md5 is checked
+    # on arrival instead (_post_provision_emos_image).
+    #
+    # This gate USED to double as an integrity check on the escrowed image: the
+    # stored SHA1 covers the kernel and ramdisk, so a byte corrupted in
+    # transfer changed the repack and was refused. That property is real and
+    # was worth keeping, so it has been replaced rather than dropped — by an
+    # md5 over the WHOLE transfer, which is strictly better than a checksum
+    # covering two of its regions.
+    #
+    # Note there is no way to keep it here. "Stored id does not match the
+    # regions" is equally true of a tool that left a stale id and of a byte
+    # corrupted in flight, so any rule that tolerates the first tolerates the
+    # second. A heuristic that appears to separate them would fire in exactly
+    # the cases the strict check was for, which is worse than not having one.
+    diff = roundtrip_diff(reference, ignore_id=True)
     if diff is not None:
         _, where, got, made = diff
         detail = f" It first differs in {where}"

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5135,6 +5135,11 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
 
     const fd = new FormData();
     fd.append('reference', new Blob([reference]), 'reference.img');
+    // The controller checks this before it reads a byte of the image. It is
+    // the integrity check on the escrow — the packer's round trip used to
+    // provide one as a side effect of reproducing the boot header's SHA1, and
+    // that had to be relaxed for images carrying a stale id.
+    fd.append('reference_md5', await _md5Hex(reference));
     fd.append('init', initBlob, 'init');
     fd.append('version', version);
     const resp = await fetch(ingressPath('/api/provision/emos_image'), {

--- a/controller/tests/test_emos_build.py
+++ b/controller/tests/test_emos_build.py
@@ -128,20 +128,56 @@ def test_round_trip_fails_when_the_image_is_not_what_it_says():
     """
     The gate has to be capable of saying no, or it is decoration.
 
-    Two ways in, and the first is broader than it looks: because the header
-    carries a SHA1 over the regions, a single flipped byte ANYWHERE in the
-    kernel makes the repack disagree with the stored id. So the round trip is
-    an integrity check on the escrowed image as well as a check on the packer
-    — a reference that arrived corrupted cannot pass it.
+    A header field that does not describe the body is the case that matters:
+    the packer would reassemble it wrongly, and the refusal is what stops that
+    reaching a partition.
     """
-    bad = bytearray(make_reference())
-    bad[eb.PAGE + 0x200 + 4] ^= 0xFF        # one byte inside the zImage
-    assert not eb.roundtrip_identical(bytes(bad))
-
-    # And a header field that does not describe the body.
     bad = bytearray(make_reference())
     struct.pack_into("<I", bad, 8, struct.unpack_from("<I", bad, 8)[0] + 16)
     assert not eb.roundtrip_identical(bytes(bad))
+
+
+def test_a_stale_image_id_does_not_block_a_build():
+    """
+    Some images legitimately carry an id that does not describe their contents
+    — a tool that repacks a ramdisk while preserving the header verbatim
+    leaves one, and f1r30s does exactly that. Reproducing it is impossible by
+    definition, and requiring it refused stock FireOS 5 + f1r30s, which is the
+    state docs/rooting.md tells users to be in (measured 2026-09-06).
+
+    The id is a checksum over regions this build replaces outright, and pack()
+    computes a fresh one for what it emits, so the reference's is not an input
+    to anything.
+    """
+    bad = bytearray(make_reference())
+    for i in range(eb._ID_START, eb._ID_START + 20):
+        bad[i] ^= 0xFF
+    assert not eb.roundtrip_identical(bytes(bad)), "the strict check still sees it"
+    assert eb.roundtrip_diff(bytes(bad), ignore_id=True) is None
+
+
+def test_relaxing_the_id_does_not_relax_anything_else():
+    """
+    Everything the packer SYNTHESISES must still reproduce. The kernel and the
+    ramdisk are copied verbatim so they cannot differ, but the MTK kernel
+    header, the product name, the extra command line and every pad byte are
+    rebuilt, and a disagreement in any of them means the image was misread.
+    """
+    for offset, what in ((50, "product name"), (700, "extra cmdline")):
+        bad = bytearray(make_reference())
+        bad[offset] ^= 0xFF
+        assert eb.roundtrip_diff(bytes(bad), ignore_id=True) is not None, what
+
+
+def test_the_round_trip_diff_names_the_field():
+    """A bare False is not actionable — finding out why a real image was
+    refused cost a hex dump over adb and a field-by-field decode."""
+    bad = bytearray(make_reference())
+    bad[eb._ID_START] ^= 0xFF
+    off, where, got, made = eb.roundtrip_diff(bytes(bad))
+    assert off == eb._ID_START
+    assert "image id" in where
+    assert got != made
 
 
 def test_build_refuses_an_image_it_cannot_reproduce():

--- a/docs/rooting.md
+++ b/docs/rooting.md
@@ -13,8 +13,26 @@ risk.
 - Codename: biscuit
 - SoC: MediaTek MT8163, quad-core ARM Cortex-A53 @ 1.5GHz
 - RAM: 512MB
-- OS: FireOS 5 (Android 5.1, API 22) or FireOS 6 (Android 7.2)
+- OS: FireOS 5 (Android 5.1, API 22) — see the note below on FireOS 6
 - MicroUSB cable required
+
+> **FireOS 6 exists for biscuit and cannot be booted once you have unlocked.**
+> `Fire OS 6.5.7.0 (NS6570/6077)` is real, and amonet's instructions tell you
+> to update *to* it before unlocking, because the exploit downgrades the
+> firmware partitions on the way through. But after unlocking, only FireOS 5
+> based ROMs boot — R0rt1z2's thread is explicit that flashing FireOS 6 "may
+> result in a (soft) brick".
+>
+> Two reasons, and the second is the real one. FireOS 6 on this board is a
+> **32-bit** kernel while amonet's payload forced 64-bit — since fixed
+> upstream, by parsing the cmdline. The blocker underneath is the signature
+> chain: FireOS 6 likely needs a newer TrustZone, and a newer TZ cannot be
+> flashed because the FireOS 5 preloader refuses to boot one whose signature
+> differs. That is below the boundary this project writes to, so it is not
+> something EchoMuse can address.
+>
+> Practically: EchoMuse targets FireOS 5, and a newer Android is not a route
+> to a newer kernel on this device.
 
 ## What you need
 

--- a/emos/README.md
+++ b/emos/README.md
@@ -241,6 +241,28 @@ created if absent**: deleted on EFF, the device rebooted and was back on WiFi
 in 25 seconds with the file recreated. A device that never completed Alexa
 setup is not stranded.
 
+**A device that has never had WiFi has no conf, and then nothing works.**
+wpa_supplicant is started with `-c/data/misc/wifi/wpa_supplicant.conf` and its
+control socket comes from `ctrl_interface` INSIDE that file — so with no file
+it exits immediately, creates no socket, and every `wpa_cli` fails with
+"Failed to connect to non-global ctrl_ifname". That includes init's own
+`reassociate` nudge, which is what association depends on here, so the device
+sits at boot stage 11 for ever with the ring throbbing at position 12.
+Measured on 3611NF, 2026-09-06: no conf, `sockets/` empty, `wpa_supplicant`
+and `wpa_cli` both zombies, the nudge failing every five seconds.
+
+It stayed hidden because the first emOS device had crossed from FireOS
+carrying a good conf on `/data`, which is the path this section describes. A
+device provisioned straight to emOS has never had one, so the wizard now
+writes a skeleton (`ctrl_interface` + `update_config=1`) while `/data` is
+writable and before the flash. Recovering by hand needs only those two lines
+and a reboot.
+
+**`reboot` does nothing; use `busybox reboot`.** Plain `reboot` signals init,
+and emOS's init does not handle that signal, so it exits silently having done
+nothing. `busybox reboot` goes to the syscall. Worth knowing before concluding
+a device is wedged.
+
 `wpa_cli -p /data/misc/wifi/sockets -i wlan0` works for `scan`,
 `scan_results` (bssid, frequency, signal, flags), `get_capability key_mgmt`
 and `save_config`. Note `get_capability key_mgmt` returns


### PR DESCRIPTION
ea.9's diagnostic named it on the first attempt — the **image id** at offset 576:

```
the image has     0b03ca5fe407ea80798aea16a23d0089
repacking produces 568801a4471496715168d4411eeb65c9
```

The id is a SHA1 over the kernel and ramdisk. f1r30s repacks the ramdisk while preserving the header verbatim, so the stored id describes contents that no longer exist — **impossible to reproduce by definition.** Requiring it refused stock FireOS 5 + f1r30s, which is the exact state `docs/rooting.md` tells users to be in.

It is also not worth requiring: the id covers regions this build replaces outright, and `pack()` computes a fresh correct one for what it emits. The reference's id is an input to nothing.

## But the round trip was doing a second job

`test_round_trip_fails_when_the_image_is_not_what_it_says` spelled it out: because the id covers the regions, a byte corrupted in transfer changed the repack and was refused. That made this an integrity check on the escrow as well as a check on the packer, and it is worth keeping.

**It cannot be kept here.** "Stored id does not match the regions" is equally true of a tool that left a stale id and of a byte corrupted in flight, so any rule tolerating the first tolerates the second. I wrote that heuristic, realised it would fire in exactly the cases the strict check existed for, and removed it — a safeguard that isn't one is worse than none.

## So the integrity check is now explicit

The wizard sends the md5 it already computes for the escrow; the controller verifies it before reading a byte. Strictly better than what it replaces — it covers the **whole transfer** rather than two of its regions. An older wizard sends none and is accepted (refusing would break provisioning for a dashboard that hasn't been reloaded); present-and-wrong always refuses.

## What still has to reproduce

Everything the packer **synthesises**: the MTK kernel header, product name, extra command line, size and address fields, every pad byte. The kernel and ramdisk are copied verbatim so they cannot differ — which is why relaxing the id costs nothing structural.

Four tests pin it, including that relaxing the id relaxes nothing else. Controller suite: 998 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgf491o1DBmA4zeUFBnNQS