### PR TITLE
Say what ea.14 actually contains: the wake word metadata change landed after it

### DIFF
--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -41,6 +41,18 @@ it. The wizard now turns that check off during setup and clears the counter
 that had already built up, so a device provisioned onto a network it used under
 Alexa recovers too.
 
+**Custom wake word models now carry their own name and language.** A model
+trained in the wake word trainer is stamped with the phrase it was actually
+trained on, so Home Assistant shows that rather than a name guessed from the
+filename — which could only ever be one phrase, even for a model trained on
+several, and was always English. Models without that stamp, including every
+stock one, keep the existing behaviour. Thanks to **@be-student**.
+
+One thing to expect the first time you update: stamping changes each model's
+checksum, so every custom model is pushed to its devices once more. They are
+about 1.2MB and the push is verified, so it costs a few seconds and nothing
+else.
+
 **Fixed: repacking an emOS image added a second copy of its own boot
 parameters** each time, so an Echo updated in place three times would refuse to
 build a fourth image. **The emOS console now carries a banner** with the

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -41,6 +41,18 @@ it. The wizard now turns that check off during setup and clears the counter
 that had already built up, so a device provisioned onto a network it used under
 Alexa recovers too.
 
+**Custom wake word models now carry their own name and language.** A model
+trained in the wake word trainer is stamped with the phrase it was actually
+trained on, so Home Assistant shows that rather than a name guessed from the
+filename — which could only ever be one phrase, even for a model trained on
+several, and was always English. Models without that stamp, including every
+stock one, keep the existing behaviour. Thanks to **@be-student**.
+
+One thing to expect the first time you update: stamping changes each model's
+checksum, so every custom model is pushed to its devices once more. They are
+about 1.2MB and the push is verified, so it costs a few seconds and nothing
+else.
+
 **Fixed: repacking an emOS image added a second copy of its own boot
 parameters** each time, so an Echo updated in place three times would refuse to
 build a fourth image. **The emOS console now carries a banner** with the


### PR DESCRIPTION
#442 merged between the ea.14 changelog being written and the tag being cut, so the entry described twelve of the thirteen commits in the image Supervisor will offer.

Also states the one-off cost, which is not inferable from the feature: stamping a model changes its checksum, so every custom model is pushed to its devices once more on the first update.

Caught before the tag, which is why this is a changelog edit rather than a re-cut. Changelogs only; `test_channels.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zuK5VZZut5EZm3jf3sPxk