### PR TITLE
Ask which userspace the device booted before the OTA pushes the debloat

### DIFF
--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -1884,10 +1884,33 @@ async def _run_update_locked(device_id: str, release: dict,
 
         # Sync the startup script while we're here — OTA is the only update
         # path existing devices have for it (see _sync_start_script).
+        #
+        # NOT gated on the platform, deliberately: emOS runs this same script.
+        # Its init supervises `/system/bin/sh /data/local/bin/start_server.sh`
+        # (emos/init/init.c), because the script owns the A/B slot symlink and
+        # the fast-exit backoff, which both bases need. Gating it here by
+        # symmetry with the debloat below would strand emOS devices on whatever
+        # script they were provisioned with.
         await _sync_start_script(live, device_id)
         # Payload drift is not limited to the start script — the debloat
         # halves had no update path at all until 2026-07-30.
-        await _sync_debloat(live, device_id)
+        #
+        # Gated, because the debloat is Android-only: a pm-hide list and a
+        # Magisk service.d script, and emOS has neither a package manager nor
+        # Magisk. This was the THIRD call site of _sync_debloat and the only
+        # one that did not ask — reconcile_on_connect and _post_debloat both
+        # check. Found on EFF 2026-09-07 at its first OTA onto emOS: the
+        # transfer targeted /sbin/.core/img/.core/service.d/ on a device with
+        # no Magisk daemon to have created it.
+        #
+        # It cost only a wasted shell round trip because the destination
+        # directory probe caught it. Without that probe it is the 240s stall
+        # measured on this same device on 2026-09-04 — TRANSFER_OK never
+        # arrives and the transfer holds the shell lock for its full timeout,
+        # twice. The gate belongs here anyway: the probe bounds the damage of
+        # a payload that should never have been sent.
+        if live.android_userspace:
+            await _sync_debloat(live, device_id)
 
         inactive_slot = "server_b" if active_slot == "server_a" else "server_a"
 

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -6,6 +6,7 @@ forgotten (bitten by em_scenes.py 2026-07-10 and em_oww_models.py
 2026-07-19).
 """
 
+import ast
 import re
 from pathlib import Path
 
@@ -2557,3 +2558,73 @@ def test_the_emos_release_workflow_asserts_what_it_publishes():
     # so the only thing published is the init.
     assert "files: emos/build/init" in wf, \
         "only the init is published — an image would carry Amazon's kernel"
+
+
+def test_every_debloat_push_asks_which_userspace_the_device_booted():
+    """
+    The debloat payload is Android-only — a pm-hide list and a Magisk
+    service.d script — and emOS has neither a package manager nor Magisk.
+
+    `_sync_debloat` has THREE call sites and for a while only two of them
+    asked. `reconcile_on_connect` gates on `live.android_userspace` and
+    `_post_debloat` refuses with `not_android`, but the OTA path in
+    `_run_update_locked` called it unconditionally. Found on EFF, 2026-09-07,
+    at its first OTA after being moved to emOS: the transfer targeted
+    `/sbin/.core/img/.core/service.d/` on a device with no Magisk daemon to
+    have created it.
+
+    That cost only a wasted shell round trip, because the destination
+    directory probe caught it — but the probe is the backstop, not the gate.
+    Without it this is the 240s stall measured on the same device on
+    2026-09-04, where TRANSFER_OK never arrives and the transfer holds the
+    device's shell lock for its full timeout, twice.
+
+    Asserted per call site rather than by counting, so a fourth one has to
+    answer the question too.
+    """
+    # Parsed, not grepped, so _strip_prose is neither needed nor wanted: an
+    # AST contains no comments at all, and stripping them first breaks the
+    # parse on any line whose prose was load-bearing to the syntax.
+    tree = ast.parse((CONTROLLER / "em_api.py").read_text())
+
+    def gated(node) -> bool:
+        """True when `android_userspace` is tested anywhere above this call."""
+        for anc in ancestors.get(node, ()):
+            if isinstance(anc, ast.If) and "android_userspace" in ast.dump(anc.test):
+                return True
+        return False
+
+    ancestors: dict = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            ancestors[child] = (parent,) + ancestors.get(parent, ())
+
+    calls = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "_sync_debloat"
+    ]
+    assert len(calls) >= 3, (
+        f"expected at least three _sync_debloat call sites, found {len(calls)} — "
+        "if one was removed, update this test rather than deleting it"
+    )
+
+    ungated = [n.lineno for n in calls if not gated(n)]
+    # _post_debloat guards by returning `not_android` BEFORE reaching the call,
+    # so its call site has no enclosing `if` and is exempt by name.
+    enclosing = {
+        n.lineno: next(
+            (a.name for a in ancestors.get(n, ())
+             if isinstance(a, (ast.AsyncFunctionDef, ast.FunctionDef))),
+            "?",
+        )
+        for n in calls
+    }
+    ungated = [ln for ln in ungated if enclosing[ln] != "_post_debloat"]
+    assert not ungated, (
+        "these _sync_debloat call sites do not check android_userspace: "
+        + ", ".join(f"line {ln} in {enclosing[ln]}()" for ln in ungated)
+        + " — an emOS device has no package manager to hide packages from and "
+          "no Magisk daemon to have created the service.d directory."
+    )


### PR DESCRIPTION
`_sync_debloat` has **three** call sites and only two asked. `reconcile_on_connect` gates on `live.android_userspace` and `_post_debloat` refuses with `not_android` — the OTA path in `_run_update_locked` called it unconditionally.

## Found in the field, today

Reading the EA log after Wil OTA'd EFF onto the new firmware. EFF is on **emOS**, and its first update there pushed a Magisk `service.d` script at a device with no Magisk daemon to have created the directory:

```
G090LF1180440EFF: /sbin/.core/img/.core/service.d/echomuse-debloat.sh.new
— the destination directory does not exist on this device; not sending
```

It cost a wasted shell round trip and nothing else, because the **destination directory probe caught it**. That probe is the backstop, not the gate. Without it this is the **240s stall measured on this same device on 2026-09-04** — `TRANSFER_OK` never arrives and the transfer holds the shell lock for its full timeout, twice, presenting as "the OTA timed out" on a perfectly healthy OTA.

The gate bounds what gets sent; the probe bounds the damage when something is sent that shouldn't have been. Both belong.

## Why this call site was the one missed

It was already known to be special. `controller/CLAUDE.md` notes the reconcile **debounce** does not cover it — *"`_sync_debloat` is called directly inside `_run_update_locked`, so every OTA pushes it regardless of the stamp."*

So somebody looked at this exact line, reasoned about one guard it bypasses, and didn't ask what else it bypassed. **A call site documented as skipping one guard is worth checking against every other guard its siblings have.**

## `_sync_start_script` is deliberately NOT gated

Checked rather than assumed by symmetry. **emOS runs that same script** — its init supervises `/system/bin/sh /data/local/bin/start_server.sh` (`emos/init/init.c:1723`), because the script owns the A/B slot symlink and the fast-exit backoff, which both bases need. Gating it would strand every emOS device on whatever script it was provisioned with — the more expensive of the two mistakes. The comment now says so.

## The test

Asserts **per call site** rather than counting, so a fourth has to answer too. It **parses rather than greps**: an AST carries no comments, so `_strip_prose` is neither needed nor wanted — and stripping first breaks the parse outright.

Verified by reverting the fix and watching it name the offender:

```
AssertionError: these _sync_debloat call sites do not check android_userspace:
line 1912 in _run_update_locked() — an emOS device has no package manager to
hide packages from and no Magisk daemon to have created the service.d directory.
```

`test_deploy.py`: **99 passed**. pyflakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zuK5VZZut5EZm3jf3sPxk