### PR TITLE
Record tonight's two findings where the next person will hit them

### DIFF
--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -856,16 +856,49 @@ is #373.** `_ring_timer_alarm` gates every burst on `speaker_busy` because two
 writers would interleave frames on `0x02` — but `_standalone_play` performs no
 such check and streams straight into a chime already in flight. Measured
 2026-08-28: an announcement landing between bursts plays, one landing during a
-burst is **inaudible**. Both paths also share a single `device.playback_done`
-Event, so one device report satisfies two waiters (observed as two `Playback
-complete` lines in the same millisecond, and an announcement whose wait ended
-after a chime's duration rather than its own). **The exclusion being
-one-directional is the bug** — do not "fix" it by blocking announcements while
-ringing, because HA blocks on the announce call holding `_is_announcing` and a
-120s `MAX_RING_S` would fail every other announcement to that satellite. See
-`docs/audio-states.md` §6 Q4 for the options, including the longer-term move of
-the alarm onto the music plane (which needs `audio_mix` gating, or the alarm is
-silent on firmware that cannot mix).
+burst is **inaudible**.
+
+**The priority model is decided (Wil, 2026-09-07) and it INVERTS what the ring
+does today.** A timer must go off exactly when it ends — ringing late is simply
+wrong — so the alarm never waits; it silences music in its favour and is itself
+ducked under a voice response. The announcement is the writer that waits: for a
+response to finish, and behind other announcements. So the fix is not "add the
+missing check to `_standalone_play`", it is to move the check to the other
+side, and the code currently makes the one writer whose timing is the whole
+point the one that defers.
+
+**Ducking the alarm under a response needs no new firmware**, which is why this
+shape was chosen. `Mixer.Mix(voice, music, target)` takes exactly two inputs
+and attenuates only the music side, so the alarm rides the music plane, music
+is suspended while it rings, and the existing duck does the rest — on the
+device, sample-interpolated and click-free. It must be gated on `audio_mix`:
+firmware without it never plays `0x04`, and a silent timer is the worst
+available failure. Those devices keep `0x02`, where the alarm takes the plane
+rather than yielding. An alarm-specific duck depth is wanted rather than
+borrowing `duckDb`, which was tuned for a music bed under speech.
+
+**Do not "fix" the announcement by blocking it for the whole ring** — HA blocks
+on the announce call holding `_is_announcing`, and a 120s `MAX_RING_S` would
+fail every other announcement to that satellite. Waiting for the BURST in
+flight is a different thing: the chime is 1.68s of every 2.3s, and real
+responses measure 1.6–2.6s of audio, so a capped wait is seconds rather than
+minutes. That distinction is why this sat open — the warning against the
+unbounded wait was read as forbidding the bounded one too.
+
+**The shared completion Event is FIXED** (#481, 2026-09-07). `playback_done`
+was one `asyncio.Event` per device with two waiters and one setter, so
+concurrent playbacks both woke on whichever report arrived first — two
+`Playback complete` lines in the same millisecond. It is now a FIFO queue of
+per-playback waiters (`begin_playback` / `signal_playback_done` /
+`end_playback`), FIFO because the device plays one stream at a time and reports
+in the order it finishes them. **`end_playback` belongs in a `finally`**: a
+playback cancelled mid-stream never gets its report, and a waiter left queued
+takes the next playback's report and desynchronises every one after it,
+permanently. The old `clear()` calls are gone with it — a fresh Event per
+playback cannot carry a stale set, so that hazard is removed by construction
+rather than by discipline.
+
+See `docs/audio-states.md` §6 Q4 for the surrounding options.
 
 **A cancelled playback must release `speaking` (#366).** `_run_post_turn_playback`
 clears it in the `finally`, beside `speaker_busy`, and shielded — it used to sit
@@ -1240,7 +1273,11 @@ on connect, debounced per device.
 
 **A transfer probes that the destination DIRECTORY exists before sending.** The heredoc writes with `>`, so a write into a directory that is not there fails, the trailing `echo TRANSFER_OK` never runs, and the transfer waits out its whole 120s timeout holding the device's shell lock. The probe rides the round trip that already detects the base64 decoder and the md5 tool, so it costs nothing, and it is checked BEFORE the decoder because "nowhere to put the file" is the more specific answer. The case that found it: the debloat payload targets Magisk's `/sbin/.core` overlay, which a device without Magisk has no daemon to create.
 
-**Android-only payloads are gated on `Device.android_userspace`** (`em_platform`, pure and tested), which is False only for a device that has POSITIVELY reported `base_os: emos`. Old firmware, a device that has not registered, and any unrecognised value all keep today's behaviour — the two ways of being wrong are not equal. `_post_debloat` refuses server-side rather than relying on the greyed-out control, since it is a plain POST with a session token; the endpoint and the dashboard read the same derived `androidUserspace` so they cannot disagree. Note the reconcile debounce does NOT cover this: `_sync_debloat` is called directly inside `_run_update_locked`, so every OTA pushes it regardless of the stamp.
+**Android-only payloads are gated on `Device.android_userspace`** (`em_platform`, pure and tested), which is False only for a device that has POSITIVELY reported `base_os: emos`. Old firmware, a device that has not registered, and any unrecognised value all keep today's behaviour — the two ways of being wrong are not equal. `_post_debloat` refuses server-side rather than relying on the greyed-out control, since it is a plain POST with a session token; the endpoint and the dashboard read the same derived `androidUserspace` so they cannot disagree. **All THREE call sites must check, and for a while only two did.** `reconcile_on_connect` gates on `android_userspace` and `_post_debloat` refuses `not_android`, but the OTA path in `_run_update_locked` called `_sync_debloat` unconditionally until #480. Found in the field 2026-09-07 on EFF's first OTA after it moved to emOS: the transfer targeted `/sbin/.core/img/.core/service.d/` on a device with no Magisk daemon to have created it. It cost only a wasted shell round trip because the destination-directory probe above caught it — **the probe is the backstop, not the gate**, and without it this is the 240s stall measured on the same device on 2026-09-04. `tests/test_deploy.py` now asserts per call site rather than by counting, so a fourth has to answer too.
+
+Worth noting HOW it was missed, because this exact line was already documented as special: the reconcile debounce does NOT cover it either — `_sync_debloat` is called directly inside `_run_update_locked`, so every OTA pushes it regardless of the stamp. Somebody reasoned about one guard this call site bypasses and stopped there. **A call site documented as an exception to one rule is worth checking against every rule its siblings follow.**
+
+`_sync_start_script` beside it is deliberately NOT gated: emOS runs that same script — its init supervises `/system/bin/sh /data/local/bin/start_server.sh` (`emos/init/init.c`) because the script owns the A/B slot symlink and the fast-exit backoff, which both bases need. Gating it by symmetry would strand every emOS device on whatever script it was provisioned with.
 
 **md5 decides whether a transfer succeeded, not the shell's exit status.**
 `TRANSFER_OK` only ever proved that the base64 decode pipeline and `chmod`

--- a/docs/audio-states.md
+++ b/docs/audio-states.md
@@ -173,24 +173,37 @@ process.
 - **Q2 — where does the output chain belong?** EQ, limiter and bass guard all
   run controller-side today, on the voice plane, before the audio reaches the
   wire (#243). Music does not go through them at all.
-- **Q4 — the alarm and an announcement both write `0x02`, and only one of
-  them asks first (#373).** `_ring_timer_alarm` waits on `speaker_busy`
-  before every burst, for the stated reason that two writers would interleave
-  frames; `_standalone_play` performs no such check and streams into a chime
-  already in flight. Measured 2026-08-28: an announcement landing between
-  bursts plays, one landing during a burst is inaudible. Both paths also
-  share a single `playback_done` Event, so one device report satisfies two
-  waiters — observed as two `Playback complete` lines in the same
-  millisecond, and an announcement whose wait ended after a chime's duration
-  rather than its own.
-  **The exclusion is one-directional, which is the bug**; whether the silence
-  itself is EOS ordering on the device (§3, `stream_speaker`) is unconfirmed.
-  Blocking announcements outright while ringing is NOT the answer — HA blocks
-  on the announce call holding `_is_announcing`, so a 120s `MAX_RING_S` would
-  fail every other announcement to that satellite meanwhile. The longer-term
-  answer is likely the alarm moving to the music plane, where the device's
-  own mixer ducks it for free; that needs `audio_mix` gating, since a device
-  without it never plays `0x04` and the alarm would be silent.
+- **Q4 — DECIDED 2026-09-07: the alarm never waits, the announcement does
+  (#373).** Both write `0x02` today and only `_ring_timer_alarm` asks first,
+  which is backwards: a timer must go off exactly when it ends, so the writer
+  whose timing is the whole point is the one currently deferring. Measured
+  2026-08-28: an announcement landing between chime bursts plays, one landing
+  during a burst is inaudible.
+
+  The rule is **silence the music in favour of the alarm, duck the alarm in
+  favour of the response**. That resolves the three-way case — music playing,
+  turn active, timer fires — without new firmware: `Mixer.Mix(voice, music,
+  target)` takes exactly two inputs and attenuates only the music side, so the
+  alarm rides the music plane, music is suspended while it rings, and the
+  device's existing duck does the rest. Gated on `audio_mix`, since firmware
+  without it never plays `0x04` and a silent timer is the worst available
+  failure; those devices keep `0x02` with the alarm taking the plane.
+
+  The announcement waits for a response to finish and queues behind other
+  announcements, with a cap. Blocking it for the whole ring is still wrong —
+  HA holds `_is_announcing` and 120s of `MAX_RING_S` would fail every other
+  announcement — but that is the UNBOUNDED wait. Waiting for the burst in
+  flight is under two seconds, and reading the warning as forbidding both is
+  why this sat open.
+
+  Open: the alarm's duck depth wants its own value rather than `duckDb`, which
+  was tuned for a music bed under speech; and music resumption after dismissal
+  rejoins the live edge on a non-seekable stream, so a 30s alarm costs 30s of
+  the track.
+
+  **The shared `playback_done` Event is fixed** (#481): it is now a FIFO queue
+  of per-playback waiters, so one device report no longer satisfies two.
+
 - **Q3 — what owns the speaker when the jack is occupied?** A plug in the jack
   degrades the whole audio subsystem (#117/#141) and, with a music session
   live, can silence everything including voice. That is a hardware/HAL fault


### PR DESCRIPTION
## #373's open question is now a decision — and it inverts the code

Both `controller/CLAUDE.md` and `docs/audio-states.md` described the ring waiting on `speaker_busy` as correct-but-one-directional. Under Wil's rule (2026-09-07) **the ring should not wait at all**: a timer must go off exactly when it ends, so the writer whose timing is the whole point is the one currently deferring. The announcement is the writer that waits.

Both files now carry the rule and why this shape was chosen: silencing music in favour of the alarm and ducking the alarm under the response needs **no new firmware**, because `Mixer.Mix` takes exactly two inputs and attenuates only the music side. The `audio_mix` gate is stated with its consequence — firmware without it never plays `0x04`, and **a silent timer is the worst available failure**.

## Also recorded: why it sat open

Both files warned against blocking an announcement while ringing — correctly, because HA holds `_is_announcing` and 120s of `MAX_RING_S` would fail every other announcement to that satellite.

**That warning is about the unbounded wait.** Waiting for the *burst in flight* is under two seconds: the chime is 1.68s of every 2.3s, and real responses measure 1.6–2.6s of audio. Reading the warning as forbidding both closed off the workable option. **A warning that names one wait should say which one.**

## The OTA gate (#480), with its own lesson

The passage already said that call site bypasses the reconcile **debounce**. Somebody reasoned about one guard it skips and stopped there — and the platform gate went missing for as long as emOS has existed.

Written down as the general rule: **a call site documented as an exception to one rule is worth checking against every rule its siblings follow.**

The probe-versus-gate distinction is recorded too, since the destination-directory probe is what stopped this costing 240s, and it's easy to mistake a backstop for a guard.

`_sync_start_script` is documented as **deliberately not gated**, with the reason — gating it by symmetry is the obvious next mistake and the expensive one, because emOS runs that same script.

## #481 folded in

`playback_done` is a queue now, and `end_playback` belongs in a `finally` for a reason worth stating rather than rediscovering.

Docs only. 121 passed across the two suites that read these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zuK5VZZut5EZm3jf3sPxk