### PR TITLE
Reuse the reference's MTK kernel header instead of guessing its padding byte

### DIFF
--- a/controller/em_emos_build.py
+++ b/controller/em_emos_build.py
@@ -143,13 +143,37 @@ def build_ramdisk(init_binary: bytes, version: str, build_id: str = "") -> bytes
 
 # ── The Android/MTK boot image ───────────────────────────────────────────────
 
-def mtk_wrap(payload: bytes, name: bytes) -> bytes:
-    """Prepend the 0x200-byte MediaTek header LK validates before jumping."""
+def mtk_wrap(payload: bytes, name: bytes, header: bytes = b"") -> bytes:
+    """Prepend the 0x200-byte MediaTek header LK validates before jumping.
+
+    `header` is the reference image's OWN 0x200 header, reused verbatim when
+    given. That is the only correct answer: the padding byte after the name
+    field is NOT constant across images. Amazon's own images pad it with 0xff
+    and anything repacked by magiskboot pads it with 0x00, so a packer that
+    picks either one is right on half the fleet and puts 472 differing bytes
+    inside the header LK validates on the other half. This code has now been
+    wrong in BOTH directions: an early version padded 0xff on the strength of
+    a note, was corrected to 0x00 against a device that had been through the
+    FireOS flow, and then refused a stock FireOS 5 + f1r30s image at offset
+    0x28 of this header (measured on 3611NF, 2026-09-06).
+
+    Reusing it is safe because an emOS build does not touch the kernel: the
+    zImage and the DTBs are carried over from the reference, so the payload
+    this header describes is byte-identical and its size field still holds.
+    That is checked rather than assumed.
+    """
+    if header:
+        if len(header) != 0x200:
+            raise BuildError(
+                f"the reference kernel header is {len(header)} bytes, expected 512")
+        magic, size = struct.unpack("<II", header[:8])
+        if magic != MTK_MAGIC or size != len(payload):
+            raise BuildError(
+                "the reference kernel header does not describe its own payload "
+                f"(size says {size}, payload is {len(payload)} bytes)")
+        return header + payload
     hdr = struct.pack("<II", MTK_MAGIC, len(payload))
     hdr += name.ljust(32, b"\0")
-    # Padded with 0x00, read off the device's own image. Padding with 0xff on
-    # the strength of a note put 472 differing bytes inside the header LK
-    # validates — see emos/mkboot.py.
     hdr = hdr.ljust(0x200, b"\0")
     return hdr + payload
 
@@ -183,6 +207,10 @@ def split_reference(ref: bytes) -> dict:
         raise BuildError("no DTB found in the reference kernel payload")
     roff = PAGE + len(pad(kernel))
     return dict(
+        # The reference's own MTK kernel header, reused verbatim by pack().
+        # See mtk_wrap: the padding byte after the name field is not constant
+        # across images, so synthesising one is right on half the fleet.
+        mtkhdr=kernel[:0x200],
         zimage=payload[:i],
         dtbs=payload[i:],
         ramdisk=ref[roff:roff + rsz],
@@ -202,7 +230,7 @@ def pack(parts: dict, zimage: bytes, dtbs: bytes, ramdisk: bytes,
             f"the kernel command line is too long for the 512-byte field "
             f"({len(cmdline)} bytes)")
 
-    kernel = mtk_wrap(zimage + dtbs, b"KERNEL")
+    kernel = mtk_wrap(zimage + dtbs, b"KERNEL", parts.get("mtkhdr", b""))
 
     hdr = b"ANDROID!"
     hdr += struct.pack("<10I", len(kernel), parts["kaddr"],
@@ -268,8 +296,14 @@ def roundtrip_diff(ref: bytes, ignore_id: bool = False):
     difference, with 16 bytes of context either side.
     """
     parts = split_reference(ref)
-    rebuilt = pack(parts, parts["zimage"], parts["dtbs"], parts["ramdisk"],
-                   extra_cmdline="")
+    try:
+        rebuilt = pack(parts, parts["zimage"], parts["dtbs"], parts["ramdisk"],
+                       extra_cmdline="")
+    except BuildError as e:
+        # A structural refusal from pack() IS a difference, and a more specific
+        # one than an offset — reported rather than raised so this function
+        # keeps its contract of returning a diff or None.
+        return (0, str(e), b"", b"")
     if rebuilt == ref:
         return None
     if len(rebuilt) != len(ref):
@@ -300,7 +334,8 @@ def roundtrip_diff(ref: bytes, ignore_id: bool = False):
 def pack_kernel_of(parts: dict) -> bytes:
     """The MTK-wrapped kernel as pack() will emit it. Used only for locating a
     difference; pack() builds its own."""
-    return mtk_wrap(parts["zimage"] + parts["dtbs"], b"KERNEL")
+    return mtk_wrap(parts["zimage"] + parts["dtbs"], b"KERNEL",
+                    parts.get("mtkhdr", b""))
 
 
 def init_binary_problems(init_binary: bytes) -> list:

--- a/controller/tests/test_emos_build.py
+++ b/controller/tests/test_emos_build.py
@@ -47,11 +47,20 @@ KADDR, RADDR, SADDR, TAGS, HDRV, OSV = 0x40080000, 0x44000000, 0, 0x40000100, 0,
 CMDLINE = b"bootopt=64S3,32N2,64N2 androidboot.selinux=enforce"
 
 
-def make_reference(zimage=b"ZIMAGE" * 400, dtbs=None, ramdisk=b"RAMDISK" * 300):
-    """A boot image shaped like biscuit's, assembled the way the device's is."""
+def make_reference(zimage=b"ZIMAGE" * 400, dtbs=None, ramdisk=b"RAMDISK" * 300,
+                   mtk_pad=b"\x00"):
+    """A boot image shaped like biscuit's, assembled the way the device's is.
+
+    `mtk_pad` is the byte after the kernel header's name field. Amazon's own
+    images use 0xff and magiskboot-repacked ones use 0x00, and both are real —
+    see test_either_mtk_header_padding_round_trips.
+    """
     if dtbs is None:
         dtbs = DTB_MAGIC + b"\x11" * 512
-    kernel = eb.mtk_wrap(zimage + dtbs, b"KERNEL")
+    payload = zimage + dtbs
+    khdr = struct.pack("<II", eb.MTK_MAGIC, len(payload))
+    khdr += b"KERNEL".ljust(32, b"\0")
+    kernel = khdr.ljust(0x200, mtk_pad) + payload
     hdr = b"ANDROID!"
     hdr += struct.pack("<10I", len(kernel), KADDR, len(ramdisk), RADDR,
                        0, SADDR, TAGS, eb.PAGE, HDRV, OSV)
@@ -135,6 +144,38 @@ def test_round_trip_fails_when_the_image_is_not_what_it_says():
     bad = bytearray(make_reference())
     struct.pack_into("<I", bad, 8, struct.unpack_from("<I", bad, 8)[0] + 16)
     assert not eb.roundtrip_identical(bytes(bad))
+
+
+def test_either_mtk_header_padding_round_trips():
+    """
+    The byte after the MTK kernel header's name field is NOT constant across
+    images. Amazon's own images pad it with 0xff; anything repacked by
+    magiskboot pads it with 0x00. A packer that picks one is right on half the
+    fleet and puts 472 differing bytes inside the header LK validates on the
+    other half — and this code has now been wrong in BOTH directions.
+
+    The fix is to reuse the reference's own header rather than synthesise one,
+    which is safe because an emOS build carries the kernel over untouched.
+    """
+    for padbyte in (b"\x00", b"\xff"):
+        ref = make_reference(mtk_pad=padbyte)
+        assert eb.roundtrip_diff(ref, ignore_id=True) is None, padbyte.hex()
+        parts = eb.split_reference(ref)
+        built = eb.pack(parts, parts["zimage"], parts["dtbs"], parts["ramdisk"],
+                        extra_cmdline="")
+        assert built[eb.PAGE + 40:eb.PAGE + 41] == padbyte, \
+            "the reference's own padding must survive the repack"
+
+
+def test_a_kernel_header_that_lies_about_its_payload_is_refused():
+    """Reusing the header is only safe while it still describes the payload."""
+    ref = make_reference()
+    parts = eb.split_reference(ref)
+    bad = bytearray(parts["mtkhdr"])
+    struct.pack_into("<I", bad, 4, 12345)
+    parts["mtkhdr"] = bytes(bad)
+    with pytest.raises(eb.BuildError, match="does not describe its own payload"):
+        eb.pack(parts, parts["zimage"], parts["dtbs"], parts["ramdisk"])
 
 
 def test_a_stale_image_id_does_not_block_a_build():

--- a/emos/mkboot.py
+++ b/emos/mkboot.py
@@ -28,14 +28,37 @@ MTK_MAGIC = 0x58881688
 PAGE = 2048
 
 
-def mtk_wrap(payload: bytes, name: bytes) -> bytes:
-    """Prepend the 0x200-byte MediaTek header LK validates before jumping."""
+def mtk_wrap(payload: bytes, name: bytes, header: bytes = b"") -> bytes:
+    """Prepend the 0x200-byte MediaTek header LK validates before jumping.
+
+    `header` is the reference image's OWN 0x200 header, reused verbatim when
+    given. That is the only correct answer: the padding byte after the name
+    field is NOT constant across images. Amazon's own images pad it with 0xff
+    and anything repacked by magiskboot pads it with 0x00, so a packer that
+    picks either one is right on half the fleet and puts 472 differing bytes
+    inside the header LK validates on the other half. This code has now been
+    wrong in BOTH directions: an early version padded 0xff on the strength of
+    a note, was corrected to 0x00 against a device that had been through the
+    FireOS flow, and then refused a stock FireOS 5 + f1r30s image at offset
+    0x28 of this header (measured on 3611NF, 2026-09-06).
+
+    Reusing it is safe because an emOS build does not touch the kernel: the
+    zImage and the DTBs are carried over from the reference, so the payload
+    this header describes is byte-identical and its size field still holds.
+    That is checked rather than assumed.
+    """
+    if header:
+        if len(header) != 0x200:
+            raise SystemExit(
+                f"the reference kernel header is {len(header)} bytes, expected 512")
+        magic, size = struct.unpack("<II", header[:8])
+        if magic != MTK_MAGIC or size != len(payload):
+            raise SystemExit(
+                "the reference kernel header does not describe its own payload "
+                f"(size says {size}, payload is {len(payload)} bytes)")
+        return header + payload
     hdr = struct.pack("<II", MTK_MAGIC, len(payload))
     hdr += name.ljust(32, b"\0")
-    # Padded with 0x00, READ OFF THE DEVICE'S OWN IMAGE. An earlier version of
-    # this script padded with 0xff on the strength of a note that turned out to
-    # be wrong; round-tripping stock through this packer put 472 differing
-    # bytes inside the very header LK validates before it jumps.
     hdr = hdr.ljust(0x200, b"\0")
     return hdr + payload
 
@@ -60,7 +83,8 @@ def split_reference(ref: bytes):
     i = payload.find(b"\xd0\x0d\xfe\xed")
     if i < 0:
         raise SystemExit("no DTB found in reference kernel payload")
-    return payload[i:], dict(kaddr=kaddr, raddr=raddr, saddr=saddr,
+    return payload[i:], dict(mtkhdr=kernel[:0x200],
+                             kaddr=kaddr, raddr=raddr, saddr=saddr,
                              tags=tags, hdrv=hdrv, osv=osv,
                              cmdline=ref[64:64 + 512].rstrip(b"\0"))
 
@@ -111,7 +135,7 @@ def main():
     if len(cmdline) > 511:
         raise SystemExit(f"cmdline too long for the 512-byte field: {len(cmdline)}")
 
-    kernel = mtk_wrap(zimage + dtbs, b"KERNEL")
+    kernel = mtk_wrap(zimage + dtbs, b"KERNEL", hf.get("mtkhdr", b""))
 
     hdr = b"ANDROID!"
     hdr += struct.pack("<10I", len(kernel), hf["kaddr"],


### PR DESCRIPTION
ea.10 got past the image id and landed on the next difference:

```
It first differs in the kernel image (offset 2088):
the image has      ffffffffffffffffffffffffffffffff
repacking produces 00000000000000000000000000000000
```

Offset 2088 is `0x28` into the MTK kernel header — exactly where the 32-byte name field ends and the padding begins.

## This code has now been wrong in both directions

`mtk_wrap`'s comment records the opposite finding: an early version padded `0xff`, and correcting it to `0x00` was done *"read off the device's own image"*, noting that `0xff` had put **472 differing bytes** inside the header LK validates. 472 is `0x200 - 40` — the whole padding region.

**Both are real.** Amazon's own images pad `0xff`; anything repacked by magiskboot pads `0x00`. The packer was developed against a device that had been through the FireOS flow — which repacks with magiskboot — so it learned `0x00`, and a freshly restored stock device is the first `0xff` image it has ever seen. **Any constant is right on half the fleet.**

## So it no longer picks one

An emOS build carries the kernel over untouched — the zImage and DTBs come from the reference and only the ramdisk is replaced — so the reference's own header describes the same payload it always did and is correct by construction, padding included.

`split_reference` keeps it, `pack` reuses it verbatim, and its size field is checked against the payload rather than assumed. A header that lies about its own payload is refused with its own message.

Changed in **`emos/mkboot.py` as well**, because `test_agrees_with_mkboot` requires the two to produce identical bytes — and a drift there is one the device finds out about after a partition write.

`roundtrip_diff` now reports a structural refusal from `pack()` as a difference rather than letting it raise through, so it keeps its contract of returning a diff or `None` while `build_emos_image` still shows the specific reason.

## Testing

Both padding bytes round trip, and each keeps its own byte through the repack. A header whose size field disagrees with its payload is refused. Controller suite: **1000 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgf491o1DBmA4zeUFBnNQS