### PR TITLE
Docs freshness pass: correct four claims the last fortnight falsified

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ hear the answer through the Dot's speaker. The hardware you already own
   its own event instead, if you'd rather bind the tap. The hold keeps working
   with the mic muted, so a Dot muted for privacy is still a button.
 - **Headphones** — plug into the 3.5mm jack and audio moves there, unplug and
-  it comes back, no reboot needed.
+  it comes back, no reboot needed. Two known faults, both open: booting with a
+  plug already inserted is unreliable, and unplugging can stall the microphone
+  for around thirty seconds ([#117](https://github.com/wilbowes/EchoMuse/issues/117),
+  [#141](https://github.com/wilbowes/EchoMuse/issues/141)). Plugging in and out
+  of a running device works.
 - **Fleet dashboard** — provisioning wizard, per-device or global config
   pushed live (EQ, LED ring scenes, mic tuning), A/B-slot OTA updates with
   automatic fallback, root shell, logs, and per-turn activity analytics

--- a/SETUP.md
+++ b/SETUP.md
@@ -690,7 +690,11 @@ done
 
 **Why device 23?** The biscuit exposes 25+ PCM devices. Device 23 is the TLV320 DAC output path. Most other devices are modem/voice paths or internal DSP routes that hang or error on open.
 
-**Why keep echoaudioservice?** The MediaTek audio DSP requires initialisation that happens inside Amazon's audio HAL (`audio.primary.mt8163.so`). Without `echoaudioservice` running, the I2S clock never starts and `tinyplay` hangs indefinitely. The service is a manifest stub — no Java code — its sole job is to trigger HAL initialisation via the Android audio framework.
+**Why keep echoaudioservice?** The service is a manifest stub — no Java code — whose job is to trigger HAL initialisation via the Android audio framework, and it is left in place because nothing has been gained by removing it.
+
+> **Corrected 2026-09-04.** This paragraph used to say the MediaTek DSP needed initialisation inside Amazon's HAL, and that without `echoaudioservice` the I2S clock never starts and `tinyplay` hangs for ever. **That was reasoning rather than measurement, and it is false.** Both capture and playback clock with no HAL, no mediaserver and no Android framework at all — demonstrated by emOS, which runs a full voice turn without any of them (`emos/README.md`).
+>
+> What the HAL *was* silently doing is a different thing: it configured the codec's DAPM routes, which nothing in our firmware ever did because the HAL always got there first. On a device with no Android, the microphones and the speaker are both powered down until we set those routes ourselves. See `device/internal/bindings/codec`.
 
 **`stop media`, and why the ordering matters.** Since the audio-jack fix (#80), `PcmSpeaker.Init()` also runs `stop media` before opening the PCM. It has to: with a headphone plug inserted at boot, mediaserver claims device 23 and our blocking `snd_pcm_open` waits behind it forever, taking the whole device down with it (no buttons, no wake word, no registration — everything in `main()` is initialised after the speaker).
 
@@ -698,9 +702,18 @@ This depends on the HAL having already initialised by the time we stop it, per t
 
 **`stop media` is temporary, and that is fine — better than fine.** Android restarts mediaserver shortly afterwards: measured on hardware, `init.svc.media` reads `running` again with a live pid, while our server still owns `pcm23p` in `RUNNING` state. So `stop media` is a "get out of the way for a moment" rather than a removal, and what actually makes the fix work is winning the device once and then holding it for the life of the process. `Init()` re-runs it on every start, so an OTA or supervisor restart gets the same treatment.
 
-That also disposes of the worry above: because mediaserver comes back, the HAL, the DSP and the I2S clock stay initialised. Nothing is being permanently deprived. `echoaudioservice` is untouched and still required. **Do not turn this into a permanent disable** — that would remove the very thing the first note says the audio path depends on.
+**Do not turn this into a permanent disable.** The reason is not the one this section used to give — it is not that the DSP or the I2S clock would be deprived, which is false per the correction above. It is that **holding mediaserver down makes everything worse, measured 2026-09-03**: the mic stall rate doubles (0.9/min → 1.8/min) and `wlan0` disappears entirely, twice, once needing a reboot. The mechanism is that mediaserver publishes `AudioFlinger` and `AudioPolicyService`, so denying them crash-loops `system_server` — which owns `WifiService`.
 
-One consequence worth knowing: with mediaserver alive, Android still reacts to jack events. Inserting a plug makes its `AudioOut_2` thread reconfigure the amp, DAC mux and ramp underneath us. Removal produced no such reaction in testing — only our own `tinymix`. If codec state changes with nothing in our logs to explain it, this is why.
+The consequence for project direction is worth stating plainly: **the vendor HAL cannot be evicted while the Android framework runs**, because AOSP's own `system_server` is built on the media stack hosting it. "Ditch Amazon's audio" is not a patch to this file; it is the emOS direction.
+
+One consequence worth knowing: with mediaserver alive, Android still reacts to jack events. Inserting a plug makes its `AudioOut_2` thread reconfigure the amp, DAC mux and ramp underneath us, and it wipes `HP Driver Gain Volume` on every one of its restarts (~every 60–90s). If codec state changes with nothing in our logs to explain it, this is why.
+
+**The jack's output stage is `HP Driver Gain Volume` (tinymix ctl 62), and it is ours to set.** Root-caused 2026-09-03 by diffing all 239 mixer controls across an insert on our device and on a stock one: accdet's switch state makes the HAL drop ctl 62 to **0, the floor of a 0..35 range**, and a stock Dot's HAL then raises it to 11. We had nothing that did, so the external output sat at minimum gain and read as "the jack does not work". `PcmSpeaker.SetJackRouting` now owns both the amp switch and the gain, in both directions, and `WatchJackRouting` re-applies them every 30s because mediaserver keeps wiping them.
+
+Two things this does NOT fix, so do not read it as "the jack works":
+
+- **Booting with a plug already inserted is still faulty** — that is [#117](https://github.com/wilbowes/EchoMuse/issues/117), still open. accdet acts on the insert *transition* and a boot has no transition, and the reproduction is simply "boot with a plug in, wait ~16 minutes" (measured: `stalls=0` → `+10806ms, stalls=12`). The 30s reconciler has never been exercised against that path, because doing so requires the mediaserver churn that only a boot-with-plug produces.
+- **The accdet driver writes no mixer control at all.** Read the source rather than inferring: `accdet_report_status()` reads the GPIO and calls `switch_set_state()` on `/sys/class/switch/h2w`, and touches no codec register ever. Every "accdet mutes the amp" line elsewhere in this project's docs was wrong. It is Android's HAL reacting to that switch state, which relocates the whole insert-versus-boot difference out of the kernel and into Android userspace.
 
 **The mixer defaults are wrong.** Three mixer controls must be set after every boot — `start_server.sh` handles this automatically. Without them, tinyplay hangs silently on device 23.
 

--- a/docs/rooting.md
+++ b/docs/rooting.md
@@ -113,9 +113,33 @@ Once those are done, EchoMuse takes over. The provisioning wizard in the
 dashboard handles the rest — see the [Quickstart](quickstart.md). It starts
 from a device already in that state; it does not run the exploit.
 
-The steps the wizard performs (the SELinux patch, Magisk, and the root-grant
-database) happen with TWRP already installed, so a failure can usually be
-re-flashed from recovery.
+### The wizard has two flows, and they write different things
+
+**This matters before you start, because they are not equally reversible.**
+
+- **emOS** — the current default. Nine steps, all inside TWRP. It escrows your
+  boot partition and hands you the file, then replaces that partition with an
+  image built from your own kernel and device trees plus our init. The result
+  runs no Amazon userspace at all. See [`emos/README.md`](../emos/README.md).
+- **FireOS** — thirteen steps, reached at `?flow=fireos` on the dashboard URL.
+  Keeps Android and adds root: the SELinux cmdline patch, Magisk, and the
+  root-grant database. This is the path every device in the field took.
+
+Both leave a failed step with the device still in TWRP and say so. The
+difference that matters afterwards:
+
+**A device on emOS cannot be re-provisioned by the wizard, and going back
+wipes it.** emOS runs no adbd — it cannot, since adbd needs Android's property
+service — so the wizard's first step finds no device to talk to. Returning to
+FireOS means booting TWRP by hand, wiping cache and data, sideloading the
+FireOS 5 image and then flashing `f1r30s.zip`. That erases `/data`, taking
+EchoMuse, its configuration and its credentials with it. **`f1r30s.zip` is not
+optional** — a stock flash restores dm-verity against a partition table the
+unlock modified, and without it the device does not boot.
+
+Keep the escrowed boot image the emOS flow hands you at step 3. Writing it back
+takes about ten seconds, leaves `/data` alone, and is the undo for everything
+below.
 
 ## What EchoMuse writes, and what it does not
 
@@ -131,9 +155,12 @@ ever writes the FireOS one. Lowest first:
 | FireOS kernel and ramdisk | `mmcblk0p10` / `p11`. | **Yes**, one write |
 | `/system`, `/data` | FireOS userspace. | Yes, files only |
 
-The single partition write is in the wizard's Patch Boot Image step, and it
-puts the SELinux permissive cmdline and the `service echomuse` init entry into
-the FireOS kernel. TWRP presents that partition as `/dev/block/other-boot`.
+There is a single partition write either way, and TWRP presents that partition
+as `/dev/block/other-boot`. What goes into it differs by flow: the **FireOS**
+flow's Patch Boot Image step adds the SELinux permissive cmdline and the
+`service echomuse` init entry to the kernel already there, while the **emOS**
+flow replaces the partition with an image rebuilt from that same kernel and
+device trees. Neither touches any layer above `No` in the table.
 
 **The by-name directory means different things in TWRP and in Android**, which
 is worth knowing before reading any of it as gospel. Measured on hardware:
@@ -178,9 +205,19 @@ situation into the second.
 
 ## How well tested is this?
 
-Eight devices have been through the wizard's steps without a failure. That is
-a small sample, all of it on the same model by the same person, so treat it
-as encouraging rather than conclusive.
+**The two flows have very different amounts of evidence behind them, and the
+default is the newer one.**
+
+Eight devices have been through the **FireOS** flow's steps without a failure.
+That is a small sample, all of it on the same model by the same person, so
+treat it as encouraging rather than conclusive.
+
+The **emOS** flow has completed end to end on hardware, but only recently and
+on a handful of devices. Its first full run against a device restored to
+genuine stock failed at four separate steps before it worked — all four were
+faults in the wizard's own checks rather than in the writes, and all four are
+fixed, but that is the maturity to price in. If you want the better-evidenced
+path today, use `?flow=fireos`.
 
 ## Recovery
 
@@ -210,9 +247,11 @@ This is the step that isn't documented anywhere else.
 
 The Little Kernel (LK) bootloader hardcodes `androidboot.selinux=enforce` into the kernel command line — this is set before Android even loads, and it's what blocks every attempt to disable SELinux at runtime. You cannot `setenforce 0` as shell, you cannot `resetprop`, you cannot use `magiskpolicy`. The kernel won't let you.
 
-The fix: we append `androidboot.selinux=permissive` to the boot image's own cmdline field. When both values are present in the kernel cmdline, permissive mode wins in practice on this device.
+The fix: we append `androidboot.selinux=permissive` to the boot image's own cmdline field. LK splices that field into the middle of its own parameters and adds its `enforce` afterwards, so both values end up on the kernel command line with ours first — and **the first one wins**. `androidboot.*` becomes a `ro.boot.*` property through Android's init, read-only properties are write-once, and the second set is refused. Measured on two devices, 2026-09-06: `getenforce` Permissive, `ro.boot.selinux` permissive.
 
-> **Note:** The `androidboot.selinux` value is a null-terminated ASCII string stored at a fixed offset (byte 64) in the Android boot image header, in a 512-byte field. We patch it directly rather than using magiskboot, which doesn't support cmdline modification on this version.
+Do not reason about this as a kernel parameter, where a later value would override an earlier one. `androidboot.selinux` is not one — the kernel's own switches are `selinux=` and `enforcing=`, which nothing here sets.
+
+> **Note:** The cmdline is a null-terminated ASCII string in a 512-byte field at a fixed offset (byte 64) of the Android boot image header. We patch it directly rather than using magiskboot, which doesn't support cmdline modification on this version.
 
 ### From TWRP, extract magiskboot and pull the boot image:
 
@@ -226,28 +265,52 @@ adb pull /tmp/work/boot.img boot_fresh.img
 
 ### Patch the cmdline on your host machine:
 
+This **appends** to what FireOS already put there. An earlier version of these
+instructions zeroed the whole 512-byte field and wrote a short replacement,
+which silently discarded FireOS's own arguments — `rootwait`, `ro`,
+`init=/init`, `buildvariant`, the `lowmemorykiller` tuning and `veritykeyid`.
+Devices booted anyway, because LK supplies `root=` and `androidboot.hardware`
+and kernel defaults covered the rest, so it went unnoticed for a long time. It
+is still the wrong thing to do to somebody's boot image.
+
 ```python
 python3 - <<'EOF'
+ARG = b'androidboot.selinux=permissive'
+START, END = 64, 576          # the 512-byte cmdline field
+
 with open('boot_fresh.img', 'rb') as f:
     data = bytearray(f.read())
 
-cmdline_offset = 64
-new_cmdline = b'bootopt=64S3,32N2,64N2 androidboot.selinux=permissive'
+if bytes(data[:8]) != b'ANDROID!':
+    raise SystemExit("Not an Android boot image — refusing to patch.")
 
-# Zero the full 512-byte field, then write new cmdline
-data[cmdline_offset:cmdline_offset+512] = b'\x00' * 512
-data[cmdline_offset:cmdline_offset+len(new_cmdline)] = new_cmdline
+field = data[START:END]
+used  = field.index(0) if 0 in field else len(field)
+existing = bytes(field[:used])
+print("Old cmdline:", existing.decode(errors='replace'))
 
-# Verify
-print("New cmdline:", data[cmdline_offset:cmdline_offset+60])
+if ARG in existing.split():
+    print("Already patched — nothing to do.")
+elif any(a.startswith(b'androidboot.selinux=') for a in existing.split()):
+    raise SystemExit(
+        "This image already sets androidboot.selinux to something else. "
+        "Appending would lose to it, because the FIRST value wins. Fix that "
+        "value rather than adding a second one.")
+else:
+    addition = (b' ' if used else b'') + ARG
+    if used + len(addition) >= len(field):      # keep room for the terminator
+        raise SystemExit("Cmdline too long to append without truncating it.")
+    data[START + used:START + used + len(addition)] = addition
+    data[START + used + len(addition)] = 0
+    print("New cmdline:", bytes(data[START:START + used + len(addition)]).decode())
 
-with open('boot_patched.img', 'wb') as f:
-    f.write(data)
-print("Written to boot_patched.img")
+    with open('boot_patched.img', 'wb') as f:
+        f.write(data)
+    print("Written to boot_patched.img")
 EOF
 ```
 
-Verify the output shows your new cmdline cleanly — no garbage bytes after `permissive`.
+Check that the new cmdline is your original one with `androidboot.selinux=permissive` on the end, and nothing missing from the front.
 
 ### Flash the patched image:
 

--- a/emos/README.md
+++ b/emos/README.md
@@ -8,18 +8,27 @@ It is a distribution in the ordinary sense: it does not include a kernel of its
 own. It pairs the device's existing MediaTek 3.18 kernel with our own PID 1,
 busybox, and bionic and tinyalsa mounted read-only from the device's `/system`.
 
-**Status: 0.1, bench-proven, not field-proven.** One device, two days. A
-complete voice turn has run on it — wake word scored on-device, Home Assistant
-pipeline, spoken answer — along with WiFi, the 9-channel mic array, hardware
-AEC, the BLE proxy, buttons, ambient light, jack detect and the LED ring. The
-known gaps are listed at the bottom and none of them is a research problem.
+**Status: 0.3, bench-proven, not field-proven.** Still a small number of
+devices over a handful of days. A complete voice turn has run on it — wake word
+scored on-device, Home Assistant pipeline, spoken answer — along with WiFi, the
+9-channel mic array, hardware AEC, the BLE proxy, buttons, ambient light, jack
+detect and the LED ring. The known gaps are listed at the bottom and none of
+them is a research problem.
 
-`emos-v0.1` is tagged and published so the provisioning wizard can fetch the
-init, which is the only part of an image that can be distributed. **A tag is
-not a claim that this is finished**: it has run on one device, and the wizard
-that installs it has not been through a full run on hardware at all. Try it on
-a spare Echo, and read the Known gaps first — in particular, a device on emOS
-cannot be re-provisioned by the wizard, and going back wipes it.
+Two things changed since 0.1 that are worth knowing before you try it:
+
+- **The provisioning wizard has now run end to end**, on a device restored to
+  genuine stock. It failed at four different steps first, and every one of
+  those failures was in a *check* rather than in the operation being checked.
+- **emOS updates in place, over the network.** A device was taken 0.1 → 0.3
+  with no TWRP, no cable and no wipe. So a bug in a released emOS is something
+  we can push a fix for, rather than something that strands a device.
+
+`emos-v0.3` is tagged and published so the wizard can fetch the init, which is
+the only part of an image that can be distributed. **A tag is not a claim that
+this is finished.** Try it on a spare Echo, and read the Known gaps first — in
+particular, a device on emOS cannot be re-provisioned by the wizard, and going
+back means a TWRP wipe that erases `/data`.
 
 ## Why
 
@@ -31,7 +40,7 @@ than that in one sense and much thicker in another:
 - SETUP.md claimed Amazon's audio HAL was what started the I2S clock and that
   playback would hang without it. **That was reasoning, not measurement, and it
   is false.** Both directions clock with no HAL, no mediaserver and no
-  framework.
+  framework. (SETUP.md now carries the correction rather than the claim.)
 - But the HAL *was* silently configuring the codec for us. Nothing in the
   firmware ever closed the codec's DAPM routes, because the HAL always got
   there first. On a device with no Android, both the microphones and the
@@ -72,11 +81,11 @@ with `git describe --match 'emos-v*'`, so without those tags it stamps
 whatever tag is nearest — a controller release number, which is worse than
 "unknown" because it looks plausible. The namespace also keeps emOS out of the
 firmware OTA's way: `_fetch_latest_release` selects a tag starting `v` with a
-`server` asset, and `emos-v0.1` matches neither.
+`server` asset, and `emos-v0.3` matches neither.
 
 ```sh
-git tag -a --cleanup=verbatim emos-v0.1 -m "..."   # -a always; the annotation IS the notes
-git push origin emos-v0.1
+git tag -a --cleanup=verbatim emos-v0.4 -m "..."   # -a always; the annotation IS the notes
+git push origin emos-v0.4
 ```
 
 `emos-release.yml` compiles the init with the pinned NDK, asserts it is


### PR DESCRIPTION
Audited by enumerating ground truth from the code and the measurements, then diffing the prose against it — the method from #75. **Wrong beats missing:** every item here is a doc asserting something we have since measured to be false, not a doc that is merely thin.

## `SETUP.md` said Amazon's HAL starts the I2S clock

It does not, and `emos/README.md` has said so since 2026-09-04 while SETUP.md went on claiming the opposite. **Two files in the tree disagreeing is worse than one being wrong** — a reader has no way to tell which half is the measurement.

The same section's advice survives with its reasoning replaced. "Do not permanently disable mediaserver" is still right, but not because the DSP would be deprived: holding it down doubles the mic stall rate (0.9 → 1.8/min) and takes `wlan0` with it, because denying `AudioFlinger` crash-loops `system_server`, which owns `WifiService`.

Also adds the jack's actual root cause — `HP Driver Gain Volume` (ctl 62) — which lived in `device/CLAUDE.md` and nowhere a reader of the architecture reference would find it. Written with **both things it does not fix stated plainly**: #117 is still open and boot-with-plug is still faulty. "The jack was fixed" is exactly the misreading this project already made once.

## `docs/rooting.md` taught the destructive cmdline patch

Its prose said *append*; its script zeroed the 512-byte field and wrote 51 bytes, discarding `rootwait`, `init=`, `buildvariant`, the `lowmemorykiller` tuning and `veritykeyid`. This is the manual path a user runs against their own hardware, and it is the same fault #463 fixes in the wizard.

Replaced with a script that appends, refuses an image already setting `androidboot.selinux` to something else, refuses rather than truncates, and is idempotent. **All four paths were executed against synthetic boot images before committing**, not just eyeballed.

It also now says *why* the first occurrence wins — `androidboot.*` becomes a write-once `ro.boot.*` property — because "permissive wins in practice" invites the reader to reason about it as a kernel parameter, where the last value would win instead.

## `rooting.md` described one wizard flow and the default is the other

It documented the FireOS flow's single cmdline patch as "what EchoMuse writes", while the wizard has defaulted to **emOS** — which replaces the whole boot partition — since that flow shipped. Both are now described, with the asymmetry stated where someone will read it before starting: a device on emOS cannot be re-provisioned by the wizard, and the way back is a TWRP wipe that erases `/data`. `f1r30s.zip` named as not optional.

"Eight devices without a failure" was the FireOS flow's record and now says so.

## `emos/README.md` said 0.1 on a tree at 0.3

Understating its own progress — the wizard has run end to end, and a device was taken 0.1 → 0.3 over the network with no TWRP, cable or wipe.

## `README.md` promised a jack with no caveats

While `docs/uat.md` listed #117 and #141 as known faults. Same internal disagreement as the first item, in the two files most likely to be read by different people.

---

Docs only. Controller suite: **1003 passed**.

**Not fixed here, and worth its own decision:** `docs/` has no user-facing page on emOS at all — only `emos/README.md`, which is written for someone building it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zuK5VZZut5EZm3jf3sPxk