### PR TITLE
Say WebUSB is unavailable before a device is unboxed, not at the first click

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           node controller/tests/boot_target.test.mjs
           node controller/tests/pm_verdict.test.mjs
           node controller/tests/wizard_log_class.test.mjs
+          node controller/tests/web_usb_blocked.test.mjs
           node controller/tests/emos_md5.test.mjs
           node controller/tests/boot_image_length.test.mjs
 

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -21,6 +21,39 @@ function isIngress() {
   return document.baseURI.includes('/hassio_ingress/');
 }
 
+// Why WebUSB is unavailable, or null when it is fine.
+//
+// WebUSB needs a secure context and no amount of code changes that, so this
+// exists only to say so BEFORE somebody unboxes a device — it used to surface
+// at the first click of Connect, with a cable already in their hand.
+//
+// One copy, read by both the wizard's pre-flight panel and requestDevice's
+// throw. A second copy would drift, and this is text somebody acts on.
+//
+// The origin is named because Chrome's allowlist matches scheme, host and port
+// exactly, and the add-on's page is served from HOME ASSISTANT's origin rather
+// than the controller's — so an entry added for the standalone dashboard does
+// nothing here and gives no clue why (#169).
+function webUsbBlocked() {
+  if (navigator.usb) return null;
+  const origin = window.location.origin;
+  return {
+    origin,
+    why: `WebUSB needs a secure context, and this page is on ${origin}.`,
+    // Under the add-on there is no localhost route to offer:
+    // _ingress_only_middleware rejects anything that is not the Supervisor
+    // gateway, so suggesting a direct port would send the user to a 403.
+    fix: isIngress()
+      ? `Serve Home Assistant over HTTPS, or add exactly ${origin} to `
+        + `chrome://flags/#unsafely-treat-insecure-origin-as-secure and relaunch `
+        + `the browser. An allowlist entry for the controller's own address does `
+        + `not cover this one.`
+      : `Open the dashboard at http://localhost:8768, or add exactly ${origin} to `
+        + `chrome://flags/#unsafely-treat-insecure-origin-as-secure and relaunch `
+        + `the browser.`,
+  };
+}
+
 function ingressWebSocketUrl(path) {
   const url = new URL(ingressPath(path), document.baseURI);
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -2531,30 +2564,8 @@ const _ADB = (() => {
     // Open the browser USB picker, load the library, authenticate, return a
     // ready Client.  logFn is optional — wizard passes addLog.
     static async requestDevice(logFn = () => {}) {
-      if (!navigator.usb) {
-        // Name the origin. Chrome's insecure-origin allowlist is per-origin
-        // and matches on scheme, host and port exactly, so someone who has
-        // already allowlisted the standalone dashboard gets no benefit here
-        // and has no way to tell why — the add-on's page is served from
-        // Home Assistant's origin, not the controller's.
-        const origin = window.location.origin;
-        throw new Error(
-          `WebUSB not available — requires a secure context (HTTPS or localhost). ` +
-          `This page is on ${origin}. ` +
-          (isIngress()
-            // Under the add-on there is no localhost route to offer:
-            // _ingress_only_middleware rejects anything that is not the
-            // Supervisor gateway, so suggesting a direct port would send
-            // the user to a 403.
-            ? `Serve Home Assistant over HTTPS, or add exactly ${origin} to ` +
-              `chrome://flags/#unsafely-treat-insecure-origin-as-secure and ` +
-              `relaunch the browser. An allowlist entry for the controller's ` +
-              `own address does not cover this one.`
-            : `Open the dashboard at http://localhost:8768, or add exactly ` +
-              `${origin} to chrome://flags/#unsafely-treat-insecure-origin-as-secure ` +
-              `and relaunch the browser.`)
-        );
-      }
+      const blocked = webUsbBlocked();
+      if (blocked) throw new Error(`${blocked.why} ${blocked.fix}`);
 
       const { manager, Transport, Adb, defaultAuths } = await _load(logFn);
 
@@ -5992,6 +6003,9 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
   const progressPct = Math.min(100, ((doneCount + (running ? 0.35 : 0)) / STEPS.length) * 100);
   const upcoming = STEPS.slice(step + 1, step + 3);
   const stepFailed = !running && stepState[step] === 'error';
+  // Evaluated per render rather than held in state: a browser relaunched with
+  // the flag set is a new page load, so there is nothing to invalidate.
+  const usbBlocked = webUsbBlocked();
   const statusColors = { pending: 'var(--muted)', running: 'var(--accent)', done: 'var(--ok)', error: 'var(--warn)' };
   const statusIcons  = { pending: '○', running: '◌', done: '●', error: '✕' };
 
@@ -6083,6 +6097,24 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
               <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--text2)', lineHeight: 1.6 }}>{cur.desc}</div>
             </div>
 
+            {/* WebUSB pre-flight. Shown on step 0 rather than at the first
+                click, because the point is to be read before a device is
+                unboxed — the throw in requestDevice says the same thing to
+                somebody already holding a cable. Both fixes are named; there
+                is no third one, and nothing here can be worked around in
+                code. */}
+            {step === 0 && usbBlocked && (
+              <div className="em-panel" style={{ marginBottom: 12, borderColor: 'var(--warn)' }}>
+                <div className="em-label" style={{ marginBottom: 6 }}>USB is unavailable in this browser</div>
+                <p style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--text2)', lineHeight: 1.6, margin: '0 0 6px' }}>
+                  {usbBlocked.why}
+                </p>
+                <p style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--text2)', lineHeight: 1.6, margin: 0 }}>
+                  {usbBlocked.fix}
+                </p>
+              </div>
+            )}
+
             {/* Which OS to install. Step 0 only, and gone once anything has
                 run — see flowLocked. Both options state the thing that
                 actually decides it, because a choice offered without one is
@@ -6146,7 +6178,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
             {/* Steps 0, 1, 6: connect / reconnect buttons */}
             {CONNECT.has(step) && stepState[step] === 'pending' && !running && (
               <div style={{ marginBottom: 10 }}>
-                <Pill onClick={() => runStep(step)}>
+                <Pill disabled={!!usbBlocked} onClick={() => runStep(step)}>
                   {step === 0 ? 'Connect Device' : step === 1 ? 'Connect to TWRP' : 'Reconnect Device'}
                 </Pill>
               </div>

--- a/controller/tests/web_usb_blocked.test.mjs
+++ b/controller/tests/web_usb_blocked.test.mjs
@@ -1,0 +1,123 @@
+// Tests for the WebUSB pre-flight check in dashboard.jsx.
+//
+//     node controller/tests/web_usb_blocked.test.mjs
+//
+// Same source-extraction approach as wizard_log_class.test.mjs: the functions
+// are lifted out of dashboard.jsx rather than imported, because the dashboard
+// compiles to a single classic script. If either is renamed or moved, the lift
+// fails loudly and this file must follow.
+//
+// What matters here is the ADVICE, not the detection. WebUSB needs a secure
+// context and nothing in this repo changes that, so the only job these strings
+// have is telling somebody what to do — and getting that wrong sends them
+// somewhere that cannot work:
+//
+//   - Under the add-on, `localhost:8768` is a 403. _ingress_only_middleware
+//     rejects anything that is not the Supervisor gateway, so offering a
+//     direct port there is worse than offering nothing.
+//   - Chrome's insecure-origin allowlist matches scheme, host AND port
+//     exactly, and the add-on's page is served from Home Assistant's origin
+//     rather than the controller's. Naming the wrong origin, or not naming one
+//     at all, is what #169 was filed for.
+
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const JSX = join(HERE, "..", "static", "dashboard.jsx");
+const src = readFileSync(JSX, "utf8");
+
+function liftFunction(name) {
+  const start = src.indexOf(`function ${name}`);
+  if (start < 0) {
+    throw new Error(`dashboard.jsx no longer defines ${name}() — if it was `
+                  + `renamed or moved, update this test to match`);
+  }
+  let depth = 0;
+  let i = src.indexOf("{", start);
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") { depth--; if (depth === 0) break; }
+  }
+  return src.slice(start, i + 1);
+}
+
+// Both are lifted: webUsbBlocked calls isIngress, so stubbing isIngress here
+// would test a copy of the branch rather than the branch.
+const code = [
+  liftFunction("isIngress"),
+  liftFunction("webUsbBlocked"),
+  "export { webUsbBlocked };",
+].join("\n");
+
+const { webUsbBlocked } = await import(
+  "data:text/javascript;base64," + Buffer.from(code).toString("base64"));
+
+let failures = 0;
+function check(label, cond, detail) {
+  if (cond) { console.log(`ok    ${label}`); return; }
+  failures++;
+  console.error(`FAIL  ${label}${detail ? `\n      ${detail}` : ""}`);
+}
+
+// The globals the two functions read. Set per-case rather than once, since the
+// whole point is that the answer differs by deployment.
+function withPage({ usb, origin, baseURI }, fn) {
+  globalThis.navigator = usb ? { usb: {} } : {};
+  globalThis.window = { location: { origin } };
+  globalThis.document = { baseURI };
+  try { return fn(); } finally {
+    delete globalThis.navigator; delete globalThis.window; delete globalThis.document;
+  }
+}
+
+const STANDALONE = { origin: "http://192.168.1.10:8768", baseURI: "http://192.168.1.10:8768/" };
+const INGRESS = {
+  origin: "http://homeassistant.local:8123",
+  baseURI: "http://homeassistant.local:8123/api/hassio_ingress/abc123/",
+};
+
+// A working browser must produce nothing at all — this gates a panel and a
+// disabled button, so a false positive blocks provisioning outright.
+check("secure context returns null (standalone)",
+      withPage({ ...STANDALONE, usb: true }, () => webUsbBlocked()) === null);
+check("secure context returns null (ingress)",
+      withPage({ ...INGRESS, usb: true }, () => webUsbBlocked()) === null);
+
+// Standalone: localhost is a real route, so it is offered.
+{
+  const b = withPage({ ...STANDALONE, usb: false }, () => webUsbBlocked());
+  check("standalone reports a blocker", b !== null);
+  check("standalone names its own origin", b.why.includes(STANDALONE.origin), b.why);
+  check("standalone offers localhost", b.fix.includes("http://localhost:8768"), b.fix);
+  check("standalone names the origin in the flag advice",
+        b.fix.includes(STANDALONE.origin), b.fix);
+}
+
+// Ingress: localhost is a 403 there, so it must NOT be offered. This is the
+// check worth having — the advice being actively wrong is how #169 started.
+{
+  const b = withPage({ ...INGRESS, usb: false }, () => webUsbBlocked());
+  check("ingress reports a blocker", b !== null);
+  check("ingress does NOT offer localhost", !b.fix.includes("localhost"), b.fix);
+  check("ingress offers HTTPS on Home Assistant", /HTTPS/.test(b.fix), b.fix);
+  check("ingress names HOME ASSISTANT's origin, not the controller's",
+        b.fix.includes(INGRESS.origin) && !b.fix.includes("8768"), b.fix);
+  check("ingress warns an existing controller allowlist entry does not cover it",
+        /does not cover/.test(b.fix), b.fix);
+}
+
+// Both deployments must name the flag exactly; a paraphrase is not actionable.
+for (const [name, page] of [["standalone", STANDALONE], ["ingress", INGRESS]]) {
+  const b = withPage({ ...page, usb: false }, () => webUsbBlocked());
+  check(`${name} names the chrome flag exactly`,
+        b.fix.includes("chrome://flags/#unsafely-treat-insecure-origin-as-secure"), b.fix);
+  check(`${name} says to relaunch the browser`, /relaunch/.test(b.fix), b.fix);
+}
+
+if (failures) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nall checks passed");

--- a/controller/tests/web_usb_blocked.test.mjs
+++ b/controller/tests/web_usb_blocked.test.mjs
@@ -45,13 +45,21 @@ function liftFunction(name) {
 
 // Both are lifted: webUsbBlocked calls isIngress, so stubbing isIngress here
 // would test a copy of the branch rather than the branch.
+//
+// The browser globals are declared at MODULE scope so the lifted functions
+// resolve them lexically, rather than being assigned onto globalThis. Node 21
+// added a real `navigator` global with only a getter, so assigning to it
+// throws — which passes on Node 20 and fails in CI. Shadowing needs no
+// permission from the runtime and cannot rot the same way.
 const code = [
+  "let navigator, window, document;",
+  "export function __setPage(n, w, d) { navigator = n; window = w; document = d; }",
   liftFunction("isIngress"),
   liftFunction("webUsbBlocked"),
   "export { webUsbBlocked };",
 ].join("\n");
 
-const { webUsbBlocked } = await import(
+const { webUsbBlocked, __setPage } = await import(
   "data:text/javascript;base64," + Buffer.from(code).toString("base64"));
 
 let failures = 0;
@@ -64,12 +72,8 @@ function check(label, cond, detail) {
 // The globals the two functions read. Set per-case rather than once, since the
 // whole point is that the answer differs by deployment.
 function withPage({ usb, origin, baseURI }, fn) {
-  globalThis.navigator = usb ? { usb: {} } : {};
-  globalThis.window = { location: { origin } };
-  globalThis.document = { baseURI };
-  try { return fn(); } finally {
-    delete globalThis.navigator; delete globalThis.window; delete globalThis.document;
-  }
+  __setPage(usb ? { usb: {} } : {}, { location: { origin } }, { baseURI });
+  try { return fn(); } finally { __setPage(undefined, undefined, undefined); }
 }
 
 const STANDALONE = { origin: "http://192.168.1.10:8768", baseURI: "http://192.168.1.10:8768/" };


### PR DESCRIPTION
Closes #170 as far as it can be closed. **WebUSB requires a secure context and nothing here changes that** — this moves the moment somebody learns about it, it does not remove the requirement.

> Stacked on #471 (base is `feat/wizard-flow-toggle`), because both add a block to the wizard's step 0 and would otherwise conflict. GitHub retargets this to `main` automatically when #471 merges.

## The message was already right and fired too late

#169 made `requestDevice`'s throw accurate. But the throw happens when the operator clicks **Connect Device** — after they have unboxed a Dot, found a micro-USB cable and plugged it in. The same sentences on step 0 cost them nothing.

The advice now lives in **one place**, read by both the panel and the throw. It is text somebody acts on, and two copies of instructions drift in the way that leaves half your users following the older half. The Connect button is disabled while it applies, since `navigator.usb` is undefined and the click can only fail.

## The test guards the advice, not the detection

Detection is one property read. The *advice* is what sends somebody somewhere:

- **The ingress branch must never offer `localhost:8768`.** `_ingress_only_middleware` rejects anything that is not the Supervisor gateway, so that is a 403 rather than a workaround — and it is the shape of the original #169 report. **Verified by reintroducing that exact bug and watching three checks fail.**
- **It must name Home Assistant's origin, not the controller's.** Chrome's allowlist matches scheme, host and port exactly, so somebody who allowlisted the standalone dashboard has an entry that silently covers nothing here.

Both functions are lifted from source rather than stubbed, so the test drives the real branch.

## Not attempted, deliberately

A downloadable or `file://` provisioner. Whether Chrome treats `file://` as a secure context is genuinely unsettled — and even where it does, the wizard is not self-contained: it fetches firmware, mints TLS credentials and creates the device row, which from a null origin is a CORS and auth surface on the endpoints that issue device credentials. A localhost helper *would* work, and is a signed per-platform binary serving one page for a step run once per device.

**The flag and HTTPS remain the answers.** This just says so before it costs anyone an evening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zuK5VZZut5EZm3jf3sPxk