### PR TITLE
Hold numpy at 2.3.5 so the add-on starts on Proxmox kvm64

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,9 +43,16 @@ updates:
     # above — as an ordinary weekly PR, alongside bumps that genuinely were
     # routine. Nothing in CI can catch an inference regression, so the guard
     # has to be here or it does not exist.
+    #
+    # numpy is ignored on MINOR too since it was held at 2.3 (#496): 2.4+
+    # wheels need an x86-64-v2 CPU and stop the add-on starting on Proxmox
+    # kvm64. A weekly PR offering 2.4 would be red on the kvm64 check every
+    # Monday, which is noise, not a decision — moving it is #224.
     ignore:
       - dependency-name: numpy
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
       - dependency-name: onnxruntime
         update-types:
           - version-update:semver-major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,9 +258,22 @@ jobs:
         with:
           context: controller
           push: false
+          load: true
+          tags: echomuse-controller:pr
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      # A wheel's CPU baseline is invisible to every other check, because
+      # every runner is newer than the CPUs it excludes. numpy 2.4 needed
+      # x86-64-v2 and the add-on would not start on Proxmox's kvm64 (#496)
+      # while this job was green. The trigger above is exactly right for it:
+      # only a Dockerfile or requirements change can move a baseline.
+      - name: CPU baseline (kvm64)
+        if: steps.changed.outputs.build == 'true'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq qemu-user-static
+          controller/tools/cpu_baseline_check.sh echomuse-controller:pr
 
 
   controller-imports:

--- a/.github/workflows/controller-build.yml
+++ b/.github/workflows/controller-build.yml
@@ -90,6 +90,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # The PR check (ci.yml) only runs when the Dockerfile or requirements
+      # change, but the base image FLOATS, so what ships can move without a
+      # PR. This is the artifact that gets promoted, so it is checked here
+      # too, by digest. amd64 only — see the script. #496.
+      - name: CPU baseline (kvm64)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq qemu-user-static
+          controller/tools/cpu_baseline_check.sh \
+            ghcr.io/${{ github.repository_owner }}/echomuse-controller@${{ steps.build.outputs.digest }}
+
       # By digest, for the reason the release workflow documents: there is
       # no string to get wrong and no chance of scanning something other
       # than the artifact just built.

--- a/controller/requirements.txt
+++ b/controller/requirements.txt
@@ -33,7 +33,30 @@ zeroconf==0.150.0
 # Wake word inference — openwakeword deps installed manually to avoid
 # tflite-runtime which has no Python 3.12 x86_64 build.
 # openwakeword itself is installed via --no-deps in the Dockerfile.
-numpy==2.4.4
+#
+# numpy is held BELOW 2.4 for the CPU, not for the API (#496). numpy 2.4's
+# x86_64 wheels are built with an x86-64-v2 baseline (SSE4.2, POPCNT), so
+# on a CPU without it `import numpy` dies before our code runs — and
+# Proxmox's `kvm64` CPU type, still what many Home Assistant VMs carry,
+# is exactly such a CPU. The add-on did not start at all there. scipy,
+# scikit-learn and openwakeword go down with it, since they import numpy.
+#
+# Measured 2026-09-11 against the published 2.23.0 image under
+# `qemu-x86_64 -cpu kvm64`: 2.4.4 dies; 2.3.5 in the same image runs the
+# whole stack including a wake word prediction. It costs nothing on a
+# modern CPU, because numpy dispatches AVX2/AVX-512 at RUNTIME whatever
+# the baseline — oww scoring 2.96-3.06% of realtime against 2.92-2.99%,
+# three runs each — and wake scores are bit-identical across 4,588 frames
+# of real recordings (with np.random seeded: openwakeword fills its
+# feature buffer with random noise at Model init, and an unseeded
+# comparison measures that instead of numpy).
+#
+# The `CPU baseline (kvm64)` step in CI runs the built image under that
+# emulated CPU, so this is guarded rather than remembered: a bump past 2.3,
+# or ANY dependency raising its baseline the same way, fails there. Moving
+# numpy forward (#224) therefore means deciding to drop kvm64, or building
+# numpy from source with a lower baseline — not a version edit.
+numpy==2.3.5
 scipy
 tqdm
 scikit-learn

--- a/controller/tools/README.md
+++ b/controller/tools/README.md
@@ -31,3 +31,11 @@ docker exec echomuse-controller python /tmp/devshell.py "<shell command>" ["<ano
   multi-megabyte files; **deletes the destination first** unless
   `--resume`, since resuming on size alone will append to a different file
   and then report success. Success means md5 agreement, nothing less.
+
+One runs on the **host**, not in the container:
+
+- **cpu_baseline_check.sh** — runs an image under an emulated Proxmox
+  `kvm64` CPU and fails if any dependency needs more (#496):
+  `controller/tools/cpu_baseline_check.sh <image>`. Needs
+  `qemu-user-static`. CI runs it on every image build; `cpu_baseline_probe.py`
+  is its payload.

--- a/controller/tools/cpu_baseline_check.sh
+++ b/controller/tools/cpu_baseline_check.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run a controller image under an emulated Proxmox `kvm64` CPU (#496).
+#
+#   controller/tools/cpu_baseline_check.sh <image>
+#
+# WHY: numpy 2.4's x86_64 wheels need x86-64-v2 (SSE4.2, POPCNT), and on a
+# CPU without it the add-on did not start at all. kvm64 is such a CPU and
+# is what a lot of Home Assistant VMs on Proxmox carry. Nothing else in CI
+# could see this: every runner, and every machine we test on, is newer.
+# The fault is a property of a WHEEL's build flags, so any dependency can
+# reintroduce it in a routine bump, with every other check green.
+#
+# HOW: qemu-user translates the image's own python3 with `-cpu kvm64`, so
+# the whole process sees kvm64's CPUID and faults on anything past it. It
+# runs inside `docker run` rather than a bare chroot because onnxruntime's
+# cpuinfo aborts without /proc, which looks exactly like a CPU fault and
+# is not one. The probe checks that the emulated CPU really lacks SSE4.2,
+# so a qemu that ignored `-cpu` cannot produce a pass.
+#
+# `--init` is REQUIRED, not tidiness. Without it qemu is PID 1, and when
+# the guest faults qemu reports it by sending ITSELF the signal — which the
+# kernel ignores for PID 1. So the failure this script exists to catch did
+# not fail: it hung at 0% CPU, and in CI that is a job sitting out its
+# timeout rather than a red check. Found on the first negative-control run.
+#
+# amd64 only: arm64 has no equivalent baseline problem here, and kvm64 is
+# an x86 model.
+set -euo pipefail
+
+image="${1:?usage: $0 <image>}"
+here="$(cd "$(dirname "$0")" && pwd)"
+qemu="$(command -v qemu-x86_64-static || true)"
+if [ -z "$qemu" ]; then
+  echo "qemu-x86_64-static not found (apt-get install qemu-user-static)" >&2
+  exit 2
+fi
+
+run() {
+  docker run --rm --init --platform linux/amd64 \
+    -v "$qemu:/qemu:ro" \
+    -v "$here/cpu_baseline_probe.py:/probe.py:ro" \
+    -w /app --entrypoint /qemu "$image" -cpu kvm64 "$@"
+}
+
+echo "== python stack under kvm64"
+run /usr/local/bin/python3 /probe.py --kvm64
+
+# ffmpeg is spawned as a subprocess, and qemu-user does not follow execve
+# into a child — so the probe above cannot cover it. Decode a second of
+# tone under the same CPU on its own.
+echo "== ffmpeg under kvm64"
+bytes="$(run /usr/bin/ffmpeg -hide_banner -loglevel error \
+          -f lavfi -i sine=d=1 -f s16le -ar 48000 -ac 1 - | wc -c)"
+if [ "$bytes" -ne 96000 ]; then
+  echo "ffmpeg decoded $bytes bytes, expected 96000" >&2
+  exit 1
+fi
+echo "ffmpeg decoded 1s of audio"

--- a/controller/tools/cpu_baseline_probe.py
+++ b/controller/tools/cpu_baseline_probe.py
@@ -1,0 +1,73 @@
+"""Exercise the controller's native dependencies on whatever CPU runs this.
+
+Run by cpu_baseline_check.sh under `qemu-x86_64 -cpu kvm64`, inside the
+built image. See that script for why; this file is only the payload.
+
+Three parts, and the order matters:
+
+1. Import numpy, then confirm the CPU really is the emulated one. numpy's
+   own runtime CPU detection reads CPUID, so under a genuine kvm64 it must
+   report no SSE4.1/SSE4.2/POPCNT/AVX2. If it reports any of them, qemu
+   ignored `-cpu` and every pass below would be a pass on the host CPU,
+   so that is a failure, not a warning.
+2. Import every controller module, the same set CI's import job uses, so
+   a dependency added tomorrow is covered on the day it lands.
+3. Actually run the code paths whose wheels carry compiled kernels: a
+   wake word prediction (onnxruntime + openwakeword's numpy features), the
+   output chain (scipy), the noise suppressor. Importing a module does
+   not execute its SIMD kernels, so a clean import proves less than it
+   looks like it does.
+"""
+import importlib
+import pathlib
+import sys
+import traceback
+
+import numpy as np
+from numpy._core._multiarray_umath import __cpu_features__ as feats
+
+EXPECT_ABSENT = ("SSE41", "SSE42", "POPCNT", "AVX2")
+present = [f for f in EXPECT_ABSENT if feats.get(f)]
+if "--kvm64" in sys.argv and present:
+    sys.exit(f"harness fault: CPU reports {present}, so this is not kvm64 "
+             f"and a pass would prove nothing")
+print(f"numpy {np.__version__}; CPU reports "
+      f"{', '.join(f for f in EXPECT_ABSENT if f not in present) or 'all'} "
+      f"absent of {', '.join(EXPECT_ABSENT)}")
+
+sys.path.insert(0, "/app")
+mods = sorted(p.stem for p in pathlib.Path("/app").glob("*.py"))
+mods = [m for m in mods if m != "em_start"]
+failed = []
+for m in mods:
+    try:
+        importlib.import_module(m)
+    except BaseException:
+        failed.append(m)
+        print(f"--- {m} ---", file=sys.stderr)
+        traceback.print_exc()
+if failed:
+    sys.exit("FAILED to import: " + ", ".join(failed))
+print(f"imported {len(mods)} controller modules")
+
+from openwakeword.model import Model  # noqa: E402
+
+model = Model(wakeword_models=["hey_jarvis"], inference_framework="onnx")
+pcm = (np.random.default_rng(0).standard_normal(16000 * 3) * 3000).astype(np.int16)
+for i in range(0, len(pcm) - 1280, 1280):
+    model.predict(pcm[i:i + 1280])
+print("wake word prediction ran")
+
+import em_eq  # noqa: E402
+import scipy.signal as ss  # noqa: E402
+
+sos = ss.butter(4, [100, 8000], "bandpass", fs=48000, output="sos")
+ss.sosfilt(sos, np.random.default_rng(0).standard_normal(48000))
+print(f"scipy filter ran; em_eq loaded from {em_eq.__file__}")
+
+from speexdsp_ns import NoiseSuppression  # noqa: E402
+
+ns = NoiseSuppression.create(160, 16000)
+ns.process(bytes(320))
+print("speexdsp noise suppression ran")
+print("OK")


### PR DESCRIPTION
Fixes #496. The add-on failed to start on Proxmox VMs using the `kvm64` CPU type.

- **Cause:** numpy 2.4's wheels need an x86-64-v2 CPU, and kvm64 doesn't have one, so `import numpy` crashed before the controller started.
- **Fix:** pin `numpy==2.3.5`. Under an emulated kvm64 the whole stack then runs: every controller module, a wake word prediction, scipy, speexdsp and ffmpeg.
- **Cost:** none measured. Wake scoring costs 2.96–3.06% of realtime against 2.92–2.99% before, and scores are bit-identical across 4,588 frames of real recordings.

**Guard:** `controller/tools/cpu_baseline_check.sh` runs the image under qemu's `kvm64` model. CI runs it in the PR image job, which only triggers when the Dockerfile or requirements change, and again on the main build by digest. Checked both ways locally: 2.23.0 fails (exit 132) and this branch passes.

**Also:** Dependabot now ignores numpy minor bumps as well as majors. Moving past 2.3 becomes part of #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015D6ssR69sXM4mm1dcsfb82
