### PR TITLE
A console banner for emOS, and the check it constrains

### DIFF
--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -1538,6 +1538,26 @@ throughout — so the rules below are all one rule seen from different angles.
   equally true of a stale id and of a corrupted byte, so any rule tolerating
   one tolerates the other.
 
+- **`/api/devices` returns a bare ARRAY, not `{devices: [...]}`.** The WiFi
+  step read `.devices` off it, which is `undefined`, and the `|| []` made that
+  an empty list on every pass — so its wait loop never examined a single device
+  and always timed out on a device that had registered perfectly. THREE
+  successive rewrites of the success condition were all debugging a predicate
+  that was never evaluated against anything, while two other call sites in the
+  same file use the response directly as an array. A shape mismatch between an
+  endpoint and its caller is invisible at every layer: the fetch succeeds, the
+  parse succeeds, and an empty result is indistinguishable from "nothing
+  matched yet". Pinned by `tests/test_deploy.py`.
+- **Success is the device REGISTERING, not connecting.** An unapproved device
+  is recorded with `upsert_device_seen`, sent `{"type": "pending"}` and then
+  DISCONNECTED, so it never enters `_devices` and `connected` stays false until
+  somebody approves it — which the operator cannot do without closing the
+  wizard. Waiting on that is a deadlock. `firmware_ver` is the signal:
+  `ensure_device_token` leaves it NULL when it creates the row for the TLS
+  token, and only a real registration sets it. **Nothing in the wizard's
+  completion may depend on something reachable only after the wizard is
+  closed.**
+
 **The restore is the wizard's undo and it is proven.** `_writeBootPartition` is
 shared by the flash and the restore deliberately — it is the only code here
 that can leave a device unbootable, and a second copy is one that drifts from

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5471,7 +5471,15 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     const uname = await con.run('uname -a');
     addLog(uname || '(no answer)');
     const osrel = await con.run('cat /etc/os-release 2>/dev/null | head -3');
-    if (!/emos/i.test(osrel)) {
+    // ID=emos at the start of a line, not "emos" anywhere in the reply.
+    //
+    // A substring match was safe only while nothing else on this console ever
+    // said "emOS". The login banner now prints the name and the version, so a
+    // loose match could be satisfied by the banner rather than by
+    // /etc/os-release — a false positive on the one check that decides whether
+    // to keep going after a partition write. The line-anchored form can only
+    // be produced by the file.
+    if (!/^ID=emos\s*$/m.test(osrel)) {
       throw new Error('The console answered but this does not look like emOS '
         + `(/etc/os-release says "${osrel.trim() || 'nothing'}"). `
         + 'Restore the escrowed boot image before going further.');

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -5613,8 +5613,16 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     let seen = null;
     while (Date.now() < deadline) {
       await new Promise(r => setTimeout(r, 5000));
+      // /api/devices returns a bare ARRAY, not {devices: [...]}. Reading
+      // .devices off it yielded undefined and the `|| []` made that an empty
+      // list on every pass — so this loop never examined a single device, and
+      // three successive rewrites of the condition below were all debugging a
+      // predicate that was never evaluated against anything. Two other call
+      // sites in this file use the response directly as an array; checking one
+      // of them would have settled it in seconds.
       let list = [];
-      try { list = (await API.get('/api/devices')).devices || []; } catch {}
+      try { list = await API.get('/api/devices') || []; } catch {}
+      if (!Array.isArray(list)) list = list.devices || [];
       seen = list.find(d => (d.connected || d.firmware_ver)
         && (!provSerial || (d.device_id || '').includes(provSerial)));
       if (seen) break;

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -2439,6 +2439,34 @@ def test_the_serial_console_disables_echo_before_anything_else():
         "with 'The port is already open'")
 
 
+def test_the_wizard_reads_the_device_list_the_way_the_api_returns_it():
+    """
+    /api/devices returns a bare ARRAY (`_ok([...])`), not {devices: [...]}.
+
+    The emOS WiFi step read `.devices` off it, which is undefined, and the
+    `|| []` turned that into an empty list on every pass — so its wait loop
+    never examined a single device and always timed out on a device that had
+    registered perfectly. Three successive rewrites of the success condition
+    were all debugging a predicate that was never evaluated against anything
+    (2026-09-06).
+
+    A shape mismatch between an endpoint and its caller is invisible at every
+    layer: the fetch succeeds, the parse succeeds, and the empty result is
+    indistinguishable from "nothing matched yet".
+    """
+    src = _jsx()
+    assert "(await API.get('/api/devices')).devices" not in src, (
+        "/api/devices returns an array; reading .devices off it is silently "
+        "undefined")
+
+    api = (CONTROLLER / "em_api.py").read_text()
+    handler = api[api.index("async def _get_devices"):]
+    handler = handler[:handler.index("\n@")] if "\n@" in handler else handler[:400]
+    assert "_ok([" in handler, (
+        "this test assumes /api/devices returns a bare list — if that changed, "
+        "every caller in dashboard.jsx has to change with it")
+
+
 def test_emos_wpa_cli_calls_carry_the_control_socket_path():
     """
     wpa_cli defaults to /var/run/wpa_supplicant. emOS starts its supplicant

--- a/emos/README.md
+++ b/emos/README.md
@@ -258,6 +258,32 @@ writes a skeleton (`ctrl_interface` + `update_config=1`) while `/data` is
 writable and before the flash. Recovering by hand needs only those two lines
 and a reboot.
 
+### The console banner
+
+A shell on `/dev/ttyGS0` opens with the device's name, serial, address, the
+controller it is connected to, and where the logs are. Somebody on this console
+is usually there because something is wrong, over a USB cable, with no
+dashboard — these are the facts they would otherwise spend five minutes
+gathering.
+
+**The controller address is read from `/proc/net/tcp`, not from a stored
+value**, because there is not one: the firmware keeps its last-known server in
+memory only. An ESTABLISHED connection to 8767 or 8770 IS the controller, so
+the banner names who the device is talking to NOW, and says "not connected"
+when there is nobody.
+
+The version is read from `/etc/os-release` rather than compiled in, so it
+cannot disagree with the file `build.sh` stamps. It prints AFTER
+`console_gate()`, so it is not a free hint to somebody who has not answered the
+password prompt.
+
+**It also constrains the wizard.** Step 8 decides a device is emOS by reading
+`/etc/os-release` over this console, and the banner now says "emOS" and the
+version too — so that check is anchored to `^ID=emos$` rather than matching the
+substring anywhere in the reply. A loose match could otherwise be satisfied by
+the banner rather than the file, which is a false positive on the one test that
+gates continuing after a partition write.
+
 **The eMMC reports its own wear, and debugfs is how you read it.** The flash
 carries `PRE_EOL_INFO` and two life-time estimates in its Extended CSD, and on
 this kernel the only route to them is

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <net/if.h>
+#include <netinet/in.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -2077,6 +2078,122 @@ static void console_gate(void)
         tcsetattr(0, TCSANOW, &saved);
 }
 
+/* The console banner.
+ *
+ * Somebody reaching this console is usually doing so because something is
+ * wrong, over a USB cable, with no dashboard. The four facts below are the
+ * ones they would otherwise spend their first five minutes gathering, and
+ * three of them are questions this session has actually had to ask by hand.
+ *
+ * The controller address is read from /proc/net/tcp rather than from any
+ * stored value, because there isn't one — the firmware keeps its last-known
+ * server in memory only. An ESTABLISHED connection to 8767 or 8770 IS the
+ * controller, and reading it live means the banner says who we are talking to
+ * now rather than who we once did.
+ *
+ * ASCII only and inside 80 columns: this is a vt100 over a serial gadget.
+ */
+static void tcp_peer(char *out, size_t n)
+{
+    out[0] = 0;
+    FILE *f = fopen("/proc/net/tcp", "r");
+    if (!f)
+        return;
+    char line[512];
+    if (!fgets(line, sizeof line, f)) {          /* header */
+        fclose(f);
+        return;
+    }
+    while (fgets(line, sizeof line, f)) {
+        unsigned int ra, rp, st;
+        /* sl  local_address rem_address st ... */
+        if (sscanf(line, "%*d: %*8x:%*4x %8x:%4x %2x", &ra, &rp, &st) != 3)
+            continue;
+        if (st != 0x01)                          /* ESTABLISHED */
+            continue;
+        if (rp != 8767 && rp != 8770)
+            continue;
+        snprintf(out, n, "%u.%u.%u.%u:%u",
+                 ra & 0xff, (ra >> 8) & 0xff, (ra >> 16) & 0xff,
+                 (ra >> 24) & 0xff, rp);
+        break;
+    }
+    fclose(f);
+}
+
+static void iface_addr(char *out, size_t n)
+{
+    out[0] = 0;
+    int s = socket(AF_INET, SOCK_DGRAM, 0);
+    if (s < 0)
+        return;
+    struct ifreq r;
+    memset(&r, 0, sizeof r);
+    strncpy(r.ifr_name, "wlan0", IFNAMSIZ - 1);
+    if (ioctl(s, SIOCGIFADDR, &r) == 0) {
+        struct sockaddr_in *a = (struct sockaddr_in *)&r.ifr_addr;
+        unsigned char *b = (unsigned char *)&a->sin_addr;
+        snprintf(out, n, "%u.%u.%u.%u", b[0], b[1], b[2], b[3]);
+    }
+    close(s);
+}
+
+static void console_banner(void)
+{
+    char host[80], ip[32], ctl[48];
+    const char *sn = serialno();
+
+    if (gethostname(host, sizeof host) != 0 || !host[0])
+        snprintf(host, sizeof host, "emos");
+    host[sizeof host - 1] = 0;
+    iface_addr(ip, sizeof ip);
+    tcp_peer(ctl, sizeof ctl);
+
+    long up = mono_ms() / 1000;
+
+    /* The version comes from /etc/os-release, which build.sh stamps from
+     * `git describe --match 'emos-v*'`. Read rather than compiled in, so the
+     * banner cannot disagree with the file everything else reads. */
+    char ver[64] = "";
+    FILE *osr = fopen("/etc/os-release", "r");
+    if (osr) {
+        char l[160];
+        while (fgets(l, sizeof l, osr)) {
+            if (strncmp(l, "VERSION=\"", 9) == 0) {
+                char *q = strchr(l + 9, '"');
+                if (q) {
+                    *q = 0;
+                    snprintf(ver, sizeof ver, "emOS %s", l + 9);
+                }
+                break;
+            }
+        }
+        fclose(osr);
+    }
+
+    dprintf(1,
+        "\r\n"
+        "   ___  _ __ ___     ___  ___\r\n"
+        "  / _ \\| '_ ` _ \\   / _ \\/ __|   EchoMuse\r\n"
+        " |  __/| | | | | | | (_) \\__ \\   %s\r\n"
+        "  \\___||_| |_| |_|  \\___/|___/   an Echo with no Amazon on it\r\n"
+        "\r\n"
+        "   host        %s\r\n"
+        "   serial      %s\r\n"
+        "   address     %s\r\n"
+        "   controller  %s\r\n"
+        "   up          %ldm %02lds\r\n"
+        "\r\n"
+        "   logs: /run/net.log  /run/messages  /tmp/server.log\r\n"
+        "\r\n",
+        *ver ? ver : "emOS",
+        host,
+        *sn  ? sn  : "(unknown)",
+        *ip  ? ip  : "no address",
+        *ctl ? ctl : "not connected",
+        up / 60, up % 60);
+}
+
 static pid_t start_console(void)
 {
     int t = open(TTY, O_RDWR | O_NOCTTY);
@@ -2089,6 +2206,7 @@ static pid_t start_console(void)
         dup2(t, 0); dup2(t, 1); dup2(t, 2);
         if (t > 2) close(t);
         console_gate();
+        console_banner();
         char *argv[] = { "/system/bin/sh", NULL };
         char *envp[] = { "HOME=/", "TERM=vt100", "ANDROID_ROOT=/system",
                          "PATH=/sbin:/system/bin:/system/xbin", NULL };


### PR DESCRIPTION
Somebody reaching the emOS console is usually there because something is wrong, over a USB cable, with no dashboard. This answers the four questions they would otherwise spend five minutes gathering — three of which this project has had to ask by hand.

```
   ___  _ __ ___     ___  ___
  / _ \| '_ ` _ \   / _ \/ __|   EchoMuse
 |  __/| | | | | | | (_) \__ \   emOS 0.3
  \___||_| |_| |_|  \___/|___/   an Echo with no Amazon on it

   host        em-G090LF1180440EFF
   serial      G090LF1180440EFF
   address     10.10.1.163
   controller  10.10.1.81:8770
   up          42m 07s

   logs: /run/net.log  /run/messages  /tmp/server.log
```

**The controller address is read live from `/proc/net/tcp`**, not from a stored value — there isn't one, the firmware keeps its last-known server in memory only. An `ESTABLISHED` connection to 8767 or 8770 *is* the controller, so it names who the device is talking to **now** and says `not connected` honestly when there is nobody.

**The version comes from `/etc/os-release`**, not compiled in, so it cannot disagree with the file `build.sh` stamps from `git describe`.

**It prints after `console_gate()`**, so it is not a free hint to somebody who has not answered the password prompt.

## What it constrains, and the fix that goes with it

Step 8 decides a device is emOS by reading `/etc/os-release` over this console and matching `emos` **anywhere** in the reply. That was safe only while nothing else on the console ever said "emOS". The banner now prints the name and version, so a loose match could be satisfied by the *banner* rather than the file — a false positive on the one check gating whether to continue after a partition write.

Anchored to `^ID=emos$`, which only the file can produce. Demonstrated on EFF by emitting banner-like text inside a command's output window: the old form matches the banner line alone, the new one does not.

In practice the banner prints once when the console shell starts, before the wizard's first command, so the two-marker protocol discards it by position anyway — but this removes the class rather than relying on that timing.

## Also documented

Two rules from tonight, in `controller/CLAUDE.md`:

- **`/api/devices` returns a bare array**, and the WiFi step read `.devices` off it. Three rewrites of the success condition were all debugging a predicate that was never evaluated against anything.
- **Success is the device registering, not connecting** — an unapproved device is disconnected by design, and the operator cannot approve it without closing the wizard. Nothing in the wizard's completion may depend on something reachable only after it closes.

ASCII only, inside 80 columns; `ringsim --check` and `pwcheck` pass; static aarch64, no `NEEDED` entries. Controller suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgf491o1DBmA4zeUFBnNQS