### PR TITLE
Say what to watch on the first emOS boot, and how to reach TWRP without one

### DIFF
--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -6326,9 +6326,36 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
 
             {/* emOS steps 7 and 8: reboot into emOS and configure WiFi over
                 the console. */}
+            {/* The first boot is the one moment the operator has to watch,
+                and the only one where the wrong reaction makes things worse.
+                Told BEFORE the reboot rather than after it goes wrong: this
+                asks somebody to act on their own hardware, so it keeps its
+                length. The ring states are the ones in emos/README.md — the
+                orbiting segment is the case that needs a human, because it
+                means PID 1 never ran and nothing on the device will recover
+                itself. */}
             {isEmos && step === 7 && stepState[7] !== 'done' && !running && (
-              <div style={{ marginBottom: 12 }}>
-                <Pill accent onClick={() => runStep(7)}>Reboot and Connect Console</Pill>
+              <div className="em-panel" style={{ marginBottom: 12, borderColor: 'var(--warn)' }}>
+                <div className="em-label" style={{ marginBottom: 6 }}>Watch the light ring on this boot</div>
+                <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--text2)', lineHeight: 1.7 }}>
+                  <div><strong style={{ color: 'var(--ok)' }}>Filling, then white, then fading</strong> — up and on the network. Done, about 30 seconds.</div>
+                  <div><strong>Two lit segments at the top, throbbing</strong> — waiting for the network. Normal, and most of the boot.</div>
+                  <div><strong style={{ color: 'var(--warn)' }}>Solid amber</strong> — the device is restoring its own last good image. Leave it alone; it reboots itself.</div>
+                  <div><strong style={{ color: 'var(--warn)' }}>Red and stopped</strong> — a boot stage failed. Recoverable, see below.</div>
+                  <div><strong style={{ color: 'var(--error)' }}>A single segment orbiting a full blue ring, for more than a minute</strong> — emOS never started. This is the one that needs you.</div>
+                </div>
+                <p style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--text2)', lineHeight: 1.7, margin: '10px 0 0' }}>
+                  <strong>If it does not come up, do not keep power cycling it.</strong> To reach
+                  TWRP: unplug the power, hold the <strong>mute</strong> button down, and apply
+                  power with it still held — the ring shows an <strong>alternating cyan
+                  pattern</strong> once you are in recovery. Reconnect here and use
+                  <strong> Restore escrowed boot image</strong> below: about ten seconds, and it
+                  leaves everything on /data alone. Repeatedly power cycling a device that will
+                  not boot is what turns a recoverable one into a case-opening job.
+                </p>
+                <div style={{ marginTop: 12 }}>
+                  <Pill accent onClick={() => runStep(7)}>Reboot and Connect Console</Pill>
+                </div>
               </div>
             )}
             {isEmos && step === 8 && stepState[8] !== 'done' && !running && (

--- a/docs/rooting.md
+++ b/docs/rooting.md
@@ -222,9 +222,57 @@ path today, pick FireOS on the wizard's first step.
 
 ## Recovery
 
-If one of the wizard's steps fails, the device should still boot to TWRP —
-reboot to recovery and re-flash the affected component. If it will not reach
-TWRP at all, that is the unlock's territory and R0rt1z2's thread covers
+**The rule that matters: if a device will not boot, do not keep power cycling
+it.** Repeatedly power cycling one that will not come up is what turns a
+device recoverable from a cable into one that needs the case opened and a pin
+shorted. Go to TWRP instead — it is one button combo away and it costs about
+ten seconds to put the old boot image back.
+
+**Reaching TWRP on a device that will not boot:**
+
+1. Unplug the power.
+2. Hold the **mute** button down, and keep holding it.
+3. Apply power with the button still held.
+4. Wait for the ring to show an **alternating cyan pattern** — that is the
+   confirmation you are in recovery, and you can let go once you see it.
+
+`adb reboot recovery` is the easy route and it needs a device that is already
+up, which is exactly what you do not have here.
+
+### If a wizard step failed
+
+The device is still in TWRP and the wizard says so. Reconnect and use
+**Restore escrowed boot image** — it writes back the image read off your own
+device at the escrow step, verifies it against the partition, and leaves
+`/data` untouched. If you have reloaded the page since, choose the
+`echomuse-stock-boot-*.img` file you downloaded at that step; it is the same
+bytes.
+
+### If the first boot after flashing emOS does not come up
+
+The light ring says which case you are in:
+
+| Ring | What it means | What to do |
+|---|---|---|
+| Filling, then white, then fading | Up and on the network | Nothing — done, about 30 seconds |
+| Two lit segments at the top, throbbing | Waiting for the network | Nothing — this is most of the boot |
+| Solid amber | emOS is restoring its own last known-good image | **Leave it.** It reboots itself |
+| Red, stopped | A boot stage failed | Recoverable — go to TWRP and restore |
+| One segment orbiting a full blue ring, for more than a minute | emOS never started | Go to TWRP and restore |
+
+The last row is the only one that needs you. It means the kernel came up and
+our init never ran, so nothing on the device is going to fix itself — the
+orbit is the kernel's own boot animation, still running because userspace
+never claimed the ring.
+
+The amber row is worth knowing about precisely so you *do not* intervene:
+emOS counts boots that never reached the network and, after three, puts its
+own known-good image back and reboots. Interrupting that is the one way to
+make it worse.
+
+### If it will not reach TWRP either
+
+That is the unlock's territory rather than ours, and R0rt1z2's thread covers
 recovery and unbricking.
 
 ## Credits

--- a/emos/README.md
+++ b/emos/README.md
@@ -725,7 +725,9 @@ is not proof it rebooted — compare uptime or a build fingerprint.
 
   Three paths exist and none of them is in the wizard:
 
-  - **Return to stock, by hand.** Boot into TWRP with the button combo, wipe
+  - **Return to stock, by hand.** Boot into TWRP — unplug the power, hold
+    **mute** down, and apply power with it still held, until the ring shows an
+    alternating cyan pattern — then wipe
     cache, wipe data, sideload the FireOS 5 image, **and then flash
     `f1r30s.zip`**. That last step is not optional: a stock flash restores
     dm-verity against a partition table the unlock modified, so **the OS will


### PR DESCRIPTION
Wil's call for GA: emOS as the default install is fine **because it is recoverable and the FireOS path is one toggle away** — provided the user can *catch* a boot that does not come up. That is the part we never wrote down.

## The ring already says which case you are in

The table existed only in `emos/README.md`, which is written for somebody *building* emOS rather than installing it. It is now where it is needed: in the wizard immediately before the reboot, and in the rooting guide's recovery section.

**Only one of the five states needs a human** — a segment orbiting a full blue ring, which is the kernel's own boot animation still running because userspace never claimed it. Our init never started, so nothing on the device is going to fix itself.

The **amber** state is called out precisely so nobody interrupts it: emOS counts boots that never reached the network and restores its own known-good image after three. Interrupting that is the one way to make it worse.

## How to reach TWRP was never written down

Both `emos/README.md` and the recovery section said *"the button combo"* without saying what it is — and `adb reboot recovery`, the only route we document, needs a device that is already up, which is exactly what somebody in this situation does not have.

> Unplug the power, hold **mute** down, apply power with it still held, and wait for the **alternating cyan ring pattern**.

The confirmation pattern matters as much as the combo: without it there is no way to tell whether it took. Both from Wil, who has done it.

## "Do not keep power cycling" is now stated first, not last

`rooting.md` already carried the fact — repeated power cycling turns a cable-recoverable device into one needing the case opened and a pin shorted — but 200 lines away, under the unlock. Somebody whose device will not boot is not reading the whole page in order.

---

Length is deliberate. This asks someone to act on their own hardware, where the root `CLAUDE.md`'s rule is that the caveat keeps whatever length it costs.

Docs plus one wizard panel. esbuild compiles, design tokens pass, all mjs suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zuK5VZZut5EZm3jf3sPxk