### PR TITLE
Give each playback its own completion waiter, not one Event per device

### DIFF
--- a/controller/em_controller.py
+++ b/controller/em_controller.py
@@ -635,11 +635,26 @@ class Device:
         # Set when the device reports playback_stats for the stream being
         # played. This is the authoritative "the audio has finished" signal
         # — the device emits it once its audio channel has drained after
-        # EOS, i.e. when the last period has gone to ALSA. Cleared at the
-        # start of every speaker stream; awaited by _run_post_turn_playback
-        # in place of the wall-clock estimate that used to clear the ring
-        # while the device was still playing (up to 6.1s early, 2026-07-24).
-        self.playback_done = asyncio.Event()
+        # EOS, i.e. when the last period has gone to ALSA. Awaited in place
+        # of the wall-clock estimate that used to clear the ring while the
+        # device was still playing (up to 6.1s early, 2026-07-24).
+        #
+        # A QUEUE of waiters, one per playback, rather than a single Event on
+        # the device. It was one Event with two waiters and one setter, so two
+        # concurrent playbacks both woke on whichever report arrived first —
+        # observed 2026-08-28 as two `Playback complete` lines in the same
+        # millisecond, and an announcement whose wait ended after a chime's
+        # duration rather than its own (#373).
+        #
+        # FIFO because the device plays one stream at a time and reports in
+        # the order it finishes them, so the oldest outstanding playback is
+        # the one a report belongs to.
+        #
+        # This also retires the `clear()` that every caller had to remember:
+        # a fresh Event per playback cannot carry a stale set from the
+        # previous one, so the hazard those calls guarded against is gone by
+        # construction rather than by discipline.
+        self._playback_waiters: collections.deque = collections.deque()
         # Outcome of the most recently persisted turn, set by em_esphome and
         # consumed once by the turn loop's ring cleanup (see _leds_turn_end).
         self.last_turn_outcome: str | None = None
@@ -682,6 +697,44 @@ class Device:
             or self.speaking
             or em_player.is_playing(self.device_id)
         )
+
+    # ── Playback completion ──────────────────────────────────────────
+    #
+    # One waiter per playback. See _playback_waiters for why this is a queue
+    # and not a single Event.
+
+    def begin_playback(self) -> asyncio.Event:
+        """Register a waiter for this playback and return it."""
+        ev = asyncio.Event()
+        self._playback_waiters.append(ev)
+        return ev
+
+    def end_playback(self, ev: asyncio.Event) -> None:
+        """
+        Retire a waiter, whether or not the device ever reported.
+
+        Must be called from a finally: a playback cancelled mid-stream (a
+        barge-in, a mute, a dropped device) never gets its report, and a
+        waiter left in the queue would take the NEXT playback's report and
+        desynchronise every one after it. Idempotent, because teardown paths
+        in this file are reached more than once by design.
+        """
+        try:
+            self._playback_waiters.remove(ev)
+        except ValueError:
+            pass
+
+    def signal_playback_done(self) -> None:
+        """
+        Resolve the oldest outstanding playback: the device has finished one.
+
+        A report with nothing waiting is dropped rather than remembered. That
+        matches the old single-Event behaviour for a stray report, and a
+        report cannot be "saved up" for a playback that has not started —
+        which is the stale-set hazard the old `clear()` calls existed for.
+        """
+        if self._playback_waiters:
+            self._playback_waiters.popleft().set()
 
     def record_rtt(self, rtt_ms: int, was_busy: bool) -> None:
         self.rtt_last_ms = rtt_ms
@@ -1634,8 +1687,8 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
             f"{em_eq.describe_activity(_limiter, _guard)}"
         )
         cancel_task    = asyncio.create_task(device.cancel_event.wait())
-        device.playback_done.clear()
-        done_task      = asyncio.create_task(device.playback_done.wait())
+        playback_ev    = device.begin_playback()
+        done_task      = asyncio.create_task(playback_ev.wait())
         stream_task    = asyncio.create_task(device.stream_speaker(speaker_pcm))
         t_stream_start = asyncio.get_event_loop().time()
         # Opens the delivery window measured against the device's
@@ -1706,6 +1759,11 @@ async def _run_post_turn_playback(device: Device, voice_response: bytes) -> None
         done_task.cancel()
     finally:
         device.speaker_busy -= 1
+        # Retire the waiter whether or not the device ever reported. A
+        # cancelled playback — barge-in, mute, a device that dropped — never
+        # gets its report, and a waiter left queued would take the NEXT
+        # playback's report and desynchronise every one after it.
+        device.end_playback(playback_ev)
 
         # The real end of audio, not the end of the socket write. The device
         # reports playback_stats once its audio channel drains after EOS, and
@@ -1989,12 +2047,13 @@ async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
         limiter=_limiter_for(device),
         guard=_guard_for(device),
     )
-    # Cleared BEFORE streaming starts: the device sets it when its audio
-    # channel drains after EOS, and a stale set from the previous response
-    # would end this turn the moment we started waiting.
-    device.playback_done.clear()
+    # Registered BEFORE streaming starts, so a report that arrives while we
+    # are still writing has a waiter to resolve. A fresh Event per playback
+    # cannot carry a stale set from the previous response, which is what the
+    # clear() this replaces was for.
+    playback_ev = device.begin_playback()
     cancel_task = asyncio.create_task(device.cancel_event.wait())
-    done_task   = asyncio.create_task(device.playback_done.wait())
+    done_task   = asyncio.create_task(playback_ev.wait())
     stream_task = asyncio.create_task(
         device.stream_speaker_chunks(pcm_chunks, stream_eq)
     )
@@ -2066,6 +2125,7 @@ async def _run_streaming_post_turn_playback(device: Device, pcm_chunks) -> int:
         # reports, not when the last byte reached the socket. In the finally so
         # a cancel or an error leaves the tile idle rather than stuck Speaking.
         await device._set_speaking(False)
+        device.end_playback(playback_ev)
         for t in (cancel_task, done_task):
             t.cancel()
         if not stream_task.done():
@@ -3881,7 +3941,7 @@ async def handle_control(ws: WebSocketServerProtocol, secure: bool = False):
                         # Release _run_post_turn_playback: this report IS the
                         # end of audio, and the ring clears on it rather than
                         # on a wall-clock guess.
-                        device.playback_done.set()
+                        device.signal_playback_done()
                         # Delivery window: first speaker frame sent -> this
                         # report. The metric the 07-20 investigation lacked —
                         # "Streaming took Xs" times the socket write and reads

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -316,8 +316,17 @@ def test_streamed_playback_waits_for_the_device_not_a_computed_sleep():
     fn = src[src.index("async def _run_streaming_post_turn_playback"):]
     fn = fn[:fn.index("\nasync def ", 1)]
 
-    assert "playback_done" in fn, \
+    # Named on the API rather than on a variable: `playback_done` was a single
+    # Event on the Device and became a queue of per-playback waiters (#373), so
+    # the thing to assert is that this path registers one and waits on it, not
+    # what the old attribute was called.
+    assert "begin_playback()" in fn, \
+        "streamed playback must register a playback waiter"
+    assert "playback_ev.wait()" in fn, \
         "streamed playback must await the device's playback_stats"
+    assert "end_playback(" in fn, \
+        ("the waiter must be retired in a finally, or a cancelled playback "
+         "takes the next one's report and desynchronises every one after it")
     assert "asyncio.sleep(remaining)" not in fn, \
         "the computed drain estimate was removed on 2026-07-24 — do not restore it"
 

--- a/controller/tests/test_playback_waiters.py
+++ b/controller/tests/test_playback_waiters.py
@@ -1,0 +1,143 @@
+"""
+Playback completion belongs to a playback, not to a device.
+
+`Device.playback_done` was a single `asyncio.Event` with two waiters —
+`_run_post_turn_playback` and the chunked voice path — and one setter, the
+`playback_stats` handler. Two concurrent playbacks therefore both woke on
+whichever report arrived first.
+
+Observed on the EA controller, 2026-08-28 20:07 (#373): two `Playback
+complete (device-confirmed)` lines in the same millisecond, and an
+announcement whose wait ended after a chime's duration rather than its own.
+
+The class under test is defined in em_controller, which the suite cannot
+import — it pulls in aiohttp, zeroconf and openwakeword. So the four methods
+are lifted from source and exercised on a bare object, the same approach
+tests/test_deploy.py uses for call-site shape. If they are renamed or moved,
+the lift fails loudly rather than silently testing nothing.
+"""
+import ast
+import asyncio
+import collections
+from pathlib import Path
+
+import pytest
+
+CONTROLLER = Path(__file__).resolve().parents[1]
+
+
+def _playback_api():
+    """Build a throwaway class carrying only the playback-waiter methods."""
+    tree = ast.parse((CONTROLLER / "em_controller.py").read_text())
+    device = next(
+        n for n in tree.body
+        if isinstance(n, ast.ClassDef) and n.name == "Device"
+    )
+    wanted = {"begin_playback", "end_playback", "signal_playback_done"}
+    methods = [n for n in device.body
+               if isinstance(n, ast.FunctionDef) and n.name in wanted]
+    missing = wanted - {m.name for m in methods}
+    assert not missing, (
+        f"em_controller.Device no longer defines {sorted(missing)} — if they "
+        "were renamed, update this test to match rather than deleting it"
+    )
+    ns: dict = {"asyncio": asyncio, "collections": collections}
+    exec(compile(ast.Module(body=methods, type_ignores=[]), "<lift>", "exec"), ns)
+
+    class Dev:
+        def __init__(self):
+            self._playback_waiters = collections.deque()
+    for name in wanted:
+        setattr(Dev, name, ns[name])
+    return Dev
+
+
+Dev = _playback_api()
+
+
+def test_a_report_resolves_only_its_own_playback():
+    """
+    The bug, directly: two playbacks in flight, one report.
+
+    Under the old single Event both woke. The first report belongs to the
+    first playback — the device plays one stream at a time and reports in the
+    order it finishes them.
+    """
+    d = Dev()
+    first, second = d.begin_playback(), d.begin_playback()
+
+    d.signal_playback_done()
+    assert first.is_set(), "the first playback's waiter was not resolved"
+    assert not second.is_set(), (
+        "the second playback woke on a report belonging to the first — this "
+        "is the two-Playback-complete-lines-in-one-millisecond bug (#373)"
+    )
+
+    d.signal_playback_done()
+    assert second.is_set()
+
+
+def test_a_cancelled_playback_does_not_steal_the_next_report():
+    """
+    A barge-in, a mute or a dropped device ends a playback with no report
+    coming. Its waiter must leave the queue, or every later playback resolves
+    one report early and for ever — a silent desync that would present as
+    playback completing before the audio does.
+    """
+    d = Dev()
+    abandoned = d.begin_playback()
+    d.end_playback(abandoned)
+
+    live = d.begin_playback()
+    d.signal_playback_done()
+
+    assert live.is_set(), "the live playback did not get its own report"
+    assert not abandoned.is_set()
+
+
+def test_end_playback_is_idempotent():
+    """Teardown paths in em_controller are reached more than once by design."""
+    d = Dev()
+    ev = d.begin_playback()
+    d.end_playback(ev)
+    d.end_playback(ev)  # must not raise
+    assert not d._playback_waiters
+
+
+def test_a_stray_report_is_dropped_not_saved():
+    """
+    A report with nothing waiting must not be remembered for a playback that
+    has not started yet. That is the stale-set hazard the old `clear()` calls
+    existed to work around, and a fresh Event per playback removes it by
+    construction — but only if a spare report is discarded rather than queued.
+    """
+    d = Dev()
+    d.signal_playback_done()          # nothing waiting
+    later = d.begin_playback()
+    assert not later.is_set(), (
+        "a playback resolved before its audio was sent — a stray report was "
+        "saved up instead of dropped"
+    )
+
+
+def test_waiters_do_not_accumulate_across_playbacks():
+    """A leak here would grow unbounded on a device that plays a lot."""
+    d = Dev()
+    for _ in range(50):
+        ev = d.begin_playback()
+        d.signal_playback_done()
+        d.end_playback(ev)
+    assert not d._playback_waiters
+
+
+@pytest.mark.parametrize("n", [2, 5])
+def test_reports_resolve_in_order(n):
+    """FIFO: the device finishes streams in the order it received them."""
+    d = Dev()
+    evs = [d.begin_playback() for _ in range(n)]
+    for i in range(n):
+        d.signal_playback_done()
+        assert evs[i].is_set()
+        assert not any(e.is_set() for e in evs[i + 1:]), (
+            "a later playback resolved out of order"
+        )


### PR DESCRIPTION
First half of #373 — and the half with **no product decision attached**. This is wrong under any speaker-ownership policy, so it can land ahead of the priority rules.

## The bug

`Device.playback_done` was a single `asyncio.Event` with **two waiters** — `_run_post_turn_playback` and the chunked voice path — and **one setter**, the `playback_stats` handler. Two concurrent playbacks both woke on whichever report arrived first.

Observed on the EA controller, 2026-08-28 20:07:

```
20:07:05,283  Playback complete (device-confirmed)
20:07:05,284  Playback complete (device-confirmed)   ← two, same millisecond
```

...and an announcement whose wait ended after a chime's duration rather than its own.

## The fix

A **FIFO queue of waiters, one per playback**. FIFO because the device plays one stream at a time and reports in the order it finishes them, so the oldest outstanding playback is the one a report belongs to.

```
begin_playback()       → register a waiter, return it
signal_playback_done() → resolve the OLDEST outstanding playback
end_playback(ev)       → retire it, reported or not
```

## `end_playback` in a `finally` is the part that matters

A playback cancelled mid-stream — barge-in, mute, a dropped device — never gets its report. A waiter left queued would take the **next** playback's report and desynchronise every one after it, **permanently**. That presents as playback completing before the audio does, which is a horrible thing to reach from the symptom.

Both call sites retire their waiter whether or not the device reported, and it's idempotent because teardown paths in this file are reached more than once by design.

## The `clear()` calls are gone, and that's an improvement

Both sites had to *remember* to clear the Event before streaming, or a stale set from the previous response ended the next turn the instant it started waiting. A fresh Event per playback can't carry a stale set — **the hazard is removed by construction rather than by discipline**. A stray report with nothing waiting is dropped rather than saved, which is the same rule from the other side.

## One existing test broke, correctly

`test_streamed_playback_waits_for_the_device_not_a_computed_sleep` grepped for the literal `playback_done` — asserting on the old attribute name rather than on behaviour. Retargeted at the API, and strengthened: it now also requires `end_playback` in the path, which the original couldn't have checked because with a shared Event there was nothing to clean up.

## Verified by reintroducing the bug

Reverted `signal_playback_done` to wake every waiter, as one shared Event did:

```
AssertionError: the second playback woke on a report belonging to the first —
this is the two-Playback-complete-lines-in-one-millisecond bug (#373)
```

Two of the seven new tests named it. They cover the stray report, the cancelled playback, idempotent teardown, FIFO ordering and waiter accumulation, and lift the methods out via AST since the suite can't import `em_controller`.

**Controller suite: 1024 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zuK5VZZut5EZm3jf3sPxk