### PR TITLE
Journal the release evening, and correct what emOS 0.4 made untrue

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -2419,3 +2419,88 @@ It is now a command on the console you are already connected to, and most of
 the one-way-door objection to emOS-as-default goes with it. It is also the
 first genuinely useful entry for the guided console menu (#451), which until
 now had nothing to guide anyone to.
+
+## 2026-09-10 — GA 2.23.0, firmware v2.15.0 and emOS 0.4, cut together
+
+**Three release trains in one evening, because two of them gate the third.**
+The wizard fetches its init from whatever emOS release is latest, so without
+an `emos-v0.4` the GA would have shipped a wizard installing a four-releases-
+stale init — no `/init recovery`, no console idle timeout. And the controller
+changelog had been carrying an apology since ea.4: three features listed and
+then withdrawn as "needs device firmware newer than v2.14.0, which is not
+published yet". Publishing v2.15.0 turned that into an instruction.
+
+Order was `emos-v0.4` → `v2.15.0` → `controller-v2.23.0`, so the controller's
+notes could promise things that were already installable.
+
+**#488's console-password clear was validated end to end on hardware**, which
+was the last GA blocker. Four steps, and the third is the one that had only
+ever been read rather than run: the clear fires during provisioning; the emOS
+wizard gets through steps 8 and 9 with no prompt, on a device that genuinely
+had a record; the controller re-applies it on connect; and the console
+challenges on the next session. That last one needed a reboot, because
+`console_gate()` runs when init SPAWNS the console and never again — the
+session Wil was sitting on predated the push, which is exactly the property
+#484 exists to bound.
+
+**Two things cost a run each, and both were checks rather than operations.**
+
+A stale dashboard tab ran the ea.14 bundle against an ea.15 controller, so the
+console-password clear silently did not happen and the wizard log simply
+lacked the line. The bundle URL is already cache-busted by mtime, but that
+only applies on a page LOAD — a tab open across an add-on update keeps its
+JavaScript indefinitely. **The version in the header is fetched once, in the
+"Load initial data" effect, so it reports the controller version as of page
+load** — which means the one number you would check to detect a stale page is
+itself stale, and lies in the same direction. Not fixed yet; it is the
+smallest useful thing on the list.
+
+And `/init reboot` on an emOS **0.3** device, which has no multi-call: the
+argument was ignored and the entire init sequence ran again as an ordinary
+process. `/system` and `/data` were already mounted, so both returned EBUSY
+and `led_fail()` lit the ring red at stages 2 and 4 — a real failure
+indication for a boot that was never happening. It then incremented the
+rollback counter (`/data/emos/boot.state`) and ran on to the shutdown path,
+which is why the device eventually rebooted on its own. At `MAX_TRIES` 3 that
+counter restores the known-good image over the boot partition, so one of three
+was spent on nothing. It self-healed: the counter is reset when the network
+comes up and the boot confirms, and read 0 afterwards.
+
+**That is the failure `/init recovery`'s `getpid()` guard prevents, and it
+arrived from the direction I did not write it for.** The guard exists because
+the kernel can pass arguments to init from the boot cmdline; the likelier path
+turns out to be a person at a console typing `/init` something.
+
+**emOS stopped being a one-way door, and the README had to be corrected rather
+than merely updated.** It said a device on emOS cannot be re-provisioned and
+that going back means a TWRP wipe erasing `/data`. Both were true when
+written. But `runConnectAndroid()` — step 0 of BOTH flows — already accepts a
+device sitting in TWRP and reads the FireOS build off `/system`, so reaching
+recovery was the whole of what was missing, and `/init recovery` is that.
+emOS → recovery → re-provision now works. What survives is that nothing tells
+you so, and the duplicate-serial guard still stops you until you take its
+offer to delete the row.
+
+**Also confirmed in passing, from three lines of console output.**
+`boot-good.img` is 6,914,048 bytes — byte-identical to what the wizard
+flashed — so `promote_good()` has run and a rollback would now restore emOS
+rather than silently putting the device back on FireOS. And the file's
+timestamp is correct, which on emOS only happens because the controller told
+the device the time (#430); nothing else there can, since bionic resolves
+through Android's property service.
+
+**Two corrections of mine.** `sync_channels.py --set-version` targets the
+CHANNEL, not GA — the first attempt moved `controller-ea` to `2.23.0`, which
+would have pinned the EA add-on to an image tagged for GA. And I hedged that
+v2.15.0 was "14 commits of device changes I have never seen run", which was
+wrong in the unhelpful direction: Wil's local builds are
+`v2.14.0-81-gd5e397d`, so 13 of the 14 were already field-exercised, and the
+single exception is #484 — whose device half and emOS half are both new and
+both already declared untested in the 0.4 notes.
+
+**Still owed.** `vad_start=—` is now measurable across every GA fleet rather
+than one bench, and it remains the count that says whether HA's endpointing is
+still failing — the fix hides that fault rather than removing it. The 2.5s
+grace is set from two samples (1,077ms and 1,025ms). home-assistant/core#181747
+has had no human response; #122177 died to the stale bot twice, so that one
+wants a nudge with a PR offer rather than an "any update?".

--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -1868,3 +1868,21 @@ while a value lives at the call site.**
   inline styles cannot express `:hover` or `:focus-visible` at all, so until
   the class layer existed the dashboard had **no keyboard focus ring
   anywhere**.
+- **Slider or NumberField is a question about the SETTING, not the layout.**
+  A slider is right where the value is tuned by ear against a real room — the
+  LED meter response, `duckDb` — and you drag, listen, and the number is
+  incidental. It is wrong where somebody already knows the number they want,
+  because `step` decides which values exist at all: the console idle timeout
+  ran 0-90 at step 5, so "twenty minutes" meant hitting a 1px target and
+  "seven" could not be expressed (Wil, 2026-09-10).
+  **NumberField takes integers by STRIPPING non-digits as they are typed, not
+  by rounding afterwards**, and those are not equivalent in the way they look.
+  `Math.round("0.1")` is 0, and 0 in that control means NEVER — so the single
+  entry somebody makes when they want the shortest possible timeout would have
+  silently switched the timeout off. Stripping makes 0 reachable only by typing
+  it. It is `type="text"` with `inputMode="numeric"` rather than
+  `type="number"`, because a number input accepts `0.1` and `1e3` anyway and
+  hands some browsers an empty string for them, leaving the filter nothing to
+  bite on. Empty is "still typing" and commits nothing; out of range clamps
+  rather than rejects, since an error nobody can act on beside a box still
+  showing their number is worse than the nearest legal value.

--- a/emos/README.md
+++ b/emos/README.md
@@ -8,14 +8,14 @@ It is a distribution in the ordinary sense: it does not include a kernel of its
 own. It pairs the device's existing MediaTek 3.18 kernel with our own PID 1,
 busybox, and bionic and tinyalsa mounted read-only from the device's `/system`.
 
-**Status: 0.3, bench-proven, not field-proven.** Still a small number of
+**Status: 0.4, bench-proven, not field-proven.** Still a small number of
 devices over a handful of days. A complete voice turn has run on it — wake word
 scored on-device, Home Assistant pipeline, spoken answer — along with WiFi, the
 9-channel mic array, hardware AEC, the BLE proxy, buttons, ambient light, jack
 detect and the LED ring. The known gaps are listed at the bottom and none of
 them is a research problem.
 
-Two things changed since 0.1 that are worth knowing before you try it:
+Three things changed since 0.1 that are worth knowing before you try it:
 
 - **The provisioning wizard has now run end to end**, on a device restored to
   genuine stock. It failed at four different steps first, and every one of
@@ -23,12 +23,15 @@ Two things changed since 0.1 that are worth knowing before you try it:
 - **emOS updates in place, over the network.** A device was taken 0.1 → 0.3
   with no TWRP, no cable and no wipe. So a bug in a released emOS is something
   we can push a fix for, rather than something that strands a device.
+- **emOS is no longer a one-way door.** `/init recovery` reboots the device
+  into TWRP from its own console, and the wizard's first step already accepts
+  a device that is in TWRP — so emOS → recovery → re-provision is a path that
+  works, without powering the device off and holding the mute button in the
+  dark. New in 0.4, confirmed on hardware 2026-09-10.
 
-`emos-v0.3` is tagged and published so the wizard can fetch the init, which is
+`emos-v0.4` is tagged and published so the wizard can fetch the init, which is
 the only part of an image that can be distributed. **A tag is not a claim that
-this is finished.** Try it on a spare Echo, and read the Known gaps first — in
-particular, a device on emOS cannot be re-provisioned by the wizard, and going
-back means a TWRP wipe that erases `/data`.
+this is finished.** Try it on a spare Echo, and read the Known gaps first.
 
 ## Why
 
@@ -81,7 +84,7 @@ with `git describe --match 'emos-v*'`, so without those tags it stamps
 whatever tag is nearest — a controller release number, which is worse than
 "unknown" because it looks plausible. The namespace also keeps emOS out of the
 firmware OTA's way: `_fetch_latest_release` selects a tag starting `v` with a
-`server` asset, and `emos-v0.3` matches neither.
+`server` asset, and `emos-v0.4` matches neither.
 
 ```sh
 git tag -a --cleanup=verbatim emos-v0.4 -m "..."   # -a always; the annotation IS the notes
@@ -746,18 +749,28 @@ is not proof it rebooted — compare uptime or a build fingerprint.
   board.
 - The boot trail is a fixed-size buffer rewritten in place, so a shorter trail
   leaves the tail of the previous boot's behind and can be misread.
-- **A device on emOS cannot be re-provisioned by the wizard, and nothing in
-  the wizard says so.** Step 0 needs adbd, which emOS does not have and will
-  not — `f_acm` is the whole point of not needing a daemon. So the USB picker
-  offers nothing and the step fails with an error about the wrong device,
-  which does not name the actual reason. The duplicate-serial guard would
-  refuse it a second time over, since a provisioned device is registered.
+- **A device on emOS cannot start the wizard directly, and nothing in the
+  wizard says so** — but since 0.4 there is a one-command way round it, so
+  this is an unhelpful error rather than the dead end it was.
+
+  Step 0 needs adbd, which emOS does not have and will not — `f_acm` is the
+  whole point of not needing a daemon. So the USB picker offers nothing and
+  the step fails with an error about the wrong device, which does not name the
+  actual reason.
+
+  **`/init recovery` from the console is the way through.** The wizard's first
+  step already accepts a device that is in TWRP (it reads the FireOS build off
+  `/system`, since every property in recovery belongs to the ramdisk), so
+  reaching recovery is the whole of what was missing. What remains is that
+  nothing tells you that, and the duplicate-serial guard still refuses a
+  device that is already registered — it offers to delete it, which is the
+  right answer but has to be found.
 
   Noticed by Wil on 2026-09-05, after the flow was built. The design's open
   questions covered FireOS → emOS and deferred it; **nobody asked the
   reverse**, which is how it got this far.
 
-  Three paths exist and none of them is in the wizard:
+  The other three paths remain, and none of them is in the wizard either:
 
   - **Return to stock, by hand.** Boot into TWRP — unplug the power, hold
     **mute** down, and apply power with it still held, until the ring shows an
@@ -780,9 +793,12 @@ is not proof it rebooted — compare uptime or a build fingerprint.
     re-provision and needs no USB at all.
   - **The console**, for a device that is on emOS but not on the network.
 
-  The middle one is the fix worth building, and it is the same self-flash the
-  design deferred for FireOS → emOS. Until then this is a one-way door: keep
-  the escrowed boot image.
+  The middle one is still the fix worth building, and it is the same self-flash
+  the design deferred for FireOS → emOS — it needs no USB and no recovery at
+  all. It is no longer urgent, though: `/init recovery` plus the wizard's
+  existing TWRP entry covers the case that mattered. Keep the escrowed boot
+  image regardless; it is the ten-second undo for a device that will not boot,
+  which is the one situation none of these paths help with.
 
 ## What emOS is worth beyond the stunt
 


### PR DESCRIPTION
`JOURNAL.md` gains the release entry — a second one for 2026-09-10, following the precedent from 09-02 where a findings entry and a release entry sat side by side.

### The correction worth reading

`emos/README.md` said a device on emOS **cannot** be re-provisioned, and that going back means a TWRP wipe erasing `/data`. Both were true when written and neither is now.

`runConnectAndroid` — step 0 of **both** flows — already accepts a device sitting in TWRP and reads the FireOS build off `/system`. So reaching recovery was the whole of what was missing, and `/init recovery` is that. **emOS → recovery → re-provision now works.**

What survives is narrower, and is written as such:

- Nothing in the wizard tells you to do it; starting it on a running emOS device still fails with an error that doesn't name the reason.
- The duplicate-serial guard still stops you until you take its offer to delete the row.
- **A device on 0.3 has no multi-call at all** — running `/init` there re-runs the entire boot sequence as an ordinary process, lights the ring red via `led_fail()` on the already-mounted `/system` and `/data`, and spends one of three rollback attempts. Found the hard way tonight.

Status line, tag references and the closing "until then this is a one-way door" all move with it.

### Also

`controller/CLAUDE.md` records why `NumberField` exists beside `Slider` — as a question about the **setting**, not the layout — and why integers are enforced by stripping rather than rounding (`Math.round("0.1")` is 0, and 0 in that control means *never*).

### Verified

Controller suite 1032 passed, all eight dashboard `.mjs` suites pass, design tokens green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBGUwJuEtMQAikjyy1Bskh