### PR TITLE
Journal: 2026-09-06, the emOS wizard end to end and in-place updates

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -2151,3 +2151,100 @@ was branched off main when it and #415 were sitting uncommitted on #413's
 branch; and I twice reported a local test run that my own branch-switching had
 contaminated. The pattern is claiming a verification I had not actually
 performed.
+
+## 2026-09-06 — the emOS wizard runs end to end, and emOS updates in place
+
+**The provisioning wizard went from dying at step 3 to a complete run**, across
+seven EA builds (2.23.0-ea.5 through ea.13), two emOS releases (0.2, 0.3) and
+eleven PRs. It began with a device that would not provision at all and ended
+with one running emOS on WiFi, provisioned from a device restored to genuine
+stock — which is the state `docs/rooting.md` tells users to be in and which
+nothing had ever been tested against.
+
+**Almost every failure was in a CHECK, not in the thing being checked.** The
+writes, pushes and flashes were correct throughout. In order: the `su` shim
+tested whether a FILE existed rather than whether it RAN, so a shim with an
+unusable `#!/bin/sh` interpreter — there is no `/bin` in a recovery ramdisk —
+satisfied `command -v su` and the retry skipped the verification that had just
+caught it. `Cleared.` was logged after every command failed, because `readlink`
+with stderr discarded returns the same empty string for "gone" and "su cannot
+run". The flash read-back hashed whole megabytes against a zero-padded image,
+so 425,984 bytes of the PREVIOUS boot image were compared against zeros nobody
+wrote — every emOS flash failed on a write `dd` reported complete, and it hid
+because the only path ever exercised was the restore, whose image is exactly
+sixteen blocks. The serial console read its own echo as an answer, because the
+completion marker was sent whole and arrived in the echo before the command
+ran. And the WiFi step's success condition was wrong three times over.
+
+**The packer had only ever seen images that had been through our own FireOS
+flow.** A stock + f1r30s device produced four refusals in sequence, each
+revealed by fixing the last: a stale image id (f1r30s repacks the ramdisk and
+preserves the header, so the SHA1 describes contents that no longer exist), and
+an MTK kernel header padded `0xff` where magiskboot pads `0x00` — a byte this
+code had now been wrong about in BOTH directions, once each way, against two
+real devices. It no longer picks: the reference's own header is reused, which
+is safe because an emOS build carries the kernel over untouched.
+
+**Do not try to make the boot image id serve as an integrity check.** It was
+doing that job by accident — a corrupted byte changed the repack and was
+refused — and I wrote a heuristic to preserve it while tolerating stale ids.
+The heuristic is worthless: "stored id does not match the regions" is equally
+true of a stale id and of a byte corrupted in flight, so any rule tolerating
+one tolerates the other. Removed, and replaced with the escrow's md5 checked on
+arrival, which covers the whole transfer rather than two of its regions.
+
+**emOS can be updated in place, proven on EFF.** 0.1 to 0.3 over the network
+from a running device: escrow the partition with `dd | nc`, build with
+`em_emos_build`, serve over HTTP, `wget` to `/data` (NOT `/run` — 4MB tmpfs,
+the 6.6MB image short-writes and the md5 check caught it), verify, `dd
+conv=fsync`, drop caches, read back, reboot. No TWRP, no cable, no wipe. Doing
+it found two bugs nothing else could reach: the ramoops cmdline was appended
+unconditionally, so each rebuild doubled it and the 511-byte field would
+overflow on the third update; and `build_emos_image` reconstructed the cmdline
+it reported instead of reading it from the image, so the two disagreed the
+moment the first fix landed.
+
+**`net.log` was writing to the eMMC every five seconds, for ever.** On `/data`,
+appended with no bound — and not only its own lines, since `spawn()` points
+every child's stdout and stderr there. A device that cannot join its network
+wrote to flash continuously in exactly the failure state where nobody is
+watching; EFF had accumulated 728,577 bytes in three days. Moved to `/run` and
+capped. Sweeping both halves for the same shape found nothing else:
+`boot-good.img` compares the header's SHA1 image id and writes only on change,
+`server.log` was already trimmed after reaching 45MB in July, and the syslog
+was already on tmpfs at 256KB x 2.
+
+**The eMMC reports its own wear and nothing was reading it.** `PRE_EOL_INFO`
+and two life-time estimates live in the Extended CSD, reachable only through
+`/sys/kernel/debug/mmc0/mmc0:0001/ext_csd` on this kernel — the generic sysfs
+attributes are a Linux 4.9 addition and Samsung's `samsung_smart` answers
+"error mode: Invalid". emOS did not mount debugfs, so the health of the part we
+write to was unreadable on the OS doing the writing. Both devices carry Samsung
+`FJ25AB` dated 08/2017 and read one life-time bucket apart, for reasons nobody
+recorded — which is the argument for capturing it rather than a finding.
+
+**Two questions settled against.** FireOS 6 exists for biscuit and cannot be
+booted once unlocked, blocked by the TrustZone signature chain rather than
+merely its 32-bit kernel. WPA3 is blocked in three layers — wpa_supplicant
+v2.3 predates the spec, `NL80211_CMD_EXTERNAL_AUTH` is a 4.17 addition against
+this 3.18 kernel, and PMF needs the closed MediaTek blob. The wlan driver
+cannot be lifted from a FireOS 6 image either: `/proc/modules` lists only
+`perfinfo`, so it is compiled in.
+
+**The permissive cmdline patch is NOT inert, and this file said otherwise.**
+Measured on 0C95 and 71VVV: `ro.boot.selinux` commits `permissive` with both
+values present, because `androidboot.*` becomes a read-only property and those
+are write-once, so the FIRST occurrence wins and LK splices the image's cmdline
+in ahead of its own. Wil said so from experience and the devices agreed.
+
+**Five corrections of mine, and the last is the worst.** I claimed the SELinux
+patch was inert; I blamed LED rail coupling for the speaker noise until Wil's
+question about the silence loop killed it; I nearly shipped the id heuristic
+above; I reported a `0-10%` eMMC reading as "ten months of EchoMuse" when it
+was a FireOS device and a nine-year-old part. And I rewrote the WiFi success
+condition THREE times — new-device, then `connected`, then `firmware_ver` —
+while `/api/devices` returns a bare array and the code read `.devices` off it,
+so the list was empty on every pass and none of the conditions was ever
+evaluated. Two other call sites in the same file use the response directly as
+an array. The whole day was about checks that cannot see what they claim to
+check, and I spent three rounds inside one.


### PR DESCRIPTION
The journal stopped at **2026-09-02**. This adds today.

Covers: the wizard going from failing at step 3 to a complete run on a device restored to genuine stock; the first in-place emOS update (0.1 → 0.3 over the network, no TWRP, no cable, no wipe); `net.log` writing to the eMMC every five seconds for ever; the eMMC health route nothing was reading; and the two dead ends now settled with evidence — FireOS 6 and WPA3.

The through-line, and the reason it's worth writing down: **almost every failure was in a check, not in the thing being checked.** The writes were correct throughout.

Also includes the five things I got wrong, of which the worst is rewriting the WiFi success condition three times while `/api/devices` returns a bare array the code read `.devices` off — so the list was empty on every pass and none of the conditions was ever evaluated.

## Not included

**The 3rd, 4th and 5th are still missing.** I didn't live those days, and backfilling them from second-hand notes would put things in the record I can't stand behind. Worth doing from the handovers if you want the continuity, but that's a deliberate omission rather than an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgf491o1DBmA4zeUFBnNQS