### PR TITLE
Say the flow is chosen in the wizard, now that it is

### DIFF
--- a/docs/rooting.md
+++ b/docs/rooting.md
@@ -121,7 +121,8 @@ from a device already in that state; it does not run the exploit.
   boot partition and hands you the file, then replaces that partition with an
   image built from your own kernel and device trees plus our init. The result
   runs no Amazon userspace at all. See [`emos/README.md`](../emos/README.md).
-- **FireOS** — thirteen steps, reached at `?flow=fireos` on the dashboard URL.
+- **FireOS** — thirteen steps, chosen on the wizard's first step (or by
+  adding `?flow=fireos` to the dashboard URL).
   Keeps Android and adds root: the SELinux cmdline patch, Magisk, and the
   root-grant database. This is the path every device in the field took.
 
@@ -217,7 +218,7 @@ on a handful of devices. Its first full run against a device restored to
 genuine stock failed at four separate steps before it worked — all four were
 faults in the wizard's own checks rather than in the writes, and all four are
 fixed, but that is the maturity to price in. If you want the better-evidenced
-path today, use `?flow=fireos`.
+path today, pick FireOS on the wizard's first step.
 
 ## Recovery
 

--- a/emos/README.md
+++ b/emos/README.md
@@ -71,8 +71,8 @@ what made a day of failed boots cheap rather than frightening.
 Or use the **provisioning wizard**, which does all three from TWRP and never
 boots Android: it escrows your boot partition (and hands you the file), sends
 it to the controller to be repacked, flashes it and reads it back to check.
-The wizard is the emOS path by default; `?flow=fireos` still runs the old
-thirteen-step FireOS install.
+The wizard defaults to emOS and offers FireOS beside it on the first step;
+`?flow=fireos` still selects the old thirteen-step FireOS install directly.
 
 ### Releasing emOS
 


### PR DESCRIPTION
Follow-up to #471, which moved the FireOS flow out of `?flow=fireos` and onto a control on the wizard's first step. Three lines written hours earlier in #470 describe the query string as the only way to reach it.

The query string stays in the prose rather than being dropped — it still works and still wins, so a support answer can put somebody on a known path without talking them through a control they may be describing inaccurately.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zuK5VZZut5EZm3jf3sPxk