### PR TITLE
Reach TWRP from emOS with `/init recovery`

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -2366,3 +2366,56 @@ never run on hardware — the next provisioning run is its first real test. And
 the thing most likely to mislead later: those turns still happen, we just stop
 waiting on them, so `vad_start=—` is the count to watch rather than the absence
 of complaints.
+
+## 2026-09-10 — emOS can reach TWRP with one syscall, and Amazon's reboot cannot reboot at all
+
+**A device on emOS had no way to get to TWRP except powering off and holding
+the mute button.** That is the whole of what made emOS a one-way door for the
+provisioning wizard, and it is what made "emOS as the GA default" a decision
+rather than a formality. It turns out to be one syscall.
+
+**`adb reboot recovery` is not an adb feature.** adbd calls
+`android_reboot(ANDROID_RB_RESTART2, 0, "recovery")`, which is the `reboot()`
+syscall with `LINUX_REBOOT_CMD_RESTART2` and a mode string; MediaTek's restart
+handler reads that string and sets the boot-mode value LK checks on the next
+boot. No property service, no ueventd, no by-name symlinks, no BCB write into
+`misc`.
+
+**Amazon's own `/system/bin/reboot` cannot do it under emOS — and cannot
+reboot at all.** It fails with `reboot: No such file or directory` for
+`recovery` AND with no argument, which is the tell. It reaches Android's
+property service over `/dev/socket/property_service`; nothing here runs one, so
+`connect()` returns ENOENT. The error names a missing file and the file it
+means is a socket that was never going to exist.
+
+**Three of my guesses were wrong before that landed**, all in the same
+direction — assuming the failure was specific to the recovery path. I suspected
+the missing `/dev/block/platform/*/by-name/` symlinks (emOS has no ueventd and
+creates four nodes by hand), then a `/proc` bootmode node, then the BCB. Wil's
+greps found no such strings in libcutils, `/proc/dumchar_info` does not exist on
+this kernel, and then **plain `reboot` with no argument failed identically**,
+which killed all three at once. The discriminator was the cheapest test
+available and I should have asked for it first.
+
+**Getting the test binary onto the device was the real obstacle**, and it is
+the same obstacle the feature exists to remove: no adb, and a 4MB static build
+with nowhere to come from. A freestanding version came to 680 bytes — small
+enough to paste as base64 through the console — and Wil then pointed out the
+device has WiFi and this box has an HTTP server, which is obviously right and
+took thirty seconds.
+
+It is now `/init recovery`. The init is already static, already in the ramdisk
+at a known path, and already owns the syscall, so nothing has to be pushed to
+the device at all. **The multi-call discriminator is `getpid()`, not `argc`**:
+the kernel can pass arguments to init from the boot cmdline, so a device whose
+bootloader appended one would take the tool path and never boot — a brick
+produced by an argument nobody typed. The console banner now names it, since
+the banner exists for exactly the facts someone would otherwise spend five
+minutes gathering.
+
+**What this changes.** "Wipe and reprovision isn't really an issue, the device
+has TWRP" was true and meant a power-off and a held mute button in the dark.
+It is now a command on the console you are already connected to, and most of
+the one-way-door objection to emOS-as-default goes with it. It is also the
+first genuinely useful entry for the guided console menu (#451), which until
+now had nothing to guide anyone to.

--- a/controller-ea/CHANGELOG.md
+++ b/controller-ea/CHANGELOG.md
@@ -1,5 +1,124 @@
 # Changelog
 
+## 2.23.0
+
+The Early Access work from ea.1 to ea.15, in one release. The headline is that
+**an Echo can now run without any of Amazon's software on it**, but most of
+this is voice turns behaving the way you expected them to already.
+
+### Your Echo can run without Amazon's software
+
+**emOS replaces Android on the device entirely**, keeping Amazon's kernel and
+nothing above it. The setup wizard installs it, and it is now the option the
+wizard offers first — FireOS is still there, one click away, labelled, and is
+what every device in the field is running today.
+
+Two reasons it is the default rather than the adventurous choice. Amazon's
+audio layer cannot be evicted while Android is running, which is why the 3.5mm
+jack behaves properly on emOS and imperfectly on FireOS. And FireOS is not the
+safe option so much as the known-bad one we understand.
+
+**Before you choose it**, two things are worth knowing. The wizard escrows your
+original boot image before it writes anything, and restoring that takes about
+ten seconds and leaves everything on the device alone — this has been used in
+anger and it works. And a device already running emOS cannot be re-run through
+the wizard; getting back means going through TWRP, which is a cable and a
+button press rather than a dead end.
+
+### Voice turns
+
+**Fixed: some commands took fifteen seconds to answer.** Speaking immediately
+after the wake word, or saying something short like "stop", could leave the
+Echo silent for about fifteen seconds while the same words after a pause came
+back in three. The cause is in Home Assistant's end-of-speech detection rather
+than here — it is reported upstream as home-assistant/core#181747 — and the
+controller now stops waiting on it instead of sitting out the full fifteen
+seconds. Reported by **@maxwellh**.
+
+**Fixed: long spoken answers were cut off part-way through.** The controller
+sent audio faster than the Echo could play it, which eventually broke the
+connection mid-sentence. Short answers never showed it, which is why this
+looked intermittent for so long.
+
+**Fixed: interrupting your Echo mid-response.** Barge-in never actually worked
+— the interrupting turn died in milliseconds every time. It also used to fire
+on its own voice during long answers, cutting them off and then ignoring you.
+
+**Fixed: the Echo threw away the question you had just asked**, in three
+separate ways, and stopped answering after a timer was dismissed mid-chime.
+
+**Timers ring on the Echo itself**, with the chime coming from the device, and
+stopping one no longer leaves it deaf.
+
+**Home Assistant can ask your Echo a question** and wait for the answer —
+`assist_satellite.ask_question` and `start_conversation` both work, including
+the attention chime.
+
+**Fixed: noise suppression could cut speech to complete silence** rather than
+merely cleaning it up.
+
+### The light ring tells you more
+
+An Echo with no Home Assistant behind it now says so **every time** you speak
+to it, rather than lighting up and going dark as though it were thinking. The
+ring also stops listening visibly whichever way the turn started, and says when
+there is nothing available to answer you.
+
+### Sound
+
+**The headphone jack works properly.** Plugging in during playback, unplugging,
+and booting with something already plugged in all behave.
+
+**The Bluetooth proxy no longer crowds out the device running it.** Advertisements
+were sharing a connection with the keepalive traffic, so the Echo doing proxy
+duty had a measurably worse link than the others.
+
+### Setup
+
+**The wizard is considerably easier to follow** — a progress bar, numbered
+steps, a visible indicator while it waits on the Echo, and a failure panel that
+puts the useful action in front of you. Thanks to **@Mr-Neutr0n** for this and
+for the WiFi fix below.
+
+**Fixed: WiFi stopped reconnecting after a reboot on a network with no internet
+access.** Android decides such a network is bad and eventually refuses to
+auto-join it.
+
+**If your browser cannot do USB, the wizard says so on the first step**, naming
+your exact address, rather than at the first click with an Echo already
+unboxed.
+
+**Fixed: setting up a device that already had a console password could not
+finish.** The password survives a reinstall, so a device set up again — or
+moved from somebody else's EchoMuse — arrived still holding it. Provisioning
+now clears it and the controller puts it back when the device connects. If you
+are taking on an Echo from someone else, their password should not follow the
+hardware to you.
+
+### Smaller things
+
+- **Your Echoes know what time it is.** An Echo has no clock that survives a
+  power cut, and under emOS nothing was correcting it.
+- **Custom wake word models carry their own name and language**, instead of
+  being renamed by the file they arrived in.
+- **Deleting an Echo actually removes it.** It used to keep serving turns.
+- **An Echo running emOS can have a password on its USB console**, with an idle
+  timeout.
+- **Updates no longer stall** pushing Android-only payloads at a device with no
+  Android on it.
+- Two announcements or timers playing at once no longer collide.
+- Config → Microphones → Advanced gains an echo-reference control, for testing
+  echo cancellation on hardware that supports it.
+
+### Before you update
+
+Nothing to do — the database migrates itself, and there is no manual step.
+
+**Some of this needs device firmware newer than v2.14.0, which is not published
+yet.** The jack fixes, the clock, and the echo reference are device changes;
+your Echoes will ignore those settings until a firmware release catches up.
+Everything else in this list is controller-side and works as soon as you update.
+
 ## 2.23.0-ea.15 (Early Access)
 
 **Fixed: some commands took fifteen seconds to answer.** If you spoke

--- a/controller/CHANGELOG.md
+++ b/controller/CHANGELOG.md
@@ -1,5 +1,124 @@
 # Changelog
 
+## 2.23.0
+
+The Early Access work from ea.1 to ea.15, in one release. The headline is that
+**an Echo can now run without any of Amazon's software on it**, but most of
+this is voice turns behaving the way you expected them to already.
+
+### Your Echo can run without Amazon's software
+
+**emOS replaces Android on the device entirely**, keeping Amazon's kernel and
+nothing above it. The setup wizard installs it, and it is now the option the
+wizard offers first — FireOS is still there, one click away, labelled, and is
+what every device in the field is running today.
+
+Two reasons it is the default rather than the adventurous choice. Amazon's
+audio layer cannot be evicted while Android is running, which is why the 3.5mm
+jack behaves properly on emOS and imperfectly on FireOS. And FireOS is not the
+safe option so much as the known-bad one we understand.
+
+**Before you choose it**, two things are worth knowing. The wizard escrows your
+original boot image before it writes anything, and restoring that takes about
+ten seconds and leaves everything on the device alone — this has been used in
+anger and it works. And a device already running emOS cannot be re-run through
+the wizard; getting back means going through TWRP, which is a cable and a
+button press rather than a dead end.
+
+### Voice turns
+
+**Fixed: some commands took fifteen seconds to answer.** Speaking immediately
+after the wake word, or saying something short like "stop", could leave the
+Echo silent for about fifteen seconds while the same words after a pause came
+back in three. The cause is in Home Assistant's end-of-speech detection rather
+than here — it is reported upstream as home-assistant/core#181747 — and the
+controller now stops waiting on it instead of sitting out the full fifteen
+seconds. Reported by **@maxwellh**.
+
+**Fixed: long spoken answers were cut off part-way through.** The controller
+sent audio faster than the Echo could play it, which eventually broke the
+connection mid-sentence. Short answers never showed it, which is why this
+looked intermittent for so long.
+
+**Fixed: interrupting your Echo mid-response.** Barge-in never actually worked
+— the interrupting turn died in milliseconds every time. It also used to fire
+on its own voice during long answers, cutting them off and then ignoring you.
+
+**Fixed: the Echo threw away the question you had just asked**, in three
+separate ways, and stopped answering after a timer was dismissed mid-chime.
+
+**Timers ring on the Echo itself**, with the chime coming from the device, and
+stopping one no longer leaves it deaf.
+
+**Home Assistant can ask your Echo a question** and wait for the answer —
+`assist_satellite.ask_question` and `start_conversation` both work, including
+the attention chime.
+
+**Fixed: noise suppression could cut speech to complete silence** rather than
+merely cleaning it up.
+
+### The light ring tells you more
+
+An Echo with no Home Assistant behind it now says so **every time** you speak
+to it, rather than lighting up and going dark as though it were thinking. The
+ring also stops listening visibly whichever way the turn started, and says when
+there is nothing available to answer you.
+
+### Sound
+
+**The headphone jack works properly.** Plugging in during playback, unplugging,
+and booting with something already plugged in all behave.
+
+**The Bluetooth proxy no longer crowds out the device running it.** Advertisements
+were sharing a connection with the keepalive traffic, so the Echo doing proxy
+duty had a measurably worse link than the others.
+
+### Setup
+
+**The wizard is considerably easier to follow** — a progress bar, numbered
+steps, a visible indicator while it waits on the Echo, and a failure panel that
+puts the useful action in front of you. Thanks to **@Mr-Neutr0n** for this and
+for the WiFi fix below.
+
+**Fixed: WiFi stopped reconnecting after a reboot on a network with no internet
+access.** Android decides such a network is bad and eventually refuses to
+auto-join it.
+
+**If your browser cannot do USB, the wizard says so on the first step**, naming
+your exact address, rather than at the first click with an Echo already
+unboxed.
+
+**Fixed: setting up a device that already had a console password could not
+finish.** The password survives a reinstall, so a device set up again — or
+moved from somebody else's EchoMuse — arrived still holding it. Provisioning
+now clears it and the controller puts it back when the device connects. If you
+are taking on an Echo from someone else, their password should not follow the
+hardware to you.
+
+### Smaller things
+
+- **Your Echoes know what time it is.** An Echo has no clock that survives a
+  power cut, and under emOS nothing was correcting it.
+- **Custom wake word models carry their own name and language**, instead of
+  being renamed by the file they arrived in.
+- **Deleting an Echo actually removes it.** It used to keep serving turns.
+- **An Echo running emOS can have a password on its USB console**, with an idle
+  timeout.
+- **Updates no longer stall** pushing Android-only payloads at a device with no
+  Android on it.
+- Two announcements or timers playing at once no longer collide.
+- Config → Microphones → Advanced gains an echo-reference control, for testing
+  echo cancellation on hardware that supports it.
+
+### Before you update
+
+Nothing to do — the database migrates itself, and there is no manual step.
+
+**Some of this needs device firmware newer than v2.14.0, which is not published
+yet.** The jack fixes, the clock, and the echo reference are device changes;
+your Echoes will ignore those settings until a firmware release catches up.
+Everything else in this list is controller-side and works as soon as you update.
+
 ## 2.23.0-ea.15 (Early Access)
 
 **Fixed: some commands took fifteen seconds to answer.** If you spoke

--- a/emos/README.md
+++ b/emos/README.md
@@ -188,6 +188,40 @@ diagnosis (two shells fighting over one tty; there was one, and the second
 console — a script here, or the provisioning wizard over WebSerial, which has
 no `stty` to remind you — must do it explicitly.
 
+### Getting to TWRP: `/init recovery`
+
+**`/system/bin/reboot` cannot reboot an emOS device at all**, and the way it
+fails is misleading. It reaches Android's property service over
+`/dev/socket/property_service`, which nothing here runs, so `connect()` returns
+ENOENT and it prints `reboot: No such file or directory` — naming a missing
+file, where the file it means is a socket that was never going to exist. It
+fails identically with **no argument**, which is the tell: this is not the
+recovery path being unavailable, it is Amazon's userspace talking to an Android
+that is not there.
+
+What `adb reboot recovery` actually does is one syscall — `RESTART2` carrying a
+mode string, which MediaTek's restart handler turns into the value LK reads on
+the next boot. No property service, no ueventd, no by-name symlinks, no BCB
+write into `misc`. The init owns that syscall and runs as a tool when it is not
+PID 1, so from the console:
+
+```
+/init recovery
+```
+
+Confirmed on hardware 2026-09-10: the kernel accepts the string and LK acts on
+it, landing in TWRP.
+
+**The multi-call discriminator is `getpid()`, not `argc`.** The kernel can pass
+arguments to init from the boot cmdline, so a device whose bootloader appended
+one would take the tool path and never boot — a brick produced by an argument
+nobody typed.
+
+This matters beyond convenience: a device on emOS has no adb, so "get a binary
+onto it" is a real problem rather than a step, and reaching TWRP used to mean a
+power-off and a held mute button. Re-provisioning an emOS device is now a
+command from the console you are already connected to.
+
 ### The console password
 
 The console is an unauthenticated root shell — anyone with a cable gets one,

--- a/emos/init/init.c
+++ b/emos/init/init.c
@@ -35,7 +35,9 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <stdint.h>
+#include <sys/syscall.h>
 #include <sys/sysmacros.h>
+#include <linux/reboot.h>
 #include <sys/wait.h>
 #include <termios.h>
 #include <time.h>
@@ -806,6 +808,37 @@ static void write_state(int n)
     close(fd);
 }
 
+/* Reboot into a named boot mode — "recovery" gets you TWRP.
+ *
+ * This is the whole of what `adb reboot recovery` does: one syscall carrying a
+ * mode string, which MediaTek's restart handler turns into the value LK reads
+ * on the next boot. No property service, no ueventd, no by-name symlinks, no
+ * BCB write into the misc partition.
+ *
+ * It has to be done here because **Amazon's /system/bin/reboot cannot reboot an
+ * emOS device at all** — not merely for recovery, but with no argument either.
+ * It reaches Android's property service over /dev/socket/property_service,
+ * which nothing here runs, so every mode fails with ENOENT. That is a confusing
+ * error to meet at a console, because it names a missing file and the file it
+ * means is a socket that was never going to exist. Measured on hardware
+ * 2026-09-10, along with the confirmation that the kernel accepts the string
+ * and LK acts on it.
+ *
+ * bionic's reboot(2) wrapper takes no argument, so it cannot express a mode.
+ * The raw syscall can, which is why this is syscall() rather than reboot().
+ *
+ * Returns only when the kernel refused; there is nothing useful to do then but
+ * say so, since the caller is a person at a serial console.
+ */
+static int reboot_into(const char *mode)
+{
+    sync();
+    sync();
+    syscall(__NR_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2,
+            LINUX_REBOOT_CMD_RESTART2, mode);
+    return -1;
+}
+
 /* Write the known-good image back over the boot partition and reboot into it. */
 static void restore_good(void)
 {
@@ -1374,9 +1407,42 @@ static void svc_add(const char *name, char *const *argv, const char *req,
                     const char *after);
 static void supervise(void);
 
-int main(void)
+/* Run as anything other than PID 1, this binary is a small tool instead of an
+ * init. It is the obvious place for the reboot: it is already static, already
+ * in the ramdisk at a known path, and already owns the syscall — so a person
+ * at the console types `/init recovery` and needs nothing pushed to the device.
+ * That matters more than it sounds, because a device on emOS has no adb, so
+ * "get a binary onto it" is the problem this avoids rather than solves.
+ *
+ * THE DISCRIMINATOR IS getpid(), NOT argc. The kernel can pass arguments to
+ * init from the boot cmdline, so a device whose bootloader appended one would
+ * take the tool path and never boot — a brick produced by an argument nobody
+ * typed. PID 1 is what "am I the init" actually means.
+ */
+static int tool_main(int argc, char **argv)
+{
+    const char *mode = (argc > 1) ? argv[1] : "recovery";
+
+    if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+        dprintf(1, "usage: %s [mode]    (default: recovery)\n"
+                   "reboots into the named boot mode; \"recovery\" is TWRP\n",
+                argv[0]);
+        return 0;
+    }
+
+    dprintf(1, "rebooting into \"%s\"...\n", mode);
+    reboot_into(mode);
+    dprintf(2, "the kernel refused the boot mode \"%s\": %s\n",
+            mode, strerror(errno));
+    return 1;
+}
+
+int main(int argc, char **argv)
 {
     char buf[512];
+
+    if (getpid() != 1)
+        return tool_main(argc, argv);
 
     /* mknod's mode is masked by the umask, so without this every node below
      * comes out 0644 no matter what it asks for — which is how dhcpcd's hook
@@ -2239,6 +2305,7 @@ static void console_banner(void)
         "   up          %ldm %02lds\r\n"
         "\r\n"
         "   logs: /run/net.log  /run/messages  /tmp/server.log\r\n"
+        "   /init recovery   reboot into TWRP  (Amazon's reboot cannot)\r\n"
         "\r\n",
         *ver ? ver : "emOS",
         host,

--- a/emos/tools/emreboot.c
+++ b/emos/tools/emreboot.c
@@ -1,0 +1,60 @@
+/* emreboot — reboot into a boot mode on a device whose init cannot yet do it.
+ *
+ * `/init recovery` is the supported way to reach TWRP from emOS, and on any
+ * device running an init from this tree onward that is what you should use.
+ * This exists for the devices that predate it: emos-v0.3 and earlier have no
+ * multi-call init, and a device on emOS has no adb, so the only ways in are a
+ * console paste or an HTTP fetch over its own WiFi.
+ *
+ * Freestanding for that reason — no libc, 680 bytes, small enough that its
+ * base64 pastes through a serial console in one go. Size is the only design
+ * constraint here, and it is the one that decides whether this is usable at
+ * all on a device you cannot copy a file to.
+ *
+ * Not built by CI and not part of the image. Build it with the pinned
+ * compiler:
+ *
+ *   docker run --rm -v "$PWD/emos":/emos -v /tmp:/out -w /emos echomuse-compiler \
+ *     bash -lc '$NDK/aarch64-linux-android21-clang -nostdlib -static -Os \
+ *               -o /out/emreboot tools/emreboot.c' && llvm-strip /tmp/emreboot
+ *
+ * What it does is one syscall: RESTART2 carrying a mode string, which
+ * MediaTek's restart handler turns into the value LK reads on the next boot.
+ * Amazon's /system/bin/reboot cannot do this under emOS — it reaches Android's
+ * property service over a socket that does not exist here and fails with
+ * ENOENT for every mode, including no mode at all. See emos/README.md.
+ */
+#define MAGIC1 0xfee1dead
+#define MAGIC2 0x28121969
+#define RESTART2 0xA1B2C3D4
+#define NR_reboot 142
+#define NR_write  64
+#define NR_exit   93
+#define NR_sync   81
+
+static long sys4(long n, long a, long b, long c, long d)
+{
+    register long x8 __asm__("x8") = n;
+    register long x0 __asm__("x0") = a;
+    register long x1 __asm__("x1") = b;
+    register long x2 __asm__("x2") = c;
+    register long x3 __asm__("x3") = d;
+    __asm__ volatile("svc #0" : "+r"(x0)
+                     : "r"(x8), "r"(x1), "r"(x2), "r"(x3) : "memory");
+    return x0;
+}
+
+static const char mode[] = "recovery";
+static const char msg[]  = "emreboot: RESTART2 recovery\n";
+static const char bad[]  = "emreboot: kernel refused RESTART2\n";
+
+void _start(void)
+{
+    sys4(NR_write, 1, (long)msg, sizeof msg - 1, 0);
+    sys4(NR_sync, 0, 0, 0, 0);
+    sys4(NR_reboot, MAGIC1, MAGIC2, RESTART2, (long)mode);
+    /* Only reached if the kernel refused the command string. */
+    sys4(NR_write, 2, (long)bad, sizeof bad - 1, 0);
+    sys4(NR_exit, 1, 0, 0, 0);
+    for (;;) { }
+}


### PR DESCRIPTION
A device on emOS had no way into TWRP except powering it off and holding the mute button. That's what made emOS a one-way door for the wizard, and what made emOS-as-the-GA-default a decision rather than a formality. **It turns out to be one syscall.**

`adb reboot recovery` isn't an adb feature — adbd calls `android_reboot(ANDROID_RB_RESTART2, 0, "recovery")`, which is the `reboot()` syscall with `LINUX_REBOOT_CMD_RESTART2` and a mode string. MediaTek's restart handler turns that string into the value LK reads on the next boot. No property service, no ueventd, no by-name symlinks, no BCB write into `misc`. **Confirmed on hardware today**: kernel accepts it, LK acts on it, lands in TWRP.

### Amazon's reboot can't do it — or anything

`/system/bin/reboot` fails with `reboot: No such file or directory` for `recovery` **and with no argument at all**. That was the tell: this was never about the recovery path. It reaches Android's property service over `/dev/socket/property_service`, which nothing here runs, so `connect()` returns ENOENT — an error that names a missing file where the file it means is a socket that was never going to exist.

Three of my guesses died on that one test (missing by-name symlinks, a `/proc` bootmode node, the BCB). The no-argument case was the cheapest discriminator available and I should have asked for it first.

### The discriminator is `getpid()`, not `argc`

The kernel can pass arguments to init from the boot cmdline, so a device whose bootloader appended one would take the tool path and **never boot** — a brick produced by an argument nobody typed. PID 1 is what "am I the init" means, and it can't vary.

Putting it in the init is what makes it need nothing pushed to the device, which matters because a device on emOS has no adb — "get a binary onto it" is the problem this avoids rather than solves.

### `emos/tools/emreboot.c`

The freestanding version that proved the mechanism, kept because **every device in the field predates the multi-call**. No adb, so a console paste or an HTTP fetch over its own WiFi are the only ways in, and 680 bytes is what makes the paste viable. Not built by CI, not part of the image, and it rebuilds byte-identical (`474cddedb171ce7803cac2360b1ca24f`) to the binary actually tested on hardware.

### Verified

`ringsim --check` and `pwcheck` still pass — both `#include init.c` whole, so the signature change to `main` is covered — and the init builds static aarch64 in the pinned compiler image.

Doesn't block the GA either way; the button route to TWRP still exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBGUwJuEtMQAikjyy1Bskh