### PR TITLE
End the turn ourselves when Home Assistant's VAD never engages (#485)

### DIFF
--- a/controller/em_db.py
+++ b/controller/em_db.py
@@ -905,6 +905,33 @@ MIGRATIONS: list[str] = [
 
     UPDATE system_config SET value = '21' WHERE key = 'schema_version';
     """,
+
+    # ── v22 — record when HA's VAD started, so the turns it never started are
+    #          countable ─────────────────────────────────────────────────────
+    #
+    # We have always stored vad_end_ms and never vad_start_ms, which made two
+    # very different turns identical in the record: one Home Assistant
+    # endpointed when the user stopped talking, and one where its VAD never
+    # engaged at all and the turn ran to HA's hardcoded 15s cap. HA reports
+    # both as the same STT_VAD_END — its segmenter sets `timed_out` and
+    # nothing in home-assistant/core reads it — so the satellite cannot tell
+    # them apart on the wire either.
+    #
+    # It was visible in the data all along and nobody had looked at the shape:
+    # 3.2% of wake turns on this fleet (27 of 845, 2026-07-14..08-13) sit in a
+    # single 250ms bin at 15.25s with 0-3 turns in every neighbouring bin, all
+    # with exactly 15,120ms of audio, half of them returning no_tts. That is a
+    # fixed cap firing, not people talking for a long time.
+    #
+    # -1 means HA's VAD never engaged on that turn, and is the counter for
+    # exactly this fault. NULL means the row predates this column — the two
+    # must not be conflated, which is why the sentinel is not NULL: an old row
+    # and a stalled VAD want opposite conclusions.
+    """
+    ALTER TABLE turns ADD COLUMN vad_start_ms INTEGER;
+
+    UPDATE system_config SET value = '22' WHERE key = 'schema_version';
+    """,
 ]
 
 # Post-migration fixups that need Python rather than SQL. Keyed by the schema
@@ -1963,6 +1990,8 @@ _TURN_COLUMNS = {
     "outcome":          "outcome",
     "stt_text":         "stt_text",
     "total_ms":         "total_ms",
+    # -1 = HA's VAD never engaged (schema v22); NULL = row predates the column
+    "vad_start_ms":     "vad_start_ms",
     "vad_end_ms":       "vad_end_ms",
     "stt_ms":           "stt_ms",
     "tts_url_ms":       "tts_url_ms",

--- a/controller/em_esphome.py
+++ b/controller/em_esphome.py
@@ -119,6 +119,13 @@ class TurnTrace:
     trigger:          str   = ""      # "wakeword(0.522)" or "button"
     t0:               float = 0.0     # turn start (time.monotonic())
     t_first_frame_ms: int   = -1      # ms from t0 to first real audio frame
+    # ms from t0 to HA's STT_VAD_START. Stays -1 when HA's VAD never engaged,
+    # which is the whole point of recording it: that is the turn shape that
+    # runs to HA's 15s cap, and until now nothing distinguished it from a turn
+    # HA endpointed properly. It is also the number the fallback's grace
+    # window should be tuned from — 2.5s is currently set against a single
+    # measured turn (1.077s) plus microVAD's floor of ~1.06s.
+    t_vad_start_ms:   int   = -1
     t_vad_end_ms:     int   = -1      # ms from t0 to VAD sentinel received
     audio_frames:     int   = 0       # number of PCM frames sent to HA
     t_stt_ms:         int   = -1      # ms from t0 to STT result received
@@ -173,6 +180,7 @@ class TurnTrace:
             f"[TURN] trigger={self.trigger} outcome={self.outcome} "
             f"total={fmt(self.t_complete_ms)} "
             f"first_frame={fmt(self.t_first_frame_ms)} "
+            f"vad_start={fmt(self.t_vad_start_ms)} "
             f"vad_end={fmt(self.t_vad_end_ms)} audio={self.audio_frames}frames/{audio_ms}ms "
             f"stt={fmt(self.t_stt_ms)} text={self.stt_text!r} "
             f"tts_url={fmt(self.t_tts_url_ms)} "
@@ -896,6 +904,8 @@ class EchoMuseSatellite(SatelliteServerProtocol):
             # _stream_mic_audio (covers quiet speech in a noisy room that
             # misses the 3×-floor test there).
             self._ha_vad_start.set()
+            if self._trace and self._trace.t_vad_start_ms == -1:
+                self._trace.t_vad_start_ms = self._trace.elapsed_ms()
 
         elif event_type == ET.VOICE_ASSISTANT_STT_VAD_END:
             # Speech ended — HA is now processing (STT → intent → TTS).
@@ -1524,6 +1534,7 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     "noise_floor":    wi.get("noise_floor"),
                     "outcome":        trace.outcome,
                     "total_ms":       trace.t_complete_ms,
+                    "vad_start_ms":   trace.t_vad_start_ms,
                     "vad_end_ms":     trace.t_vad_end_ms,
                     "stt_ms":         trace.t_stt_ms,
                     "tts_url_ms":     trace.t_tts_url_ms,
@@ -1655,6 +1666,16 @@ class EchoMuseSatellite(SatelliteServerProtocol):
         listening_since = None      # monotonic; set when the first real frame lands
         turn_start = time.monotonic()
 
+        # Controller-side endpointing, armed only when HA's VAD has been ruled
+        # out — see em_turnclock.ha_vad_stalled_verdict for why the absence of
+        # STT_VAD_START is the discriminator and not a timer. These two marks
+        # are what that verdict reads. Keeping them current costs one RMS over
+        # an 80ms frame for the whole turn rather than only until the first
+        # hit, which is the same arithmetic the barge watcher already runs per
+        # frame throughout playback.
+        first_speech_at = None
+        last_speech_at  = None
+
         def _is_speech(chunk: bytes) -> bool:
             samples = np.frombuffer(chunk, dtype=np.int16)
             if samples.size == 0:
@@ -1707,6 +1728,25 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     )
                     self._send_one(api_pb2.VoiceAssistantAudio(data=b"", end=True))
                     self._no_speech_timeout = True
+                    return
+
+                # HA's VAD failed to engage — endpoint the turn ourselves
+                # rather than sitting out HA's 15s cap. This is a real end of
+                # speech, so it takes the same exit as the device sentinel
+                # below: end=True to HA, and the thinking transition, or the
+                # ring stays lit through STT and intent (#370).
+                stalled, stall_why = em_turnclock.ha_vad_stalled_verdict(
+                    now=time.monotonic(), speech_seen=speech_seen,
+                    ha_vad_started=self._ha_vad_start.is_set(),
+                    first_speech_at=first_speech_at,
+                    last_speech_at=last_speech_at,
+                )
+                if stalled:
+                    log.info(f"[{self._log_name}] {stall_why} — sending audio end to HA")
+                    if self._trace and self._trace.t_vad_end_ms == -1:
+                        self._trace.t_vad_end_ms = self._trace.elapsed_ms()
+                    self._send_one(api_pb2.VoiceAssistantAudio(data=b"", end=True))
+                    self._enter_thinking()
                     return
 
                 # Race the queue-get against _ha_vad_end directly rather than a
@@ -1786,7 +1826,16 @@ class EchoMuseSatellite(SatelliteServerProtocol):
                     if self._trace:
                         self._trace.t_first_frame_ms = self._trace.elapsed_ms()
 
-                if not speech_seen and _is_speech(payload):
+                # Every frame, not just until the first hit: the controller's
+                # own endpoint needs to know when speech LAST was, not only
+                # that it once happened.
+                if _is_speech(payload):
+                    now = time.monotonic()
+                    last_speech_at = now
+                    if first_speech_at is None:
+                        first_speech_at = now
+
+                if not speech_seen and last_speech_at is not None:
                     speech_seen = True
                     log.debug(
                         f"[{self._log_name}] Speech detected (above noise floor "

--- a/controller/em_support.py
+++ b/controller/em_support.py
@@ -69,7 +69,12 @@ _CONFIG_DENY = ("psk", "password", "token", "secret", "key")
 _TURN_FIELDS = (
     "id", "device_id", "ts", "trigger_type", "wake_model", "wake_score",
     "wake_threshold", "dev_shadow", "dev_wake_score", "dev_threshold",
-    "noise_floor", "outcome", "total_ms", "vad_end_ms", "stt_ms",
+    # vad_start_ms sits beside vad_end_ms because the PAIR is the diagnosis:
+    # an end with no start is a turn HA's VAD never engaged on, which runs to
+    # HA's 15s cap and reports as an ordinary endpoint. A bundle carrying only
+    # the end cannot tell those apart, and #485 had to be read out of a log
+    # excerpt for exactly that reason.
+    "noise_floor", "outcome", "total_ms", "vad_start_ms", "vad_end_ms", "stt_ms",
     "tts_url_ms", "tts_fetch_ms", "playback_ms", "send_ms", "delivery_ms",
     "eq_ms", "underruns", "min_depth", "prime_wait_ms", "recv_span_ms",
     "max_gap_ms", "bytes_recv",

--- a/controller/em_turnclock.py
+++ b/controller/em_turnclock.py
@@ -25,6 +25,26 @@ captured that audio perfectly and TCP was holding it.
 # accidental wake is closed quietly. Matches the device's own noSpeechTimeout.
 NO_SPEECH_TIMEOUT = 5.0
 
+# Seconds from the first frame of speech before we accept that HA's VAD is not
+# going to engage on this turn. Home Assistant's microVAD returns a "no answer"
+# sentinel for its first 760ms whatever the input (measured across digital
+# silence, room tone at 0.0021 and 0.0043, continuous speech and a 1kHz tone),
+# and its VoiceCommandSegmenter then needs 0.3s of audio above its speech
+# threshold before it declares a command started. So the earliest an
+# STT_VAD_START can physically arrive is ~1.06s of audio, and a real turn was
+# measured at 1.077s. This is more than twice that: it must never expire on a
+# turn HA was about to endpoint normally.
+HA_VAD_GRACE = 2.5
+
+# Seconds of consecutive non-speech before we endpoint a turn ourselves, once
+# HA's VAD has been ruled out. Deliberately longer than both of the endpointing
+# rules it stands in for — HA's own default silence window is 0.7s and the
+# device's vadSilenceMs default is 900ms — because our test is a crude RMS bar
+# against the room's noise floor rather than a model, so it needs more evidence
+# before it acts. Cutting somebody off mid-sentence is worse than the stall
+# this exists to prevent.
+FALLBACK_SILENCE = 1.0
+
 # Seconds to wait for the first real frame before giving up on the turn
 # entirely. Bounds the other side: audio that never arrives must still end the
 # turn, or a device that dies immediately after the wake holds the HA pipeline
@@ -43,8 +63,9 @@ def no_speech_verdict(now, turn_start, listening_since, speech_seen,
 
     `listening_since` is when the first real (post-preroll) frame arrived, or
     None if none has. `speech_seen` is whether anything above the room's noise
-    floor has been heard — once true this never closes the turn, because HA's
-    VAD owns end-of-turn from that point.
+    floor has been heard — once true this never closes the turn, because
+    end-of-turn belongs to HA's VAD from that point, or failing that to
+    `ha_vad_stalled_verdict` below.
 
     Returns (close, reason); reason is "" when close is False.
     """
@@ -61,3 +82,60 @@ def no_speech_verdict(now, turn_start, listening_since, speech_seen,
     if waited > limit:
         return True, why
     return False, ""
+
+
+def ha_vad_stalled_verdict(now, speech_seen, ha_vad_started,
+                           first_speech_at, last_speech_at,
+                           grace=HA_VAD_GRACE,
+                           fallback_silence=FALLBACK_SILENCE):
+    """Should the controller endpoint this turn itself, HA's VAD having failed?
+
+    All times are monotonic seconds from the same clock.
+
+    Home Assistant's endpointing can fail to engage AT ALL, and when it does
+    the turn does not end late — it runs to HA's own hardcoded 15s cap and
+    reports that as an ordinary end of speech. The satellite cannot see the
+    difference: `VoiceCommandSegmenter` sets `timed_out` and nothing in the
+    whole of home-assistant/core ever reads it, so a timeout and a real
+    endpoint arrive as the same `STT_VAD_END`.
+
+    The failure is structural rather than flaky. The segmenter needs 0.3s of
+    audio scored above its speech threshold before it will declare a command
+    started, and a command that does not clear that bar can never fire
+    STT_VAD_START however long it waits. Measured on this fleet: 3.2% of wake
+    turns (27 of 845) ended in a 250ms bin at 15.25s, against 0-3 turns in
+    every neighbouring bin, each with exactly 15,120ms of audio. Half of them
+    returned nothing at all.
+
+    So the discriminator is the ABSENCE of STT_VAD_START, not a timer — the
+    same shape as the RUN_END-with-no-RUN_START rule in em_esphome, and for
+    the same reason: the protocol's structure says what a timeout cannot.
+    While HA's VAD is engaged this never fires and HA keeps end-of-turn, which
+    is where it belongs; its endpointing is model-driven and pause-tolerant
+    and ours is a threshold.
+
+    `first_speech_at` / `last_speech_at` are when speech was first and most
+    recently heard by the controller's own SNR-relative check. Silence is
+    measured from the LAST speech frame rather than tracked as a run, so a
+    turn whose frames stop arriving mid-utterance still ends: an empty queue
+    and a quiet room are the same thing to a user waiting for an answer.
+
+    Returns (end, reason); reason is "" when end is False.
+    """
+    if not speech_seen or ha_vad_started:
+        return False, ""
+
+    if first_speech_at is None or last_speech_at is None:
+        return False, ""
+
+    if now - first_speech_at < grace:
+        return False, ""
+
+    quiet = now - last_speech_at
+    if quiet < fallback_silence:
+        return False, ""
+
+    return True, (
+        f"HA VAD never engaged and {quiet:.1f}s quiet since speech "
+        f"(controller-side endpoint)"
+    )

--- a/controller/tests/test_esphome_mac.py
+++ b/controller/tests/test_esphome_mac.py
@@ -176,9 +176,12 @@ def test_migrations_are_append_only():
     rather than edited — which is the mistake this guards, and the one that
     broke every stats write and disconnect-looped the fleet when it happened.
     """
-    assert len(db.MIGRATIONS) == 21
+    assert len(db.MIGRATIONS) == 22
     assert "esphome_mac" in db.MIGRATIONS[18]
     assert "esphome_mac" not in db.MIGRATIONS[17]
     # v20 is its own entry and did not get appended onto v19's.
     assert "ble_restarts_last" in db.MIGRATIONS[19]
     assert "ble_restarts_last" not in db.MIGRATIONS[18]
+    # v22 likewise: vad_start_ms is a new entry, not an edit to v21's.
+    assert "vad_start_ms" in db.MIGRATIONS[21]
+    assert "vad_start_ms" not in db.MIGRATIONS[20]

--- a/controller/tests/test_turnclock.py
+++ b/controller/tests/test_turnclock.py
@@ -73,3 +73,127 @@ def test_limits_are_overridable_for_callers_and_tests():
                                     listening_since=0.0, speech_seen=False,
                                     no_speech_timeout=2.0)
     assert close is True
+
+
+# ── HA's VAD failing to engage at all (#485) ────────────────────────────────
+#
+# The fault these guard against is not a late endpoint, it is no endpoint:
+# HA's VoiceCommandSegmenter needs 0.3s of audio above its speech threshold
+# before it will declare a command started, and a command that never clears
+# that bar runs to HA's hardcoded 15s cap and is reported as an ordinary end
+# of speech. Measured on the fleet at 3.2% of wake turns.
+
+def test_ha_vad_engaged_keeps_end_of_turn():
+    # The whole safety property. While HA's VAD is working it owns the
+    # endpoint — its endpointing is model-driven and pause-tolerant, ours is
+    # a threshold — so this must stay out of the way no matter how long the
+    # user pauses mid-sentence.
+    end, _ = tc.ha_vad_stalled_verdict(
+        now=60.0, speech_seen=True, ha_vad_started=True,
+        first_speech_at=1.0, last_speech_at=1.0,
+    )
+    assert end is False
+
+
+def test_a_stalled_ha_vad_endpoints_the_turn():
+    # Speech at 1.0s, quiet ever since, HA silent. At 4.5s we are past the
+    # 2.5s grace and have 3.5s of quiet — end it rather than wait out HA's 15s.
+    end, why = tc.ha_vad_stalled_verdict(
+        now=4.5, speech_seen=True, ha_vad_started=False,
+        first_speech_at=1.0, last_speech_at=1.0,
+    )
+    assert end is True
+    assert "HA VAD never engaged" in why
+
+
+def test_grace_outlasts_the_earliest_possible_vad_start():
+    # microVAD answers nothing for its first 760ms and the segmenter then
+    # needs 0.3s above threshold, so an STT_VAD_START cannot arrive before
+    # ~1.06s; a real turn measured 1.077s. Firing inside that window would
+    # cut off turns HA was about to endpoint perfectly well.
+    end, _ = tc.ha_vad_stalled_verdict(
+        now=1.0 + 1.5, speech_seen=True, ha_vad_started=False,
+        first_speech_at=1.0, last_speech_at=1.0,
+    )
+    assert end is False, "must not pre-empt a VAD_START that is still coming"
+
+
+def test_a_speaker_still_talking_is_never_cut_off():
+    # Long command, well past the grace, but they are still going: the last
+    # speech frame is 200ms old. Cutting here is worse than the stall.
+    end, _ = tc.ha_vad_stalled_verdict(
+        now=12.0, speech_seen=True, ha_vad_started=False,
+        first_speech_at=1.0, last_speech_at=11.8,
+    )
+    assert end is False
+
+    # They stop, and a full second later it ends.
+    end, _ = tc.ha_vad_stalled_verdict(
+        now=12.7, speech_seen=True, ha_vad_started=False,
+        first_speech_at=1.0, last_speech_at=11.8,
+    )
+    assert end is False, "0.9s of quiet is not yet enough"
+    end, _ = tc.ha_vad_stalled_verdict(
+        now=12.8, speech_seen=True, ha_vad_started=False,
+        first_speech_at=1.0, last_speech_at=11.8,
+    )
+    assert end is True
+
+
+def test_a_pause_mid_sentence_restarts_the_silence_window():
+    # Silence is measured from the LAST speech frame, so someone who pauses to
+    # think and then carries on resets the clock rather than accumulating
+    # toward an endpoint.
+    end, _ = tc.ha_vad_stalled_verdict(
+        now=8.0, speech_seen=True, ha_vad_started=False,
+        first_speech_at=1.0, last_speech_at=7.5,
+    )
+    assert end is False
+
+
+def test_no_speech_heard_leaves_the_no_speech_path_alone():
+    # Nothing was ever heard, so this is an accidental wake and belongs to
+    # no_speech_verdict. Two decisions acting on one turn would race.
+    end, _ = tc.ha_vad_stalled_verdict(
+        now=30.0, speech_seen=False, ha_vad_started=False,
+        first_speech_at=None, last_speech_at=None,
+    )
+    assert end is False
+
+
+def test_speech_seen_via_ha_without_our_own_marks_is_safe():
+    # speech_seen can be set by HA's VAD start rather than our own RMS check,
+    # leaving both marks None. That must not raise or fire.
+    end, _ = tc.ha_vad_stalled_verdict(
+        now=30.0, speech_seen=True, ha_vad_started=False,
+        first_speech_at=None, last_speech_at=None,
+    )
+    assert end is False
+
+
+def test_it_beats_has_15s_cap_by_a_wide_margin():
+    # The user-visible point, and the bound is the GRACE, not the silence:
+    # a short command ("what's the weather", the reported case) stops well
+    # inside the window HA is still owed, so the turn ends at grace-plus-a-bit
+    # rather than the moment they stop. That is deliberate — the alternative
+    # is racing a VAD_START that was still coming.
+    first_speech, speech_ended = 0.3, 1.5
+    quiet_enough = speech_ended + tc.FALLBACK_SILENCE
+    grace_over   = first_speech + tc.HA_VAD_GRACE
+    assert quiet_enough < grace_over, "this is the grace-bounded case"
+
+    end, _ = tc.ha_vad_stalled_verdict(
+        now=quiet_enough, speech_seen=True, ha_vad_started=False,
+        first_speech_at=first_speech, last_speech_at=speech_ended,
+    )
+    assert end is False, "the grace has to run out first"
+
+    end, _ = tc.ha_vad_stalled_verdict(
+        now=grace_over, speech_seen=True, ha_vad_started=False,
+        first_speech_at=first_speech, last_speech_at=speech_ended,
+    )
+    assert end is True
+
+    # maxwellh's turn took 15,056ms from the first audio frame to HA's
+    # STT_VAD_END. Whichever bound binds, this is far inside it.
+    assert grace_over < 4.0


### PR DESCRIPTION
Fixes the 15-second turns in #485. The 15s is Home Assistant's, not ours, and it fires because HA's VAD never *starts* — not because it ends late.

HA's `VoiceCommandSegmenter` needs 0.3s of audio above its speech threshold before it will declare a command started. Below that bar it never emits `STT_VAD_START`, runs to a hardcoded 15s cap, then emits an `STT_VAD_END` byte-identical to a real endpoint. The satellite can't tell them apart: the segmenter sets `timed_out` and nothing in the whole of home-assistant/core reads it. Our own 20s streaming cap sits *above* HA's 15s, so HA always won the race.

**Not one reporter's setup.** 3.2% of wake turns on this fleet (27 of 845, 2026-07-14..08-13) sit in a single 250ms bin at 15.25s, 0–3 turns in every neighbouring bin, all with exactly 15,120ms of audio, half returning `no_tts`. It was in our own stats the whole time; nobody had looked at the shape of `vad_end_ms`.

## The fix

Keys on the **absence** of `STT_VAD_START`, not a timer — same shape as the `RUN_END`-with-no-`RUN_START` rule beside it, and for the same reason: the protocol's structure says what a timeout cannot. While HA's VAD is engaged this never fires and HA keeps end-of-turn, which is where it belongs.

The decision is a pure function in `em_turnclock` next to `no_speech_verdict` — that module exists precisely so this class of two-clock timing logic is testable, since the suite can't import `em_esphome`. Note `no_speech_verdict`'s docstring claimed HA's VAD owns end-of-turn once speech is heard; that's the assumption being corrected.

## Measurements behind the constants

Against HA's own segmenter and its pinned `pymicro-vad==1.0.1`, 10ms chunks as `assist_pipeline` feeds them:

- microVAD returns a `-1.0` "no answer" sentinel for its **first 760ms whatever the input** — identical for digital silence, room tone at 0.0021 and 0.0043, continuous speech and a 1kHz tone. HA compares it straight against its 0.2 threshold, so the warm-up counts as silence while still spending the 15s budget.
- Earliest an `STT_VAD_START` can arrive is therefore ~1.06s of audio; a real turn measured 1.077s.
- Short commands never clear the bar: synthesised "Stop" yields 0.09s of detected speech against the 0.30s needed, and 0.00s once our 240ms preroll discard takes the front off it. 40/40 timeouts at every lead tried.

Both constants are conservative because cutting somebody off mid-sentence is worse than the stall: 2.5s grace (>2x the earliest possible start), 1.0s silence (longer than HA's 0.7s default and the device's 900ms `vadSilenceMs`, because our test is an RMS bar and not a model). Silence is measured from the last speech frame, so a mid-sentence pause restarts it and a turn whose frames stop arriving still ends.

## Schema v22

Records `vad_start_ms` beside `vad_end_ms`, because the **pair** is the diagnosis — an end with no start is this fault. `-1` = HA's VAD never engaged; `NULL` = row predates the column; the two must not be conflated. Rides the support bundle too, since #485 had to be read out of a log excerpt for want of exactly this field.

## Verification

- Full suite: **1032 passed**.
- Migration **v17 → v22** applied to a copy of a real database: 1228 turns and 6 devices intact, `integrity_check` ok.
- The append-only length pin failed as designed when the migration was added.

## Review notes

- **The 2.5s grace is the weakest number here** — set from one measured turn plus microVAD's floor. `vad_start_ms` exists so it can be retuned from a distribution once the EA has run a few days.
- Hardware confirmation still outstanding: whether short commands fail deterministically on real audio, and whether the 240ms preroll discard is the deciding margin. The `[TURN]` line now carries `vad_start=`, so a bad turn reads `vad_start=—` and that is directly checkable.
- Two upstream defects confirmed as code facts and not yet reported: `timed_out` set and read nowhere, and the warm-up sentinel compared as though it were a probability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBGUwJuEtMQAikjyy1Bskh