### PR TITLE
Do not double the cmdline when repacking an emOS image

### DIFF
--- a/controller/em_emos_build.py
+++ b/controller/em_emos_build.py
@@ -223,7 +223,16 @@ def pack(parts: dict, zimage: bytes, dtbs: bytes, ramdisk: bytes,
          extra_cmdline: str = RAMOOPS_CMDLINE) -> bytes:
     """Assemble a boot image from its parts, using the reference's own header."""
     cmdline = parts["cmdline"]
-    if extra_cmdline:
+    # Appended only if it is not already there.
+    #
+    # The reference is normally a FireOS image, which carries none of this. But
+    # rebuilding an emOS image FROM an emOS image — which is what an in-place
+    # update does — hands us a cmdline that already ends in these parameters,
+    # and appending blindly doubles them. Every rebuild would add another copy
+    # until the 511-byte field overflowed and the build failed, on the third
+    # pass. Found 2026-09-06 building 0.3 from Test Echo 2's own partition,
+    # which is the first time anything has repacked an emOS image.
+    if extra_cmdline and extra_cmdline.encode() not in cmdline:
         cmdline = cmdline + b" " + extra_cmdline.encode()
     if len(cmdline) > 511:
         raise BuildError(
@@ -442,6 +451,10 @@ def build_emos_image(reference: bytes, init_binary: bytes, version: str,
         dtb_size=len(parts["dtbs"]),
         ramdisk_size=len(ramdisk),
         kernel_addr=parts["kaddr"],
-        cmdline=(parts["cmdline"] + b" " + RAMOOPS_CMDLINE.encode()).decode(
-            errors="replace"),
+        # Read back out of the image rather than reconstructed, so what the
+        # wizard shows is what was actually written. Rebuilding it here meant
+        # duplicating pack()'s rule, and the copies disagreed the moment pack
+        # learned not to append a cmdline it already had — reporting the
+        # ramoops parameters twice for an image that carried them once.
+        cmdline=image[64:64 + 512].rstrip(b"\0").decode(errors="replace"),
     )

--- a/controller/tests/test_emos_build.py
+++ b/controller/tests/test_emos_build.py
@@ -146,6 +146,42 @@ def test_round_trip_fails_when_the_image_is_not_what_it_says():
     assert not eb.roundtrip_identical(bytes(bad))
 
 
+def test_rebuilding_an_emos_image_does_not_double_the_cmdline():
+    """
+    An in-place update repacks an emOS image, whose cmdline already ends in the
+    ramoops parameters. Appending blindly adds another copy every time, and the
+    511-byte field overflows on the third pass — so an update mechanism would
+    work twice and then refuse, with nothing to say why.
+
+    Found 2026-09-06 building 0.3 from Test Echo 2's own boot partition, the
+    first time anything had repacked an emOS image rather than a FireOS one.
+    """
+    ref = make_reference()
+    once = eb.pack(eb.split_reference(ref), *(
+        lambda p: (p["zimage"], p["dtbs"], p["ramdisk"]))(eb.split_reference(ref)))
+    assert once[64:576].count(eb.RAMOOPS_CMDLINE.encode()) == 1
+
+    # Repack the result: its cmdline already carries the parameters.
+    twice = eb.pack(eb.split_reference(once), *(
+        lambda p: (p["zimage"], p["dtbs"], p["ramdisk"]))(eb.split_reference(once)))
+    assert twice[64:576].count(eb.RAMOOPS_CMDLINE.encode()) == 1, \
+        "repacking an emOS image must not append the ramoops params again"
+    assert twice[64:576] == once[64:576]
+
+
+def test_the_reported_cmdline_is_the_one_in_the_image():
+    """
+    build_emos_image used to reconstruct the cmdline it reports instead of
+    reading it back, so the two disagreed the moment pack() learned not to
+    append a cmdline it already had — it reported the ramoops parameters twice
+    for an image that carried them once. A number the wizard shows the operator
+    has to come from the artefact, not from a second copy of the rule.
+    """
+    info = eb.build_emos_image(make_reference(), fake_init(), "0.3")
+    assert info["cmdline"] == \
+        info["image"][64:64 + 512].rstrip(b"\0").decode()
+
+
 def test_either_mtk_header_padding_round_trips():
     """
     The byte after the MTK kernel header's name field is NOT constant across

--- a/emos/mkboot.py
+++ b/emos/mkboot.py
@@ -130,7 +130,16 @@ def main():
     ramdisk = open(rd_p, "rb").read()
 
     cmdline = hf["cmdline"]
-    if extra:
+    # Appended only if it is not already there.
+    #
+    # The reference is normally a FireOS image, which carries none of this. But
+    # rebuilding an emOS image FROM an emOS image — which is what an in-place
+    # update does — hands us a cmdline that already ends in these parameters,
+    # and appending blindly doubles them. Every rebuild would add another copy
+    # until the 511-byte field overflowed and the build failed, on the third
+    # pass. Found 2026-09-06 building 0.3 from Test Echo 2's own partition,
+    # which is the first time anything has repacked an emOS image.
+    if extra and extra.encode() not in cmdline:
         cmdline = cmdline + b" " + extra.encode()
     if len(cmdline) > 511:
         raise SystemExit(f"cmdline too long for the 512-byte field: {len(cmdline)}")


### PR DESCRIPTION
Both found by performing the **first in-place emOS update** — building 0.3 from Test Echo 2's own boot partition. Nothing had ever repacked an emOS image before; the wizard always builds from a FireOS reference, which carries none of this. So neither bug could show up until an update was attempted.

## The ramoops parameters were appended unconditionally

An emOS image's cmdline already ends in them, so a rebuild added a second copy, a rebuild of that a third — and the **511-byte field overflows on the third pass**.

An update mechanism would therefore have worked twice and then refused to build, with nothing in the message connecting it to how many times the device had been updated. Now appended only when not already present.

## `build_emos_image` reported a cmdline it reconstructed

Instead of reading it out of the image. The two disagreed the moment `pack()` learned the rule above — the wizard would have shown the ramoops parameters **twice for an image that carried them once**.

It now reads bytes 64–576 back out of the artefact. A number shown to an operator has to come from the thing itself, not from a second copy of the logic that made it.

Changed in `emos/mkboot.py` too, since `test_agrees_with_mkboot` requires the two packers to produce identical bytes.

## Testing

Both pinned. The doubling guard was verified by removing the condition and watching it fail; the reported-cmdline test compares against the image's own header bytes rather than a reconstruction, so it cannot drift the same way.

**Verified end to end on hardware.** EFF now runs emOS 0.3, flashed over the network from a running device — no TWRP, no USB cable, no wipe:

```
write     : 6+1 records out, 6,914,048 bytes @ 20.1 MB/s
read back : b6c2084068c7cc9645b60a3878eacc13   ← matches the staged image
after boot: PRETTY_NAME="emOS 0.3", hostname em-G090LF1180440EFF
            /run/net.log live, /data/local/tmp/net.log frozen at 728,577 bytes
            debugfs mounted, ext_csd readable: PRE_EOL 01, life-time 02 02
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgf491o1DBmA4zeUFBnNQS