### PR TITLE
Warn everywhere against amonet-biscuit v2.0.0, and bring the FAQ up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ the original SDK that made this hardware accessible.
 
 ## Before you start
 
+> **⚠️ Do not install amonet-biscuit v2.0.0 on an Echo you use with EchoMuse.**
+> Version 2.0.0 of the unlock (10 September 2026) replaces the Echo's
+> bootloaders, and after that FireOS 5 no longer boots. EchoMuse only runs on
+> FireOS 5, emOS included, because emOS uses the FireOS 5 kernel. The XDA
+> thread now tells unlocked users to update. If your Echo runs EchoMuse,
+> don't.
+>
+> - **Unlocking a new Echo?** Use **amonet-biscuit v1.1.0**, which is still
+>   attached to the XDA thread.
+> - **Already updated?** Do not try to go back by flashing FireOS 5 or an
+>   older amonet. v2.0.0 rewrote the preloader, LK and TrustZone, and writing
+>   old ones back by hand is how an Echo gets hard-bricked. EchoMuse does not
+>   run on FireOS 6 today, so for now that Echo stays on FireOS 6.
+
 **New here? Start with the [quickstart](docs/quickstart.md)** — it's the
 guided path from zero to talking to your Dot, and it sends you to the
 rooting guide at the right moment rather than opening with it.
@@ -108,7 +122,7 @@ of which is a
 walkthrough.
 
 The short version:
-- Persistent unlock via [amonet-biscuit](https://xdaforums.com/t/unlock-root-twrp-unbrick-amazon-echo-dot-2nd-gen-2016-biscuit.4761416/) (R0rt1z2)
+- Persistent unlock via [amonet-biscuit](https://xdaforums.com/t/unlock-root-twrp-unbrick-amazon-echo-dot-2nd-gen-2016-biscuit.4761416/) (R0rt1z2) — **v1.1.0, not v2.0.0** (see above)
 - FireOS 5 (Android 5.1, API 22)
 - Magisk 17.3
 - Alexa voice stack disabled (the dashboard's debloat step handles this)

--- a/controller-ea/DOCS.md
+++ b/controller-ea/DOCS.md
@@ -36,6 +36,15 @@ Runs the EchoMuse controller — wake word detection, fleet dashboard, and
 Home Assistant integration for rooted Echo Dot 2nd Gen devices — as a Home
 Assistant add-on instead of a separate docker-compose deployment.
 
+> **⚠️ Do not install amonet-biscuit v2.0.0 on an Echo you use with
+> EchoMuse.** Version 2.0.0 of the unlock (10 September 2026) replaces the
+> Echo's bootloaders, and after that FireOS 5 no longer boots. EchoMuse only
+> runs on FireOS 5, emOS included. Unlock new Echoes with **v1.1.0**. If you
+> have already installed v2.0.0, **do not try to go back by flashing FireOS 5
+> or an older amonet**: that rewrites bootloaders by hand, which is how an
+> Echo gets hard-bricked. Details:
+> [Rooting a device](https://github.com/wilbowes/EchoMuse/blob/main/docs/rooting.md).
+
 ## Installation
 
 1. Install the add-on and start it. **Controller LAN IP address** can be

--- a/controller/DOCS.md
+++ b/controller/DOCS.md
@@ -4,6 +4,15 @@ Runs the EchoMuse controller — wake word detection, fleet dashboard, and
 Home Assistant integration for rooted Echo Dot 2nd Gen devices — as a Home
 Assistant add-on instead of a separate docker-compose deployment.
 
+> **⚠️ Do not install amonet-biscuit v2.0.0 on an Echo you use with
+> EchoMuse.** Version 2.0.0 of the unlock (10 September 2026) replaces the
+> Echo's bootloaders, and after that FireOS 5 no longer boots. EchoMuse only
+> runs on FireOS 5, emOS included. Unlock new Echoes with **v1.1.0**. If you
+> have already installed v2.0.0, **do not try to go back by flashing FireOS 5
+> or an older amonet**: that rewrites bootloaders by hand, which is how an
+> Echo gets hard-bricked. Details:
+> [Rooting a device](https://github.com/wilbowes/EchoMuse/blob/main/docs/rooting.md).
+
 ## Installation
 
 1. Install the add-on and start it. **Controller LAN IP address** can be

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -11,6 +11,20 @@ faults worth checking before you file, and
 
 ## Rooting and unlocking
 
+### The XDA thread says to update to amonet v2.0.0. Should I?
+**Not on an Echo you use with EchoMuse.** v2.0.0 (10 September 2026) replaces
+the Echo's bootloaders, and after that FireOS 5 no longer boots. EchoMuse only
+runs on FireOS 5, emOS included, because emOS uses the FireOS 5 kernel.
+
+- **Unlocking a new Echo:** use **v1.1.0**, which is still attached to the
+  thread.
+- **Already installed v2.0.0:** do not try to go back by flashing FireOS 5 or
+  an older amonet. v2.0.0 rewrote the preloader, LK and TrustZone, and writing
+  old ones back by hand is how an Echo gets hard-bricked. EchoMuse does not run
+  on FireOS 6 today, so for now that Echo stays on FireOS 6.
+
+Why it happens is explained at the top of [rooting](rooting.md).
+
 ### The unlock won't run on my Mac.
 **It needs Linux.** The unlock is
 [R0rt1z2's work on XDA](https://xdaforums.com/t/unlock-root-twrp-unbrick-amazon-echo-dot-2nd-gen-2016-biscuit.4761416/),
@@ -61,10 +75,12 @@ Use **Chrome or Edge**. The wizard talks to the device over WebUSB and other
 browsers vary. Brave in particular is unconfirmed.
 
 ### The wizard says it needs a secure context.
-If you reach Home Assistant over plain `http://`, the browser blocks WebUSB.
-Add your HA URL at `chrome://flags/#unsafely-treat-insecure-origin-as-secure`
-— e.g. `http://homeassistant.local:8123` — and restart the browser. Tracked as
-[#170](https://github.com/wilbowes/EchoMuse/issues/170).
+If you reach Home Assistant over plain `http://`, the browser blocks WebUSB, and
+the wizard's first step names the exact origin to allow. Either serve Home
+Assistant over HTTPS, or add that origin at
+`chrome://flags/#unsafely-treat-insecure-origin-as-secure` and restart the
+browser. The entry has to match scheme, host **and port** exactly, so one for
+some other address does not cover it.
 
 ### The USB connection drops and re-enumerates every few seconds.
 `persist.sys.usb.config` is set to `mtp,adb`, and the composite gadget is what
@@ -89,6 +105,25 @@ than the fix. Corrected 2026-09-05.)*
 ### A wizard step failed and I don't know why.
 Every failed step offers diagnostics. Grab those before retrying — the state
 the device is in is the diagnostic, and retrying destroys it.
+
+---
+
+## emOS
+
+### emOS or FireOS: which should I pick in the wizard?
+The wizard offers **emOS** first. It replaces Android on the Echo entirely,
+keeping only Amazon's kernel, and it is why the 3.5mm jack behaves properly.
+**FireOS** is one labelled click away and is what most fielded devices run.
+The emOS flow saves your original boot image before writing anything, and
+restoring it takes about ten seconds; the FireOS flow does not yet
+([#468](https://github.com/wilbowes/EchoMuse/issues/468)). Both need the amonet
+**v1.1.0** unlock; see the first question on this page.
+
+### How do I run the wizard again on an emOS device?
+emOS has no adb, so the wizard cannot see it directly. Open the USB console,
+run `/init recovery`, and the Echo reboots into TWRP, where the wizard's first
+step accepts it. This needs emOS 0.4 or later. If the wizard then says the
+device is already registered, let it delete the old entry.
 
 ---
 
@@ -121,6 +156,16 @@ docker compose pull && docker compose up -d
 or update the add-on from Home Assistant. **The dashboard's update notice is
 advisory and always will be** — the controller is your container, and a
 process cannot restart itself mid-request and then tell you how it went.
+
+### Home Assistant offers an update, but installing it fails.
+Wait a few minutes and try again. Home Assistant can see a new version shortly
+before its image has finished publishing, and until then the install fails
+with `manifest unknown`. Nothing is wrong with your setup.
+
+### The add-on won't start: "NumPy was built with baseline optimizations: (X86_V2)".
+Fixed in **2.23.1**; update the add-on. It affected Proxmox VMs using the
+`kvm64` CPU type, which lacks instructions NumPy 2.4 needed.
+[#496](https://github.com/wilbowes/EchoMuse/issues/496).
 
 ### The update notice shows no release notes.
 Notes come from the tag annotation. If they're empty, that's ours to fix —
@@ -175,7 +220,10 @@ See [#210](https://github.com/wilbowes/EchoMuse/issues/210) — and please add
 your setup, that one needs more reports than it has.
 
 ### The device isn't offered as a target for "start a conversation".
-Not implemented yet. [#335](https://github.com/wilbowes/EchoMuse/issues/335).
+**Update the controller.** `assist_satellite.start_conversation` and
+`assist_satellite.ask_question` are both supported, attention chime included.
+A device only appears as a target once it reports a working microphone, so if
+it is still missing, check the device is connected.
 
 ---
 
@@ -224,19 +272,28 @@ substantial driver correction we don't yet —
 Ducking needs firmware that advertises audio mixing. Update the device
 firmware; if it still pauses, check Device → Status and report it.
 
+### Some commands take fifteen seconds to answer.
+Fixed in **2.23.0**; update the controller. It hit short commands like
+"stop", and speaking straight after the wake word, because Home Assistant's
+end-of-speech detection sometimes never started and waited out its own
+fifteen-second limit. If it still happens, report it with a support bundle.
+[#485](https://github.com/wilbowes/EchoMuse/issues/485).
+
 ### Long responses cut off part-way.
-Known: [#324](https://github.com/wilbowes/EchoMuse/issues/324). A support
-bundle with the time it happened genuinely helps here.
+Fixed; update the controller. If a long answer still stops early, a support
+bundle with the time it happened is the right report.
+[#324](https://github.com/wilbowes/EchoMuse/issues/324).
 
 ### Can I interrupt it while it's talking?
 Yes — say the wake word again. Enable it under **Config → Wake word →
 Barge-in** if it isn't already.
 
 ### Does it do timers?
-Yes, as of the current release — ask for one the way you'd expect. **Stopping
-a ringing timer by voice is known to be unreliable**, and that half is still
-being worked on. Report what you said and what happened; the wording people
-actually use is the useful part.
+Yes — ask for one the way you'd expect, and it rings on the Echo itself.
+Stopping one no longer leaves the Echo deaf. **Stopping a ringing timer by
+voice can still be unreliable**, because the chime competes with what you say.
+Report what you said and what happened; the wording people actually use is the
+useful part.
 
 ---
 
@@ -283,8 +340,11 @@ report it.
 Not yet — [#133](https://github.com/wilbowes/EchoMuse/issues/133).
 
 ### The device won't reconnect to WiFi after a reboot.
-If your network has no internet access, this is a known Android behaviour
-blocking auto-join — [#317](https://github.com/wilbowes/EchoMuse/issues/317).
+If your network has no internet access, Android decides it is bad and stops
+auto-joining it. **Fixed for devices provisioned by the current wizard**
+([#317](https://github.com/wilbowes/EchoMuse/issues/317)). A device provisioned
+before that fix can still hit it, and clearing it on a fielded device is
+[#439](https://github.com/wilbowes/EchoMuse/issues/439).
 
 ### There's no ambient light sensor on my device.
 Some Dots ship a second-source sensor that binds a different driver. Known,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -24,6 +24,14 @@ pretending it's easy.
 
 ## Step 1 — Root the Dot (one time, per device)
 
+> **⚠️ Unlock with amonet-biscuit v1.1.0, not v2.0.0.** v2.0.0 (10 September
+> 2026) replaces the Echo's bootloaders so that FireOS 5 no longer boots, and
+> EchoMuse, emOS included, only runs on FireOS 5. The XDA thread now offers
+> v2.0.0 first and tells unlocked users to update. If you have already
+> installed it, **do not try to go back by flashing FireOS 5 or an older
+> amonet**: that rewrites bootloaders by hand, which is how an Echo gets
+> hard-bricked. The details are at the top of [rooting](rooting.md).
+
 The Dot ships locked to Amazon's software. Unlocking it involves flashing
 modified firmware over USB — it's the only genuinely fiddly part of the
 project, it takes an hour or so the first time, and it's fully documented

--- a/docs/rooting.md
+++ b/docs/rooting.md
@@ -3,6 +3,20 @@
 > **You do this at your own risk. We accept no responsibility for negative
 > outcomes experienced.**
 
+> **⚠️ Do not install amonet-biscuit v2.0.0 on an Echo you use with EchoMuse.**
+> Version 2.0.0 of the unlock (10 September 2026) replaces the Echo's
+> bootloaders, and after that FireOS 5 no longer boots. EchoMuse only runs on
+> FireOS 5, emOS included, because emOS uses the FireOS 5 kernel. The XDA
+> thread now tells unlocked users to update. If your Echo runs EchoMuse,
+> don't.
+>
+> - **Unlocking a new Echo?** Use **amonet-biscuit v1.1.0**, which is still
+>   attached to the XDA thread.
+> - **Already updated?** Do not try to go back by flashing FireOS 5 or an
+>   older amonet. v2.0.0 rewrote the preloader, LK and TrustZone, and writing
+>   old ones back by hand is how an Echo gets hard-bricked. EchoMuse does not
+>   run on FireOS 6 today, so for now that Echo stays on FireOS 6.
+
 EchoMuse needs an Echo Dot Gen 2 that is already unlocked and running
 FireOS 5. Two separate jobs get you there, and they carry very different
 risk.
@@ -16,23 +30,22 @@ risk.
 - OS: FireOS 5 (Android 5.1, API 22) — see the note below on FireOS 6
 - MicroUSB cable required
 
-> **FireOS 6 exists for biscuit and cannot be booted once you have unlocked.**
-> `Fire OS 6.5.7.0 (NS6570/6077)` is real, and amonet's instructions tell you
-> to update *to* it before unlocking, because the exploit downgrades the
-> firmware partitions on the way through. But after unlocking, only FireOS 5
-> based ROMs boot — R0rt1z2's thread is explicit that flashing FireOS 6 "may
-> result in a (soft) brick".
+> **Which FireOS boots depends on which amonet you used.** Up to v1.1.0, only
+> FireOS 5 based ROMs boot after unlocking; R0rt1z2's thread said flashing
+> FireOS 6 "may result in a (soft) brick". v2.0.0 (10 September 2026) turns
+> that round: it boots FireOS 6, and FireOS 5 no longer boots.
 >
-> Two reasons, and the second is the real one. FireOS 6 on this board is a
-> **32-bit** kernel while amonet's payload forced 64-bit — since fixed
-> upstream, by parsing the cmdline. The blocker underneath is the signature
-> chain: FireOS 6 likely needs a newer TrustZone, and a newer TZ cannot be
-> flashed because the FireOS 5 preloader refuses to boot one whose signature
-> differs. That is below the boundary this project writes to, so it is not
-> something EchoMuse can address.
+> What changes is the bootloaders, not the kernel's bitness. The v2.0.0
+> installer writes a newer preloader, LK and TrustZone to the device, and
+> FireOS 5's kernel does not run on them. Its LK patch starts a 32-bit or
+> 64-bit kernel according to what the boot image asks for, so bitness was not
+> the obstacle. (This corrects an earlier version of this note, which put it
+> down to the TrustZone signature chain.)
 >
-> Practically: EchoMuse targets FireOS 5, and a newer Android is not a route
-> to a newer kernel on this device.
+> EchoMuse, emOS included, runs on FireOS 5, so it needs **v1.1.0**. For that
+> version, `Fire OS 6.5.7.0 (NS6570/6077)` still matters: its instructions
+> tell you to update *to* it before unlocking, because the exploit downgrades
+> the firmware partitions on the way through.
 
 ## What you need
 
@@ -41,7 +54,9 @@ For the unlock itself (R0rt1z2's thread has the authoritative list):
 - **Linux machine** with ADB and fastboot installed — see the note below on macOS
 - Python 3 (for boot image patching and Magisk DB creation)
 - The following files downloaded and ready:
-  - `amonet-biscuit-v1.1.0.zip` — from R0rt1z2's XDA thread
+  - `amonet-biscuit-v1.1.0.zip` — from R0rt1z2's XDA thread. **Not
+    v2.0.0**, which is what the thread now offers first; see the warning at
+    the top of this page.
   - `update-kindle-csm_biscuit-272.6.8.0_user_680767620.bin` — FireOS 5 firmware
     (**this exact build** — see below)
   - `f1r30s.zip` — from R0rt1z2's XDA thread. Does four things, not one:
@@ -93,7 +108,9 @@ The persistent unlock, the bootrom exploit and TWRP for this device are
 
 Follow that thread, not this page. We link to it rather than copying it
 because a copy goes out of date without anyone noticing. If the two ever
-disagree, the thread is correct.
+disagree, the thread is correct, **with one exception: the version.** Use
+v1.1.0, not v2.0.0. v2.0.0 stops FireOS 5 booting, and EchoMuse needs
+FireOS 5; see the warning at the top of this page.
 
 **This is the part that can ruin a device.** It runs a bootrom exploit,
 modifies the partition table and wipes userdata. A failure here can leave a

--- a/emos/README.md
+++ b/emos/README.md
@@ -8,6 +8,15 @@ It is a distribution in the ordinary sense: it does not include a kernel of its
 own. It pairs the device's existing MediaTek 3.18 kernel with our own PID 1,
 busybox, and bionic and tinyalsa mounted read-only from the device's `/system`.
 
+> **⚠️ emOS needs the FireOS 5 kernel, so do not install amonet-biscuit
+> v2.0.0.** Version 2.0.0 of the unlock (10 September 2026) replaces the
+> Echo's bootloaders, and after that FireOS 5, and with it emOS, no longer
+> boots. The emOS init is also a 64-bit (aarch64) binary, which FireOS 6's
+> 32-bit kernel cannot run. Unlock with **v1.1.0**. If you have already
+> installed v2.0.0, **do not try to go back by flashing FireOS 5 or an older
+> amonet**: that rewrites bootloaders by hand, which is how an Echo gets
+> hard-bricked. See the top of [`docs/rooting.md`](../docs/rooting.md).
+
 **Status: 0.4, bench-proven, not field-proven.** Still a small number of
 devices over a handful of days. A complete voice turn has run on it — wake word
 scored on-device, Home Assistant pipeline, spoken answer — along with WiFi, the


### PR DESCRIPTION
**amonet-biscuit v2.0.0 stops FireOS 5 booting, and EchoMuse only runs on FireOS 5 (emOS included).** This PR puts a warning at the top of every page that talks about unlocking.

- **Where:** README, `docs/rooting.md`, `docs/quickstart.md`, the add-on's `DOCS.md` (shown inside Home Assistant; EA copy synced), `emos/README.md` and the FAQ.
- **What it says:** unlock new Echoes with v1.1.0. If you've already installed v2.0.0, don't try to go back by flashing FireOS 5 or an older amonet, because v2.0.0 rewrote the bootloaders (preloader, LK and TrustZone). This caveat is kept at full length on every page, since the obvious recovery is the one that hard-bricks.
- **Why FireOS 5 stops:** it's the bootloaders, not 32- vs 64-bit. The v2 installer writes a new preloader, LK and TrustZone, and its bootloader patch boots whichever bitness the image asks for. I read this from R0rt1z2's published source, since XDA wouldn't serve the zip. The old explanation in `docs/rooting.md` is corrected.

**FAQ review:** entries on "start a conversation", long responses, WiFi auto-join, the secure context and timers are updated to match what has shipped. New entries cover the fifteen-second delay, kvm64, updates that fail for a few minutes, and emOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015D6ssR69sXM4mm1dcsfb82
