### PR TITLE
Wait for the device to REGISTER, which is not the same as connecting

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -3053,17 +3053,25 @@ class _EmosConsole {
     // stty being present and on the shell being up, and neither is something
     // this can afford to assume. Splitting the marker makes run() correct
     // whether echo is on or off, which is the property worth having.
-    await this._send(`${cmd}; __a=__EM; __b=${id}__; echo "$__a$__b"`);
+    // TWO markers, so the echo can be discarded by POSITION rather than by
+    // recognising it. Everything before the start marker is the console
+    // repeating the request back; everything between them is the answer.
+    //
+    // Matching the echo textually does not work: the terminal wraps at 80
+    // columns, so the request arrives split across lines and no single line
+    // contains the command. That left the request interleaved through the
+    // transcript at exactly the moment someone needs to read it (2026-09-06).
+    const start = `__EM${id}S__`;
+    await this._send(
+      `__a=__EM; __b=${id}S__; echo "$__a$__b"; ${cmd}; __b=${id}__; echo "$__a$__b"`);
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       const i = this.buf.indexOf(mark);
       if (i >= 0) {
         let out = this.buf.slice(0, i);
-        // With echo on, the first line is the request. Drop it rather than
-        // returning it as output.
-        const nl = out.indexOf('\n');
-        if (nl >= 0 && out.slice(0, nl).includes(cmd)) out = out.slice(nl + 1);
-        return out;
+        const j = out.lastIndexOf(start);
+        if (j >= 0) out = out.slice(j + start.length);
+        return out.replace(/^\r?\n/, '');
       }
       await new Promise(r => setTimeout(r, 100));
     }
@@ -5581,38 +5589,60 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     // Association is not the success condition. A device can be perfectly on
     // the network and running nothing; only registration proves EchoMuse was
     // installed, its credentials are right, and the assistant actually runs.
-    // Success is THIS device being CONNECTED, asked by serial.
+    // Success is THIS device having REGISTERED, asked by serial, and the
+    // evidence is firmware_ver rather than `connected`.
     //
-    // It used to be "a device_id appeared that was not in the list when the
-    // wizard opened", and that is broken in both directions by the wizard's
-    // own behaviour: step 4 mints TLS credentials, which creates a device row
-    // to hold the token whether or not the device ever connects. So the old
-    // test could match a row that proves nothing, and — if the serial was
-    // already on file from an earlier run — never match at all while the
-    // device sat there working perfectly. The second is what happened on
-    // 3611NF, 2026-09-06: associated, registered, and the wizard timed out.
+    // A device pending approval is not connected and cannot become connected:
+    // em_controller records it with upsert_device_seen, sends {"type":
+    // "pending"} and CLOSES the socket, so it never enters _devices and
+    // `connected` stays false until somebody approves it. Waiting on that is a
+    // deadlock — the wizard would be waiting for the very thing it exists to
+    // tell the operator to go and do.
+    //
+    // firmware_ver is the right signal: ensure_device_token leaves it NULL
+    // when it creates the row to hold the TLS token at step 4, and only
+    // upsert_device_seen sets it, which only a real registration reaches. So
+    // it means "this device has actually talked to the controller" regardless
+    // of approval.
+    //
+    // Two earlier versions of this were wrong. "A device_id appeared that was
+    // not in the list when the wizard opened" matched the credential row that
+    // proves nothing, or never matched if the serial was already on file.
+    // Then `connected` deadlocked. Both found on 3611NF, 2026-09-06.
     const deadline = Date.now() + 120000;
     let seen = null;
     while (Date.now() < deadline) {
       await new Promise(r => setTimeout(r, 5000));
       let list = [];
       try { list = (await API.get('/api/devices')).devices || []; } catch {}
-      seen = list.find(d => d.connected
+      seen = list.find(d => (d.connected || d.firmware_ver)
         && (!provSerial || (d.device_id || '').includes(provSerial)));
       if (seen) break;
-      const st = (await con.run('wpa_cli -p /data/misc/wifi/sockets -i wlan0 status | grep wpa_state')).trim();
-      addLog(`  ${st || 'no answer'}`);
+      // The address, not the association. wpa_state has said COMPLETED since
+      // before this loop started, so repeating it says nothing — a device
+      // that associates and never gets an address looks identical, and that
+      // is the failure this wait is actually exposed to.
+      const ip = (await con.run(
+        "ip addr show wlan0 | grep 'inet '")).trim().split(/\s+/)[1] || '';
+      addLog(`  ${ip ? `address ${ip}, waiting for it to register`
+                     : 'associated, still no address'}`);
     }
     if (!seen) {
       throw new Error('The device did not register within two minutes. It may be '
         + 'on the network without EchoMuse running — check the console, and '
         + 'restore the escrowed boot image if you want to start over.');
     }
-    addLog(`Registered as ${seen.label || seen.device_id}.`, 'ok');
+    addLog(`Registered as ${seen.label || seen.device_id}`
+         + `${seen.firmware_ver ? ` running ${seen.firmware_ver}` : ''}.`, 'ok');
     addLog('── PROVISIONING COMPLETE ──', 'head');
-    addLog(`This Echo is now running emOS and talking to the controller. `
-         + `${seen.approved ? 'It is already approved and ready to use.'
-                            : 'One thing left: approve it on the Devices page.'}`, 'ok');
+    if (seen.approved) {
+      addLog('This Echo is running emOS, on your network, and approved. '
+           + 'Nothing further to do — say the wake word.', 'ok');
+    } else {
+      addLog('This Echo is running emOS and has reached the controller. '
+           + 'ONE THING LEFT: approve it on the Devices page, and it will '
+           + 'connect within a few seconds.', 'ok');
+    }
   }
 
   // ── Step executor ──

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -2423,6 +2423,13 @@ def test_the_serial_console_disables_echo_before_anything_else():
         "the marker must be assembled on the device from parts that do not "
         "spell it in the echoed command")
 
+    # Two markers, so the echo is discarded by POSITION. Recognising it
+    # textually does not work — the terminal wraps at 80 columns, so the
+    # request arrives split across lines and no line holds the whole command.
+    assert "S__" in cls and "lastIndexOf(start)" in cls, (
+        "run() must bracket the answer between a start and an end marker, or "
+        "the console's echo of the request is returned as part of the answer")
+
     # A failed attempt must release the serial port. The browser refuses to
     # reopen one that is already open, and no amount of retrying clears it.
     step = src[src.index("async function runRebootAndWatch"):]


### PR DESCRIPTION
A run completed end to end and still never printed a completion line. Cancelling the wizard, clicking the device and approving it worked instantly — so the device was fine and the **wait** was wrong.

## Waiting on `connected` is a deadlock

```python
if not row["approved"]:
    upsert_device_seen(...)          # records it
    await ws.send({"type": "pending"})
    await ws.close()                 # ← disconnects it
    return
```

An unapproved device registers and is immediately closed. It never enters `_devices`, so `connected` is `live is not None` → **always false until approved**. The wizard was waiting for the exact thing it exists to tell the operator to go and do.

## `firmware_ver` answers the question actually being asked

`ensure_device_token` leaves it NULL when it creates the row to hold the TLS token at step 4, and only `upsert_device_seen` sets it — which only a real registration reaches. So it means *"this device has talked to the controller"*, regardless of approval.

Three attempts at this condition now, each wrong differently:

| condition | why it failed |
|---|---|
| "a `device_id` appeared that wasn't in the list" | matched the credential row, proved nothing — or never matched if the serial was already on file |
| `connected` | deadlocked: unapproved devices are disconnected by design |
| `firmware_ver` | asks whether the device registered |

The completion line now says which of the two states it is in, and names the firmware it came up on.

## The console echo is discarded by position

The marker fix worked; the *stripping* didn't. It dropped a first line containing the whole command, and the terminal wraps at 80 columns — so the request arrives split across lines and never matched, leaving it interleaved through the transcript at exactly the moment someone needs to read it. `run()` now brackets the answer between a start and an end marker, which doesn't care about wrapping. Pinned by a test.

## The wait reports the IP, not `wpa_state`

`wpa_state` had said `COMPLETED` since before the loop started, so repeating it every five seconds said nothing. A device that associates and never gets an address looks identical — and that's the failure this wait is genuinely exposed to.

Controller suite: 1000 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgf491o1DBmA4zeUFBnNQS