### PR TITLE
Refuse a device unlocked with amonet-biscuit v2.0.0 at the wizard's first step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
           node controller/tests/emos_md5.test.mjs
           node controller/tests/boot_image_length.test.mjs
           node controller/tests/number_field.test.mjs
+          node controller/tests/unlock_verdict.test.mjs
 
   device-tests:
     name: Device Go tests

--- a/controller/CLAUDE.md
+++ b/controller/CLAUDE.md
@@ -1622,6 +1622,26 @@ throughout — so the rules below are all one rule seen from different angles.
   `system_<slot>` read-only, by NAME and by slot rather than as p13, and read
   `build.prop`. That is also the partition emOS mounts at runtime for bionic
   and tinyalsa, so it is the build that actually matters.
+  **The FireOS 5 check itself used TWRP's getprop until 2026-09-11**, and
+  passed only because v1's TWRP 3.2.3 happens to report 5.1.1. In recovery
+  the release now comes from `/system` (`readFireosBuild().release`), and an
+  unknown one skips the check rather than guessing.
+- **A device unlocked with amonet-biscuit v2.0.0 is refused at the connect
+  step, on EVIDENCE, never on absence** (`_unlockVerdict`). v2.0.0 (R0rt1z2,
+  10 Sep 2026) writes a newer preloader, LK and TrustZone, FireOS 5 does not
+  boot on them, and neither does emOS, which runs the FireOS 5 kernel — so
+  without this the emOS flow would escrow, build and flash an image that
+  cannot boot. Any one of three signs refuses: an MTK image header
+  (`88168858`) at the start of `expdb`, where v2's preloader exploit loads LK
+  from (amonet-koboreru's `LK_PART_NAME`); TWRP 3.7 or later (v2 ships
+  3.7.0_9-0, v1 3.2.3-0); or Android 6+ as the release that matters. A probe
+  that could not run yields empty strings, and empty is NOT evidence — the
+  error that must not happen is refusing a working v1.1.0 device because `od`
+  was missing. The absence of `boot_[ab]_amonet` is deliberately not one of
+  the signs: v2's installer does not rewrite the GPT, so a device upgraded
+  from v1 may still carry v1's names. Derived from R0rt1z2's published
+  sources, not from a v2 device, since none has been through the wizard yet.
+  `unlock_verdict.test.mjs`.
 - **`_STEP_MODE` is enforced at every step, not only on Reconnect.** It existed
   and was correct and was consulted in one place, where a mismatch logged a
   line and left Retry enabled. In Android `/dev/block/other-boot` is amonet's

--- a/controller/static/dashboard.jsx
+++ b/controller/static/dashboard.jsx
@@ -2851,6 +2851,39 @@ service echomuse /data/local/bin/start_server.sh
 const _TESTED_FIREOS_BUILD = '272.6.8.0_user_680767620';
 const _TESTED_FIREOS_NAME  = 'Fire OS 5.5.5.4';
 
+// Was this Echo unlocked with amonet-biscuit v2.0.0 or later? v2.0.0
+// (R0rt1z2, 10 Sep 2026) writes a newer preloader, LK and TrustZone, and
+// FireOS 5 does not boot on them — so neither does EchoMuse, emOS included,
+// since emOS runs the FireOS 5 kernel. Provisioning such a device ends in a
+// flash that cannot boot, so the connect step refuses it up front.
+//
+// Decided from EVIDENCE of v2, never from the absence of v1. A probe that
+// fails to run returns empty strings, and empty must read as "no evidence":
+// refusing a working v1.1.0 device because `od` was missing would be the
+// worse error. Three independent signs, any one of which is enough:
+//
+//   expdb   — first four bytes of the expdb partition, as hex. v2's preloader
+//             exploit loads the real LK from expdb (amonet-koboreru,
+//             `LK_PART_NAME "expdb"` for biscuit), so an MTK image header —
+//             magic 0x58881688, stored little-endian as 88 16 88 58 — at its
+//             start is v2's own mechanism rather than a side effect of it.
+//             v1 leaves expdb alone. Checked in recovery only: it needs root.
+//   twrp    — the TWRP version. v2 installs 3.7.0_9-0, v1 ships 3.2.3-0.
+//             Compared numerically, so 3.10 is not read as older than 3.7.
+//   release — the Android release that MATTERS: getprop in Android, but
+//             /system's build.prop in recovery, because TWRP answers getprop
+//             with its own ramdisk. FireOS 6 is Android 7.1; v1 boots only
+//             FireOS 5, so a release of 6 or later on this board means v2.
+const _unlockVerdict = ({ release = '', expdb = '', twrp = '' }) => {
+  const evidence = [];
+  if (expdb.toLowerCase() === '88168858') evidence.push('a bootloader image in expdb');
+  const tv = twrp.match(/(\d+)\.(\d+)/);
+  if (tv && (+tv[1] > 3 || (+tv[1] === 3 && +tv[2] >= 7))) evidence.push(`TWRP ${twrp}`);
+  const major = parseInt(release, 10);
+  if (major >= 6) evidence.push(`Android ${release}, which is FireOS 6`);
+  return { v2: evidence.length > 0, evidence };
+};
+
 // WiFi security labels, used in the network picker and in error messages.
 // Module scope so WifiPanel and the wizard's step runners share one set.
 const _SECURITY_LABEL = {
@@ -3557,7 +3590,7 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
       + '[ -z "$S" ] && exit 0; '
       + 'WAS=$(mount | grep " /system " ); '
       + '[ -z "$WAS" ] && mount -o ro "$S" /system 2>&1; '
-      + 'grep -E "^ro\\.(build\\.version\\.(name|incremental)|product\\.(model|name))=" '
+      + 'grep -E "^ro\\.(build\\.version\\.(name|incremental|release)|product\\.(model|name))=" '
       + '  /system/build.prop 2>/dev/null; '
       + '[ -z "$WAS" ] && umount /system 2>/dev/null; '
       + 'echo _SYSREAD_OK');
@@ -3567,6 +3600,11 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     return build ? {
       build,
       name:  pick('ro\\.build\\.version\\.name'),
+      // The ANDROID release of the build on /system. In recovery the running
+      // getprop is TWRP's: v1's TWRP happens to say 5.1.1, which made the
+      // FireOS 5 check pass by accident, and v2's TWRP 3.7 says something
+      // newer and would be refused as a wrong device. See _unlockVerdict.
+      release: pick('ro\\.build\\.version\\.release'),
       // The DEVICE's identity, not the recovery's. TWRP answers ro.product.*
       // with its own strings ("Echo Dot 2nd Gen" / "omni_biscuit"), which pass
       // the board check by containing "biscuit" — true, but it is TWRP being
@@ -3603,10 +3641,14 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     const inRecovery = _bannerMode(c.banner) === 'twrp';
     if (serial) setProvSerial(serial);
     addLog(`Model: ${model || '(unknown)'}  Build: Android ${release}  Codename: ${name || '(unknown)'}  Serial: ${serial || '(unknown)'}`);
+    // In recovery the release that matters is /system's, not TWRP's; unknown
+    // stays '' so the checks below skip it rather than guess.
+    let effRelease = release;
     if (inRecovery) {
       addLog('Device is already in TWRP recovery — reading the FireOS build off '
            + '/system, since every property above is the recovery ramdisk\'s.');
       const sys = await readFireosBuild(c);
+      effRelease = (sys && sys.release) || '';
       if (sys) {
         fwBuild = sys.build; fwName = sys.name;
         if (sys.model) model = sys.model;
@@ -3621,8 +3663,40 @@ function ProvisionWizard({ token, onClose, knownDevices }) {
     } else {
       addLog(`Firmware: ${fwName || '(unknown)'}  ${fwBuild || ''}`);
     }
-    if (!release.startsWith('5.')) {
-      throw new Error(`Expected FireOS 5 (Android 5.x), got Android ${release}. Wrong device?`);
+    // amonet v2.0.0 — see _unlockVerdict. expdb and the TWRP version can only
+    // be read in recovery (expdb needs root); in Android the release is the
+    // evidence, and a v2 device that boots Android is necessarily on FireOS 6.
+    let expdb = '', twrp = '';
+    if (inRecovery) {
+      const u = await c.shell(
+        'P=""; for d in /dev/block/platform/*/by-name /dev/block/by-name; do '
+        + '[ -z "$P" ] && [ -e "$d/expdb" ] && P="$d/expdb"; done; '
+        + 'echo "EXPDB=$([ -n "$P" ] && dd if="$P" bs=4 count=1 2>/dev/null | od -An -tx1 | tr -d \' \\n\')"; '
+        + 'echo "TWRP=$(getprop ro.twrp.version)"; '
+        + 'echo "TWRPLOG=$(grep -m1 -o \'Starting TWRP [0-9][^ ]*\' /tmp/recovery.log 2>/dev/null)"; '
+        + 'echo _UNLOCKCHK');
+      if (u.includes('_UNLOCKCHK')) {
+        const pick = k => ((u.match(new RegExp('^' + k + '=(.*)$', 'm')) || [])[1] || '').trim();
+        expdb = pick('EXPDB');
+        twrp  = pick('TWRP') || pick('TWRPLOG').replace(/^Starting TWRP /, '');
+      }
+      addLog(`Unlock check: TWRP ${twrp || 'unknown'}, expdb ${expdb || 'unreadable'}`);
+    }
+    const unlock = _unlockVerdict({ release: effRelease, expdb, twrp });
+    if (unlock.v2) {
+      expectDisconnect.current = true;
+      try { await c.close(); } catch {}
+      setAdb(null);
+      throw new Error(
+        `This Echo was unlocked with amonet-biscuit v2.0.0 or later (${unlock.evidence.join('; ')}). `
+        + 'v2.0.0 replaces the Echo\'s bootloaders and FireOS 5 does not boot on them, and '
+        + 'EchoMuse, emOS included, needs FireOS 5 — so nothing has been written. Do not try '
+        + 'to go back by flashing FireOS 5 or an older amonet: that means writing bootloaders '
+        + 'by hand, which is how an Echo gets hard-bricked. See the warning at the top of '
+        + 'docs/rooting.md.');
+    }
+    if ((!inRecovery || effRelease) && !effRelease.startsWith('5.')) {
+      throw new Error(`Expected FireOS 5 (Android 5.x), got Android ${effRelease}. Wrong device?`);
     }
     if (fwBuild && fwBuild !== _TESTED_FIREOS_BUILD) {
       addLog(`Untested firmware — EchoMuse is developed against ${_TESTED_FIREOS_NAME} `

--- a/controller/tests/unlock_verdict.test.mjs
+++ b/controller/tests/unlock_verdict.test.mjs
@@ -1,0 +1,95 @@
+// Tests for _unlockVerdict() in dashboard.jsx — whether the wizard concludes
+// an Echo was unlocked with amonet-biscuit v2.0.0 or later, and refuses it.
+//
+//     node controller/tests/unlock_verdict.test.mjs
+//
+// Source extraction rather than import, for the reason pm_verdict.test.mjs
+// gives: the dashboard compiles to a single classic script with no module
+// boundary, so the alternative is a second copy that drifts.
+//
+// Two ways to be wrong, and they are not equal. Missing a v2 device lets the
+// wizard build and flash an image that cannot boot. Refusing a v1.1.0 device
+// stops somebody whose Echo works. So the rule under test is that the verdict
+// comes from EVIDENCE of v2, and that a probe which could not run — every
+// input empty — is never evidence.
+
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(HERE, "..", "static", "dashboard.jsx"), "utf8");
+
+function liftArrow(name) {
+  const start = src.indexOf(`const ${name} = (`);
+  if (start < 0) {
+    throw new Error(`dashboard.jsx no longer defines ${name}() — if it was `
+                  + `renamed or moved, update this test to match`);
+  }
+  let depth = 0;
+  for (let i = start; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === "{" || ch === "(" || ch === "[") depth++;
+    else if (ch === "}" || ch === ")" || ch === "]") depth--;
+    else if (ch === ";" && depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`could not find the end of ${name}`);
+}
+
+const { _unlockVerdict } = await import(
+  "data:text/javascript;base64," + Buffer.from(
+    liftArrow("_unlockVerdict") + "\nexport { _unlockVerdict };"
+  ).toString("base64"));
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) return;
+  failures++;
+  console.error(`FAIL: ${name}${detail ? `\n      ${detail}` : ""}`);
+}
+const v2 = (args) => _unlockVerdict(args).v2;
+
+// ── A v1.1.0 device must pass, in every state the wizard can meet it in ──
+check("v1 in TWRP: FireOS 5 on /system, empty expdb, TWRP 3.2.3",
+  !v2({ release: "5.1.1", expdb: "00000000", twrp: "3.2.3-0" }));
+check("v1 in Android: only the release is known",
+  !v2({ release: "5.1.1" }));
+check("every probe failed: nothing is evidence",
+  !v2({ release: "", expdb: "", twrp: "" }));
+check("no arguments at all is not evidence either", !v2({}));
+check("expdb holding something other than an LK header is not evidence",
+  !v2({ release: "5.1.1", expdb: "ffffffff", twrp: "3.2.3-0" }));
+
+// ── Each sign of v2 is enough on its own ──
+check("an MTK image header in expdb is v2",
+  v2({ release: "5.1.1", expdb: "88168858", twrp: "3.2.3-0" }));
+check("the header is matched whatever the hex case",
+  v2({ expdb: "88168858".toUpperCase() }));
+check("TWRP 3.7 is v2", v2({ twrp: "3.7.0_9-0" }));
+check("TWRP 3.10 is compared as a number, not a string", v2({ twrp: "3.10.0" }));
+check("TWRP 4.0 is v2", v2({ twrp: "4.0.0" }));
+check("TWRP 3.6 is not v2", !v2({ twrp: "3.6.2_9-0" }));
+check("FireOS 6 on /system (Android 7.1) is v2", v2({ release: "7.1.2" }));
+
+// ── The refusal names what it found ──
+const both = _unlockVerdict({ release: "7.1.2", expdb: "88168858", twrp: "3.7.0_9-0" });
+check("all three signs are reported, so the message says why",
+  both.evidence.length === 3, JSON.stringify(both.evidence));
+check("the TWRP version appears in the evidence",
+  both.evidence.some(e => e.includes("3.7.0_9-0")), JSON.stringify(both.evidence));
+
+// ── The connect step actually consults it, with the release from /system ──
+// Comments stripped first: a guard that greps for a call also finds the
+// comment explaining it, and passes on the prose.
+const code = src.split("\n").filter(l => !l.trim().startsWith("//")).join("\n");
+const connect = code.slice(code.indexOf("async function runConnectAndroid"));
+check("runConnectAndroid calls _unlockVerdict",
+  /_unlockVerdict\(\{\s*release:\s*effRelease/.test(connect));
+check("in recovery the release comes from /system, not TWRP's getprop",
+  /effRelease\s*=\s*\(sys && sys\.release\)/.test(connect));
+
+if (failures) {
+  console.error(`\n${failures} failure(s)`);
+  process.exit(1);
+}
+console.log("unlock_verdict: all checks passed");


### PR DESCRIPTION
**The wizard now recognises an Echo unlocked with amonet-biscuit v2.0.0 and refuses it at step 1, before anything is written, with a clear reason.** Without this, the emOS flow could flash an image that won't boot.

- **How it decides:** any one of three positive signs. A bootloader image at the start of `expdb` (where v2's exploit loads its bootloader from), TWRP 3.7 or later (v2 installs 3.7.0_9-0; v1 shipped 3.2.3-0), or FireOS 6 on `/system`. A check that fails to run counts as no evidence, so a working v1.1.0 device is never refused.
- **Bug fixed along the way:** in TWRP, step 1 was checking the recovery's own Android version (5.1.1 on v1's TWRP), so the FireOS 5 check only passed by accident. It now reads `/system`.
- **The message:** says nothing has been written, and not to go back by flashing FireOS 5 or an older amonet (the obvious recovery, and the one that risks a hard brick).

**Tested:** new `unlock_verdict.test.mjs` (added to CI), which catches all five deliberate breaks I tried. The shell probe was pulled out of the source and run under sh, bash and busybox against a fake `expdb`. `dashboard.jsx` compiles with the image's esbuild. **Not yet run on a real device in TWRP**, v1 or v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015D6ssR69sXM4mm1dcsfb82
