### PR TITLE
Tell a stale dashboard tab that it is stale

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -2419,3 +2419,88 @@ It is now a command on the console you are already connected to, and most of
 the one-way-door objection to emOS-as-default goes with it. It is also the
 first genuinely useful entry for the guided console menu (#451), which until
 now had nothing to guide anyone to.
+
+## 2026-09-10 — GA 2.23.0, firmware v2.15.0 and emOS 0.4, cut together
+
+**Three release trains in one evening, because two of them gate the third.**
+The wizard fetches its init from whatever emOS release is latest, so without
+an `emos-v0.4` the GA would have shipped a wizard installing a four-releases-
+stale init — no `/init recovery`, no console idle timeout. And the controller
+changelog had been carrying an apology since ea.4: three features listed and
+then withdrawn as "needs device firmware newer than v2.14.0, which is not
+published yet". Publishing v2.15.0 turned that into an instruction.
+
+Order was `emos-v0.4` → `v2.15.0` → `controller-v2.23.0`, so the controller's
+notes could promise things that were already installable.
+
+**#488's console-password clear was validated end to end on hardware**, which
+was the last GA blocker. Four steps, and the third is the one that had only
+ever been read rather than run: the clear fires during provisioning; the emOS
+wizard gets through steps 8 and 9 with no prompt, on a device that genuinely
+had a record; the controller re-applies it on connect; and the console
+challenges on the next session. That last one needed a reboot, because
+`console_gate()` runs when init SPAWNS the console and never again — the
+session Wil was sitting on predated the push, which is exactly the property
+#484 exists to bound.
+
+**Two things cost a run each, and both were checks rather than operations.**
+
+A stale dashboard tab ran the ea.14 bundle against an ea.15 controller, so the
+console-password clear silently did not happen and the wizard log simply
+lacked the line. The bundle URL is already cache-busted by mtime, but that
+only applies on a page LOAD — a tab open across an add-on update keeps its
+JavaScript indefinitely. **The version in the header is fetched once, in the
+"Load initial data" effect, so it reports the controller version as of page
+load** — which means the one number you would check to detect a stale page is
+itself stale, and lies in the same direction. Not fixed yet; it is the
+smallest useful thing on the list.
+
+And `/init reboot` on an emOS **0.3** device, which has no multi-call: the
+argument was ignored and the entire init sequence ran again as an ordinary
+process. `/system` and `/data` were already mounted, so both returned EBUSY
+and `led_fail()` lit the ring red at stages 2 and 4 — a real failure
+indication for a boot that was never happening. It then incremented the
+rollback counter (`/data/emos/boot.state`) and ran on to the shutdown path,
+which is why the device eventually rebooted on its own. At `MAX_TRIES` 3 that
+counter restores the known-good image over the boot partition, so one of three
+was spent on nothing. It self-healed: the counter is reset when the network
+comes up and the boot confirms, and read 0 afterwards.
+
+**That is the failure `/init recovery`'s `getpid()` guard prevents, and it
+arrived from the direction I did not write it for.** The guard exists because
+the kernel can pass arguments to init from the boot cmdline; the likelier path
+turns out to be a person at a console typing `/init` something.
+
+**emOS stopped being a one-way door, and the README had to be corrected rather
+than merely updated.** It said a device on emOS cannot be re-provisioned and
+that going back means a TWRP wipe erasing `/data`. Both were true when
+written. But `runConnectAndroid()` — step 0 of BOTH flows — already accepts a
+device sitting in TWRP and reads the FireOS build off `/system`, so reaching
+recovery was the whole of what was missing, and `/init recovery` is that.
+emOS → recovery → re-provision now works. What survives is that nothing tells
+you so, and the duplicate-serial guard still stops you until you take its
+offer to delete the row.
+
+**Also confirmed in passing, from three lines of console output.**
+`boot-good.img` is 6,914,048 bytes — byte-identical to what the wizard
+flashed — so `promote_good()` has run and a rollback would now restore emOS
+rather than silently putting the device back on FireOS. And the file's
+timestamp is correct, which on emOS only happens because the controller told
+the device the time (#430); nothing else there can, since bionic resolves
+through Android's property service.
+
+**Two corrections of mine.** `sync_channels.py --set-version` targets the
+CHANNEL, not GA — the first attempt moved `controller-ea` to `2.23.0`, which
+would have pinned the EA add-on to an image tagged for GA. And I hedged that
+v2.15.0 was "14 commits of device changes I have never seen run", which was
+wrong in the unhelpful direction: Wil's local builds are
+`v2.14.0-81-gd5e397d`, so 13 of the 14 were already field-exercised, and the
+single exception is #484 — whose device half and emOS half are both new and
+both already declared untested in the 0.4 notes.
+
+**Still owed.** `vad_start=—` is now measurable across every GA fleet rather
+than one bench, and it remains the count that says whether HA's endpointing is
+still failing — the fix hides that fault rather than removing it. The 2.5s
+grace is set from two samples (1,077ms and 1,025ms). home-assistant/core#181747
+has had no human response; #122177 died to the stale bot twice, so that one
+wants a nudge with a PR offer rather than an "any update?".

--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -1868,3 +1868,21 @@ while a value lives at the call site.**
   inline styles cannot express `:hover` or `:focus-visible` at all, so until
   the class layer existed the dashboard had **no keyboard focus ring
   anywhere**.
+- **Slider or NumberField is a question about the SETTING, not the layout.**
+  A slider is right where the value is tuned by ear against a real room — the
+  LED meter response, `duckDb` — and you drag, listen, and the number is
+  incidental. It is wrong where somebody already knows the number they want,
+  because `step` decides which values exist at all: the console idle timeout
+  ran 0-90 at step 5, so "twenty minutes" meant hitting a 1px target and
+  "seven" could not be expressed (Wil, 2026-09-10).
+  **NumberField takes integers by STRIPPING non-digits as they are typed, not
+  by rounding afterwards**, and those are not equivalent in the way they look.
+  `Math.round("0.1")` is 0, and 0 in that control means NEVER — so the single
+  entry somebody makes when they want the shortest possible timeout would have
+  silently switched the timeout off. Stripping makes 0 reachable only by typing
+  it. It is `type="text"` with `inputMode="numeric"` rather than
+  `type="number"`, because a number input accepts `0.1` and `1e3` anyway and
+  hands some browsers an empty string for them, leaving the filter nothing to
+  bite on. Empty is "still typing" and commits nothing; out of range clamps
+  rather than rejects, since an error nobody can act on beside a box still
+  showing their number is worse than the nearest legal value.

--- a/controller/em_api.py
+++ b/controller/em_api.py
@@ -500,6 +500,25 @@ async def _serve_spa(request: web.Request) -> web.Response:
     )
 
 
+def _bundle_version() -> str:
+    """The dashboard bundle's mtime, as the string used in its URL.
+
+    One function so `_serve_dashboard` (which stamps it) and
+    `/api/system/status` (which publishes it for comparison) cannot disagree
+    about what identifies a build. Two call sites deriving the same value
+    independently is how a staleness check ends up permanently stale, or
+    permanently fresh, with nothing to show for it either way.
+
+    An unreadable bundle returns "", which compares equal to the "" a client
+    reports when it cannot find its own script tag — so the check degrades to
+    "say nothing" rather than to a reload prompt nobody can satisfy.
+    """
+    try:
+        return str(int((STATIC_DIR / "dashboard.js").stat().st_mtime))
+    except OSError:
+        return ""
+
+
 async def _serve_dashboard(request: web.Request) -> web.Response:
     """
     Serve dashboard.html for /dashboard, with the JS bundle cache-busted.
@@ -522,11 +541,11 @@ async def _serve_dashboard(request: web.Request) -> web.Response:
     if not dashboard.exists():
         return web.Response(status=503, text="dashboard.html not found in static/")
     page = _with_ingress_base(dashboard.read_text(encoding="utf-8"), request)
-    bundle = STATIC_DIR / "dashboard.js"
-    if bundle.exists():
+    stamp = _bundle_version()
+    if stamp:
         page = page.replace(
             "static/dashboard.js",
-            f"static/dashboard.js?v={int(bundle.stat().st_mtime)}",
+            f"static/dashboard.js?v={stamp}",
         )
     return web.Response(
         text=page,
@@ -3283,6 +3302,23 @@ async def _get_system_status(request: web.Request) -> web.Response:
 
     return _ok({
         "controller_version": CONTROLLER_VERSION,
+        # The mtime stamped onto the dashboard bundle's URL by
+        # _serve_dashboard, so a running page can tell whether the JavaScript
+        # it is executing is still the JavaScript this controller serves.
+        #
+        # A long-lived SPA tab survives an add-on update and keeps its old
+        # bundle indefinitely — the URL is cache-busted, but only on a page
+        # LOAD. Nothing in the page could notice, and `controller_version`
+        # above made it worse rather than better: it is read from the server,
+        # so it reports the NEW version while the page runs the OLD code.
+        # Measured 2026-09-10, when a wizard run on a stale tab silently
+        # skipped a provisioning step that had shipped hours earlier and the
+        # header cheerfully named a version whose code was not running.
+        #
+        # Compared rather than displayed, so it does not matter that an mtime
+        # is meaningless to a person; `version.py` cannot be used here because
+        # a local build is "dev" for every build and would never differ.
+        "bundle_version": _bundle_version(),
         # True when running as a Home Assistant add-on behind Supervisor's
         # ingress proxy. Presentation only — the dashboard is the same
         # dashboard either way, with the same features, and nothing should

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -1,5 +1,29 @@
 const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
+// The bundle THIS page is executing, read off its own script tag.
+//
+// _serve_dashboard stamps `?v=<mtime>` onto the URL so a browser cannot serve
+// a cached bundle after a deploy — but that only bites on a page LOAD. A tab
+// left open across a controller update keeps its JavaScript indefinitely, and
+// until this existed nothing in the page could tell.
+//
+// It is not a cosmetic problem. On 2026-09-10 a provisioning run on a stale
+// tab silently skipped a step that had shipped hours earlier: the server was
+// right, the file on disk was right, and the wizard was running yesterday's
+// code. The version in the header made it WORSE — that comes from the API, so
+// it names the new controller while the old code runs, which is the one number
+// somebody checks to rule this out.
+//
+// "" when the tag cannot be found, which compares equal to the "" the server
+// sends for an unreadable bundle: the check then says nothing rather than
+// prompting for a reload that would fix nothing.
+const LOADED_BUNDLE = (() => {
+  try {
+    const el = document.querySelector('script[src*="dashboard.js"]');
+    return new URL(el.src, location.href).searchParams.get('v') || '';
+  } catch { return ''; }
+})();
+
 // ─── Ingress ──────────────────────────────────────────────────────────────────
 
 // Under Home Assistant Ingress the dashboard is mounted below a generated
@@ -7976,6 +8000,10 @@ function App() {
   const [ctrlNotesOpen, setCtrlNotesOpen] = useState(false);
   const [checkingRelease, setCheckingRelease] = useState(false);
   const [status, setStatus] = useState(null);
+  // Latched, never cleared: a controller that is updated twice while this tab
+  // is open is still one stale tab, and a prompt that flickered off would be
+  // read as having fixed itself.
+  const [staleBundle, setStaleBundle] = useState(false);
   const [loadError, setLoadError] = useState(null);
   const [showWizard, setShowWizard] = useState(false);
   const [showDeployAll, setShowDeployAll] = useState(false);
@@ -8131,9 +8159,29 @@ function App() {
       API.get('/api/devices').then(setDevices).catch(() => {});
     }, 5000);
 
+    // Staleness is checked on its own, much slower, timer. It rides no
+    // existing poll because /api/system/status gathers process and disk
+    // stats, and a controller update happens on the order of weeks — asking
+    // every five seconds would spend real work answering a question whose
+    // answer almost never changes.
+    //
+    // setStatus is deliberately NOT called here. The header's version must
+    // keep naming the controller this page was LOADED against, or the stale
+    // indicator contradicts itself: a fresh version beside a reload prompt
+    // reads as a bug in the prompt. Only the comparison is updated.
+    const stale = setInterval(() => {
+      API.get('/api/system/status')
+        .then(st => {
+          if (st?.bundle_version && LOADED_BUNDLE &&
+              st.bundle_version !== LOADED_BUNDLE) setStaleBundle(true);
+        })
+        .catch(() => {});
+    }, 60000);
+
     return () => {
       ws.close();
       clearInterval(poll);
+      clearInterval(stale);
     };
 
   }, [token]);
@@ -8160,7 +8208,20 @@ function App() {
           <div style={{ fontFamily: "'DM Sans',sans-serif", fontSize: 28, color: 'var(--text)', fontWeight: 600, letterSpacing: '-0.02em' }}>EchoMuse</div>
           <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)', letterSpacing: '0.12em', textTransform: 'uppercase' }}>Device Management</div>
           {status?.controller_version && (
-            <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)' }}>{status.controller_version}</div>
+            /* Deliberately IN PLACE of the version rather than a banner beside
+               it: this is the element that was lying, so it is the element
+               that should say so, and it costs no vertical space. */
+            staleBundle ? (
+              <button onClick={() => location.reload()}
+                title={`This page is running an older build than the controller (${status.controller_version}). Reload to update.`}
+                style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--warn)',
+                         background: 'none', border: '1px solid var(--warn)', borderRadius: 4,
+                         padding: '1px 6px', cursor: 'pointer' }}>
+                {status.controller_version} · reload
+              </button>
+            ) : (
+              <div style={{ fontFamily: "'DM Mono',monospace", fontSize: 10, color: 'var(--muted)' }}>{status.controller_version}</div>
+            )
           )}
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>

--- a/controller/tests/test_deploy.py
+++ b/controller/tests/test_deploy.py
@@ -49,7 +49,17 @@ def test_dashboard_bundle_is_cache_busted():
         "dashboard.html itself must be revalidated, or the new URL is never seen"
     # A version-string token would not change between two local "dev" builds;
     # mtime changes on every rebuild.
-    assert "st_mtime" in handler, \
+    # The token must be an mtime, not a version string: `version.py` reports
+    # "dev" for every local build and so would never change between two of
+    # them. The stamp moved into _bundle_version() when /api/system/status
+    # started publishing it for stale-tab detection, so the requirement is now
+    # that the handler uses that ONE definition and that the definition is an
+    # mtime — see test_the_bundle_stamp_has_exactly_one_definition.
+    assert "_bundle_version()" in handler, \
+        "the handler must take its token from _bundle_version()"
+    helper = src[src.index("def _bundle_version("):]
+    helper = helper[:helper.index("\nasync def ", 1)]
+    assert "st_mtime" in helper, \
         "cache-bust on the bundle's mtime, not on a version string"
 
 
@@ -2637,3 +2647,60 @@ def test_every_debloat_push_asks_which_userspace_the_device_booted():
         + " — an emOS device has no package manager to hide packages from and "
           "no Magisk daemon to have created the service.d directory."
     )
+
+
+def test_the_bundle_stamp_has_exactly_one_definition():
+    """
+    A stale-tab check is worthless if the two ends derive the stamp
+    separately.
+
+    `_serve_dashboard` stamps the bundle URL and `/api/system/status`
+    publishes the same value for a running page to compare against. If those
+    two ever compute it independently they can drift, and the failure is
+    silent in both directions: permanently stale (a reload prompt nobody can
+    satisfy) or permanently fresh (the check does nothing, which is the state
+    this replaced).
+
+    The bug it exists for: a tab open across a controller update keeps its old
+    JavaScript, the wizard silently ran a step that had shipped hours earlier,
+    and the version in the header named the NEW controller because it comes
+    from the API — so the one number somebody checks to rule this out was the
+    number lying to them (2026-09-10).
+    """
+    src = (Path(__file__).resolve().parent.parent / "em_api.py").read_text()
+
+    assert src.count("def _bundle_version(") == 1, (
+        "_bundle_version must be the single definition of the bundle stamp")
+    assert '"bundle_version": _bundle_version()' in src, (
+        "/api/system/status must publish the stamp via _bundle_version(), so "
+        "the page can compare what it loaded against what is being served")
+
+    # The URL stamp must come from the same call, not a second stat().
+    serve = src[src.index("async def _serve_dashboard"):]
+    serve = serve[:serve.index("async def _redirect_root")]
+    assert "_bundle_version()" in serve, (
+        "_serve_dashboard must stamp the URL from _bundle_version() rather "
+        "than re-deriving the mtime")
+    assert "st_mtime" not in serve, (
+        "_serve_dashboard re-derives the bundle mtime — that is the drift "
+        "this test exists to prevent; use _bundle_version()")
+
+
+def test_the_stale_bundle_check_does_not_refresh_the_displayed_version():
+    """
+    The header must keep naming the controller the page was LOADED against.
+
+    Calling setStatus from the staleness poll would show the new version
+    beside a reload prompt, which reads as a bug in the prompt rather than a
+    stale page — and it is exactly the misleading behaviour being fixed, just
+    arrived at from the other side.
+    """
+    jsx = (Path(__file__).resolve().parent.parent
+           / "static" / "dashboard.jsx").read_text()
+
+    start = jsx.index("const stale = setInterval(")
+    block = jsx[start:jsx.index("return () => {", start)]
+    assert "bundle_version" in block, "the staleness poll must compare bundle_version"
+    assert "setStatus" not in block, (
+        "the staleness poll must not call setStatus — the header's version "
+        "has to keep naming the controller this page was loaded against")

--- a/emos/README.md
+++ b/emos/README.md
@@ -8,14 +8,14 @@ It is a distribution in the ordinary sense: it does not include a kernel of its
 own. It pairs the device's existing MediaTek 3.18 kernel with our own PID 1,
 busybox, and bionic and tinyalsa mounted read-only from the device's `/system`.
 
-**Status: 0.3, bench-proven, not field-proven.** Still a small number of
+**Status: 0.4, bench-proven, not field-proven.** Still a small number of
 devices over a handful of days. A complete voice turn has run on it — wake word
 scored on-device, Home Assistant pipeline, spoken answer — along with WiFi, the
 9-channel mic array, hardware AEC, the BLE proxy, buttons, ambient light, jack
 detect and the LED ring. The known gaps are listed at the bottom and none of
 them is a research problem.
 
-Two things changed since 0.1 that are worth knowing before you try it:
+Three things changed since 0.1 that are worth knowing before you try it:
 
 - **The provisioning wizard has now run end to end**, on a device restored to
   genuine stock. It failed at four different steps first, and every one of
@@ -23,12 +23,15 @@ Two things changed since 0.1 that are worth knowing before you try it:
 - **emOS updates in place, over the network.** A device was taken 0.1 → 0.3
   with no TWRP, no cable and no wipe. So a bug in a released emOS is something
   we can push a fix for, rather than something that strands a device.
+- **emOS is no longer a one-way door.** `/init recovery` reboots the device
+  into TWRP from its own console, and the wizard's first step already accepts
+  a device that is in TWRP — so emOS → recovery → re-provision is a path that
+  works, without powering the device off and holding the mute button in the
+  dark. New in 0.4, confirmed on hardware 2026-09-10.
 
-`emos-v0.3` is tagged and published so the wizard can fetch the init, which is
+`emos-v0.4` is tagged and published so the wizard can fetch the init, which is
 the only part of an image that can be distributed. **A tag is not a claim that
-this is finished.** Try it on a spare Echo, and read the Known gaps first — in
-particular, a device on emOS cannot be re-provisioned by the wizard, and going
-back means a TWRP wipe that erases `/data`.
+this is finished.** Try it on a spare Echo, and read the Known gaps first.
 
 ## Why
 
@@ -81,7 +84,7 @@ with `git describe --match 'emos-v*'`, so without those tags it stamps
 whatever tag is nearest — a controller release number, which is worse than
 "unknown" because it looks plausible. The namespace also keeps emOS out of the
 firmware OTA's way: `_fetch_latest_release` selects a tag starting `v` with a
-`server` asset, and `emos-v0.3` matches neither.
+`server` asset, and `emos-v0.4` matches neither.
 
 ```sh
 git tag -a --cleanup=verbatim emos-v0.4 -m "..."   # -a always; the annotation IS the notes
@@ -746,18 +749,28 @@ is not proof it rebooted — compare uptime or a build fingerprint.
   board.
 - The boot trail is a fixed-size buffer rewritten in place, so a shorter trail
   leaves the tail of the previous boot's behind and can be misread.
-- **A device on emOS cannot be re-provisioned by the wizard, and nothing in
-  the wizard says so.** Step 0 needs adbd, which emOS does not have and will
-  not — `f_acm` is the whole point of not needing a daemon. So the USB picker
-  offers nothing and the step fails with an error about the wrong device,
-  which does not name the actual reason. The duplicate-serial guard would
-  refuse it a second time over, since a provisioned device is registered.
+- **A device on emOS cannot start the wizard directly, and nothing in the
+  wizard says so** — but since 0.4 there is a one-command way round it, so
+  this is an unhelpful error rather than the dead end it was.
+
+  Step 0 needs adbd, which emOS does not have and will not — `f_acm` is the
+  whole point of not needing a daemon. So the USB picker offers nothing and
+  the step fails with an error about the wrong device, which does not name the
+  actual reason.
+
+  **`/init recovery` from the console is the way through.** The wizard's first
+  step already accepts a device that is in TWRP (it reads the FireOS build off
+  `/system`, since every property in recovery belongs to the ramdisk), so
+  reaching recovery is the whole of what was missing. What remains is that
+  nothing tells you that, and the duplicate-serial guard still refuses a
+  device that is already registered — it offers to delete it, which is the
+  right answer but has to be found.
 
   Noticed by Wil on 2026-09-05, after the flow was built. The design's open
   questions covered FireOS → emOS and deferred it; **nobody asked the
   reverse**, which is how it got this far.
 
-  Three paths exist and none of them is in the wizard:
+  The other three paths remain, and none of them is in the wizard either:
 
   - **Return to stock, by hand.** Boot into TWRP — unplug the power, hold
     **mute** down, and apply power with it still held, until the ring shows an
@@ -780,9 +793,12 @@ is not proof it rebooted — compare uptime or a build fingerprint.
     re-provision and needs no USB at all.
   - **The console**, for a device that is on emOS but not on the network.
 
-  The middle one is the fix worth building, and it is the same self-flash the
-  design deferred for FireOS → emOS. Until then this is a one-way door: keep
-  the escrowed boot image.
+  The middle one is still the fix worth building, and it is the same self-flash
+  the design deferred for FireOS → emOS — it needs no USB and no recovery at
+  all. It is no longer urgent, though: `/init recovery` plus the wizard's
+  existing TWRP entry covers the case that mattered. Keep the escrowed boot
+  image regardless; it is the ten-second undo for a device that will not boot,
+  which is the one situation none of these paths help with.
 
 ## What emOS is worth beyond the stunt
 


### PR DESCRIPTION
A tab left open across a controller update keeps its JavaScript indefinitely. The bundle URL is cache-busted on its mtime, but that only bites on a page **load**, so nothing in a running page could notice.

It cost a provisioning run tonight: the wizard silently skipped a step that had shipped hours earlier. Server right, file on disk right, browser executing yesterday's code.

### The header's version was the wrong thing to refresh

Refreshing it would have made this **worse**. `controller_version` comes from the API, so polling it shows the *new* controller while the *old* code runs — and that's the one number somebody checks to rule this out. It would have confirmed the opposite of the truth, faster.

So the check compares the **bundle**. `_serve_dashboard` already stamps `?v=<mtime>` on the script URL; `/api/system/status` now publishes the same stamp, the page reads the `?v=` off its own `<script>` tag at load, and a slow poll compares them. On a mismatch the header version becomes a **`2.23.0 · reload`** button — in place of the version rather than a banner beside it, since that's the element that was lying, and it costs no vertical space.

### Four things that aren't incidental

- **One definition of the stamp.** `_bundle_version()` serves both the URL and the API. Two independent derivations drift silently in *both* directions: permanently stale (a prompt nobody can satisfy) or permanently fresh (the state this replaces). Pinned by test — as is the mtime requirement, since `version.py` reports `dev` for every local build and would never differ between two of them.
- **The staleness poll must not call `setStatus`.** A fresh version beside a reload prompt reads as a bug in the prompt.
- **Its own 60s timer**, not the 5s device poll — `/api/system/status` gathers process and disk stats, and controller updates happen weekly at most.
- **Latched, never cleared.** Two updates while one tab is open is still one stale tab; a prompt that flickered off would look self-healing.

Both ends degrade to silence: an unreadable bundle publishes `""`, a page that can't find its script tag reports `""`, and equal values say nothing.

### One existing test updated, not weakened

`test_dashboard_bundle_is_cache_busted` asserted `st_mtime` appeared inside `_serve_dashboard`, which the shared helper moved. Its intent is kept — the token must be an mtime — and now reads through `_bundle_version()`.

### Verified

**1034 passed** (1032 plus the two new pins), all eight dashboard `.mjs` suites, bundle compiles, and `--warn` is defined in both themes so the indicator can't render as invisible text in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBGUwJuEtMQAikjyy1Bskh