### PR TITLE
Give the console idle timeout a number box, not a slider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
           node controller/tests/web_usb_blocked.test.mjs
           node controller/tests/emos_md5.test.mjs
           node controller/tests/boot_image_length.test.mjs
+          node controller/tests/number_field.test.mjs
 
   device-tests:
     name: Device Go tests

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -385,6 +385,88 @@ function Slider({ label, sub, value, min, max, step = 1, unit = '', formatValue,
   );
 }
 
+// A plain number box, for settings where the exact value is the point.
+//
+// Slider is right for anything tuned by ear against a real room — the LED
+// meter response, duck depth — where you drag and listen and the number is
+// incidental. It is wrong when somebody already knows what they want, because
+// `step` decides which values exist at all: the console timeout ran 0-90 at
+// step 5, so "twenty minutes" meant hunting a 1px target and "seven" was not
+// expressible.
+//
+// `disabled` is honoured in the HANDLER as well as the styling, for the reason
+// spelled out on Toggle below: a control that greys itself while still writing
+// is worse than one that does nothing, because the stored setting then
+// disagrees with what is on screen.
+//
+// INTEGERS ONLY, and enforced by stripping non-digits as they are typed rather
+// than by rounding afterwards. Rounding looks equivalent and is not: `0.1`
+// rounds to 0, and 0 here means NEVER — so the one entry a person makes when
+// they want the shortest possible timeout would silently turn the timeout off.
+// Stripping makes 0 reachable only by typing it, which is the property worth
+// having. It also matches the device, whose parser reads digits and stops at
+// anything else (`console_timeout_secs` in emos/init/init.c), so a fraction
+// would land there as 0 regardless — better refused at the box than
+// reinterpreted three layers down.
+//
+// Empty input is allowed WHILE TYPING and simply not committed — clearing the
+// box to type a new number must not write 0 mid-keystroke, for the same
+// reason. The value is clamped on commit rather than rejected, so a typed 200
+// becomes the maximum instead of an error nobody can act on.
+function NumberField({ label, sub, value, min = 0, max = 100, unit = '',
+                       onChange, disabled = false }) {
+  const [text, setText] = useState(String(value ?? min));
+
+  // Follow the stored value when it changes underneath us (a fleet config
+  // load, or reverting a section), except while this box is being edited.
+  const [editing, setEditing] = useState(false);
+  useEffect(() => { if (!editing) setText(String(value ?? min)); }, [value, editing, min]);
+
+  const digits = (s) => String(s).replace(/[^0-9]/g, '');
+
+  const commit = (raw) => {
+    if (disabled) return;
+    if (raw === '') return;                       // still typing
+    const n = Number(raw);
+    if (!Number.isInteger(n)) return;
+    onChange(Math.min(max, Math.max(min, n)));
+  };
+
+  return (
+    <div style={{ marginBottom: 20, minWidth: 0 }}>
+      <div style={{ marginBottom: 6 }}>
+        <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, color: disabled ? 'var(--muted)' : 'var(--text2)' }}>{label}</span>
+      </div>
+      {sub && <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)', lineHeight: 1.6, marginBottom: 8 }}>{sub}</div>}
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', minWidth: 0 }}>
+        {/* text, not type="number": a number input still ACCEPTS "0.1" and
+            "1e3" (and reports an empty string for them in some browsers,
+            which is worse), so the filtering below would have nothing to bite
+            on. inputMode brings up the numeric keypad regardless. */}
+        <input type="text" inputMode="numeric" autoComplete="off"
+          value={text} disabled={disabled}
+          onFocus={() => setEditing(true)}
+          onChange={e => { const d = digits(e.target.value); setText(d); commit(d); }}
+          onBlur={e => {
+            setEditing(false);
+            // Snap the box back to what was actually stored, so a cleared or
+            // out-of-range entry cannot be left on screen looking saved.
+            const d = digits(e.target.value);
+            const v = d === '' ? (value ?? min)
+                               : Math.min(max, Math.max(min, Number(d)));
+            setText(String(v));
+            commit(String(v));
+          }}
+          className="em-inset"
+          style={{ fontFamily: "'DM Mono',monospace", fontSize: 11, width: 84, minWidth: 0,
+                   color: 'var(--text)', border: '1px solid var(--border-hard)',
+                   opacity: disabled ? 0.45 : 1 }}/>
+        {unit && <span style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)' }}>{unit}</span>}
+      </div>
+    </div>
+  );
+}
+
 function Toggle({ label, sub, value, onChange, disabled = false }) {
   // minWidth: 0 on the flex container and label lets long label/sub text
   // shrink and wrap instead of forcing the row (and the switch with it)
@@ -7442,13 +7524,13 @@ function DeviceConfigForm({ config, onChange, disabled, sections, onScopeChange,
           {/* The gate runs when init SPAWNS the console, not per keystroke, so
               a session authenticated before a change keeps its old behaviour
               until something ends it. That is what this ends. */}
-          <Slider
+          <NumberField
             label="Console idle timeout"
             sub={emosFleet
-              ? 'logs the USB console out after this long with no typing. 0 = never. A long command is not interrupted — only an idle prompt.'
+              ? 'minutes of no typing before the USB console logs out, 0-90. 0 = never. A long command is not interrupted — only an idle prompt.'
               : 'every device in this fleet runs FireOS, which uses adb for USB access — this setting would do nothing'}
             value={config.consoleTimeoutMin ?? 0}
-            min={0} max={90} step={5} unit="min"
+            min={0} max={90} unit="min"
             disabled={!emosFleet}
             onChange={v => set('consoleTimeoutMin', v)}/>
         </div>

--- a/controller/tests/number_field.test.mjs
+++ b/controller/tests/number_field.test.mjs
@@ -1,0 +1,95 @@
+// Tests for NumberField's input filtering in dashboard.jsx — what a typed
+// string is allowed to become.
+//
+//     node controller/tests/number_field.test.mjs
+//
+// Source extraction rather than import, for the reason pm_verdict.test.mjs
+// gives: the dashboard compiles to a single classic script with no module
+// boundary, so the alternative is a second copy that drifts.
+//
+// The rule under test is that 0 must be reachable ONLY by typing it. This
+// control is the console idle timeout, where 0 means NEVER — so a fractional
+// entry that rounds to 0 does not produce a short timeout, it silently turns
+// the timeout off. `0.1` is the entry somebody makes when they want the
+// shortest possible one, which is precisely the opposite. Rounding looks like
+// the obvious way to enforce integers and has that hole in it; stripping
+// non-digits as they are typed does not.
+
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import assert from "assert";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(HERE, "..", "static", "dashboard.jsx"), "utf8");
+
+// Lift the one-line `digits` helper out of NumberField.
+function liftDigits() {
+  const m = src.match(/const digits = \(s\) => ([^;]+);/);
+  if (!m) {
+    throw new Error(
+      "dashboard.jsx no longer defines NumberField's digits() helper — if it " +
+      "was renamed, update this test; if the filtering moved, make sure 0 is " +
+      "still reachable only by typing it.");
+  }
+  return new Function("s", `return ${m[1]};`);
+}
+
+const digits = liftDigits();
+
+// The commit path, mirrored from the component: filter, then clamp.
+const commit = (raw, min, max) => {
+  const d = digits(raw);
+  if (d === "") return null;                 // still typing; nothing written
+  return Math.min(max, Math.max(min, Number(d)));
+};
+
+// ── The hazard this exists for ───────────────────────────────────────────────
+
+// Round(0.1) is 0 and 0 means "never". Stripping gives 1: the shortest
+// timeout, which is what was being asked for.
+assert.strictEqual(commit("0.1", 0, 90), 1,
+  "a fractional entry must not become 0 — 0 means the timeout is off");
+
+assert.strictEqual(commit("0.9", 0, 90), 9, "no rounding, digits only");
+
+// The only way to 0.
+assert.strictEqual(commit("0", 0, 90), 0, "typing 0 means 0");
+
+// ── Integers only ────────────────────────────────────────────────────────────
+
+assert.strictEqual(commit("7.5", 0, 90), 75,
+  "the decimal point is dropped rather than rounded");
+// Not 1000-clamped-to-90: the 'e' goes and the remaining digits are read as
+// written. Either way the point holds — exponent notation cannot survive, and
+// what lands is a plain integer.
+assert.strictEqual(commit("1e3", 0, 90), 13, "exponent notation cannot survive");
+assert.strictEqual(commit("-5", 0, 90), 5, "a minus sign is not a digit");
+assert.strictEqual(commit("12abc", 0, 90), 12, "letters are dropped");
+assert.strictEqual(commit(" 20 ", 0, 90), 20, "whitespace is dropped");
+
+// ── Clamping, not rejecting ──────────────────────────────────────────────────
+//
+// An out-of-range entry becomes the nearest legal value. Refusing it instead
+// leaves an error nobody can act on next to a box that still shows their
+// number.
+
+assert.strictEqual(commit("200", 0, 90), 90, "above max clamps to max");
+assert.strictEqual(commit("90", 0, 90), 90, "max itself is allowed");
+
+// ── Empty is "still typing", never a write ───────────────────────────────────
+//
+// Clearing the box to type a new number must not commit 0 on the way past.
+
+assert.strictEqual(commit("", 0, 90), null, "an empty box writes nothing");
+
+// The device parser agrees with all of the above: it reads digits and stops at
+// anything else, so a fraction would land there as 0 whatever we sent. Pin
+// that the two are still describing the same thing.
+const init = readFileSync(
+  join(HERE, "..", "..", "emos", "init", "init.c"), "utf8");
+assert.ok(/console_timeout_secs/.test(init),
+  "emos/init/init.c no longer has console_timeout_secs — the device half of " +
+  "this contract moved, so check the box still cannot send it a fraction");
+
+console.log("number_field: all ok");


### PR DESCRIPTION
A slider is right for a setting tuned by ear against a real room — the LED meter response, duck depth — where you drag, listen, and the number is incidental. It's wrong when somebody already knows what they want, because `step` decides which values exist at all: this ran 0–90 at step 5, so "twenty minutes" meant hunting a 1px target and "seven" couldn't be expressed.

### Integers only, by stripping rather than rounding

Those aren't equivalent, and the difference matters here. `Math.round("0.1")` is **0**, and 0 in this control means **never** — so the single entry somebody makes when they want the *shortest possible* timeout would have silently turned the timeout off. Stripping non-digits as they're typed makes 0 reachable only by typing it.

It's an `<input type="text">` with `inputMode="numeric"`, **not** `type="number"`. A number input still accepts `0.1` and `1e3`, and reports an empty string for them in some browsers — so the filtering would have had nothing to bite on and the invalid entry would arrive as a blank.

The device already agrees: `console_timeout_secs()` in `emos/init/init.c` reads digits and stops at anything else, so a fraction lands there as 0 whatever we send. Better refused at the box than reinterpreted three layers down — and the test pins that both halves still describe the same contract.

### Smaller rules, each with a failure behind it

- **Empty is "still typing"** and commits nothing. Clearing the box to type a new number must not write 0 on the way past.
- **Out of range clamps rather than rejects.** An error nobody can act on, sitting next to a box still showing their number, is worse than the nearest legal value.
- **`disabled` is honoured in the handler**, not only the styling — the rule already written on `Toggle`.

### Testing

`tests/number_field.test.mjs` lifts the filter out of the source rather than copying it, and **is added to `ci.yml`** — the `.mjs` suites are named explicitly there, so a new file is otherwise never run and passes by not existing.

All eight dashboard suites pass, the bundle compiles, and `test_design_tokens` / `test_deploy` / `test_config_sections` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBGUwJuEtMQAikjyy1Bskh